### PR TITLE
fix(native): apply externalMetadata on iOS too

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ player.$currentAVPlayer  // active AVPlayer, re-emitted on every reload (MPNowPl
 player.audioTracks    // [TrackInfo]
 player.selectAudioTrack(index: trackID)
 
-// tvOS info panel / Now Playing
+// Info panel / Now Playing (iOS / tvOS)
 player.setExternalMetadata([
     AVMetadataItem(/* title, artwork, etc. */)
 ])

--- a/Sources/AetherEngine/Native/NativeAVPlayerHost.swift
+++ b/Sources/AetherEngine/Native/NativeAVPlayerHost.swift
@@ -1,5 +1,6 @@
 import Foundation
 import AVFoundation
+import AVKit
 import Combine
 
 /// `AVPlayer` + `AVPlayerLayer` wrapper owned by AetherEngine. Drives
@@ -143,9 +144,10 @@ final class NativeAVPlayerHost {
         // load (e.g. system Now Playing title + artwork). Setting it
         // BEFORE AVPlayer.replaceCurrentItem-equivalent is the documented
         // safe order; doing it after the asset has started loading races
-        // with AVPlayer's internal track-load. tvOS only; AVPlayerItem.externalMetadata
-        // is unavailable on iOS / macOS.
-        #if os(tvOS)
+        // with AVPlayer's internal track-load. `AVPlayerItem.externalMetadata`
+        // is unavailable on macOS — macOS hosts must write
+        // `MPNowPlayingInfoCenter` directly.
+        #if !os(macOS)
         if !pendingExternalMetadata.isEmpty {
             item.externalMetadata = pendingExternalMetadata
         }
@@ -452,7 +454,7 @@ final class NativeAVPlayerHost {
     /// next item created by `load(url:startPosition:)`.
     func setExternalMetadata(_ items: [AVMetadataItem]) {
         pendingExternalMetadata = items
-        #if os(tvOS)
+        #if !os(macOS)
         playerItem?.externalMetadata = items
         #endif
     }


### PR DESCRIPTION
## Summary

- Add `import AVKit` so the AVKit extension that declares `AVPlayerItem.externalMetadata` is in scope.
- Widen the platform gate around both `externalMetadata` assignments from `#if os(tvOS)` to `#if !os(macOS)`.

## Why

`AVPlayerItem.externalMetadata` is declared by an **AVKit** extension on `AVPlayerItem`, not by AVFoundation (the doc URL lives under AVFoundation because that's the extended type, which is misleading). The file previously imported only `AVFoundation`, so the property was invisible on every platform. The original `#if os(tvOS)` gate hid the resulting compile error by skipping the assignment everywhere except tvOS — where some transitive import was apparently bringing AVKit in by accident.

After adding `import AVKit`, the property resolves on every platform that actually declares it. Apple ships it on iOS / iPadOS / Mac Catalyst / tvOS / visionOS — but **not on macOS**. So the correct gate is `#if !os(macOS)`, not `#if os(tvOS)`.

macOS hosts still skip the assignment; they have to write `MPNowPlayingInfoCenter` directly because there's no AVKit auto-publish path on macOS that reads `externalMetadata`.

## Effect

- **iOS / iPadOS / tvOS:** `setExternalMetadata(_:)` now actually feeds title / subtitle / artwork to AVKit, which auto-publishes to the system Now Playing surface (Control Center, Lock Screen, AirPlay receivers).
- **macOS:** unchanged — assignment is still skipped; embedding apps must write `MPNowPlayingInfoCenter` directly.