### PR TITLE
fix(seek): await loopback-HLS landing + publish isSeeking/seekTarget (#37, #38)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ the public-API contract.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Seek on the native loopback-HLS path no longer bounces back through the pre-seek position.** A seek wrote the target clock optimistically and flipped state back to `.playing` without waiting for AVPlayer's seek to physically land, so the 100 ms periodic time observer kept publishing the stale pre-seek clock until the (seconds-late) loopback seek completed — the reported time read the target, snapped back to the old position, then re-settled. `seek(to:)` now awaits the real AVPlayer completion, and the native host suppresses the periodic observer's stale reads while a seek is in flight, so the clock holds the target across the landing (AetherEngine#37).
+
+### Added
+
+- **`isSeeking` / `seekTarget` published seek signal.** `AetherEngine.isSeeking` is true from seek entry until the seek physically lands (not the optimistic `.playing` flip), uniform across programmatic `seek(to:)` and native AVKit transport-bar scrubs (which drive a producer restart out of the served window). `seekTarget` carries the in-flight destination on the source-PTS axis. A host coordinating playback across devices can gate on these to tell a deliberate seek from a rebuffer or underflow skip without inferring it from `currentTime` jumps (AetherEngine#38).
+
 ## [3.6.1] — 2026-06-16
 
 ### Fixed

--- a/Sources/AetherEngine/AetherEngine+Live.swift
+++ b/Sources/AetherEngine/AetherEngine+Live.swift
@@ -136,7 +136,7 @@ extension AetherEngine {
                     "[AetherEngine] live-only edge snap: clockTarget=\(String(format: "%.1f", clockTarget))",
                     category: .engine
                 )
-                host.seek(to: clockTarget)
+                await host.seek(to: clockTarget)
                 nativeClockSeconds = clockTarget
                 clock.currentTime = clockTarget + playlistShiftSeconds
                 clock.sourceTime = currentTime

--- a/Sources/AetherEngine/AetherEngine+Loading.swift
+++ b/Sources/AetherEngine/AetherEngine+Loading.swift
@@ -254,6 +254,18 @@ extension AetherEngine {
                 self.clock.sourceTime = self.currentTime
             }
         }
+        session.onSeekStateChanged = { [weak self] inFlight, playlistTime in
+            Task { @MainActor in
+                guard let self = self else { return }
+                // Fold the playlist-axis segment time onto the source-PTS
+                // axis the published seekTarget/currentTime use (#38), the
+                // same fold as the $currentTime sink. nil target while
+                // clearing leaves the last value untouched until both seek
+                // sources settle.
+                let target = playlistTime.map { $0 + self.playlistShiftSeconds }
+                self.setNativeScrubSeek(inFlight: inFlight, target: target)
+            }
+        }
         session.onPlaylistShiftRebased = { [weak self] seconds, seamOutputSeconds in
             Task { @MainActor in
                 guard let self = self else { return }

--- a/Sources/AetherEngine/AetherEngine.swift
+++ b/Sources/AetherEngine/AetherEngine.swift
@@ -66,6 +66,68 @@ public final class AetherEngine: ObservableObject {
     /// Always false on the initial load spin-up (that is `state == .loading`).
     @Published public internal(set) var isBuffering: Bool = false
 
+    /// True from the moment a seek begins until it **physically lands**,
+    /// uniform across programmatic `seek(to:)` and native AVKit
+    /// transport-bar scrubs. Unlike `state == .seeking` (which the engine
+    /// optimistically flips back to `.playing` so a host UI does not stick
+    /// on the spinner), this spans the real landing on the loopback-HLS
+    /// native path, where the seek resolves seconds after the call. A host
+    /// coordinating playback across devices can gate on this to tell a
+    /// deliberate seek from a rebuffer or an underflow skip without
+    /// inferring it from `currentTime` jumps (AetherEngine#38). Paired with
+    /// `seekTarget`.
+    @Published public internal(set) var isSeeking: Bool = false
+
+    /// The source-PTS destination of the in-flight seek (the same axis as
+    /// `currentTime`), or `nil` when no seek is in flight. Set at seek
+    /// entry, cleared on the real landing. For native scrubs it is the
+    /// time of the segment AVPlayer requested out of range (AetherEngine#38).
+    @Published public internal(set) var seekTarget: Double? = nil
+
+    /// Monotonic counter bumped at the entry of every programmatic
+    /// `seek(to:)`. A seek finalizes its clock/state and clears the
+    /// `isSeeking` signal only if its captured generation still matches,
+    /// so a superseded seek's late landing cannot clobber the newer seek's
+    /// in-flight state (the engine-side mirror of the host's guard).
+    private var seekGeneration: UInt64 = 0
+
+    /// The two independent in-flight sources `isSeeking` unions over. A
+    /// programmatic `seek(to:)` and a native AVKit scrub are NOT mutually
+    /// exclusive: a programmatic seek to a far target drives AVPlayer,
+    /// which requests an out-of-range segment and triggers the same
+    /// producer-restart path a transport-bar scrub does. Tracking them
+    /// separately and OR-ing keeps `isSeeking` true until BOTH settle, so
+    /// the native restart finishing (producer rebuilt) cannot drop the
+    /// signal before a programmatic seek's AVPlayer landing, and vice
+    /// versa. Routed through `setProgrammaticSeek`/`setNativeScrubSeek`.
+    private var programmaticSeekInFlight = false
+    private var nativeScrubSeekInFlight = false
+
+    /// Publish `isSeeking`/`seekTarget` from the two in-flight sources.
+    /// `target` updates `seekTarget` only while seeking; cleared to nil
+    /// once both sources settle. Idempotent on `isSeeking` to avoid
+    /// redundant Combine emissions.
+    private func recomputeSeekSignal(target: Double?) {
+        let seeking = programmaticSeekInFlight || nativeScrubSeekInFlight
+        if isSeeking != seeking { isSeeking = seeking }
+        if seeking {
+            if let target { seekTarget = target }
+        } else {
+            seekTarget = nil
+        }
+    }
+
+    private func setProgrammaticSeek(inFlight: Bool, target: Double?) {
+        programmaticSeekInFlight = inFlight
+        recomputeSeekSignal(target: target)
+    }
+
+    /// Wired to `HLSVideoEngine.onSeekStateChanged`; see `requestRestart`.
+    func setNativeScrubSeek(inFlight: Bool, target: Double?) {
+        nativeScrubSeekInFlight = inFlight
+        recomputeSeekSignal(target: target)
+    }
+
     /// High-frequency playback clock (`currentTime`, `sourceTime`,
     /// live-edge fields). Deliberately a SEPARATE ObservableObject:
     /// its ~10 Hz ticks must not fire `objectWillChange` on the
@@ -1513,6 +1575,13 @@ public final class AetherEngine: ObservableObject {
         // window's session-relative seekable range.
         let target: Double = isLive ? (liveWindow?.clamp(seconds) ?? seconds) : max(0, min(seconds, duration))
         state = .seeking
+        // Span the real landing (not the optimistic .playing flip below) so a
+        // host gets an accurate in-flight seek signal (#38). The generation
+        // guard at each finalize point ensures a superseded seek's late
+        // landing cannot clear this while a newer seek is still in flight.
+        seekGeneration &+= 1
+        let seekGen = seekGeneration
+        setProgrammaticSeek(inFlight: true, target: target)
         if isLive {
             // Live/DVR native path: translate the session-time target into the
             // AVPlayer live clock. Measure how far behind the live edge the
@@ -1531,21 +1600,31 @@ public final class AetherEngine: ObservableObject {
             if softwareHost != nil, nativeHost == nil {
                 EngineLog.emit("[AetherEngine] SW live seek target=\(target)", category: .engine)
                 await softwareHost?.seek(to: target)
+                guard seekGeneration == seekGen else { return }
                 clock.currentTime = target
                 clock.sourceTime = target
                 state = .playing
+                setProgrammaticSeek(inFlight: false, target: nil)
                 return
             }
             let behind = (liveWindow?.edgeTime ?? target) - target   // >= 0; 0 == "to the edge"
             let clockTarget = max(0, (nativeHost?.seekableEnd ?? 0) - behind)
             EngineLog.emit("[AetherEngine] live seek target=\(target) behind=\(behind) seekableEnd=\(nativeHost?.seekableEnd ?? 0) clockTarget=\(clockTarget)", category: .engine)
-            nativeHost?.seek(to: clockTarget)
+            // Publish the target up front so the playhead holds it while the
+            // host suppresses the periodic observer's stale pre-seek reads,
+            // then await the real landing before flipping back to .playing.
+            nativeClockSeconds = clockTarget
+            clock.currentTime = target
+            clock.sourceTime = target
+            await nativeHost?.seek(to: clockTarget)
+            guard seekGeneration == seekGen else { return }
             nativeClockSeconds = clockTarget
             clock.currentTime = target
             clock.sourceTime = target
             // publishLiveWindow on the next tick recomputes behindLiveSeconds
             // against the new playhead.
             state = .playing
+            setProgrammaticSeek(inFlight: false, target: nil)
             return
         }
         // seek(to:) speaks source PTS (the unified engine clock). On the
@@ -1554,6 +1633,19 @@ public final class AetherEngine: ObservableObject {
         // run on source time (shift 0), making this a no-op there.
         let clockTarget = target - playlistShiftSeconds
         let gen = loadGeneration
+        // Native loopback-HLS lands a seek seconds late. Publish the target
+        // up front so the playhead snaps to the drop point; the host
+        // suppresses the periodic observer's stale pre-seek reads until the
+        // seek lands, so the clock holds the target instead of bouncing back
+        // through the old position (#37). Audio/SW hosts run on source time
+        // and resolve their seek synchronously to the await, so they write
+        // the clock only at finalize below, as before.
+        let nativeOnly = !audioAVPlayerActive && audioHost == nil && softwareHost == nil && nativeHost != nil
+        if nativeOnly {
+            nativeClockSeconds = clockTarget
+            clock.currentTime = target
+            clock.sourceTime = target
+        }
         if audioAVPlayerActive, let host = audioAVPlayerHost {
             await host.seek(to: clockTarget)
         } else if let host = audioHost {
@@ -1561,12 +1653,15 @@ public final class AetherEngine: ObservableObject {
         } else if let host = softwareHost {
             await host.seek(to: clockTarget)
         } else {
-            nativeHost?.seek(to: clockTarget)
+            // Await the real AVPlayer landing before flipping back to
+            // .playing so isSeeking spans it (#37/#38).
+            await nativeHost?.seek(to: clockTarget)
         }
         // A stop()/load() landing during the await above already tore
         // the session down; writing clock state + .playing into the
-        // singleton afterwards would publish a phantom session.
-        guard loadGeneration == gen else { return }
+        // singleton afterwards would publish a phantom session. A
+        // superseding seek bumped seekGeneration and owns the final state.
+        guard loadGeneration == gen, seekGeneration == seekGen else { return }
         nativeClockSeconds = clockTarget
         clock.currentTime = target
         clock.sourceTime = target
@@ -1590,10 +1685,10 @@ public final class AetherEngine: ObservableObject {
             }
         }
 
-        // AVPlayer surfaces post-seek readiness via its own KVO; the
-        // engine optimistically flips back to .playing so the host UI
-        // doesn't stick on .seeking when the seek lands fast.
+        // The host seek has physically landed (we awaited it). Flip back to
+        // .playing and clear the in-flight seek signal.
         state = .playing
+        setProgrammaticSeek(inFlight: false, target: nil)
     }
 
     /// Deprecated alias for `seek(to:)`, which is now itself source-PTS
@@ -1898,6 +1993,13 @@ public final class AetherEngine: ObservableObject {
         nativeClockSeconds = 0
         clock.sourceTime = 0
         isBuffering = false
+        // A stop landing mid-seek must not strand the in-flight signal: a
+        // late host completion or restart-drain callback is dropped by the
+        // generation/session guards, so clear hard here (#38).
+        programmaticSeekInFlight = false
+        nativeScrubSeekInFlight = false
+        isSeeking = false
+        seekTarget = nil
 
         liveWindowTimerTask?.cancel()
         liveWindowTimerTask = nil

--- a/Sources/AetherEngine/Native/NativeAVPlayerHost.swift
+++ b/Sources/AetherEngine/Native/NativeAVPlayerHost.swift
@@ -42,6 +42,24 @@ final class NativeAVPlayerHost {
     /// play/pause press" symptom).
     @Published private(set) var timeControlStatus: AVPlayer.TimeControlStatus = .paused
 
+    // MARK: - Seek landing state
+
+    /// Monotonic seek counter. A scrub that supersedes an in-flight seek
+    /// bumps this so AVPlayer's `finished == false` completion for the
+    /// abandoned seek can be told apart from the latest seek's real
+    /// landing: only the newest generation clears the in-flight state
+    /// and publishes the landed time. See `seek(to:)`.
+    private var seekGeneration: UInt64 = 0
+
+    /// True between a `seek(to:)` call and the AVPlayer completion handler
+    /// firing for the latest seek. While set, the periodic time observer
+    /// suppresses `currentTime` publishing: the loopback HLS-fMP4 source
+    /// lands a seek seconds after the call, so the observer would read the
+    /// stale pre-seek clock and bounce the engine clock back through the
+    /// old position (issue #37). The completion handler publishes the
+    /// landed time once and clears this.
+    private(set) var seekInFlight: Bool = false
+
     // MARK: - Output
 
     /// The AVPlayerLayer the engine attaches to the bound
@@ -503,7 +521,14 @@ final class NativeAVPlayerHost {
         ) { [weak self] time in
             let value = time.seconds.isFinite ? time.seconds : 0
             Task { @MainActor in
-                self?.currentTime = value
+                guard let self else { return }
+                // While a seek is in flight AVPlayer still reports the
+                // pre-seek clock until the seek physically lands on the
+                // loopback HLS-fMP4 source; publishing it bounces the
+                // engine clock back through the old position (issue #37).
+                // The seek completion handler publishes the landed time.
+                guard !self.seekInFlight else { return }
+                self.currentTime = value
             }
         }
 
@@ -583,7 +608,12 @@ final class NativeAVPlayerHost {
         // device repro). See LiveReloadPolicy.skipInitialSeek. VOD /
         // initial loopback joins (default) seek to startPosition.
         if !skipInitialSeek {
-            seek(to: startPosition ?? 0)
+            // Load-time positioning, not a user seek: no in-flight signal or
+            // landing await needed (the item is not yet serving a clock the
+            // host observes). Drive AVPlayer directly; the async public
+            // seek(to:) carries the #37/#38 landing semantics for scrubs.
+            avPlayer.seek(to: CMTime(seconds: startPosition ?? 0, preferredTimescale: 600),
+                          toleranceBefore: .zero, toleranceAfter: .zero)
         }
     }
 
@@ -635,21 +665,55 @@ final class NativeAVPlayerHost {
         avPlayer.pause()
     }
 
-    func seek(to seconds: Double) {
+    /// Seek the underlying AVPlayer and resolve only when the seek
+    /// **physically lands** (AVPlayer's completion handler), not when the
+    /// call returns. The loopback HLS-fMP4 source lands a seek seconds
+    /// after the call; resolving early let the engine flip back to
+    /// `.playing` and let the 100 ms periodic observer overwrite the
+    /// target with the stale pre-seek clock (issue #37). `seekInFlight`
+    /// spans the real landing so the observer is suppressed across it.
+    ///
+    /// A superseding seek (the user scrubs again before this lands) bumps
+    /// `seekGeneration`; AVPlayer reports the abandoned seek's completion
+    /// with `finished == false`. Only the latest generation clears the
+    /// in-flight state and publishes the landed time, so a stale
+    /// completion can't drop the in-flight flag while a newer seek is
+    /// still in flight.
+    func seek(to seconds: Double) async {
         let target = CMTime(seconds: seconds, preferredTimescale: 600)
-        // Frame-accurate seek. Earlier experiment with
-        // `.positiveInfinity` tolerances to skip the IDR-to-target
-        // decode pre-roll caused AVPlayer to land on apparently-
-        // arbitrary sync samples far from the requested time — the
-        // user's TestFlight session showed the image "hanging" on
-        // wrong-position content during forward scrubs. AVPlayer's
-        // "most efficient seek" interpretation of unbounded tolerance
-        // appears to be undefined for HLS-fMP4 served over loopback,
-        // matching the long-standing openradar 44904505 bug report.
-        // Keep tolerances at zero until we have a different lever
-        // (predictive engine prefetch on scrub commit) that doesn't
-        // depend on tolerance semantics.
-        avPlayer.seek(to: target, toleranceBefore: .zero, toleranceAfter: .zero)
+        seekGeneration &+= 1
+        let gen = seekGeneration
+        seekInFlight = true
+        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+            // Frame-accurate seek. Earlier experiment with
+            // `.positiveInfinity` tolerances to skip the IDR-to-target
+            // decode pre-roll caused AVPlayer to land on apparently-
+            // arbitrary sync samples far from the requested time — the
+            // user's TestFlight session showed the image "hanging" on
+            // wrong-position content during forward scrubs. AVPlayer's
+            // "most efficient seek" interpretation of unbounded tolerance
+            // appears to be undefined for HLS-fMP4 served over loopback,
+            // matching the long-standing openradar 44904505 bug report.
+            // Keep tolerances at zero until we have a different lever
+            // (predictive engine prefetch on scrub commit) that doesn't
+            // depend on tolerance semantics.
+            avPlayer.seek(to: target, toleranceBefore: .zero, toleranceAfter: .zero) { [weak self] _ in
+                Task { @MainActor in
+                    guard let self else { cont.resume(); return }
+                    // A newer seek already owns the in-flight state; just
+                    // unblock this awaiter and leave its flags intact.
+                    if gen == self.seekGeneration {
+                        self.seekInFlight = false
+                        // Publish the exact landed position so the clock
+                        // settles on the target immediately instead of
+                        // waiting a tick for the periodic observer.
+                        let landed = self.avPlayer.currentTime().seconds
+                        if landed.isFinite { self.currentTime = landed }
+                    }
+                    cont.resume()
+                }
+            }
+        }
     }
 
     func setRate(_ value: Float) {

--- a/Sources/AetherEngine/Video/HLSVideoEngine.swift
+++ b/Sources/AetherEngine/Video/HLSVideoEngine.swift
@@ -239,6 +239,16 @@ public final class HLSVideoEngine: @unchecked Sendable {
     /// lookup uses the right source-time conversion.
     var onPlaylistShiftChanged: (@Sendable (Double) -> Void)?
 
+    /// Fires when a native AVKit transport-bar scrub (or any AVPlayer seek
+    /// that lands out of the currently-served LRU window) drives a producer
+    /// restart, so AetherEngine can publish an accurate in-flight seek
+    /// signal for scrubs that bypass `engine.seek()` (AetherEngine#38).
+    /// `(true, playlistTime)` at the start of a coalesced restart run,
+    /// `(false, nil)` once the run drains. `playlistTime` is the requested
+    /// segment's start on the AVPlayer/playlist axis; the host folds it
+    /// with `playlistShiftSeconds` onto its source-PTS `seekTarget`.
+    var onSeekStateChanged: (@Sendable (Bool, Double?) -> Void)?
+
     /// Engine-owned deep copy of an AVCodecParameters. The saved
     /// video/audio configs previously held raw pointers INTO the
     /// session demuxer's AVStreams; a live reopen closes that demuxer
@@ -1895,6 +1905,9 @@ public final class HLSVideoEngine: @unchecked Sendable {
     func requestRestart(at idx: Int) {
         restartLock.lock()
         let shouldRun = restartCoalescer.begin(idx)
+        // Map the requested segment to its playlist-axis start time while we
+        // hold the lock that guards segmentPlan (issue #38 seek signal).
+        let seekTime = segmentStartSecondsLocked(idx)
         restartLock.unlock()
         guard shouldRun else {
             EngineLog.emit(
@@ -1903,19 +1916,38 @@ public final class HLSVideoEngine: @unchecked Sendable {
             )
             return
         }
+        // A native AVKit scrub (or any AVPlayer seek that landed out of the
+        // served LRU window) is now in flight; publish it until the coalesced
+        // restart run drains (#38). Purely additive to the #35 coalescer.
+        onSeekStateChanged?(true, seekTime)
         var target = idx
         while true {
             performRestart(at: target)
             restartLock.lock()
             let nextTarget = restartCoalescer.next(justRan: target)
+            let nextSeekTime = nextTarget.map { segmentStartSecondsLocked($0) } ?? nil
             restartLock.unlock()
             guard let nextTarget else { break }
             EngineLog.emit(
                 "[HLSVideoEngine] coalesced restart advancing to settled target idx=\(nextTarget)",
                 category: .session
             )
+            // Burst scrub coalesced to a new settled target: keep the signal
+            // in flight, update the published target.
+            onSeekStateChanged?(true, nextSeekTime)
             target = nextTarget
         }
+        // The restart run settled at the final target and the producer is
+        // rebuilt and serving; clear the in-flight seek signal.
+        onSeekStateChanged?(false, nil)
+    }
+
+    /// `segmentPlan[idx].startSeconds` on the AVPlayer/playlist axis, or nil
+    /// if out of range. Caller must hold `restartLock` (segmentPlan is
+    /// guarded by it).
+    private func segmentStartSecondsLocked(_ idx: Int) -> Double? {
+        guard idx >= 0, idx < segmentPlan.count else { return nil }
+        return segmentPlan[idx].startSeconds
     }
 
     // Renamed from restartProducer(at:). Now driven exclusively through

--- a/Sources/aetherctl/SeekTest.swift
+++ b/Sources/aetherctl/SeekTest.swift
@@ -75,6 +75,48 @@ private func seekTestRun(url: URL, seeks: Int, gapMs: Int, settleSeconds: Double
     // Let playback settle for a moment before the burst.
     try? await Task.sleep(nanoseconds: 1_500_000_000)
 
+    // ---- #37/#38 probe: single backward seek with a concurrent sampler ----
+    // A 20 ms sampler records (currentTime, isSeeking) across one backward
+    // seek. Pre-fix the engine clock bounces back through the pre-seek
+    // position before AVPlayer's seek physically lands (the 100 ms time
+    // observer overwrites the optimistic target with the stale clock);
+    // post-fix the host suppresses that stale publish so the clock holds the
+    // target, and isSeeking spans the real landing. Runs the sampler for a
+    // fixed window so it catches both the in-flight hold (post-fix, inside
+    // the await) and the post-return bounce (pre-fix, after the await).
+    let probeHi = duration * 0.85
+    let probeLo = duration * 0.10
+    await engine.seek(to: probeHi)
+    try? await Task.sleep(nanoseconds: 800_000_000)
+    let preSeekCt = engine.currentTime
+    struct Probe { let ct: Double; let seeking: Bool }
+    let probeBox = UncheckedBox<[Probe]>([])
+    let sampler = Task { @MainActor in
+        for _ in 0..<200 {   // ~4 s at 20 ms
+            probeBox.value.append(Probe(ct: engine.currentTime, seeking: engine.isSeeking))
+            try? await Task.sleep(nanoseconds: 20_000_000)
+        }
+    }
+    await engine.seek(to: probeLo)
+    _ = await sampler.value
+    let probes = probeBox.value
+    let tol = max(2.0, duration * 0.02)
+    var firstTargetIdx: Int?
+    var bounceAfterTarget = false
+    for (i, p) in probes.enumerated() {
+        if firstTargetIdx == nil, abs(p.ct - probeLo) <= tol { firstTargetIdx = i }
+        if let ft = firstTargetIdx, i > ft, abs(p.ct - preSeekCt) <= tol { bounceAfterTarget = true }
+    }
+    let sawSeeking = probes.contains { $0.seeking }
+    let endedCleared = !(probes.last?.seeking ?? true)
+    print("")
+    print("=== #37/#38 PROBE (single backward seek, concurrent sampler) ===")
+    print(String(format: "  preSeek=%.1f target=%.1f tol=%.1f samples=%d", preSeekCt, probeLo, tol, probes.count))
+    print("  #37 clock bounce back through pre-seek after reaching target: "
+          + (bounceAfterTarget ? "YES  <-- FAIL" : "no  <-- PASS"))
+    print("  #38 isSeeking observed in-flight=\(sawSeeking ? "yes" : "NO") ended-cleared=\(endedCleared ? "yes" : "NO")  "
+          + ((sawSeeking && endedCleared) ? "<-- PASS" : "<-- FAIL"))
+
     struct Sample { let wall: Double; let ct: Double; let playing: Bool }
     var samples: [Sample] = []
     let t0 = Date()


### PR DESCRIPTION
Resolves #37 and the programmatic + native-scrub halves of #38.

## #37 — clock bounce on the native loopback-HLS seek

`seek(to:)` wrote the target clock optimistically and flipped state back to `.playing` without waiting for AVPlayer's seek to physically land. The 100 ms periodic time observer then kept publishing the stale pre-seek clock until the seconds-late loopback seek completed, so the reported time read the target, snapped back through the pre-seek position, then re-settled (the reporter's `97012 → 29345 → 97012 → 29345` trace).

- `NativeAVPlayerHost.seek` is now `async` and resolves on AVPlayer's `seek(to:completionHandler:)` callback.
- While a seek is in flight the periodic observer suppresses its stale `currentTime` publishing, so the clock holds the target across the landing.
- A `seekGeneration` guard lets a superseding scrub own the final state (AVPlayer reports the abandoned seek `finished == false`; this is also the #35 coalescing case).
- `seek(to:)` awaits that landing before flipping back to `.playing`.

## #38 — `isSeeking` / `seekTarget` signal

- `AetherEngine.isSeeking` is true from seek entry until the seek physically lands (not the optimistic `.playing` flip), uniform across programmatic `seek(to:)` **and** native AVKit transport-bar scrubs.
- Native scrubs bypass `engine.seek()` and instead drive a producer restart out of the served window, so the signal is fired from the `requestRestart` coalescer and folded onto the source-PTS `seekTarget` axis (additive to the #35 coalescer, no change to its mechanics).
- The programmatic and native in-flight sources are OR-ed, so a producer restart finishing cannot drop the signal before a programmatic seek's AVPlayer landing, and vice versa.
- A `stopInternal` hard-clear keeps a stop landing mid-seek from stranding the signal.

## Verification

Off-device via `aetherctl seektest` (extended with a concurrent 20 ms sampler probe):

- Fix active: no bounce through the pre-seek position, `isSeeking` observed in-flight and cleared after → **PASS**.
- Suppression disabled (teeth-test): the probe flips to `#37 ... YES` → **FAIL**, proving it detects the exact bug and the suppression is the load-bearing fix.
- Full test suite: 125 tests, 0 failures.

The definitive #37 confirmation is latency-dependent (loopback / slow source / device), so a device retest is still worthwhile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)