### PR TITLE
feat(subtitles): opt-in advertise subtitle tracks as renditions for native pickers

### DIFF
--- a/Sources/AetherEngine/AetherEngine+Loading.swift
+++ b/Sources/AetherEngine/AetherEngine+Loading.swift
@@ -233,7 +233,13 @@ extension AetherEngine {
             liveSourceCadenceHint: liveSourceCadenceHint,
             preopenedDemuxer: preopenedDemuxer,
             sourceReopenableByURL: !isCustomSource,
-            companionAudioReader: companionAudioReader
+            companionAudioReader: companionAudioReader,
+            // Decoy subtitle renditions for AVKit's native picker. Mapped
+            // from the published list the load probe populated (empty
+            // unless the active load set advertiseSubtitleRenditions).
+            subtitleRenditions: subtitleRenditions.map {
+                (renditionID: $0.renditionID, name: $0.name, language: $0.language)
+            }
         )
         session.onFirstHDR10PlusDetected = { [weak self] in
             Task { @MainActor in self?.handleHDR10PlusDetected() }

--- a/Sources/AetherEngine/AetherEngine+Probe.swift
+++ b/Sources/AetherEngine/AetherEngine+Probe.swift
@@ -64,6 +64,94 @@ extension AetherEngine {
         return makeSourceProbe(demuxer: demuxer, displayURL: displayURL)
     }
 
+    /// Build the decoy subtitle rendition list (native-picker path) from
+    /// the probed subtitle tracks. Each rendition's `renditionID` embeds
+    /// the engine subtitle AVStream index (`TrackInfo.id`) so the host can
+    /// correlate AVKit's selected legible option back to the track; the
+    /// `name` is a human label (the track's localized language name, then
+    /// its declared name, then "Subtitle N"); `language` is the ISO code
+    /// (fallback "und").
+    nonisolated static func makeSubtitleRenditions(
+        from tracks: [TrackInfo]
+    ) -> [SubtitleRendition] {
+        // The native picker lists each rendition by its NAME, and AVKit
+        // collapses entries sharing NAME + LANGUAGE. Build a consistent,
+        // self-describing label from the reliable signals (localized language +
+        // format derived from the codec), then append the container title only
+        // when it carries a real distinguisher (SDH / Forced / Commentary /
+        // Simplified), dropping bare echoes and remux auto-titles like
+        // "ENG (srt)". Number any labels that still collide so every track stays
+        // selectable. Result e.g. "English (SRT)", "English SDH (SRT)",
+        // "Chinese Simplified (SRT)", "English (VOBSUB)".
+        var renditions: [SubtitleRendition] = []
+        var usedNameCounts: [String: Int] = [:]
+        for (offset, track) in tracks.enumerated() {
+            let language = track.language?.trimmingCharacters(in: .whitespaces)
+            let langCode = (language?.isEmpty == false) ? language! : "und"
+            let localizedLang = (langCode != "und")
+                ? Locale.current.localizedString(forLanguageCode: langCode)
+                : nil
+            let format = subtitleFormatLabel(track.codec)
+            let title = track.name.trimmingCharacters(in: .whitespaces)
+
+            // Keep the container title only when it adds information beyond the
+            // language / format. Drop bare echoes ("English", "eng", "SRT") and
+            // remux auto-titles of the form "<langcode> (<codec>)" (e.g.
+            // "ENG (srt)", "FRE (dvdsub)") -- the auto-pattern is matched against
+            // THIS track's language code so real labels like "SDH" survive.
+            let lowerTitle = title.lowercased()
+            let lowerLang = langCode.lowercased()
+            let echoesLanguageName = localizedLang.map { lowerTitle == $0.lowercased() } ?? false
+            let isEcho = title.isEmpty
+                || lowerTitle == lowerLang
+                || echoesLanguageName
+                || lowerTitle == format.lowercased()
+                || (lowerTitle.hasPrefix(lowerLang + " (") && lowerTitle.hasSuffix(")"))
+            let distinguisher = isEcho ? nil : title
+
+            // Compose "Language Distinguisher (FORMAT)".
+            let languageLabel: String? = localizedLang ?? (langCode != "und" ? langCode : nil)
+            let base: String
+            switch (languageLabel, distinguisher) {
+            case let (lang?, dist?):
+                base = "\(lang) \(dist) (\(format))"
+            case let (lang?, nil):
+                base = "\(lang) (\(format))"
+            case let (nil, dist?):
+                base = "\(dist) (\(format))"
+            case (nil, nil):
+                base = "Subtitle \(offset + 1) (\(format))"
+            }
+
+            let priorCount = usedNameCounts[base, default: 0]
+            usedNameCounts[base] = priorCount + 1
+            let displayName = (priorCount == 0) ? base : "\(base) \(priorCount + 1)"
+
+            renditions.append(SubtitleRendition(
+                renditionID: "sub\(track.id)",
+                name: displayName,
+                language: langCode,
+                trackIndex: track.id
+            ))
+        }
+        return renditions
+    }
+
+    /// Map an FFmpeg subtitle codec name to a short, user-facing format label.
+    nonisolated private static func subtitleFormatLabel(_ codec: String) -> String {
+        switch codec.lowercased() {
+        case "subrip", "srt": return "SRT"
+        case "ass", "ssa": return "ASS"
+        case "mov_text", "text", "tx3g": return "Text"
+        case "webvtt", "vtt": return "VTT"
+        case "dvd_subtitle", "dvdsub", "vobsub": return "VOBSUB"
+        case "hdmv_pgs_subtitle", "pgssub", "pgs": return "PGS"
+        case "dvb_subtitle", "dvbsub": return "DVB"
+        case "dvb_teletext": return "Teletext"
+        default: return codec.uppercased()
+        }
+    }
+
     /// Assemble a `SourceProbe` from an open demuxer. Shared by the
     /// static probe entry points and `load(source:)`'s internal probe
     /// stage, so all of them report identical metadata for the same

--- a/Sources/AetherEngine/AetherEngine.swift
+++ b/Sources/AetherEngine/AetherEngine.swift
@@ -91,6 +91,15 @@ public final class AetherEngine: ObservableObject {
     // list with the side demuxer's tracks for demuxed-audio live sources.
     @Published public internal(set) var audioTracks: [TrackInfo] = []
     @Published public private(set) var subtitleTracks: [TrackInfo] = []
+
+    /// Maps an advertised decoy subtitle rendition (HLS master playlist,
+    /// native-picker path) back to the engine subtitle track it stands
+    /// for. Non-empty only when the active load set
+    /// `LoadOptions.advertiseSubtitleRenditions == true`; empty otherwise
+    /// and whenever no session is loaded. The host uses `renditionID` /
+    /// `trackIndex` to correlate AVKit's selected legible option with the
+    /// `TrackInfo` whose cues it should then decode + paint.
+    @Published public private(set) var subtitleRenditions: [SubtitleRendition] = []
     /// Container metadata (tags + embedded cover) for the loaded source.
     /// nil while idle or when the source carries no metadata. Populated
     /// during `load(url:)` from the probe demuxer, before backend dispatch,
@@ -837,6 +846,7 @@ public final class AetherEngine: ObservableObject {
         clock.progress = 0
         audioTracks = []
         subtitleTracks = []
+        subtitleRenditions = []
         metadata = nil
         fontAttachments = []
         subtitleCueDiagnosticCount = 0
@@ -1008,6 +1018,14 @@ public final class AetherEngine: ObservableObject {
         sourceVideoFormat = detectedFormat
         audioTracks = probedAudioTracks
         subtitleTracks = probedSubtitleTracks
+        // Decoy subtitle renditions for AVKit's native picker. Populated
+        // only when the active load opted in; otherwise stays empty and
+        // the generated playlists carry no subtitle lines (no behavioral
+        // change). Mapping is published so the host can correlate the
+        // picked legible option back to the engine subtitle track.
+        subtitleRenditions = options.advertiseSubtitleRenditions
+            ? Self.makeSubtitleRenditions(from: probedSubtitleTracks)
+            : []
         metadata = probeOpened ? probe.mediaMetadata() : nil
         fontAttachments = probeOpened ? probe.fontAttachmentInfos() : []
         // Assemble the caller-facing SourceProbe now, while the probe
@@ -1618,6 +1636,7 @@ public final class AetherEngine: ObservableObject {
         metadata = nil
         audioTracks = []
         subtitleTracks = []
+        subtitleRenditions = []
         // Session-scoped like the track lists; must survive stopInternal,
         // which also runs under the audio-track-switch reload (that path
         // skips the probe, so clearing here would strand the session with

--- a/Sources/AetherEngine/Network/HLSLocalServer.swift
+++ b/Sources/AetherEngine/Network/HLSLocalServer.swift
@@ -129,6 +129,22 @@ protocol HLSSegmentProvider: AnyObject {
     /// this to `NONE` when there's no in-band CC track.
     var masterClosedCaptions: String? { get }
 
+    /// Decoy subtitle renditions to advertise in the master playlist so
+    /// AVKit's native subtitle picker lists them. Each entry produces an
+    /// `#EXT-X-MEDIA:TYPE=SUBTITLES` line in a "subs" group and a
+    /// `SUBTITLES="subs"` attribute on the variant. The server serves a
+    /// fixed empty (cue-less) WebVTT rendition for each: the host paints
+    /// the actual cues itself. Empty (default) means no subtitle lines
+    /// and no behavioral change. `renditionID` is a path-safe token (the
+    /// server matches `/subs_<renditionID>.m3u8` and `.vtt`).
+    var subtitleRenditions: [(renditionID: String, name: String, language: String)] { get }
+
+    /// Media duration in seconds, used to size the decoy WebVTT
+    /// rendition's single `#EXTINF`. nil when the provider does not know
+    /// the duration (live), in which case the server uses a large
+    /// constant so the empty cue list spans the whole asset.
+    var mediaDurationSeconds: Double? { get }
+
     /// Hook called by `HLSLocalServer.buildMediaPlaylist` at the top
     /// of each playlist build. Returns the snapshot the playlist
     /// should be built against: visible segment count, refresh
@@ -204,6 +220,14 @@ extension HLSSegmentProvider {
     var masterAverageBandwidth: Int? { nil }
     var masterHDCPLevel: String? { nil }
     var masterClosedCaptions: String? { nil }
+
+    /// Default: no decoy subtitle renditions (feature off / providers
+    /// that never carry subtitles).
+    var subtitleRenditions: [(renditionID: String, name: String, language: String)] { [] }
+
+    /// Default: duration unknown.
+    var mediaDurationSeconds: Double? { nil }
+
     /// Default: not a live provider; playlist builder uses the
     /// computed-from-segments path.
     var liveTargetSegmentDuration: Double? { nil }
@@ -339,7 +363,13 @@ final class HLSLocalServer: @unchecked Sendable {
         stateLock.lock()
         defer { stateLock.unlock() }
         guard port > 0 else { return nil }
-        let path = (provider?.masterCodecs != nil) ? "master.m3u8" : "media.m3u8"
+        // Serve the master playlist when it carries either video variant
+        // metadata (masterCodecs) OR decoy subtitle renditions (the
+        // native-picker path needs the #EXT-X-MEDIA lines, which only
+        // live in the master).
+        let hasMaster = (provider?.masterCodecs != nil)
+            || !(provider?.subtitleRenditions.isEmpty ?? true)
+        let path = hasMaster ? "master.m3u8" : "media.m3u8"
         return URL(string: "http://127.0.0.1:\(port)/\(path)")
     }
 
@@ -771,7 +801,11 @@ final class HLSLocalServer: @unchecked Sendable {
 
         switch normalizedPath {
         case "/master.m3u8":
-            if provider?.masterCodecs != nil {
+            // Build + serve the master when it has video variant metadata
+            // OR decoy subtitle renditions (the picker path). Only 404
+            // when both are absent.
+            let hasSubRenditions = !(provider?.subtitleRenditions.isEmpty ?? true)
+            if provider?.masterCodecs != nil || hasSubRenditions {
                 let body = buildMasterPlaylist()
                 stateLock.lock()
                 let firstTime = !loggedMasterPlaylist
@@ -879,6 +913,42 @@ final class HLSLocalServer: @unchecked Sendable {
                     return send200(fd: fd, path: normalizedPath, data: data,
                                    contentType: "video/mp4")
                 }
+            }
+            // Decoy subtitle rendition playlist: a fixed VOD WebVTT media
+            // playlist pointing at a single empty .vtt. AVKit fetches this
+            // when the user selects the rendition in the native picker; the
+            // host paints the real cues, so the bytes here are intentionally
+            // cue-less.
+            if normalizedPath.hasPrefix("/subs_"),
+               normalizedPath.hasSuffix(".m3u8") {
+                let id = String(normalizedPath.dropFirst("/subs_".count).dropLast(".m3u8".count))
+                guard !id.isEmpty else {
+                    return send404(fd: fd, path: normalizedPath, reason: "empty subs id")
+                }
+                let dur = provider?.mediaDurationSeconds
+                let d = (dur != nil && dur! > 0) ? dur! : 86400.0
+                let body = """
+                #EXTM3U
+                #EXT-X-VERSION:7
+                #EXT-X-TARGETDURATION:\(Int(ceil(d)))
+                #EXT-X-PLAYLIST-TYPE:VOD
+                #EXT-X-MEDIA-SEQUENCE:0
+                #EXTINF:\(String(format: "%.1f", d)),
+                subs_\(id).vtt
+                #EXT-X-ENDLIST
+
+                """
+                return send200(fd: fd, path: normalizedPath,
+                               data: Data(body.utf8),
+                               contentType: "application/vnd.apple.mpegurl")
+            }
+            // Decoy subtitle WebVTT body: a valid but cue-less WebVTT file.
+            if normalizedPath.hasPrefix("/subs_"),
+               normalizedPath.hasSuffix(".vtt") {
+                let body = "WEBVTT\n\n"
+                return send200(fd: fd, path: normalizedPath,
+                               data: Data(body.utf8),
+                               contentType: "text/vtt")
             }
             if normalizedPath.hasPrefix("/seg"),
                normalizedPath.hasSuffix(".mp4") {
@@ -1160,13 +1230,30 @@ final class HLSLocalServer: @unchecked Sendable {
     /// against the playlist URL.
     static func buildMasterPlaylistText(provider: HLSSegmentProvider,
                                          subResourceBaseURL: URL? = nil) -> String {
-        guard let codecs = provider.masterCodecs else {
+        let renditions = provider.subtitleRenditions
+        // Build a master when there's video variant metadata OR decoy
+        // subtitle renditions to advertise. Both absent → bare playlist,
+        // byte-identical to the pre-feature behavior.
+        guard provider.masterCodecs != nil || !renditions.isEmpty else {
             return "#EXTM3U\n"
         }
         var lines: [String] = []
         lines.append("#EXTM3U")
         lines.append("#EXT-X-VERSION:7")
         lines.append("#EXT-X-INDEPENDENT-SEGMENTS")
+
+        // Decoy SUBTITLES renditions. Emitted BEFORE the STREAM-INF per
+        // Apple's convention (media renditions precede the variants that
+        // reference their GROUP-ID). Each points at a fixed empty WebVTT
+        // playlist the server serves at /subs_<id>.m3u8.
+        for r in renditions {
+            lines.append(
+                "#EXT-X-MEDIA:TYPE=SUBTITLES,GROUP-ID=\"subs\","
+                + "NAME=\"\(r.name)\",LANGUAGE=\"\(r.language)\","
+                + "DEFAULT=NO,AUTOSELECT=NO,FORCED=NO,"
+                + "URI=\"subs_\(r.renditionID).m3u8\""
+            )
+        }
 
         // EXT-X-STREAM-INF attribute order follows Apple's HLS
         // Authoring Spec Appendixes example: BANDWIDTH first,
@@ -1179,7 +1266,13 @@ final class HLSLocalServer: @unchecked Sendable {
         if let avg = provider.masterAverageBandwidth {
             streamInfAttrs.append("AVERAGE-BANDWIDTH=\(avg)")
         }
-        streamInfAttrs.append("CODECS=\"\(codecs)\"")
+        // CODECS: present when the provider has video variant metadata.
+        // When masterCodecs is nil (SDR-only, no variant metadata) but
+        // renditions exist, omit CODECS rather than skip the variant —
+        // the SUBTITLES group still needs a STREAM-INF to attach to.
+        if let codecs = provider.masterCodecs {
+            streamInfAttrs.append("CODECS=\"\(codecs)\"")
+        }
         if let supplemental = provider.masterSupplementalCodecs {
             streamInfAttrs.append("SUPPLEMENTAL-CODECS=\"\(supplemental)\"")
         }
@@ -1197,6 +1290,11 @@ final class HLSLocalServer: @unchecked Sendable {
         }
         if let cc = provider.masterClosedCaptions {
             streamInfAttrs.append("CLOSED-CAPTIONS=\(cc)")
+        }
+        // Bind the variant to the SUBTITLES group so AVKit lists the
+        // renditions for this stream.
+        if !renditions.isEmpty {
+            streamInfAttrs.append("SUBTITLES=\"subs\"")
         }
         lines.append("#EXT-X-STREAM-INF:\(streamInfAttrs.joined(separator: ","))")
         lines.append("media.m3u8")

--- a/Sources/AetherEngine/PlayerState.swift
+++ b/Sources/AetherEngine/PlayerState.swift
@@ -218,6 +218,19 @@ public struct LoadOptions: Sendable, Equatable {
     /// bitmap tracks are untouched. Default `false` (AetherEngine#30).
     public var preserveASSMarkup: Bool
 
+    /// When `true`, advertise each of the source's subtitle tracks as a
+    /// decoy (empty, cue-less) WebVTT rendition in the generated HLS
+    /// master playlist, so AVKit's native subtitle picker lists them.
+    /// The engine does NOT decode or paint cues for these renditions;
+    /// the host renders the actual subtitle cues itself (via
+    /// `subtitleCues`). This is purely a picker-population hook.
+    /// Default `false`: when off, the master/media playlists are
+    /// byte-identical to a build without this feature and no subtitle
+    /// lines are emitted. The mapping the host needs to correlate a
+    /// picked rendition back to an engine subtitle track is published on
+    /// `AetherEngine.subtitleRenditions`.
+    public var advertiseSubtitleRenditions: Bool
+
     /// ENGINE-INTERNAL: marks this load as a live REJOIN (a reload of
     /// an already-running live session: background-return reopen via
     /// `reloadAtCurrentPosition`). Not part of the public API and not
@@ -247,7 +260,8 @@ public struct LoadOptions: Sendable, Equatable {
         audioOnly: Bool = false,
         dvrWindowSeconds: Double? = nil,
         nativeRemoteHLS: Bool = false,
-        preserveASSMarkup: Bool = false
+        preserveASSMarkup: Bool = false,
+        advertiseSubtitleRenditions: Bool = false
     ) {
         self.omitCriteriaColorExtensions = omitCriteriaColorExtensions
         self.suppressDisplayCriteria = suppressDisplayCriteria
@@ -261,6 +275,7 @@ public struct LoadOptions: Sendable, Equatable {
         self.dvrWindowSeconds = dvrWindowSeconds
         self.nativeRemoteHLS = nativeRemoteHLS
         self.preserveASSMarkup = preserveASSMarkup
+        self.advertiseSubtitleRenditions = advertiseSubtitleRenditions
     }
 }
 
@@ -448,6 +463,33 @@ public struct TrackInfo: Identifiable, Sendable, Equatable {
         self.isDefault = isDefault
         self.isAtmos = isAtmos
         self.assHeader = assHeader
+    }
+}
+
+/// A decoy subtitle rendition advertised in the generated HLS master
+/// playlist so AVKit's native subtitle picker lists it (see
+/// `LoadOptions.advertiseSubtitleRenditions`). Published on
+/// `AetherEngine.subtitleRenditions`; the engine paints no cues for it,
+/// it exists only to populate the picker and to let the host correlate
+/// the picked legible option back to an engine subtitle `TrackInfo`.
+public struct SubtitleRendition: Sendable, Equatable {
+    /// Path-safe identifier the master playlist uses (`"sub<trackIndex>"`).
+    /// The loopback server serves `/subs_<renditionID>.m3u8` + `.vtt`.
+    public let renditionID: String
+    /// Display name shown in the picker (the language label).
+    public let name: String
+    /// ISO language code emitted as `LANGUAGE=` (fallback `"und"`).
+    public let language: String
+    /// The engine subtitle AVStream index (`TrackInfo.id`) this rendition
+    /// stands for; the host decodes + paints this track's cues when the
+    /// rendition is selected.
+    public let trackIndex: Int
+
+    public init(renditionID: String, name: String, language: String, trackIndex: Int) {
+        self.renditionID = renditionID
+        self.name = name
+        self.language = language
+        self.trackIndex = trackIndex
     }
 }
 

--- a/Sources/AetherEngine/Video/HLSVideoEngine.swift
+++ b/Sources/AetherEngine/Video/HLSVideoEngine.swift
@@ -109,6 +109,12 @@ public final class HLSVideoEngine: @unchecked Sendable {
     private var server: HLSLocalServer?
     var provider: VideoSegmentProvider?
 
+    /// Decoy subtitle renditions to advertise in the master playlist
+    /// (native-picker path). Supplied by the engine at construction;
+    /// forwarded to the `VideoSegmentProvider` when it is built in
+    /// `start()`. Empty means the feature is off.
+    private let subtitleRenditions: [(renditionID: String, name: String, language: String)]
+
     /// Side demuxer over a demuxed-audio companion reader (live HLS
     /// ingest whose variant is video-only with a separate audio
     /// rendition playlist). Opened in `start()` when the main demuxer
@@ -449,8 +455,10 @@ public final class HLSVideoEngine: @unchecked Sendable {
         liveSourceCadenceHint: Double? = nil,
         preopenedDemuxer: Demuxer? = nil,
         sourceReopenableByURL: Bool = true,
-        companionAudioReader: IOReader? = nil
+        companionAudioReader: IOReader? = nil,
+        subtitleRenditions: [(renditionID: String, name: String, language: String)] = []
     ) {
+        self.subtitleRenditions = subtitleRenditions
         self.sourceURL = url
         self.sourceHTTPHeaders = sourceHTTPHeaders
         self.dvModeAvailable = dvModeAvailable
@@ -1231,6 +1239,7 @@ public final class HLSVideoEngine: @unchecked Sendable {
             frameRate: frameRate,
             hdcpLevel: hdcpLevel,
             sourceBitrate: sourceBitrate,
+            durationSeconds: durationSeconds,
             isLive: isLiveSession,
             liveWindowSizing: LiveWindowSizing(
                 targetSegmentDurationSeconds: Self.targetSegmentDuration,
@@ -1243,6 +1252,12 @@ public final class HLSVideoEngine: @unchecked Sendable {
             }
         )
         self.provider = prov
+        // Hand the decoy subtitle renditions to the provider before the
+        // server starts, so the very first master.m3u8 fetch already
+        // carries the #EXT-X-MEDIA subtitle lines (native-picker path).
+        // Empty when the feature is off; provider then emits no subtitle
+        // lines and the master is byte-identical to before.
+        prov.subtitleRenditionList = subtitleRenditions
         // Live producer appends each finalized segment to the provider's
         // growing list so the live playlist exposes it on the next poll.
         if isLiveSession {
@@ -1370,21 +1385,32 @@ public final class HLSVideoEngine: @unchecked Sendable {
         // #4 2026-05-27).
         let panelReadyForHDR = panelIsInHDRMode
         let dv5OnNonDVPanel = dvVariant == .profile5 && !effectiveDvMode
-        let useMasterPlaylist: Bool
+        // HDR / DV master routing. This drives `servingMasterPlaylist`, which
+        // the host wires into HDR-only AVPlayerItem flags, so it must remain
+        // strictly the HDR decision (unchanged behavior).
+        let hdrMaster: Bool
         if dv5OnNonDVPanel {
-            useMasterPlaylist = false
+            hdrMaster = false
         } else {
-            useMasterPlaylist = sourceIsHDR && panelReadyForHDR
+            hdrMaster = sourceIsHDR && panelReadyForHDR
         }
-        let resolvedURL: URL? = useMasterPlaylist
+        // Serve a MASTER playlist when the HDR path needs it OR when we are
+        // advertising subtitle renditions (EXT-X-MEDIA:TYPE=SUBTITLES can only
+        // live in a master). The subtitle case deliberately does NOT flip
+        // `servingMasterPlaylist`: an SDR title with subtitles serves a master
+        // (single SDR variant + subtitle group) but stays SDR for the host's
+        // HDR-pipeline flags. HDR/DV routing and SDR-without-subtitles are
+        // byte-for-byte unchanged.
+        let serveMaster = hdrMaster || !subtitleRenditions.isEmpty
+        let resolvedURL: URL? = serveMaster
             ? srv.playlistURL
             : srv.mediaPlaylistURL
         guard let url = resolvedURL else {
             stop()
             throw HLSVideoEngineError.openFailed(reason: "server URL not ready")
         }
-        self.servingMasterPlaylist = useMasterPlaylist
-        EngineLog.emit("[HLSVideoEngine] serving on \(url.absoluteString) (dvModeAvailable=\(dvModeAvailable) effectiveDvMode=\(effectiveDvMode) panelIsHDR=\(panelIsInHDRMode) displaySupportsHDR=\(displaySupportsHDR) matchContent=\(matchContentEnabled) sourceIsHDR=\(sourceIsHDR) useMaster=\(useMasterPlaylist) videoRange=\(videoRange) dvVariant=\(dvVariant))")
+        self.servingMasterPlaylist = hdrMaster
+        EngineLog.emit("[HLSVideoEngine] serving on \(url.absoluteString) (dvModeAvailable=\(dvModeAvailable) effectiveDvMode=\(effectiveDvMode) panelIsHDR=\(panelIsInHDRMode) displaySupportsHDR=\(displaySupportsHDR) matchContent=\(matchContentEnabled) sourceIsHDR=\(sourceIsHDR) hdrMaster=\(hdrMaster) serveMaster=\(serveMaster) subRenditions=\(subtitleRenditions.count) videoRange=\(videoRange) dvVariant=\(dvVariant))")
         return url
     }
 

--- a/Sources/AetherEngine/Video/VideoSegmentProvider.swift
+++ b/Sources/AetherEngine/Video/VideoSegmentProvider.swift
@@ -101,6 +101,18 @@ final class VideoSegmentProvider: HLSSegmentProvider, @unchecked Sendable {
     private let hdcpLevel: String?
     private let sourceBitrate: Int64
 
+    /// Decoy subtitle renditions to advertise in the master playlist
+    /// (native-picker path). Set by the engine at load time before the
+    /// server is started; empty means the feature is off and the master
+    /// emits no subtitle lines. Plain stored value: written once on the
+    /// load thread before `HLSLocalServer.start()`, then read-only for
+    /// the session, so it needs no lock.
+    var subtitleRenditionList: [(renditionID: String, name: String, language: String)] = []
+
+    /// Total source duration in seconds (0 for live / unknown), used to
+    /// size the decoy WebVTT rendition playlist's single EXTINF.
+    private let durationSeconds: Double
+
     /// Closure into the engine that tears down the current producer
     /// and brings up a fresh one rooted at the given absolute segment
     /// index. Synchronous: returns after the new producer's pump has
@@ -205,6 +217,7 @@ final class VideoSegmentProvider: HLSSegmentProvider, @unchecked Sendable {
         frameRate: Double?,
         hdcpLevel: String?,
         sourceBitrate: Int64,
+        durationSeconds: Double = 0,
         isLive: Bool = false,
         liveWindowSizing: LiveWindowSizing = LiveWindowSizing(targetSegmentDurationSeconds: 4.0, dvrWindowSeconds: nil),
         blockingReloadEnabled: Bool = true,
@@ -224,6 +237,7 @@ final class VideoSegmentProvider: HLSSegmentProvider, @unchecked Sendable {
         self.frameRate = frameRate
         self.hdcpLevel = hdcpLevel
         self.sourceBitrate = sourceBitrate
+        self.durationSeconds = durationSeconds
         self.restartHandler = restartHandler
 
     }
@@ -872,4 +886,15 @@ final class VideoSegmentProvider: HLSSegmentProvider, @unchecked Sendable {
     var masterFrameRate: Double? { frameRate }
     var masterHDCPLevel: String? { hdcpLevel }
     var masterClosedCaptions: String? { "NONE" }
+
+    /// Decoy subtitle renditions the engine installed at load time.
+    var subtitleRenditions: [(renditionID: String, name: String, language: String)] {
+        subtitleRenditionList
+    }
+
+    /// Source duration for the decoy WebVTT playlist sizing; nil when
+    /// unknown (0).
+    var mediaDurationSeconds: Double? {
+        durationSeconds > 0 ? durationSeconds : nil
+    }
 }

--- a/Tests/AetherEngineTests/MasterPlaylistSubtitleTests.swift
+++ b/Tests/AetherEngineTests/MasterPlaylistSubtitleTests.swift
@@ -1,0 +1,101 @@
+import XCTest
+@testable import AetherEngine
+
+/// Covers the opt-in decoy-subtitle-rendition advertising
+/// (`LoadOptions.advertiseSubtitleRenditions`): the master playlist must
+/// emit one `#EXT-X-MEDIA:TYPE=SUBTITLES` line per rendition and bind the
+/// variant to the group, while staying byte-identical to the pre-feature
+/// bare playlist when nothing is advertised.
+final class MasterPlaylistSubtitleTests: XCTestCase {
+
+    /// Minimal `HLSSegmentProvider`. Only the non-defaulted protocol
+    /// members are implemented; `masterCodecs` and `subtitleRenditions`
+    /// are injected per test (everything else uses the extension defaults).
+    private final class StubProvider: HLSSegmentProvider {
+        let codecs: String?
+        let renditions: [(renditionID: String, name: String, language: String)]
+
+        init(codecs: String?,
+             renditions: [(renditionID: String, name: String, language: String)]) {
+            self.codecs = codecs
+            self.renditions = renditions
+        }
+
+        func initSegment() -> Data? { nil }
+        func mediaSegment(at index: Int) -> Data? { nil }
+        var segmentCount: Int { 1 }
+        func segmentDuration(at index: Int) -> Double { 4.0 }
+        var playlistType: HLSPlaylistType { .vod }
+
+        var masterCodecs: String? { codecs }
+        var subtitleRenditions: [(renditionID: String, name: String, language: String)] { renditions }
+    }
+
+    func testMasterEmitsSubtitleRenditionsWhenAdvertising() {
+        let provider = StubProvider(
+            codecs: "hvc1.2.4.L150.90",
+            renditions: [
+                (renditionID: "sub2", name: "English (SRT)", language: "en"),
+                (renditionID: "sub3", name: "Chinese Simplified (PGS)", language: "zh"),
+            ]
+        )
+        let text = HLSLocalServer.buildMasterPlaylistText(provider: provider)
+
+        // One EXT-X-MEDIA SUBTITLES line per rendition, in the "subs" group,
+        // each pointing at its decoy media playlist.
+        XCTAssertTrue(text.contains(#"#EXT-X-MEDIA:TYPE=SUBTITLES,GROUP-ID="subs","#))
+        XCTAssertTrue(text.contains(#"NAME="English (SRT)",LANGUAGE="en""#))
+        XCTAssertTrue(text.contains(#"URI="subs_sub2.m3u8""#))
+        XCTAssertTrue(text.contains(#"NAME="Chinese Simplified (PGS)",LANGUAGE="zh""#))
+        XCTAssertTrue(text.contains(#"URI="subs_sub3.m3u8""#))
+
+        // The variant is bound to the subtitle group, and video CODECS
+        // survive (video variant metadata is present).
+        XCTAssertTrue(text.contains(#"SUBTITLES="subs""#))
+        XCTAssertTrue(text.contains(#"CODECS="hvc1.2.4.L150.90""#))
+
+        // Media renditions precede the STREAM-INF they attach to.
+        let mediaIdx = text.range(of: "#EXT-X-MEDIA:TYPE=SUBTITLES")?.lowerBound
+        let streamIdx = text.range(of: "#EXT-X-STREAM-INF")?.lowerBound
+        XCTAssertNotNil(mediaIdx)
+        XCTAssertNotNil(streamIdx)
+        if let mediaIdx, let streamIdx {
+            XCTAssertLessThan(mediaIdx, streamIdx)
+        }
+    }
+
+    func testMasterServedForSDRWithSubtitlesOmitsCodecs() {
+        // No video variant metadata (masterCodecs nil) but subtitles are
+        // advertised: a master is still produced (not the bare playlist),
+        // the STREAM-INF omits CODECS, and the subtitle group still attaches.
+        let provider = StubProvider(
+            codecs: nil,
+            renditions: [(renditionID: "sub0", name: "English (SRT)", language: "en")]
+        )
+        let text = HLSLocalServer.buildMasterPlaylistText(provider: provider)
+
+        XCTAssertNotEqual(text, "#EXTM3U\n")
+        XCTAssertTrue(text.contains("#EXT-X-STREAM-INF:"))
+        XCTAssertFalse(text.contains("CODECS="))
+        XCTAssertTrue(text.contains(#"SUBTITLES="subs""#))
+        XCTAssertTrue(text.contains(#"URI="subs_sub0.m3u8""#))
+    }
+
+    func testMasterIsBareWhenNotAdvertisingAndNoVideoMetadata() {
+        // Feature off + no video variant metadata: byte-identical to the
+        // pre-feature bare playlist (no subtitle lines, no STREAM-INF).
+        let provider = StubProvider(codecs: nil, renditions: [])
+        let text = HLSLocalServer.buildMasterPlaylistText(provider: provider)
+        XCTAssertEqual(text, "#EXTM3U\n")
+    }
+
+    func testVideoMasterHasNoSubtitleLinesWhenNotAdvertising() {
+        // Video variant metadata but feature off: normal master, with no
+        // subtitle group lines (proves the lines are gated on the opt-in).
+        let provider = StubProvider(codecs: "hvc1.2.4.L150.90", renditions: [])
+        let text = HLSLocalServer.buildMasterPlaylistText(provider: provider)
+        XCTAssertTrue(text.contains("#EXT-X-STREAM-INF:"))
+        XCTAssertFalse(text.contains("EXT-X-MEDIA:TYPE=SUBTITLES"))
+        XCTAssertFalse(text.contains("SUBTITLES="))
+    }
+}


### PR DESCRIPTION
## Summary

Adds an opt-in `LoadOptions.advertiseSubtitleRenditions` flag (default `false`). When set, AetherEngine advertises each of the source's subtitle tracks as a decoy (empty, cue-less) WebVTT rendition in the generated HLS master playlist, so AVKit's **native subtitle picker** lists them. The engine paints no cues for these renditions; the host renders the actual subtitle cues itself, consistent with the engine's host-renders subtitle design. This is purely a picker-population hook.

**Default off: with the flag unset, the master/media playlists are byte-identical to a build without this feature, and no subtitle lines are emitted. Existing behavior is unchanged.**

## Why

Hosts that paint their own subtitle cues (the engine decodes cues but does not render them) have no way to surface those tracks in AVKit's built-in Subtitles menu, because the tracks never appear in the HLS playlist AVPlayer sees. This adds a way to populate that native menu without changing how cues are rendered.

## What it does

- **`LoadOptions.advertiseSubtitleRenditions: Bool = false`** opt-in flag.
- **`AetherEngine.subtitleRenditions`** published mapping (`renditionID` / `name` / `language` / `trackIndex`). `renditionID` embeds the engine subtitle AVStream index so the host can correlate AVKit's selected legible option back to the `TrackInfo` whose cues it should decode and paint. Names are built as `"Language (FORMAT)"` with a codec-derived format label (SRT/ASS/VOBSUB/PGS/DVB/VTT/Text), preserving authored distinguishers (SDH/Forced/Commentary) and dropping bare echoes / remux auto-titles. Non-empty only while a load opted in; cleared otherwise and on stop.
- **`HLSVideoEngine`** serves a master playlist even for SDR titles while advertising (an `EXT-X-MEDIA:TYPE=SUBTITLES` line can only live in a master). This is deliberately **decoupled from `servingMasterPlaylist`**, the HDR-pipeline flag the host wires into HDR-only `AVPlayerItem` flags, which stays strictly the HDR decision. So an SDR title with subtitles serves a master (single SDR variant + subtitle group) but stays SDR for the host's HDR flags. **HDR/DV routing and SDR-without-subtitles are byte-for-byte unchanged.**
- **`HLSLocalServer`** emits one `#EXT-X-MEDIA:TYPE=SUBTITLES` line per rendition in a `subs` group (before the `STREAM-INF`, per Apple's convention) and adds `SUBTITLES="subs"` to the variant. It serves the decoy `/subs_<id>.m3u8` (a VOD WebVTT media playlist sized to the source duration) and `/subs_<id>.vtt` (an empty `WEBVTT` body). When `masterCodecs` is nil (SDR, no variant metadata) but renditions exist, `CODECS` is omitted from the `STREAM-INF` rather than skipping the variant, so the subtitle group still has a variant to attach to.

## Tests

Adds `MasterPlaylistSubtitleTests` covering:
- advertising emits the `EXT-X-MEDIA` subtitle lines, the `subs_<id>.m3u8` URIs, `SUBTITLES="subs"`, and orders media renditions before the `STREAM-INF`;
- SDR-with-subtitles serves a master and omits `CODECS`;
- the playlist is the bare `#EXTM3U\n` when the feature is off and there is no video metadata;
- a video master emits no subtitle lines when not advertising (gated on the opt-in).

`swift build` and `swift test` pass (full suite green). Branch is rebased on current `main`.

## Notes

This was developed and verified end to end against a tvOS host (text + PGS/VOBSUB bitmap tracks, language / on-off / style switching, same-language variants) using the host-paints-cues model. The change is additive and gated behind the new flag.
