### PR TITLE
fix(video): emit ec-3 for JOC on iOS

### DIFF
--- a/Sources/AetherEngine/Video/HLSVideoEngine.swift
+++ b/Sources/AetherEngine/Video/HLSVideoEngine.swift
@@ -918,8 +918,22 @@ public final class HLSVideoEngine: @unchecked Sendable {
                 // (the field experiment was JOC playing fine on Sonos
                 // even with `ec-3`, but matching the spec is the
                 // correct posture for the cases where it matters).
+                //
+                // iOS exception: iOS AVPlayer strictly enforces
+                // RFC 6381 codec strings and silently drops the
+                // variant when the audio codec is anything other
+                // than `ec-3` — `ec+3` makes `asset.load(tracks)`
+                // return 0 and the item fails with `Cannot Open`
+                // (`AVFoundationErrorDomain -11848` / underlying
+                // `CoreMediaErrorDomain -15517`). JOC stays intact
+                // because the dec3 box still carries the marker;
+                // only the playlist string changes.
                 let isJOC = compat == .eac3 && acp.profile == 30
+                #if os(iOS)
+                audioHLSCodecs = compat.hlsCodecsString
+                #else
                 audioHLSCodecs = isJOC ? "ec+3" : compat.hlsCodecsString
+                #endif
                 EngineLog.emit(
                     "[HLSVideoEngine] audio: codec=\(compat) → stream-copy as `\(audioHLSCodecs ?? "?")` "
                     + "\(isJOC ? "[JOC=Atmos] " : "")"


### PR DESCRIPTION
## Summary

Gate the audio codec advertisement so iOS emits `ec-3` for EAC-3 with JOC (Atmos) tracks; macOS and tvOS keep emitting `ec+3`.

## Why

iOS AVPlayer strictly enforces RFC 6381 codec strings in HLS variant attributes. The engine advertises `ec+3` for JOC tracks to match Apple's HLS Authoring Spec recommendation, and macOS / tvOS tolerate that fine. iOS does not: it treats `ec+3` as an unknown codec and silently drops the variant during selection, so `asset.load(tracks)` returns 0 and the item fails to open with:

- `AVFoundationErrorDomain -11848 "Cannot Open"`
- underlying `CoreMediaErrorDomain -15517`

Switching iOS to plain `ec-3` lets AVPlayer accept the variant. JOC is unaffected — the `dec3` box in the segment fMP4 still carries the JOC marker, which is what receivers use to detect Atmos. Only the playlist codec string changes.

## Effect

- **iOS:** DV + Atmos titles play instead of failing at variant selection.
- **macOS / tvOS:** unchanged; still advertises `ec+3`.
- **Atmos passthrough:** intact on all platforms (the marker lives in the segment, not the playlist).