### PR TITLE
fix: high-confidence bug-audit findings (5 isolated fixes)

### DIFF
--- a/Sources/AetherEngine/Audio/AudioBridge.swift
+++ b/Sources/AetherEngine/Audio/AudioBridge.swift
@@ -552,7 +552,19 @@ final class AudioBridge: @unchecked Sendable {
         try receiveDecodedFrames()
 
         // Drain the FIFO into encoder-frame-size chunks, each fed as one AVFrame.
-        try drainFIFOIntoEncoder(enc: enc, fifo: fifoPtr, requireFull: true, results: &results)
+        // The helper may append encoded packets before throwing; feed propagates the error (the
+        // caller logs and continues, holding no reference), so free the partial results here or
+        // they leak. flush() intentionally keeps its partial results via try?, so this cleanup
+        // lives in feed(), not in the shared helper.
+        do {
+            try drainFIFOIntoEncoder(enc: enc, fifo: fifoPtr, requireFull: true, results: &results)
+        } catch {
+            for p in results {
+                var pp: UnsafeMutablePointer<AVPacket>? = p
+                trackedPacketFree(&pp)
+            }
+            throw error
+        }
 
         return results
     }

--- a/Sources/AetherEngine/Decoder/SubtitleDecoder.swift
+++ b/Sources/AetherEngine/Decoder/SubtitleDecoder.swift
@@ -94,7 +94,9 @@ enum SubtitleDecoder {
                 throw SubtitleDecoderError.openFailed(code: -1)
             }
             ctx.pointee.pb = reader.context
