### PR TITLE
fix(muxer): drain libavformat's interleaver before each fragment cut

### DIFF
--- a/Sources/AetherEngine/Video/MP4SegmentMuxer.swift
+++ b/Sources/AetherEngine/Video/MP4SegmentMuxer.swift
@@ -29,11 +29,16 @@ import Libavutil
 ///                          (which lives in fragments instead).
 ///   +default_base_moof  — relative offsets in tfhd (cleaner fmp4)
 ///   +frag_custom        — caller controls fragment cuts via
-///                          `av_write_frame(ctx, nil)`. The mp4
-///                          muxer's internal interleave queue holds
-///                          packets until cut time, naturally
-///                          aligning audio + video at fragment
-///                          boundaries.
+///                          `av_write_frame(ctx, nil)`. Packets enter
+///                          via `av_interleaved_write_frame` and
+///                          queue in libavformat's interleaver until
+///                          cross-stream DTS ordering allows commit
+///                          to `mov_write_packet`. At cut time we
+///                          must drain the interleaver explicitly
+///                          (see `cutFragmentForNextSegment`); the
+///                          cut itself bypasses the interleaver and
+///                          would otherwise leave still-buffered
+///                          packets to spill into the next fragment.
 ///   +delay_moov         — defers writing the moov atom until the
 ///                          first `av_write_frame(ctx, nil)` call,
 ///                          AFTER packets have been queued via
@@ -60,16 +65,21 @@ import Libavutil
 ///   sidx accumulator across fragments; +frag_keyframe would interfere
 ///   with our explicit fragment-cut control via av_write_frame(nil).)
 ///
-/// First-cut semantics with delay_moov: the first call to
-/// `av_write_frame(ctx, nil)` after a fragment's worth of packets is
-/// queued writes the deferred ftyp+moov AND begins emitting moof+mdat
-/// in the same flush — but how FFmpeg splits the flush across calls
-/// depends on interleaver state at the time. To stay safe, the
-/// `cutFragmentForNextSegment` method calls `av_write_frame(nil)`
-/// twice on the first cut: the first call drains moov (via
-/// FragmentSplitter → onHeaderComplete → init.mp4), the second call
-/// emits the moof+mdat (via FragmentSplitter → onFragmentBytes →
-/// seg-0 file). Subsequent cuts are single-call.
+/// Cut sequence: each call to `cutFragmentForNextSegment` first
+/// drains libavformat's interleaver via
+/// `av_interleaved_write_frame(ctx, nil)`, so any packets still
+/// buffered there (waiting for cross-stream DTS catch-up) get
+/// committed to mov_write_packet and end up in the segment being
+/// cut. It then calls `av_write_frame(ctx, nil)` to trigger
+/// `mov_flush_fragment`, which emits the moof+mdat. On the first
+/// cut only there's a second `av_write_frame(ctx, nil)` (gated by
+/// `moovFlushed`) to handle the +delay_moov wrinkle: depending on
+/// interleaver state at the time, FFmpeg may have split the flush
+/// across calls, writing the deferred ftyp+moov first and the
+/// moof+mdat on the follow-up. When `mov_flush_fragment` already
+/// wrote both atoms in the single call, the gated second call is a
+/// safe no-op against an empty queue. Subsequent cuts are
+/// single-call after the drain.
 ///
 /// Output flow per session:
 ///
