### PR TITLE
refactor: behavior-preserving code cleanup pass

### DIFF
--- a/Sources/AetherEngine/AetherEngine.swift
+++ b/Sources/AetherEngine/AetherEngine.swift
@@ -1111,13 +1111,7 @@ public final class AetherEngine: ObservableObject {
         // toggle AVPlayer directly; the $timeControlStatus reconciliation is async, so a fast press on a stale
         // value would no-op. SW/audio hosts have no competing transport owner so `state` is authoritative there.
         let isPlaying: Bool
-        if audioAVPlayerActive {
-            isPlaying = (state == .playing)
-        } else if audioHost != nil {
-            isPlaying = (state == .playing)
-        } else if softwareHost != nil {
-            isPlaying = (state == .playing)
-        } else if let nativeHost {
+        if let nativeHost, !audioAVPlayerActive && audioHost == nil && softwareHost == nil {
             isPlaying = nativeHost.isEffectivelyPlaying
         } else {
             isPlaying = (state == .playing)

--- a/Sources/AetherEngine/Audio/AudioBridge.swift
+++ b/Sources/AetherEngine/Audio/AudioBridge.swift
@@ -666,7 +666,6 @@ final class AudioBridge: @unchecked Sendable {
             of.pointee.nb_samples = readSamples
             of.pointee.pts = nextEncoderPTS
             nextEncoderPTS += Int64(readSamples)
-            _ = nChannels
 
             let sendFrameRet = avcodec_send_frame(enc, of)
             if sendFrameRet < 0 && sendFrameRet != FFmpegErr.eof {

--- a/Sources/AetherEngine/Audio/AudioDecoder.swift
+++ b/Sources/AetherEngine/Audio/AudioDecoder.swift
@@ -208,7 +208,7 @@ final class AudioDecoder: @unchecked Sendable {
             mReserved: 0
         )
 
-        let layoutTag = channelLayoutTag(for: channels)
+        let layoutTag = audioChannelLayoutTag(for: channels)
         var layout = AudioChannelLayout(
             mChannelLayoutTag: layoutTag,
             mChannelBitmap: [],
@@ -232,10 +232,6 @@ final class AudioDecoder: @unchecked Sendable {
             throw AudioDecoderError.formatDescriptionFailed
         }
         audioFormatDescription = desc
-    }
-
-    private func channelLayoutTag(for channels: Int32) -> AudioChannelLayoutTag {
-        audioChannelLayoutTag(for: channels)
     }
 
     // MARK: - Frame → pending buffer → CMSampleBuffer
@@ -373,6 +369,5 @@ enum AudioDecoderError: Error {
     case contextAllocationFailed
     case parameterCopyFailed
     case openFailed
-    case resamplerFailed
     case formatDescriptionFailed
 }

--- a/Sources/AetherEngine/Decoder/EmbeddedSubtitleDecoder.swift
+++ b/Sources/AetherEngine/Decoder/EmbeddedSubtitleDecoder.swift
@@ -146,9 +146,9 @@ final class EmbeddedSubtitleDecoder {
         if sub.num_rects > 0, let rects = sub.rects {
             for i in 0..<Int(sub.num_rects) {
                 guard let rect = rects[i] else { continue }
-                if preserveASSMarkup, let raw = Self.rawASSLine(rect) {
+                if preserveASSMarkup, let raw = SubtitleRectText.rawASSLine(for: rect) {
                     textLines.append(raw)
-                } else if let text = Self.textForSubtitleRect(rect) {
+                } else if let text = SubtitleRectText.plainText(for: rect) {
                     textLines.append(text)
                 } else if let image = Self.imageForSubtitleRect(
                     rect,
@@ -391,16 +391,6 @@ final class EmbeddedSubtitleDecoder {
     }
 
     // MARK: - Rect → text / image
-
-    /// Raw ASS event line as libavcodec delivers it. Delegates to SubtitleRectText so embedded and sidecar paths share one source of truth.
-    private static func rawASSLine(_ rect: UnsafeMutablePointer<AVSubtitleRect>) -> String? {
-        SubtitleRectText.rawASSLine(for: rect)
-    }
-
-    private static func textForSubtitleRect(_ rect: UnsafeMutablePointer<AVSubtitleRect>) -> String? {
-        SubtitleRectText.plainText(for: rect)
-    }
-
 
     /// Render a PGS/DVB/HDMV bitmap rect into a CGImage with normalised position.
     /// Palette from libavcodec is 32-bit with alpha in the high byte and BGR below ([B,G,R,A] on little-endian);

--- a/Sources/AetherEngine/Decoder/HardwareVideoDecoder.swift
+++ b/Sources/AetherEngine/Decoder/HardwareVideoDecoder.swift
@@ -52,9 +52,6 @@ final class HardwareVideoDecoder: VideoDecodingPipeline, @unchecked Sendable {
     private var width: Int32 = 0
     private var height: Int32 = 0
 
-    /// True when source transfer is PQ ST.2084 or HLG; tells the host to flip SampleBufferRenderer into HDR mode.
-    private(set) var isHDR: Bool = false
-
     /// Color metadata from codecpar, re-applied to every CVPixelBuffer.
     /// VTDecompressionSession should propagate these from SPS+hvcC but has been observed not to;
     /// without them an HDR buffer renders as desaturated SDR on AVSampleBufferDisplayLayer.
@@ -130,7 +127,6 @@ final class HardwareVideoDecoder: VideoDecodingPipeline, @unchecked Sendable {
         let bitsPerSample = codecpar.pointee.bits_per_raw_sample
         let isHDRTransfer = ColorAttachments.isHDRTransfer(codecpar.pointee.color_trc)
         let use10Bit = bitsPerSample > 8 || isHDRTransfer
-        self.isHDR = isHDRTransfer
 
         self.colorPrimaries = ColorAttachments.primaries(codecpar.pointee.color_primaries)
         self.colorTransfer = ColorAttachments.transfer(codecpar.pointee.color_trc)

--- a/Sources/AetherEngine/Decoder/SubtitleDecoder.swift
+++ b/Sources/AetherEngine/Decoder/SubtitleDecoder.swift
@@ -188,7 +188,7 @@ enum SubtitleDecoder {
 
         // Under preserveASSMarkup: keep raw ASS event line (ASSScriptBuilder re-stamps timing); otherwise plain text.
         let lineForRect: (UnsafeMutablePointer<AVSubtitleRect>) -> String? = { rect in
-            keepMarkup ? SubtitleRectText.rawASSLine(for: rect) : textForRect(rect)
+            keepMarkup ? SubtitleRectText.rawASSLine(for: rect) : SubtitleRectText.plainText(for: rect)
         }
 
         while !cancel.isCancelled {
@@ -302,12 +302,6 @@ enum SubtitleDecoder {
             cues: cues.sorted { $0.startTime < $1.startTime },
             assHeader: assHeader
         )
-    }
-
-    // MARK: - Rect → text
-
-    private static func textForRect(_ rect: UnsafeMutablePointer<AVSubtitleRect>) -> String? {
-        SubtitleRectText.plainText(for: rect)
     }
 
 }

--- a/Sources/AetherEngine/Demuxer/AVIOReader.swift
+++ b/Sources/AetherEngine/Demuxer/AVIOReader.swift
@@ -185,11 +185,6 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
     /// reports EIO (-5) instead of EOF when the reconnect cap is hit.
     let isLive: Bool
 
-    /// Set by `readPersistent` when the reconnect cap hits on a live source.
-    /// Causes AVERROR(EIO) = -5 instead of AVERROR_EOF so the demuxer raises
-    /// `readFailed` ("live source lost") rather than a silent stall. Demux-thread-only.
-    private(set) var liveExhausted = false
-
     /// Timestamp of the last unplanned reconnect (drop/stall, not a seek).
     /// Producer correlates with a backward source-PTS reset to detect Jellyfin
     /// transcode respawn (re-serves from byte 0 on re-GET, invisible at byte level).
@@ -602,7 +597,6 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
                     if recordReconnectAndShouldGiveUp() {
                         EngineLog.emit("[AVIOReader] Persistent stall gave up at offset \(frontier) (\(unproductiveReconnects) unproductive)\(isLive ? " [live source lost]" : "")", category: .demux)
                         if isLive {
-                            liveExhausted = true
                             return totalRead > 0 ? Int32(totalRead) : AVERROR_EIO_VALUE
                         }
                         return totalRead > 0 ? Int32(totalRead) : -1
@@ -620,7 +614,6 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
             if recordReconnectAndShouldGiveUp(status: status) {
                 EngineLog.emit("[AVIOReader] Persistent reconnect exhausted at offset \(frontier) status=\(status) (\(unproductiveReconnects) unproductive)\(isLive ? " [live source lost]" : "")", category: .demux)
                 if isLive {
-                    liveExhausted = true
                     return totalRead > 0 ? Int32(totalRead) : AVERROR_EIO_VALUE
                 }
                 return totalRead > 0 ? Int32(totalRead) : -1

--- a/Sources/AetherEngine/Disc/UDFReader.swift
+++ b/Sources/AetherEngine/Disc/UDFReader.swift
@@ -166,12 +166,12 @@ final class UDFReader {
     // MARK: file entry parsing
 
     private struct AllocExt { let block: Int; let length: Int; let longPartRef: Int? }
-    private struct FE { let fileType: Int; let isDir: Bool; let partRef: Int; let allocationExtents: [AllocExt] }
+    private struct FE { let partRef: Int; let allocationExtents: [AllocExt] }
 
     private func readFileEntry(block: Int, partRef: Int) throws -> FE {
         let sector = try resolve(block: block, partRef: partRef)
         let raw = try readFileEntryRaw(sector: sector)
-        return FE(fileType: raw.fileType, isDir: raw.isDir, partRef: partRef, allocationExtents: raw.allocationExtents)
+        return FE(partRef: partRef, allocationExtents: raw.allocationExtents)
     }
 
     /// Parse (E)FE at a physical sector. Tag 261 (FE) and 266 (EFE);
@@ -180,8 +180,6 @@ final class UDFReader {
         let d = try readSector(sector)
         let tid = tagID(d)
         guard tid == 261 || tid == 266 else { throw DiscError.malformed("not a file entry @\(sector): tag \(tid)") }
-        let fileType = Int(d[27])
-        let isDir = fileType == 4
         let adType = u16(d, 34) & 0x07
         let (lEAOff, lADOff, adBase): (Int, Int, Int) = tid == 266 ? (208, 212, 216) : (168, 172, 176)
         let lEA = u32(d, lEAOff)
@@ -200,7 +198,7 @@ final class UDFReader {
             exts.append(AllocExt(block: blk, length: len, longPartRef: longRef))
             p += stride
         }
-        return FE(fileType: fileType, isDir: isDir, partRef: 0, allocationExtents: exts)
+        return FE(partRef: 0, allocationExtents: exts)
     }
 
     // MARK: directory parsing

--- a/Sources/AetherEngine/FrameExtractor/FrameExtractor.swift
+++ b/Sources/AetherEngine/FrameExtractor/FrameExtractor.swift
@@ -32,8 +32,8 @@ public actor FrameExtractor {
     private let idleInterval: Duration = .seconds(10)
     private var idleTask: Task<Void, Never>?
 
-    public init(url: URL, httpHeaders: [String: String] = [:]) {
-        self.context = FrameDecodeContext(url: url, httpHeaders: httpHeaders)
+    private init(context: FrameDecodeContext) {
+        self.context = context
         self.cache = FrameCache(
             thumbnailLimit: 24,
             snapshotLimit: 2,
@@ -42,16 +42,14 @@ public actor FrameExtractor {
         self.decodeQueue = DispatchQueue(label: "com.aetherengine.frameextractor", qos: .userInitiated)
     }
 
+    public init(url: URL, httpHeaders: [String: String] = [:]) {
+        self.init(context: FrameDecodeContext(url: url, httpHeaders: httpHeaders))
+    }
+
     /// Construct over a custom `IOReader` source (a clone with its own cursor).
     /// The extractor owns the reader and closes it on teardown.
     public init(reader: IOReader, formatHint: String? = nil) {
-        self.context = FrameDecodeContext(reader: reader, formatHint: formatHint)
-        self.cache = FrameCache(
-            thumbnailLimit: 24,
-            snapshotLimit: 2,
-            thumbnailBucketSeconds: 1.0
-        )
-        self.decodeQueue = DispatchQueue(label: "com.aetherengine.frameextractor", qos: .userInitiated)
+        self.init(context: FrameDecodeContext(reader: reader, formatHint: formatHint))
     }
 
     // MARK: - Public API

--- a/Sources/AetherEngine/Native/NativeAVPlayerHost.swift
+++ b/Sources/AetherEngine/Native/NativeAVPlayerHost.swift
@@ -344,7 +344,7 @@ final class NativeAVPlayerHost {
 
         // Explicitly load each key separately: AVPlayerItem(asset:)+KVO was observed stuck in .unknown (build-123), and separate awaits let DrHurt's "1 success, 3 failures" pattern identify which key -1008 hits.
         let urlStr = url.absoluteString
-        Task { [weak self] in
+        Task {
             for key in ["isPlayable", "tracks", "duration"] {
                 do {
                     switch key {
@@ -369,7 +369,6 @@ final class NativeAVPlayerHost {
                     }
                     // Dump partial track info even on failure: DrHurt's -1008 stall still surfaces the FourCC (hev1 vs hvc1, dvhe vs dvh1).
                     Self.dumpAssetTracks(asset, sid: sid, reason: "asset.load(\(key)).failed")
-                    _ = self
                     return
                 }
             }

--- a/Sources/AetherEngine/Network/HLSLocalServer.swift
+++ b/Sources/AetherEngine/Network/HLSLocalServer.swift
@@ -113,16 +113,9 @@ final class HLSLocalServer: @unchecked Sendable {
 
     // MARK: - Provider
 
-    private weak var externalProvider: HLSSegmentProvider?
-
-    private var provider: HLSSegmentProvider? {
-        externalProvider
-    }
+    private weak var provider: HLSSegmentProvider?
 
     // MARK: - Public state
-
-    /// When seg0 was first fetched; used to measure HLS pipeline latency.
-    private(set) var seg0FetchTime: Date?
 
     /// Kernel-assigned ephemeral port. Zero until start() succeeds.
     private(set) var port: UInt16 = 0
@@ -220,7 +213,7 @@ final class HLSLocalServer: @unchecked Sendable {
     private let subResourceBaseURL: URL?
 
     init(provider: HLSSegmentProvider, subResourceBaseURL: URL? = nil) {
-        self.externalProvider = provider
+        self.provider = provider
         self.subResourceBaseURL = subResourceBaseURL
     }
 
@@ -308,7 +301,6 @@ final class HLSLocalServer: @unchecked Sendable {
         mediaPlaylistBuildCount = 0
         let clients = clientFds
         clientFds.removeAll()
-        seg0FetchTime = nil
         stateLock.unlock()
 
         // shutdown() BEFORE close() on the listen fd: close releases the fd number while the accept loop may have captured it; a new session could recycle that number and the dying loop would accept on the new session's socket. shutdown() wakes the blocked accept without releasing the number.
@@ -584,11 +576,6 @@ final class HLSLocalServer: @unchecked Sendable {
                normalizedPath.hasSuffix(".mp4") {
                 let indexStr = normalizedPath.dropFirst(4).dropLast(4)
                 if let index = Int(indexStr), index >= 0 {
-                    if index == 0 {
-                        stateLock.lock()
-                        if seg0FetchTime == nil { seg0FetchTime = Date() }
-                        stateLock.unlock()
-                    }
                     // File-backed fast path: stream page cache -> socket without Data materialization.
                     if let url = provider?.mediaSegmentURL(at: index) {
                         return send200File(fd: fd, path: normalizedPath,

--- a/Sources/AetherEngine/Renderer/SampleBufferRenderer.swift
+++ b/Sources/AetherEngine/Renderer/SampleBufferRenderer.swift
@@ -12,8 +12,6 @@ final class SampleBufferRenderer: @unchecked Sendable {
 
     private(set) var displayLayer: AVSampleBufferDisplayLayer
 
-    private var currentlyHDR: Bool = false
-
     /// B-frame reorder buffer (4 frames): collects decoder output, flushes to display layer in ascending PTS order. Third tuple slot carries per-frame HDR10+ T.35 SEI bytes, paired through the reorder to kCMSampleAttachmentKey_HDR10PlusPerFrameData.
     private let reorderLock = NSLock()
     private var reorderBuffer: [(CVPixelBuffer, CMTime, Data?)] = []
@@ -92,7 +90,6 @@ final class SampleBufferRenderer: @unchecked Sendable {
 
     /// Opt the display layer into HDR mode. Pass true only when the decoder delivers raw HDR10/DV pixel buffers; false for SDR or tone-mapped output.
     func setHDROutput(_ isHDR: Bool) {
-        currentlyHDR = isHDR
         if #available(tvOS 26.0, iOS 26.0, macOS 26.0, *) {
             displayLayer.preferredDynamicRange = isHDR ? .high : .standard
         } else {

--- a/Sources/AetherEngine/Video/CodecRoutePolicy.swift
+++ b/Sources/AetherEngine/Video/CodecRoutePolicy.swift
@@ -43,10 +43,6 @@ extension HLSVideoEngine {
         return nil
     }
 
-    private func isHDRTransfer(_ codecpar: UnsafePointer<AVCodecParameters>) -> Bool {
-        ColorAttachments.isHDRTransfer(codecpar.pointee.color_trc)
-    }
-
     private func classifyDVVariant(
         _ record: AVDOVIDecoderConfigurationRecord?,
         codecID: AVCodecID

--- a/Sources/AetherEngine/Video/HLSSegmentProducer.swift
+++ b/Sources/AetherEngine/Video/HLSSegmentProducer.swift
@@ -137,7 +137,6 @@ final class HLSSegmentProducer: @unchecked Sendable {
     private var mergeSideEOF = false
     // var (not let): SSAI ad creative arrives on a new video PID mid-pump; re-pointed at the new stream.
     private var videoStreamIndex: Int32
-    private let videoOutputStreamIndex: Int32 = 0
     private let cache: SegmentCache
     /// Segment index offset; 0 for initial-start, non-zero for restart sessions.
     private let baseIndex: Int

--- a/Sources/AetherEngine/Video/HLSVideoEngine.swift
+++ b/Sources/AetherEngine/Video/HLSVideoEngine.swift
@@ -432,9 +432,8 @@ public final class HLSVideoEngine: @unchecked Sendable {
                     videoTimeBase: videoTimeBase,
                     sourceDurationSeconds: durationSeconds
                 )
-                let detectedFirstKeyframePts = keyframes.sorted().first ?? 0
-                self.firstKeyframePts = detectedFirstKeyframePts
-                let firstKeyframePts = detectedFirstKeyframePts
+                let firstKeyframePts = keyframes.sorted().first ?? 0
+                self.firstKeyframePts = firstKeyframePts
                 let firstKeyframeSeconds = Double(firstKeyframePts) * Double(videoTimeBase.num) / Double(videoTimeBase.den)
                 self.firstKeyframeSeconds = firstKeyframeSeconds
                 let videoStreamStart = videoStream.pointee.start_time
@@ -1198,7 +1197,7 @@ public final class HLSVideoEngine: @unchecked Sendable {
             performRestart(at: target)
             restartLock.lock()
             let nextTarget = restartCoalescer.next(justRan: target)
-            let nextSeekTime = nextTarget.map { segmentStartSecondsLocked($0) } ?? nil
+            let nextSeekTime = nextTarget.flatMap { segmentStartSecondsLocked($0) }
             restartLock.unlock()
             guard let nextTarget else { break }
             EngineLog.emit(

--- a/Sources/AetherEngine/Video/MP4SegmentMuxer.swift
+++ b/Sources/AetherEngine/Video/MP4SegmentMuxer.swift
@@ -264,14 +264,6 @@ final class MP4SegmentMuxer {
     /// Diverging from producerPacketsWritten / pktsPerFragment flags a flush stall.
     var fragmentCutCount: Int { byteCounter.fragmentCuts }
 
-    var avioPendingBytes: Int {
-        guard let pb = pb else { return 0 }
-        let base = UInt(bitPattern: Int(bitPattern: OpaquePointer(pb.pointee.buffer)))
-        let cur = UInt(bitPattern: Int(bitPattern: OpaquePointer(pb.pointee.buf_ptr)))
-        guard cur >= base else { return 0 }
-        return Int(cur - base)
-    }
-
     // MARK: - Eager probe
 
     /// Dry-run avformat_write_header to catch cascade failures the lazy muxer init would miss.

--- a/Sources/AetherEngine/Video/PacketRingBuffer.swift
+++ b/Sources/AetherEngine/Video/PacketRingBuffer.swift
@@ -148,12 +148,6 @@ final class PacketRingBuffer {
         return entries.first.map(\.pts)
     }
 
-    var newestPts: Double? {
-        lock.lock()
-        defer { lock.unlock() }
-        return entries.last.map(\.pts)
-    }
-
     // MARK: - Internal
 
     private func nextCounter() -> Int {

--- a/Sources/aetherctl/HLSLiveRepro.swift
+++ b/Sources/aetherctl/HLSLiveRepro.swift
@@ -86,7 +86,6 @@ private func hlsLiveRun(entryURL: String, seconds: Int, server: HLSFixtureServer
     }
     print(String(format: "  post-load state=%@ isLive=%@", "\(engine.state)", "\(engine.isLive)"))
 
-    var stalled = false // EngineLog stream shows "live seg-N finalized"
     for tick in 0..<seconds {
         try? await Task.sleep(nanoseconds: 1_000_000_000)
         if case .error(let m) = engine.state {
@@ -94,7 +93,7 @@ private func hlsLiveRun(entryURL: String, seconds: Int, server: HLSFixtureServer
         }
         _ = tick
     }
-    if !stalled { print("VERDICT: ran \(seconds)s, see seg-N finalize log above for cut continuity") }
+    print("VERDICT: ran \(seconds)s, see seg-N finalize log above for cut continuity")
     engine.stop()
     server.stop()
     try? await Task.sleep(nanoseconds: 500_000_000)


### PR DESCRIPTION
Quality-only cleanup across AetherEngine subsystems. **No runtime behavior change** — every edit was independently verified to be byte-for-byte behavior preserving (dead code removal, single-call pass-through inlining, redundant-branch collapse). Builds green under strict concurrency:

```
swift build -Xswiftc -strict-concurrency=complete
```

Net: 18 files, +22 / -103 lines, in 12 logical commits (one per subsystem).

## Removed / simplified

- **Video** — unread `videoOutputStreamIndex`; dead diagnostic getters `avioPendingBytes`, `newestPts`; uncalled private `isHDRTransfer`; a redundant keyframe-pts binding; `map { } ?? nil` rewritten as `flatMap`.
- **Audio** — never-thrown `AudioDecoderError.resamplerFailed`; inlined `channelLayoutTag(for:)` wrapper; obsolete `_ = nChannels` discard.
- **Network** — write-only `seg0FetchTime` (+ its empty lock guard); folded `externalProvider` + forwarding computed `provider` into one weak `provider`.
- **Demuxer** — unread `liveExhausted` flag and its two writes (the AVERROR_EIO return already carries the signal).
- **Disc** — write-only `FE.fileType` / `FE.isDir` fields and their feeding locals.
- **Subtitles** — three single-call rect-text forwarders inlined to direct `SubtitleRectText` calls.
- **Decoder** — unread `HardwareVideoDecoder.isHDR` property and its write.
- **Renderer** — unread `SampleBufferRenderer.currentlyHDR` and its dead store.
- **Native** — unused `[weak self]` capture and `_ = self` no-op in the asset-load Task.
- **FrameExtractor** — deduped identical init bodies through a private `init(context:)`.
- **Core** — collapsed three redundant `togglePlayPause` branches into the `else`.
- **aetherctl** — dead `stalled` flag and its always-true guard.

## Deliberately not touched

- `VideoSegmentProvider.firstVisibleSegmentIndex` looked like dead code (zero read-sites) but is a deliberately-retained diagnostic accessor whose racy use-site was intentionally excised by audit commit 85d7cd6 (finding L14). Left in place.
- Ground-truth intentional fixes (keyframe gate, clock re-fold / sourceTime split, dec3 / delay_moov, NOPTS-dts repair, head-of-stream audio offset, audio-gate timebase rescale, RestartCoalescer) were never flagged.

Note: the pre-existing strict-concurrency warning at `VideoSegmentProvider.swift:181` (non-Sendable `cacheRef` capture) is unrelated; that file is untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01B4hBXf5yHPUNxQsDavBKGk