### PR TITLE
refactor(log): route all engine output through EngineLog

### DIFF
--- a/Sources/AetherEngine/AetherEngine.swift
+++ b/Sources/AetherEngine/AetherEngine.swift
@@ -1680,14 +1680,6 @@ public final class AetherEngine: ObservableObject {
                     + "avBufBehind=\(String(format: "%.1f", bufferBehindSec))s"
 
                 EngineLog.emit(line, category: .engine)
-                // Also write to stdout so the line shows up in Xcode's
-                // debug console even on devices where the OSLog stream
-                // isn't being captured. EngineLog's own stdout fallback
-                // is suppressed once Sodalite installs its LogTap
-                // handler, so we duplicate the memprobe line here only.
-                // One line per 30 s is cheap; the rest of EngineLog stays
-                // single-sink to avoid console spam.
-                print(line)
             }
         }
     }

--- a/Sources/AetherEngine/Audio/AudioDecoder.swift
+++ b/Sources/AetherEngine/Audio/AudioDecoder.swift
@@ -85,7 +85,7 @@ final class AudioDecoder: @unchecked Sendable {
         // fully resolved layout/rate/format; initialise from it.
 
         #if DEBUG
-        print("[AudioDecoder] Opened: \(sampleRate)Hz, \(channels)ch, codec=\(String(cString: codec.pointee.name))")
+        EngineLog.emit("[AudioDecoder] Opened: \(sampleRate)Hz, \(channels)ch, codec=\(String(cString: codec.pointee.name))", category: .swPlayback)
         #endif
     }
 
@@ -170,7 +170,7 @@ final class AudioDecoder: @unchecked Sendable {
         }
 
         #if DEBUG
-        print("[AudioDecoder] Resampler ready: \(sampleRate)Hz, \(channels)ch, inFmt=\(inFmt.rawValue)")
+        EngineLog.emit("[AudioDecoder] Resampler ready: \(sampleRate)Hz, \(channels)ch, inFmt=\(inFmt.rawValue)", category: .swPlayback)
         #endif
         return true
     }
@@ -312,7 +312,7 @@ final class AudioDecoder: @unchecked Sendable {
         #if DEBUG
         if convertedSamples <= 0 && !_loggedZeroConvert {
             _loggedZeroConvert = true
-            print("[AudioDecoder] swr_convert returned \(convertedSamples), pipeline silent from here")
+            EngineLog.emit("[AudioDecoder] swr_convert returned \(convertedSamples), pipeline silent from here", category: .swPlayback)
         }
         #endif
         guard convertedSamples > 0 else { return }

--- a/Sources/AetherEngine/Audio/AudioOutput.swift
+++ b/Sources/AetherEngine/Audio/AudioOutput.swift
@@ -73,7 +73,7 @@ final class AudioOutput: @unchecked Sendable {
         let result = semaphore.wait(timeout: .now() + .seconds(1))
         #if DEBUG
         if result == .timedOut {
-            print("[AudioOutput] detachVideoLayer: timed out waiting for synchronizer removal")
+            EngineLog.emit("[AudioOutput] detachVideoLayer: timed out waiting for synchronizer removal", category: .swPlayback)
         }
         #endif
     }
@@ -132,10 +132,10 @@ final class AudioOutput: @unchecked Sendable {
             let sr = fmt.map { "\($0.mSampleRate)Hz" } ?? "?"
             let ch = fmt.map { "\($0.mChannelsPerFrame)ch" } ?? "?"
             let count = CMSampleBufferGetNumSamples(sampleBuffer)
-            print("[AudioOutput] first enqueue: \(sr) \(ch), \(count) samples, renderer.error=\(String(describing: renderer.error))")
+            EngineLog.emit("[AudioOutput] first enqueue: \(sr) \(ch), \(count) samples, renderer.error=\(String(describing: renderer.error))", category: .swPlayback)
         } else if let err = renderer.error, !_loggedRendererError {
             _loggedRendererError = true
-            print("[AudioOutput] renderer error: \(err)")
+            EngineLog.emit("[AudioOutput] renderer error: \(err)", category: .swPlayback)
         }
         #endif
     }