-            formatContext = ctx
+            // Assign formatContext only after a successful open: avformat_open_input frees the
+            // supplied context and NULLs its pointer on failure, so an early assignment would
+            // leave a dangling pointer for the defer to double-close (mirrors Demuxer.swift).
             var ctxPtr: UnsafeMutablePointer<AVFormatContext>? = ctx
             let ret = avformat_open_input(&ctxPtr, nil, nil, nil)
             guard ret == 0 else {

--- a/Sources/AetherEngine/Disc/ConcatIOReader.swift
+++ b/Sources/AetherEngine/Disc/ConcatIOReader.swift
@@ -77,6 +77,10 @@ final class ConcatIOReader: IOReader, @unchecked Sendable {
 
     func close() {}  // base reader is owned by the engine lifecycle
 
+    // Forward cancel to the base (mirrors makeIndependentReader) so teardown unblocks a
+    // read parked inside base.read() on a network source; close() being a no-op does not.
+    func cancel() { base.cancel() }
+
     /// Vend a second concat reader over an independent cursor of the base, so
     /// the engine's side demuxer (embedded subtitles) and scrub preview can read
     /// concurrently. Nil if the base cannot fork a cursor.

--- a/Sources/AetherEngine/Disc/DiscReader.swift
+++ b/Sources/AetherEngine/Disc/DiscReader.swift
@@ -53,12 +53,18 @@ enum DiscReader {
 
     /// Read all bytes of an extent list into memory (small files only: mpls).
     private static func readAll(_ base: IOReader, _ exts: [(offset: Int64, length: Int64)]) -> [UInt8] {
+        // Extent lengths are untrusted on-disc bytes (up to ~1 GB each). Cap the total before
+        // allocating so a crafted .mpls cannot drive an arbitrary allocation (jetsam/DoS); 8 MB
+        // matches UDFReader.readDirectory's guard and dwarfs any real playlist (KB-scale).
+        let maxBytes: Int64 = 8 * 1024 * 1024
+        let declared = exts.reduce(Int64(0)) { $0 + max(0, $1.length) }
+        guard declared > 0, declared <= maxBytes else { return [] }
+        let total = Int(declared)
         let r = ConcatIOReader(base: base, extents: exts)
-        let total = Int(exts.reduce(0) { $0 + $1.length })
         var out = [UInt8](repeating: 0, count: total); var got = 0
         out.withUnsafeMutableBufferPointer { p in
             while got < total {
-                let n = r.read(p.baseAddress!.advanced(by: got), size: Int32(total - got))
+                let n = r.read(p.baseAddress!.advanced(by: got), size: Int32(min(Int64(total - got), Int64(Int32.max))))
                 if n <= 0 { break }; got += Int(n)
             }
         }

--- a/Sources/AetherEngine/FrameExtractor/FrameDecodeContext.swift
+++ b/Sources/AetherEngine/FrameExtractor/FrameDecodeContext.swift
@@ -189,37 +189,64 @@ final class FrameDecodeContext: @unchecked Sendable {
         guard frame != nil else { return nil }
         defer { av_frame_free(&frame) }
 
+        func makeImage(_ f: UnsafeMutablePointer<AVFrame>) -> CGImage? {
+            let width = mode == .thumbnail
+                ? targetWidth
+                : Self.clampedWidth(frame: f, maxSize: maxSize)
+            if isHDR {
+                var toned = HDRToneMapper.toneMap(frame: f, targetWidth: width, timeBase: timeBase)
+                if toned != nil {
+                    defer { av_frame_free(&toned) }
+                    if let img = Self.cgImageFromRGBAFrame(toned!) { return img }
+                }
+                // tone-map failed: fall through to sws path (degraded but non-nil)
+            }
+            return convertToCGImage(frame: f, targetWidth: width)
+        }
+
+        // Once the demuxer hits EOF, flush the decoder (NULL packet) and keep draining: the
+        // context is frame-threaded, so the last GOP's frames only emit after the flush. Without
+        // this, a snapshot/thumbnail targeting the final frames returned nil (blank preview).
+        var draining = false
         while true {
             if isCancelled() { return nil }
 
-            let packetOrNil: UnsafeMutablePointer<AVPacket>?
-            do {
-                packetOrNil = try demuxer.readPacket()
-            } catch {
-                return nil
-            }
-            guard let packet = packetOrNil else {
-                return nil
-            }
-
-            if packet.pointee.stream_index != videoStreamIndex {
+            if !draining {
+                let packetOrNil: UnsafeMutablePointer<AVPacket>?
+                do {
+                    packetOrNil = try demuxer.readPacket()
+                } catch {
+                    return nil
+                }
+                guard let packet = packetOrNil else {
+                    avcodec_send_packet(ctx, nil)
+                    draining = true
+                    continue
+                }
+                if packet.pointee.stream_index != videoStreamIndex {
+                    av_packet_unref(packet)
+                    av_packet_free_safe(packet)
+                    continue
+                }
+                // Receive loop below drains before each send, so send-side EAGAIN cannot occur here.
+                let sendRet = avcodec_send_packet(ctx, packet)
                 av_packet_unref(packet)
                 av_packet_free_safe(packet)
-                continue
+                guard sendRet >= 0 else { continue }
             }
-
-            // Receive loop below drains before each send, so send-side EAGAIN cannot occur here.
-            let sendRet = avcodec_send_packet(ctx, packet)
-            av_packet_unref(packet)
-            av_packet_free_safe(packet)
-            guard sendRet >= 0 else { continue }
 
             while true {
                 if isCancelled() { return nil }
                 let recvRet = avcodec_receive_frame(ctx, frame)
-                if recvRet == FFmpegErr.eagain { break }           // need another packet
+                if recvRet == FFmpegErr.eagain {
+                    if draining { return nil }      // flushed dry without reaching the target
+                    break                           // need another packet
+                }
                 if recvRet == FFmpegErr.eof { return nil } // decoder drained
-                guard recvRet >= 0, let f = frame else { break }       // real error: try next packet
+                guard recvRet >= 0, let f = frame else {
+                    if draining { return nil }      // avoid re-flushing the same error forever
+                    break                           // real error: try next packet
+                }
 
                 // Skip frames before targetPTS for frame-accuracy. No-PTS frames
                 // (AV_NOPTS_VALUE == Int64.min) are accepted, so PTS-less streams
@@ -231,18 +258,7 @@ final class FrameDecodeContext: @unchecked Sendable {
                 }
 
                 if isCancelled() { return nil }
-                let width = mode == .thumbnail
-                    ? targetWidth
-                    : Self.clampedWidth(frame: f, maxSize: maxSize)
-                if isHDR {
-                    var toned = HDRToneMapper.toneMap(frame: f, targetWidth: width, timeBase: timeBase)
-                    if toned != nil {
-                        defer { av_frame_free(&toned) }
-                        if let img = Self.cgImageFromRGBAFrame(toned!) { return img }
-                    }
-                    // tone-map failed: fall through to sws path (degraded but non-nil)
-                }
-                return convertToCGImage(frame: f, targetWidth: width)
+                return makeImage(f)
             }
         }
     }


### PR DESCRIPTION
The 5 high-confidence findings from the adversarial bug-hunt audit that are isolated code defects, not playback state-machine changes, so they ship without on-device verification. Each survived dual-lens adversarial refutation (reachability + intentionality), and each has an in-repo correct sibling that proves the omission was an oversight.

- **fix(subtitles)** AVFormatContext double-free on sidecar HTTP open failure: assign formatContext only after open succeeds (mirrors Demuxer.swift). Heap corruption on any HTTP sidecar where avformat_open_input fails.
- **fix(disc)** ConcatIOReader.cancel() forwards to base: teardown deadlock on network-backed disc sources (parked base.read() never unblocked).
- **fix(disc)** cap untrusted UDF extent allocation in DiscReader.readAll at 8 MB (matches UDFReader.readDirectory) + clamp the per-read size: jetsam/DoS on crafted Blu-ray ISOs.
- **fix(frameextractor)** flush the decoder at EOF: frame-threaded last-GOP snapshots/thumbnails returned nil (blank scrub preview).
- **fix(audio)** free partial encoded packets when feed()'s FIFO drain throws: slow packet leak (PacketBalanceTracker.alive climbs); flush() keeps its partial results via try?, so the cleanup lives in feed().

Builds clean with `swift build -Xswiftc -strict-concurrency=complete` (zero new warnings). State-machine findings from the same audit are held on `fix/audit-statemachine-deviceverify` pending device verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)