### PR TITLE
docs: prep 3.7.0 (CHANGELOG + README pin snippets)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ the public-API contract.
 
 ## [Unreleased]
 
+## [3.7.0] — 2026-06-17
+
 ### Fixed
 
 - **Seek on the native loopback-HLS path no longer bounces back through the pre-seek position.** A seek wrote the target clock optimistically and flipped state back to `.playing` without waiting for AVPlayer's seek to physically land, so the 100 ms periodic time observer kept publishing the stale pre-seek clock until the (seconds-late) loopback seek completed — the reported time read the target, snapped back to the old position, then re-settled. `seek(to:)` now awaits the real AVPlayer completion, and the native host suppresses the periodic observer's stale reads while a seek is in flight, so the clock holds the target across the landing (AetherEngine#37).
@@ -19,6 +21,8 @@ the public-API contract.
 ### Added
 
 - **`isSeeking` / `seekTarget` published seek signal.** `AetherEngine.isSeeking` is true from seek entry until the seek physically lands (not the optimistic `.playing` flip), uniform across programmatic `seek(to:)` and native AVKit transport-bar scrubs (which drive a producer restart out of the served window). `seekTarget` carries the in-flight destination on the source-PTS axis. A host coordinating playback across devices can gate on these to tell a deliberate seek from a rebuffer or underflow skip without inferring it from `currentTime` jumps (AetherEngine#38).
+
+([release notes](https://github.com/superuser404notfound/AetherEngine/releases/tag/3.7.0))
 
 ## [3.6.1] — 2026-06-16
 

--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ Format coverage follows the engine's native-first / software-fallback split. H.2
 Install via Swift Package Manager:
 
 ```swift
-.package(url: "https://github.com/superuser404notfound/AetherEngine", from: "3.6.1")
+.package(url: "https://github.com/superuser404notfound/AetherEngine", from: "3.7.0")
 ```
 
 Two complementary samples ship in `Examples/`:
@@ -729,13 +729,13 @@ AetherEngine uses [Semantic Versioning](https://semver.org). The public API surf
 
 `internal` types and properties are not part of the contract and may change in any release. `@testable import AetherEngine` reaches them for the package's own tests, not for production use.
 
-Pin `from: "3.6.1"` in your `Package.swift` to allow patch + minor updates while excluding breaking changes:
+Pin `from: "3.7.0"` in your `Package.swift` to allow patch + minor updates while excluding breaking changes:
 
 ```swift
-.package(url: "https://github.com/superuser404notfound/AetherEngine", from: "3.6.1")
+.package(url: "https://github.com/superuser404notfound/AetherEngine", from: "3.7.0")
 ```
 
-Pin to `.upToNextMinor(from: "3.6.1")` for stricter teams that prefer to opt into minor bumps explicitly. See [CHANGELOG.md](CHANGELOG.md) for the per-release index.
+Pin to `.upToNextMinor(from: "3.7.0")` for stricter teams that prefer to opt into minor bumps explicitly. See [CHANGELOG.md](CHANGELOG.md) for the per-release index.
 
 ## Requirements
 


### PR DESCRIPTION
Version-reference sweep before the 3.7.0 tag: CHANGELOG `[Unreleased]` promoted to a dated `[3.7.0]` section (with release-notes link), README pin snippets bumped 3.6.1 → 3.7.0. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)