--- a/Sources/AetherEngine/Decoder/HardwareVideoDecoder.swift
+++ b/Sources/AetherEngine/Decoder/HardwareVideoDecoder.swift
@@ -238,7 +238,7 @@ final class HardwareVideoDecoder: VideoDecodingPipeline, @unchecked Sendable {
             "[HardwareVideoDecoder] opened HEVC \(width)x\(height) "
             + "\(use10Bit ? "10-bit" : "8-bit") "
             + "transfer=\(codecpar.pointee.color_trc.rawValue)",
-            category: .engine
+            category: .swPlayback
         )
     }
 
@@ -358,7 +358,7 @@ final class HardwareVideoDecoder: VideoDecodingPipeline, @unchecked Sendable {
         if decodeStatus != noErr {
             EngineLog.emit(
                 "[HardwareVideoDecoder] decode error \(decodeStatus) at pts=\(ptsRaw)",
-                category: .engine
+                category: .swPlayback
             )
         }
     }

--- a/Sources/AetherEngine/Decoder/SoftwareVideoDecoder.swift
+++ b/Sources/AetherEngine/Decoder/SoftwareVideoDecoder.swift
@@ -106,7 +106,7 @@ final class SoftwareVideoDecoder: VideoDecodingPipeline, @unchecked Sendable {
         use10Bit = bitsPerSample > 8 || isHDRTransfer
 
         #if DEBUG
-        print("[SWDecoder] Opened: \(codecpar.pointee.width)x\(codecpar.pointee.height), codec=\(String(cString: codec.pointee.name)), threads=\(ctx.pointee.thread_count), \(use10Bit ? "10-bit" : "8-bit")")
+        EngineLog.emit("[SWDecoder] Opened: \(codecpar.pointee.width)x\(codecpar.pointee.height), codec=\(String(cString: codec.pointee.name)), threads=\(ctx.pointee.thread_count), \(use10Bit ? "10-bit" : "8-bit")", category: .swPlayback)
         #endif
     }
 

--- a/Sources/AetherEngine/Demuxer/AVIOReader.swift
+++ b/Sources/AetherEngine/Demuxer/AVIOReader.swift
@@ -90,7 +90,7 @@ final class AVIOReader: @unchecked Sendable {
         if resolved != url && resolved != _resolvedURL {
             _resolvedURL = resolved
             #if DEBUG
-            print("[AVIOReader] Cached resolved URL host=\(resolved.host ?? "?")")
+            EngineLog.emit("[AVIOReader] Cached resolved URL host=\(resolved.host ?? "?")", category: .demux)
             #endif
         }
     }
@@ -104,7 +104,7 @@ final class AVIOReader: @unchecked Sendable {
         if _resolvedURL != nil {
             _resolvedURL = nil
             #if DEBUG
-            print("[AVIOReader] Dropped resolved URL cache (expiry status)")
+            EngineLog.emit("[AVIOReader] Dropped resolved URL cache (expiry status)", category: .demux)
             #endif
         }
     }
@@ -548,14 +548,14 @@ final class AVIOReader: @unchecked Sendable {
         task.resume()
 
         #if DEBUG
-        print("[AVIOReader] Streaming started: \(url.lastPathComponent)")
+        EngineLog.emit("[AVIOReader] Streaming started: \(url.lastPathComponent)", category: .demux)
         #endif
 
         // Wait until stream ends or reader is closed
         semaphore.wait()
 
         #if DEBUG
-        print("[AVIOReader] Streaming ended")
+        EngineLog.emit("[AVIOReader] Streaming ended", category: .demux)
         #endif
         streamSession.invalidateAndCancel()
     }
