### PR TITLE
feat(diagnostics): bridge FFmpeg av_log into EngineLog .ffmpeg category

### DIFF
--- a/Sources/AetherEngine/AetherEngine.swift
+++ b/Sources/AetherEngine/AetherEngine.swift
@@ -359,6 +359,11 @@ public final class AetherEngine: ObservableObject {
     private var lifecycleObservers: [Any] = []
 
     public init() throws {
+        // Route FFmpeg's av_log output into EngineLog before any
+        // libav* entry point runs, so probe/load diagnostics land in
+        // Console.app + the host handler from the very first call.
+        FFmpegLogBridge.install()
+
         // Configure audio session for multichannel playback. AVPlayer
         // needs `.playback` + `.moviePlayback` + multichannel-content
         // enabled before its first asset opens, otherwise output is

--- a/Sources/AetherEngine/Diagnostics/EngineLog.swift
+++ b/Sources/AetherEngine/Diagnostics/EngineLog.swift
@@ -31,6 +31,14 @@ public enum EngineLog {
         /// category — session start/stop, lifecycle errors, anything
         /// that crosses subsystem boundaries.
         case engine
+        /// FFmpeg-internal diagnostics forwarded by `FFmpegLogBridge`
+        /// from `av_log_set_callback`. Covers the muxer, demuxer,
+        /// encoders, and decoders as a single stream — FFmpeg's own
+        /// `[mp4 @ ...]` / `[h264 @ ...]` prefixes preserved by
+        /// `av_log_format_line2` identify the originating subsystem.
+        /// Threshold defaults to `AV_LOG_WARNING`; hosts that want
+        /// verbose output call `FFmpegLogBridge.install(level:)`.
+        case ffmpeg
         /// `HLSVideoEngine` session orchestration: segment plan,
         /// segment-cache lifecycle, muxer resets, anything in
         /// `VideoSegmentProvider.mediaSegment(at:)`.

--- a/Sources/AetherEngine/Diagnostics/FFmpegLogBridge.swift
+++ b/Sources/AetherEngine/Diagnostics/FFmpegLogBridge.swift
@@ -1,0 +1,77 @@
+import Foundation
+import Libavutil
+
+/// Installs a process-wide `av_log_set_callback` that funnels FFmpeg's
+/// internal diagnostic output into `EngineLog` under the `.ffmpeg`
+/// category, so muxer / demuxer / decoder warnings surface alongside
+/// the engine's own log lines in Console.app and in any host-supplied
+/// `EngineLog.handler` (in-app overlay, `aetherctl` stdout).
+///
+/// Without this bridge, FFmpeg writes to stderr via its default
+/// callback, which is invisible to App Store builds, in-app overlays,
+/// and `aetherctl`'s timestamped stdout. After install, every
+/// `av_log(...)` call at or above the configured level is formatted
+/// with `av_log_format_line2` (same prefix/format as ffmpeg's default
+/// stderr output) and emitted under `.ffmpeg`.
+///
+/// The callback fires from whichever thread inside libav* did the
+/// logging — demuxer workers, decoder threads, the muxer's interleave
+/// queue. Safe because `EngineLog.emit` is itself thread-safe (OSLog
+/// is, and any host handler is required to be by `EngineLog`'s
+/// contract).
+enum FFmpegLogBridge {
+
+    /// Installs the callback and sets the global FFmpeg log level +
+    /// flags. Idempotent: re-calling overwrites the callback with
+    /// the same function pointer, so `AetherEngine.init` can invoke
+    /// it unconditionally without a once-guard.
+    ///
+    /// `level` defaults to `AV_LOG_WARNING` — surfaces real problems
+    /// (corrupt headers, missing PTS, decoder errors) without the
+    /// per-segment `[mp4 @ ...] track ...` chatter that `AV_LOG_INFO`
+    /// emits during normal fMP4 muxing. Hosts that want verbose
+    /// diagnostics can re-call `install(level: AV_LOG_VERBOSE)` (or
+    /// `AV_LOG_DEBUG`) after engine init.
+    ///
+    /// Flags set:
+    ///   - `AV_LOG_PRINT_LEVEL` so each forwarded line carries its
+    ///     severity (`[warning]`, `[error]`); `EngineLog` itself has
+    ///     no per-line severity channel, so this is how the level
+    ///     survives into Console.app.
+    ///   - `AV_LOG_SKIP_REPEATED` so a decoder spamming the same
+    ///     warning collapses into a single line plus a
+    ///     `Last message repeated N times` follow-up, instead of
+    ///     swamping the log ring.
+    static func install(level: Int32 = AV_LOG_WARNING) {
+        av_log_set_level(level)
+        av_log_set_flags(AV_LOG_PRINT_LEVEL | AV_LOG_SKIP_REPEATED)
+        av_log_set_callback { avcl, level, fmt, vl in
+            // `av_log_set_callback` bypasses the level check the
+            // default callback applies, so re-gate here. Cheap, and
+            // means a host bumping the level after install still
+            // sees the filter take effect.
+            guard level <= av_log_get_level() else { return }
+            guard let fmt = fmt, let vl = vl else { return }
+
+            // 1024 matches ffmpeg's own default callback buffer.
+            // Truncation is acceptable for diagnostic lines; no
+            // re-alloc loop on overflow.
+            let bufSize: Int32 = 1024
+            var buf = [CChar](repeating: 0, count: Int(bufSize))
+            var printPrefix: Int32 = 1
+            _ = buf.withUnsafeMutableBufferPointer { bp in
+                av_log_format_line2(avcl, level, fmt, vl,
+                                    bp.baseAddress, bufSize,
+                                    &printPrefix)
+            }
+
+            var line = String(cString: buf)
+            // av_log_format_line2 always terminates with `\n`; strip
+            // it so OSLog doesn't render a trailing blank line.
+            if line.hasSuffix("\n") { line.removeLast() }
+            if line.isEmpty { return }
+
+            EngineLog.emit(line, category: .ffmpeg)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- New `FFmpegLogBridge` installs `av_log_set_callback` and forwards every line through `EngineLog.emit` under a new `.ffmpeg` category, formatted with `av_log_format_line2` so FFmpeg's own `[mp4 @ ...]` / `[h264 @ ...]` subsystem prefixes survive.
- New `.ffmpeg` case on `EngineLog.Category` keeps muxer / demuxer / decoder chatter filterable in Console.app independently of the engine's own log lines.
- `FFmpegLogBridge.install()` wired into `AetherEngine.init()` before any libav* entry point runs, so probe/load diagnostics land in Console.app + any host `EngineLog.handler` from the first call.

## Why

Without the bridge, FFmpeg writes to stderr via its default callback — invisible to App Store builds, in-app overlays, and `aetherctl`'s timestamped stdout. Real diagnostic value (corrupt headers, missing PTS, decoder errors) was being silently dropped.

## Behavior

- Default level: `AV_LOG_WARNING` — surfaces real problems without the per-segment `[mp4 @ ...] track ...` chatter `AV_LOG_INFO` emits during normal fMP4 muxing. Hosts wanting verbose output re-call `FFmpegLogBridge.install(level: AV_LOG_VERBOSE)`.
- Flags: `AV_LOG_PRINT_LEVEL` (severity survives into Console) + `AV_LOG_SKIP_REPEATED` (a decoder spamming the same warning collapses to one line + a `Last message repeated N times` follow-up).
- Output buffer: 1024 chars, matches ffmpeg's own default callback. Truncation acceptable for diagnostics; no re-alloc loop on overflow.
- Idempotent: re-calling `install()` overwrites the callback with the same function pointer, so the unconditional call in `AetherEngine.init()` is safe across multiple engine instances.
- Thread-safe by construction: the callback fires from libav* worker threads, and `EngineLog.emit` already promises thread-safety (OSLog is, and any host handler is required to be by `EngineLog`'s contract).