### PR TITLE
fix(hls): bound VOD cue-prewarm seek so a missing/out-of-bounds MKV C…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ the public-API contract.
 ### Fixed
 
 - **Seek on the native loopback-HLS path no longer bounces back through the pre-seek position.** A seek wrote the target clock optimistically and flipped state back to `.playing` without waiting for AVPlayer's seek to physically land, so the 100 ms periodic time observer kept publishing the stale pre-seek clock until the (seconds-late) loopback seek completed — the reported time read the target, snapped back to the old position, then re-settled. `seek(to:)` now awaits the real AVPlayer completion, and the native host suppresses the periodic observer's stale reads while a seek is in flight, so the clock holds the target across the landing (AetherEngine#37).
+- **Hang on MKV sources with a missing or out-of-bounds Cues index.** When a file's Cues seek index is absent or points past EOF (truncated / mis-muxed remux), libavformat's matroska seek degrades the VOD cue-prewarm into a multi-GB linear forward scan — tens of minutes (a de-facto hang) on a large remote source, even though every byte range of the stream serves fine. The prewarm seek is now bounded by a deadline (`HLSVideoEngine.cuePrewarmTimeout`); on timeout it falls back to the existing keyframe / uniform-stride segment plan so playback starts promptly. Healthy files (Cues resolve in well under a second) are unaffected.
 
 ### Added
 

--- a/Sources/AetherEngine/Demuxer/AVIOReader.swift
+++ b/Sources/AetherEngine/Demuxer/AVIOReader.swift
@@ -509,6 +509,43 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
     private var isClosed = false
     private var isFullyClosed = false
 
+    /// Optional wall-clock deadline for read operations. `.distantFuture`
+    /// means "no deadline" (normal playback). When armed via
+    /// `beginReadDeadline`, the read callback returns -1 once the deadline
+    /// passes, which makes an in-flight `avformat_seek_file` abort instead
+    /// of grinding through a multi-GB linear forward scan. This happens when
+    /// a source's MKV Cues index is missing or points past EOF: libavformat's
+    /// matroska seek then degrades from "one or two byte-range reads" into a
+    /// sequential read of (typically) half the file — tens of minutes on a
+    /// remote source, indistinguishable from a hang. Used only to bound the
+    /// VOD cue prewarm (see `Demuxer.seekBounded`); read relaxed from the
+    /// demux thread, exactly like `isClosed`.
+    private var readDeadline = Date.distantFuture
+    private var isPastReadDeadline: Bool { Date() >= readDeadline }
+    /// Set when a read actually returned early because the deadline passed.
+    /// Lets `Demuxer.seekBounded` report whether the seek was capped even
+    /// though `avformat_seek_file` may still return success (matroska keeps a
+    /// partial keyframe index from the bytes it scanned before the abort).
+    /// Written and read on the same thread that drives the synchronous seek.
+    private(set) var readDeadlineFired = false
+
+    /// Arm the read deadline `seconds` from now. Call immediately before a
+    /// bounded seek; always pair with `endReadDeadline()`.
+    func beginReadDeadline(secondsFromNow seconds: TimeInterval) {
+        readDeadlineFired = false
+        readDeadline = Date(timeIntervalSinceNow: seconds)
+        // Wake a read already parked in the forward-wait so it re-evaluates
+        // against the new deadline instead of sleeping the full stall window.
+        winCond.lock()
+        winCond.broadcast()
+        winCond.unlock()
+    }
+
+    /// Disarm the read deadline. Call right after the bounded seek returns.
+    func endReadDeadline() {
+        readDeadline = .distantFuture
+    }
+
     /// Streaming-mode session/task, held as fields so `markClosed()` /
     /// `close()` can cancel the in-flight download. Without this the GET
     /// kept streaming after teardown (endless for chunked responses with
@@ -626,6 +663,7 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
 
     fileprivate func read(into buf: UnsafeMutablePointer<UInt8>, size: Int32) -> Int32 {
         guard !isClosed else { return -1 }
+        if isPastReadDeadline { readDeadlineFired = true; return -1 }
         // For a live source, persistent reader is preferred even without a
         // known fileSize. Check usePersistentReader before isStreaming so a
         // live feed with no Content-Length is routed through the reconnect-
@@ -816,6 +854,7 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
 
         while totalRead < requestSize {
             if isClosed { return totalRead > 0 ? Int32(totalRead) : -1 }
+            if isPastReadDeadline { readDeadlineFired = true; return totalRead > 0 ? Int32(totalRead) : -1 }
 
             // Evaluate the whole decision under one lock acquisition so the
             // window can't shift between snapshot and use, and so the
@@ -886,8 +925,13 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
                 // blocked and re-acquires before returning; a false return
                 // means the connStallTimeout elapsed with no state change,
                 // i.e. a socket stall — treat it as a drop and reconnect.
-                let signaled = winCond.wait(until: Date(timeIntervalSinceNow: Self.connStallTimeout))
+                let signaled = winCond.wait(until: min(Date(timeIntervalSinceNow: Self.connStallTimeout), readDeadline))
                 winCond.unlock()
+                // Woken by the read deadline (bounded seek): bail at the loop
+                // top, which returns -1 and aborts the seek. Do this before the
+                // stall handling so a deadline wake isn't misread as a socket
+                // stall (which would reconnect instead of aborting).
+                if isPastReadDeadline { continue }
                 if !signaled {
                     if recordReconnectAndShouldGiveUp() {
                         EngineLog.emit("[AVIOReader] Persistent stall gave up at offset \(frontier) (\(unproductiveReconnects) unproductive)\(isLive ? " [live source lost]" : "")", category: .demux)

--- a/Sources/AetherEngine/Demuxer/Demuxer.swift
+++ b/Sources/AetherEngine/Demuxer/Demuxer.swift
@@ -690,6 +690,37 @@ public final class Demuxer: @unchecked Sendable {
         avformat_flush(ctx)
     }
 
+    /// Like `seek(to:)`, but aborts the underlying AVIO reads after `timeout`
+    /// seconds. Returns `true` if the seek completed, `false` if it was
+    /// aborted by the deadline (or otherwise failed).
+    ///
+    /// Needed for the VOD cue prewarm: on a source whose MKV Cues index is
+    /// missing or points past the end of the file (truncated / mis-muxed
+    /// remux), libavformat's matroska seek degrades from the expected "one or
+    /// two byte-range reads" into a sequential linear scan of roughly half the
+    /// file. On a 70+ GB remote source that is tens of minutes — a de-facto
+    /// hang. Bounding it lets the seek fail fast so the caller falls back to a
+    /// uniform-stride segment plan and playback can start immediately. Only
+    /// `AVIOReader` (URL-backed) honours the deadline; other providers run the
+    /// plain seek (local / custom sources don't exhibit this pathology).
+    @discardableResult
+    func seekBounded(to seconds: Double, timeout: TimeInterval) -> Bool {
+        accessLock.lock()
+        defer { accessLock.unlock() }
+        guard let ctx = formatContext else { return false }
+        let reader = avioProvider as? AVIOReader
+        reader?.beginReadDeadline(secondsFromNow: timeout)
+        defer { reader?.endReadDeadline() }
+        let timestamp = Int64(seconds * Double(AV_TIME_BASE))
+        let ret = avformat_seek_file(ctx, -1, Int64.min, timestamp, Int64.max, 0)
+        avformat_flush(ctx)
+        // matroska can return success with a partial index even after the
+        // read was aborted mid-scan, so the deadline flag — not `ret` — is the
+        // authoritative signal of whether the seek was capped.
+        let capped = reader?.readDeadlineFired ?? false
+        return ret >= 0 && !capped
+    }
+
     /// Fast, lock-free unblock: mark the AVIO reader closed so its read
     /// callback returns -1 immediately and a suspended `av_read_frame`
     /// (including one parked in the live reconnect loop) returns at once.

--- a/Sources/AetherEngine/Video/HLSVideoEngine.swift
+++ b/Sources/AetherEngine/Video/HLSVideoEngine.swift
@@ -356,6 +356,14 @@ public final class HLSVideoEngine: @unchecked Sendable {
     /// larger playlist footprint is negligible.
     static let targetSegmentDuration: Double = 4.0
 
+    /// Upper bound on the VOD cue-prewarm seek. A healthy MKV resolves its
+    /// Cues index in well under a second (one or two byte-range reads); a
+    /// source with a missing/out-of-bounds index instead triggers a multi-GB
+    /// linear scan. Past this many seconds we abort the seek and fall back to
+    /// the uniform-stride segment plan so playback starts promptly. Generous
+    /// enough not to false-trip on a slow link doing legitimate tail reads.
+    static let cuePrewarmTimeout: TimeInterval = 10.0
+
     // MARK: - Measurement spike: sliding-window prototype (superseded)
     //
     // PRODUCTIZED (Task B3): the throwaway `_liveSlidingPrototype` flag and
@@ -678,10 +686,20 @@ public final class HLSVideoEngine: @unchecked Sendable {
             //    tail, which fans out into one or two HTTP byte-range
             //    reads. Mid-duration target so the prewarm doesn't strand
             //    the demuxer cursor far from where playback starts.
+            //
+            //    Bounded: when the Cues index is missing or points past EOF
+            //    (truncated / mis-muxed remux) the matroska seek degrades into
+            //    a multi-GB linear scan (tens of minutes on a remote source).
+            //    The deadline aborts it so we fall through to the uniform-stride
+            //    plan below and start playback immediately instead of hanging.
             let prewarmStart = DispatchTime.now()
-            dem.seek(to: durationSeconds * 0.5)
+            let prewarmOK = dem.seekBounded(to: durationSeconds * 0.5, timeout: Self.cuePrewarmTimeout)
             let prewarmMs = Double(DispatchTime.now().uptimeNanoseconds - prewarmStart.uptimeNanoseconds) / 1_000_000
-            EngineLog.emit("[HLSVideoEngine] cue prewarm: seek to \(String(format: "%.1f", durationSeconds * 0.5))s took \(String(format: "%.1f", prewarmMs))ms")
+            if prewarmOK {
+                EngineLog.emit("[HLSVideoEngine] cue prewarm: seek to \(String(format: "%.1f", durationSeconds * 0.5))s took \(String(format: "%.1f", prewarmMs))ms")
+            } else {
+                EngineLog.emit("[HLSVideoEngine] cue prewarm: capped at \(String(format: "%.1f", prewarmMs))ms (no usable Cues index — index points past EOF or is absent); building plan from whatever keyframes were scanned")
+            }
 
             // 3. Build the segment plan from real keyframes in the index,
             //    using the SAME cut algorithm libavformat's hls muxer uses


### PR DESCRIPTION
## Summary

The VOD cue-prewarm seek can silently degrade into a multi-GB linear forward
scan (a de-facto hang) on MKV sources whose Cues index is missing or points
past EOF. This bounds the prewarm with a deadline so playback starts promptly,
falling back to the existing segment-plan path.

## What changed

- `HLSVideoEngine.cuePrewarmTimeout` (10s) now bounds the cue-prewarm seek.
- `AVIOReader`: optional read deadline (`beginReadDeadline` / `endReadDeadline`,
  `readDeadlineFired`). When armed, the read callback returns -1 once it passes,
  aborting the in-flight `avformat_seek_file` the same way `markClosed()` does
  for cancellation (loop-top check + deadline-bounded `winCond.wait`).
- `Demuxer.seekBounded(to:timeout:)`: arms the deadline around the seek and
  reports whether it was capped via the deadline flag — matroska can return
  success with a partial index after the abort, so the return code isn't
  authoritative.
- `HLSVideoEngine` uses `seekBounded` for the prewarm and falls through to its
  existing keyframe / uniform-stride plan from whatever keyframes were scanned.
- No public API changes (new symbols are internal and documented).

## Test plan

- Device / OS: macOS 26.2 (headless `aetherctl serve`) — verified; Apple TV 4K
  (gen 2) / tvOS 26 — original ~1h hang observed.
- Source media (container / video codec + profile / audio / HDR-DV):
  MKV / HEVC Main 10 (profile 2, level 5.1) / 4× DTS (5.1 EN, 5.1 EN, 2.0 RU,
  5.1 CS) + 2× PGS subs (EN, CS) / HDR10. 72.9 GB; SeekHead points Cues to
  ~77.4 GB — 4.5 GB past EOF.
- Result: time-to-`serving` drops from ~1 hour to ~11s; the loopback server
  serves and the segment producer streams normally. Healthy files are
  unaffected (deadline defaults to no-op; a sub-second Cues parse never trips it).

## Checklist

- [x] `CHANGELOG.md` updated
- [x] Commit messages follow Conventional Commits (`fix(...)`)
- [x] The fix lives in the engine, not in a host-side workaround
- [x] Public API changes are intentional and documented (none — new symbols are internal)