@@ -683,7 +683,7 @@ final class AVIOReader: @unchecked Sendable {
         // that don't accept Range early in the session).
         if let size = rangeProbeFileSize(), size > 0 {
             #if DEBUG
-            print("[AVIOReader] File size: \(size) bytes (Range probe)")
+            EngineLog.emit("[AVIOReader] File size: \(size) bytes (Range probe)", category: .demux)
             #endif
             return size
         }
@@ -716,14 +716,14 @@ final class AVIOReader: @unchecked Sendable {
         if semaphore.wait(timeout: .now() + .seconds(25)) == .timedOut {
             task.cancel()
             #if DEBUG
-            print("[AVIOReader] Range probe timed out → trying HEAD")
+            EngineLog.emit("[AVIOReader] Range probe timed out → trying HEAD", category: .demux)
             #endif
             return nil
         }
 
         if delegate.totalSize == nil {
             #if DEBUG
-            print("[AVIOReader] Range probe didn't yield a size → trying HEAD")
+            EngineLog.emit("[AVIOReader] Range probe didn't yield a size → trying HEAD", category: .demux)
             #endif
         }
         return delegate.totalSize
@@ -742,13 +742,13 @@ final class AVIOReader: @unchecked Sendable {
             guard let http = response as? HTTPURLResponse,
                   (200...299).contains(http.statusCode) else {
                 #if DEBUG
-                print("[AVIOReader] HEAD failed (HTTP \((response as? HTTPURLResponse)?.statusCode ?? -1)) → streaming mode")
+                EngineLog.emit("[AVIOReader] HEAD failed (HTTP \((response as? HTTPURLResponse)?.statusCode ?? -1)) → streaming mode", category: .demux)
                 #endif
                 return -1
             }
             let length = http.expectedContentLength
             #if DEBUG
-            print("[AVIOReader] File size: \(length) bytes (HEAD fallback)\(length <= 0 ? " streaming mode" : "")")
+            EngineLog.emit("[AVIOReader] File size: \(length) bytes (HEAD fallback)\(length <= 0 ? " streaming mode" : "")", category: .demux)
             #endif
             return length
         } catch {
@@ -756,7 +756,7 @@ final class AVIOReader: @unchecked Sendable {
             // This is expected for live transcode URLs where the server
             // needs to start transcoding before responding.
             #if DEBUG
-            print("[AVIOReader] HEAD probe failed: \(error.localizedDescription) → streaming mode")
+            EngineLog.emit("[AVIOReader] HEAD probe failed: \(error.localizedDescription) → streaming mode", category: .demux)
             #endif
             return -1
         }
@@ -816,7 +816,7 @@ final class AVIOReader: @unchecked Sendable {
         }
 
         #if DEBUG
-        print("[AVIOReader] Fetch failed after \(Self.maxRetries) retries at offset \(offset): \(lastError?.localizedDescription ?? "?")")
+        EngineLog.emit("[AVIOReader] Fetch failed after \(Self.maxRetries) retries at offset \(offset): \(lastError?.localizedDescription ?? "?")", category: .demux)
         #endif
         return nil
     }
@@ -997,7 +997,7 @@ private final class StreamingDelegate: NSObject, URLSessionDataDelegate {
     func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
         #if DEBUG
         if let error {
-            print("[AVIOReader] Stream error: \(error.localizedDescription)")
+            EngineLog.emit("[AVIOReader] Stream error: \(error.localizedDescription)", category: .demux)
         }
         #endif
         onComplete()

--- a/Sources/AetherEngine/Demuxer/Demuxer.swift
+++ b/Sources/AetherEngine/Demuxer/Demuxer.swift
@@ -170,7 +170,7 @@ public final class Demuxer: @unchecked Sendable {
         }
 
         #if DEBUG
-        print("[Demuxer] Opened: \(ctx.pointee.nb_streams) streams, duration=\(ctx.pointee.duration) us")
+        EngineLog.emit("[Demuxer] Opened: \(ctx.pointee.nb_streams) streams, duration=\(ctx.pointee.duration) us", category: .demux)
         for i in 0..<Int(ctx.pointee.nb_streams) {
             guard let stream = ctx.pointee.streams[i],
                   let codecpar = stream.pointee.codecpar else { continue }
@@ -182,7 +182,7 @@ public final class Demuxer: @unchecked Sendable {
             case AVMEDIA_TYPE_SUBTITLE: typeName = "subtitle"
             default: typeName = "other"
             }
-            print("[Demuxer]   stream[\(i)] type=\(typeName) \(codecpar.pointee.width)x\(codecpar.pointee.height)")
+            EngineLog.emit("[Demuxer]   stream[\(i)] type=\(typeName) \(codecpar.pointee.width)x\(codecpar.pointee.height)", category: .demux)
         }
         #endif
     }
@@ -418,7 +418,7 @@ public final class Demuxer: @unchecked Sendable {
         let ret = avformat_seek_file(ctx, -1, Int64.min, timestamp, Int64.max, 0)
         if ret < 0 {
             #if DEBUG
-            print("[Demuxer] Seek to \(seconds)s failed: \(ret)")
+            EngineLog.emit("[Demuxer] Seek to \(seconds)s failed: \(ret)", category: .demux)
             #endif
         }
         // Flush internal parser state after seek, prevents assertion

--- a/Sources/AetherEngine/Diagnostics/EngineLog.swift
+++ b/Sources/AetherEngine/Diagnostics/EngineLog.swift
@@ -2,18 +2,20 @@ import Foundation
 import os
 
 /// Single point where the engine emits human-readable diagnostic
-/// lines. Sinks (always OSLog, then either host handler or stdout):
+/// lines. Two sinks:
 ///
-///   1. **OSLog** (`os.Logger`): structured per-category logging that
-///      shows up in Console.app and `log stream` and survives Release
-///      builds without a debugger. Filterable per subsystem/category,
-///      e.g. `log stream --predicate 'subsystem == "de.superuser404.AetherEngine" AND category == "muxer"'`.
-///   2. **Host handler OR stdout** (mutually exclusive): if a host has
-///      installed `handler` (e.g. Sodalite mirroring into an in-app
-///      ring buffer), the line goes there. Otherwise it falls back to
-///      `print(line)` so the macOS `aetherctl` CLI keeps live stdout
-///      output. Gating these against each other avoids the duplicate
-///      lines that Xcode console shows when OSLog and stdout both fire.
+///   1. **OSLog** (`os.Logger`, always on): structured per-category
+///      logging that shows up in Console.app, `log stream`, and
+///      Xcode's debug console, and survives Release builds without
+///      a debugger. Filterable per subsystem/category, e.g.
+///      `log stream --predicate 'subsystem == "de.superuser404.AetherEngine" AND category == "muxer"'`.
+///   2. **Host handler** (optional): if a host sets
+///      `EngineLog.handler`, every line is mirrored there. Used by
+///      apps mirroring into an in-app overlay/ring buffer, and by
+///      `aetherctl serve`/`validate`/`probe` to add a timestamp
+///      prefix and route to stdout. No stdio fallback inside
+///      `EngineLog`; any context that wants live stdout must
+///      install a handler explicitly.
 ///
 /// Centralising on `EngineLog.emit(...)` means the call site never
 /// has to gate on build config or thread-safety; the dispatch happens
@@ -46,6 +48,11 @@ public enum EngineLog {
         /// `AudioBridge` transcoding path: source decode → S16 PCM →
         /// FLAC encode, per-segment PTS rebase, encoder lifecycle.
         case audioBridge = "audio.bridge"
+        /// `SoftwarePlaybackHost` and its decode/render pipeline:
+        /// `SoftwareVideoDecoder`, `HardwareVideoDecoder`,
+        /// `SampleBufferRenderer`, `AudioDecoder`, `AudioOutput`.
+        /// Covers the custom playback route AVPlayer doesn't drive.
+        case swPlayback = "sw.playback"
         /// Scrub / seek diagnostics: backward-seek detection, reset
         /// reasons, A/V watermarks.
         case scrub
@@ -82,10 +89,12 @@ public enum EngineLog {
     }
 
     /// Emit one diagnostic line under a specific category. Always
-    /// writes to OSLog. If the host installed a handler the line goes
-    /// to the handler, otherwise it falls back to stdout via `print`.
-    /// Picking one of the two avoids Xcode console duplicates where
-    /// OSLog and stdout would otherwise both render the same line.
+    /// writes to OSLog so Console.app, `log stream`, and Xcode's
+    /// debug console see everything. If a host has installed a
+    /// `handler`, the line is mirrored there too (in-app overlay,
+    /// or aetherctl's own timestamp-prefixed stdout). No stdio
+    /// fallback: any context that wants live stdout must install
+    /// a handler.
     ///
     /// The OSLog `\(..., privacy: .public)` interpolation marks the
     /// payload as non-sensitive (engine logs never contain user data,
@@ -93,10 +102,6 @@ public enum EngineLog {
     /// full string instead of `<private>`.
     public static func emit(_ line: String, category: Category) {
         loggers[category]?.log("\(line, privacy: .public)")
-        if let handler {
-            handler(line)
-        } else {
-            print(line)
-        }
+        handler?(line)
     }
 }

--- a/Sources/AetherEngine/Native/SoftwarePlaybackHost.swift
+++ b/Sources/AetherEngine/Native/SoftwarePlaybackHost.swift
@@ -165,7 +165,7 @@ final class SoftwarePlaybackHost {
             videoDecoder = HardwareVideoDecoder()
             EngineLog.emit(
                 "[SWHost] selected HardwareVideoDecoder (VT HEVC) for codec_id=\(codecpar.pointee.codec_id.rawValue)",
-                category: .engine
+                category: .swPlayback
             )
         } else if !(videoDecoder is SoftwareVideoDecoder) {
             // Restoring the software default if a previous load left
@@ -187,7 +187,7 @@ final class SoftwarePlaybackHost {
                 renderer.setHDROutput(true)
                 EngineLog.emit(
                     "[SWHost] HDR mode ON on display layer (transfer=\(trc.rawValue))",
-                    category: .engine
+                    category: .swPlayback
                 )
             }
         }
@@ -219,7 +219,7 @@ final class SoftwarePlaybackHost {
                 // the first enqueue on tvOS 26+.
                 self.audioOutput = AudioOutput()
             } catch {
-                EngineLog.emit("[SWHost] audio open failed (\(error)); video-only", category: .engine)
+                EngineLog.emit("[SWHost] audio open failed (\(error)); video-only", category: .swPlayback)
                 self.audioStreamIndex = -1
             }
         }
@@ -458,7 +458,7 @@ final class SoftwarePlaybackHost {
             do {
                 packet = try demuxer.readPacket()
             } catch {
-                EngineLog.emit("[SWHost] demux read failed: \(error)", category: .engine)
+                EngineLog.emit("[SWHost] demux read failed: \(error)", category: .swPlayback)
                 onError("Playback error: \(error.localizedDescription)")
                 break
             }

--- a/Sources/AetherEngine/Renderer/SampleBufferRenderer.swift
+++ b/Sources/AetherEngine/Renderer/SampleBufferRenderer.swift
@@ -202,7 +202,7 @@ final class SampleBufferRenderer: @unchecked Sendable {
         #if DEBUG
         enqueueCount = 0
         loggedLayerFailed = false
-        print("[Renderer] display layer recreated")
+        EngineLog.emit("[Renderer] display layer recreated", category: .swPlayback)
         #endif
     }
 
@@ -306,7 +306,7 @@ final class SampleBufferRenderer: @unchecked Sendable {
             )
             hdr10PlusAttachedCount += 1
             if hdr10PlusAttachedCount == 1 || hdr10PlusAttachedCount == 30 || hdr10PlusAttachedCount % 600 == 0 {
-                EngineLog.emit("[Renderer] HDR10+ attachment count: \(hdr10PlusAttachedCount) (last payload \(hdr10PlusData.count) bytes)")
+                EngineLog.emit("[Renderer] HDR10+ attachment count: \(hdr10PlusAttachedCount) (last payload \(hdr10PlusData.count) bytes)", category: .swPlayback)
             }
         }
         // If the queue target has entered the failed state (undefined-
@@ -317,13 +317,13 @@ final class SampleBufferRenderer: @unchecked Sendable {
         if queueStatus == .failed {
             if !loggedLayerFailed {
                 loggedLayerFailed = true
-                EngineLog.emit("[Renderer] queue target failed at enqueue #\(enqueueCount + 1): \(queueError?.localizedDescription ?? "nil"), attempting recovery via flush()")
+                EngineLog.emit("[Renderer] queue target failed at enqueue #\(enqueueCount + 1): \(queueError?.localizedDescription ?? "nil"), attempting recovery via flush()", category: .swPlayback)
             }
             target.flush()
         }
         if !target.isReadyForMoreMediaData, !loggedNotReady {
             loggedNotReady = true
-            EngineLog.emit("[Renderer] isReadyForMoreMediaData=false at enqueue #\(enqueueCount + 1) status=\(statusName)")
+            EngineLog.emit("[Renderer] isReadyForMoreMediaData=false at enqueue #\(enqueueCount + 1) status=\(statusName)", category: .swPlayback)
         }
         target.enqueue(sampleBuffer)
 
@@ -340,7 +340,7 @@ final class SampleBufferRenderer: @unchecked Sendable {
         // logging at #30 but actually keep enqueueing". Logging cost
         // is bounded: at 60 fps for 1 hour we emit 4 lines total.
         if enqueueCount == 1 || enqueueCount == 30 || enqueueCount == 100 || enqueueCount == 1000 || enqueueCount == 5000 {
-            EngineLog.emit("[Renderer] enqueue #\(enqueueCount): status=\(statusName) ready=\(queueTarget.isReadyForMoreMediaData) error=\(queueError?.localizedDescription ?? "nil")")
+            EngineLog.emit("[Renderer] enqueue #\(enqueueCount): status=\(statusName) ready=\(queueTarget.isReadyForMoreMediaData) error=\(queueError?.localizedDescription ?? "nil")", category: .swPlayback)
         }
     }
 

--- a/Sources/aetherctl/main.swift
+++ b/Sources/aetherctl/main.swift
@@ -89,6 +89,7 @@ private func parseSourceURL(_ raw: String) -> URL {
 // MARK: - probe
 
 private func runProbe(url: URL) -> Int32 {
+    EngineLog.handler = { print($0) }
     print("aetherctl probe: \(url.absoluteString)")
     print("")
     let probe: SourceProbe


### PR DESCRIPTION
## Summary

Every diagnostic line the engine emits now goes through one path (`EngineLog.emit`) with one sink contract: OSLog always, optional host handler. The stdio fallback that previously caused duplicate lines in Xcode is gone, and the SW playback subsystem gets its own log category (`sw.playback`) so it can be isolated from the rest of the engine in `log stream` / Console.app filters.

## Motivation

Two distinct problems with the old logging layout:

1. **Duplicate lines in Xcode.** `EngineLog.emit` wrote to OSLog unconditionally, then *also* called `print(line)` whenever no host handler was installed. Xcode renders both OSLog activity and the process's stdout in the same debug-area console, so every emit surfaced twice. The old doc comment claimed gating handler vs. stdout solved this — it did not, because OSLog still fired in parallel. A `isatty(STDOUT_FILENO)` gate was tried as an intermediate fix; Xcode wires GUI-app stdout to a pty, so the gate let duplicates through anyway. The fallback was removed entirely.

2. **23 raw `print(...)` calls** scattered across `AVIOReader`, `Demuxer`, `AudioDecoder`, `AudioOutput`, `SoftwareVideoDecoder`, `SampleBufferRenderer`, plus a vestigial duplicate in `AetherEngine` itself. These bypassed OSLog entirely, so they weren't filterable by category, didn't reach Console.app, and contributed to the Xcode duplication when their host also emitted through `EngineLog`.

The new `swPlayback` category carves the custom playback subsystem (`SoftwarePlaybackHost` + its decoders + `SampleBufferRenderer` + `AudioDecoder` + `AudioOutput`) out of the `.engine` catch-all, so `.engine` now genuinely means "cross-subsystem / lifecycle" and the SW route is filterable on its own.

## Behaviour matrix

| Context | OSLog | Handler called | Net effect |
|---|---|---|---|
| Host app in Xcode, no handler installed | ✓ | — | one line per emit in Xcode console (was two) |
| Host app on device | ✓ | — | visible via Console.app / `log stream`, no stdio noise |
| `aetherctl serve` / `validate` (tty / piped / redirected) | ✓ | ✓ | timestamped stdout, identical to before |
| `aetherctl probe` (tty / piped / redirected) | ✓ | ✓ (newly installed) | identical to pre-change stdout output |
| Any future host with no handler | ✓ | — | OSLog only; install a handler to mirror to stdout |