@@ -193,13 +203,14 @@ final class MP4SegmentMuxer {
 
     /// Latched after the first `av_write_frame(ctx, NULL)` call,
     /// which is when the `+delay_moov` muxer writes the deferred
-    /// ftyp + moov atoms. With delay_moov, the first cut needs
-    /// TWO `av_write_frame(NULL)` calls in sequence: the first emits
-    /// ftyp+moov (with valid `dec3` / `dac3` sample-entry boxes that
-    /// `mov_write_packet` populated as packets were queued via
-    /// `writePacket`), the second emits the actual moof+mdat for
-    /// seg-0. Subsequent cuts are single-call. See
-    /// `cutFragmentForNextSegment` for the call site.
+    /// ftyp + moov atoms. With delay_moov, the first cut may need a
+    /// second `av_write_frame(NULL)` after the interleaver-drain +
+    /// initial flush, because FFmpeg can split the work across calls:
+    /// the first emits ftyp+moov (with valid `dec3` / `dac3`
+    /// sample-entry boxes that `mov_write_packet` populated as
+    /// packets were queued via `writePacket`), the second emits the
+    /// actual moof+mdat for seg-0. Subsequent cuts skip the gated
+    /// second call. See `cutFragmentForNextSegment` for the call site.
     private var moovFlushed: Bool = false
 
     /// Muxer's chosen time_base for the video output stream, latched
@@ -356,9 +367,13 @@ final class MP4SegmentMuxer {
 
         // Movflags: the leak-free trio. See class docstring.
         // +frag_custom puts fragment cuts under explicit caller control
-        // via av_write_frame(ctx, nil); the mp4 muxer's interleave
-        // queue holds packets between cuts so audio + video align at
-        // fragment boundaries on its own.
+        // via av_write_frame(ctx, nil); packets enter through
+        // av_interleaved_write_frame and queue in libavformat's
+        // interleaver until cross-stream DTS ordering allows commit.
+        // Note that the cut bypasses that buffer — cutFragmentForNextSegment
+        // drains it via av_interleaved_write_frame(ctx, nil) first so
+        // the trailing packets land in the segment being cut, not the
+        // next one.
         var opts: OpaquePointer? = nil
         defer { av_dict_free(&opts) }
         av_dict_set(&opts, "movflags", "+empty_moov+default_base_moof+frag_custom+delay_moov", 0)
@@ -526,10 +541,15 @@ final class MP4SegmentMuxer {
     /// file, and rotate `fd` to a freshly-opened file for `nextIdx`.
     ///
     /// Sequence:
-    ///   1. `av_write_frame(ctx, nil)` — mp4 muxer's `+frag_custom`
-    ///      path flushes the queued packets as one moof+mdat block.
-    ///      Bytes flow through the avio callback → FragmentSplitter
-    ///      → current `fd`.
+    ///   1. Drain libavformat's interleaver with
+    ///      `av_interleaved_write_frame(ctx, nil)` so packets still
+    ///      buffered there (waiting for cross-stream DTS catch-up) get
+    ///      committed to `mov_write_packet` and end up in the
+    ///      just-completed segment instead of the next one. Then call
+    ///      `av_write_frame(ctx, nil)` to trigger `mov_flush_fragment`
+    ///      under the `+frag_custom` path, which emits one moof+mdat
+    ///      block. Bytes flow through the avio callback →
+    ///      FragmentSplitter → current `fd`.
     ///   2. After the flush returns, the current segment is fully
     ///      written. We close `fd`, capture its byte count and path,
     ///      and reset the counter.
@@ -547,19 +567,37 @@ final class MP4SegmentMuxer {
     /// atoms are emitted by the first `av_write_frame(nil)` call.
     /// The FragmentSplitter routes those bytes to `onHeaderComplete`
     /// (= init.mp4), so the segment file's byte counter sees nothing
-    /// from that call. A second call flushes the actual moof+mdat
-    /// for seg-0, which the splitter routes to `onFragmentBytes` and
-    /// the byte counter records normally. If FFmpeg's
+    /// from that call. A second `av_write_frame(nil)` call (gated by
+    /// `!moovFlushed`) flushes the actual moof+mdat for seg-0, which
+    /// the splitter routes to `onFragmentBytes`. When FFmpeg's
     /// `mov_flush_fragment` writes both moov AND moof+mdat in a
-    /// single call (which it does when packets are already queued in
-    /// the interleaver, the typical case), the second call is a
-    /// safe no-op against an empty queue.
+    /// single call, the gated second call is a safe no-op against an
+    /// empty queue.
     func cutFragmentForNextSegment(_ nextIdx: Int) -> (path: URL, bytesWritten: Int)? {
         guard let ctx = formatContext, headerWritten, fd >= 0 else { return nil }
 
-        // 1. Flush the queued fragment via the mp4 muxer's frag_custom
-        //    path. Bytes for the just-completed segment are written
-        //    to the current `fd` via the avio callback.
+        // 1. Drain libavformat's interleaver, then flush the queued
+        //    fragment via the mp4 muxer's frag_custom path. Bytes for
+        //    the just-completed segment are written to the current
+        //    `fd` via the avio callback.
+        //
+        //    The drain is the key step. `writePacket` uses
+        //    `av_interleaved_write_frame`, which buffers packets in
+        //    libavformat's interleaver until cross-stream DTS ordering
+        //    allows commit to mov_write_packet. Plain
+        //    `av_write_frame(ctx, nil)` triggers mov_flush_fragment
+        //    but bypasses that buffer, so packets still held there
+        //    (typical when audio is ahead of video and the interleaver
+        //    is waiting for video to catch up) carry over into the
+        //    next fragment instead of landing in the one we're cutting.
+        //    That manifested as ~4 trailing AC-3 frames missing from
+        //    the end of each segment's audio for matroska sources
+        //    with audio-leads-video interleave, so the segment's
+        //    actual audio coverage fell ~120 ms short of its declared
+        //    `#EXTINF`. Calling `av_interleaved_write_frame(ctx, nil)`
+        //    first commits the buffered packets, then the subsequent
+        //    `av_write_frame(ctx, nil)` emits the moof+mdat for them.
+        _ = av_interleaved_write_frame(ctx, nil)
         _ = av_write_frame(ctx, nil)
         if !moovFlushed {
             moovFlushed = true


### PR DESCRIPTION
## Summary

`MP4SegmentMuxer.cutFragmentForNextSegment` now drains libavformat's interleaver buffer (`av_interleaved_write_frame(ctx, nil)`) before triggering `mov_flush_fragment` (`av_write_frame(ctx, nil)`). Without the drain, packets still held in the interleaver — waiting for cross-stream DTS catch-up — were carried over into the *next* fragment's `moof+mdat` instead of landing in the one being cut.

## Motivation

`writePacket` uses `av_interleaved_write_frame`, which queues packets in libavformat's internal interleaver until enough cross-stream context is available to commit them in DTS order. For matroska sources where audio interleaves ahead of video (common for AC-3 / EAC-3 stream-copy), the interleaver buffers the trailing audio frames of the current segment waiting for the next IRAP to confirm ordering. When the producer triggers the segment cut, plain `av_write_frame(ctx, nil)` calls `mov_flush_fragment` directly — bypassing the interleaver. Anything still buffered re-emerges in the next fragment instead of finalising in the one being cut.

In practice this manifested as ~4 trailing AC-3 frames (~120 ms) consistently missing from the end of each segment's audio. The segment's declared `#EXTINF` therefore over-stated its audio coverage by the same amount, and the audio `tfdt` of every subsequent fragment fell behind the playlist's cumulative time.

## Fix

Insert `av_interleaved_write_frame(ctx, nil)` before each `av_write_frame(ctx, nil)` in `cutFragmentForNextSegment`. The interleaver drains its buffered packets into `mov_write_packet` first, populating the MOVTrack sample tables, and the subsequent `av_write_frame(ctx, nil)` then emits a `moof+mdat` that includes them.

## Verification


Tested against two sources with distinct codec mixes; mediastreamvalidator parses every segment cleanly in both runs.

**HEVC 10-bit 23.976 fps + AC-3 stereo, 343 segments.** Before the fix, each segment's audio fell short by ~4 AC-3 frames and the trailing frames spilled into the next segment, leaving every audio `tfdt` ~128 ms behind the playlist's cumulative time. After the fix, audio coverage matches `#EXTINF` within one AC-3 frame and tfdt is contiguous with the playlist:

| Segment | Audio range, before | Audio range, after |
|---|---|---|
| 0 | 309 frames, [0.000–9.888 s] | 313 frames, [0.000–10.016 s] |
| 1 | 313 frames, [9.888–19.904 s] | 313 frames, [10.016–20.032 s] |
| 2 | 313 frames, [19.904–29.920 s] | 313 frames, [20.032–30.048 s] |
| 5 | 312 frames, [49.952–59.936 s] | 312 frames, [50.080–60.064 s] |

Sample counts are mostly unchanged because the spillover preserved total frames across the stream — only seg-0's count moves. The fix corrects which segment each frame lands in, so the per-segment ranges shift forward by ~128 ms onto the playlist's grid.

**H.264 24 fps + EAC-3 5.1 Atmos JOC, 648 segments.** Every sampled segment has exactly 125 AC-3 frames × 1536 samples = 4.000 s of audio (the configured `targetDur`), tfdt strictly contiguous. mediastreamvalidator reports `Processed 648 out of 648 segments / Average segment duration: 3.998715`, no audio-coverage warnings.