### PR TITLE
fix: state-machine bug-audit findings + AudioBridge lock + AVIO teardown race

### DIFF
--- a/Sources/AetherEngine/AetherEngine.swift
+++ b/Sources/AetherEngine/AetherEngine.swift
@@ -1178,6 +1178,10 @@ public final class AetherEngine: ObservableObject {
         seekGeneration &+= 1
         let seekGen = seekGeneration
         setProgrammaticSeek(inFlight: true, target: target)
+        // Capture loadGeneration so the live finalize can detect a concurrent stop()/load()/zap
+        // (which bumps loadGeneration in stopInternal but leaves seekGeneration untouched), matching
+        // the VOD guard below. Without it a superseded live seek writes clock/state onto a torn-down session.
+        let loadGen = loadGeneration
         if isLive {
             // Live/DVR native: translate session-time target into AVPlayer live clock via behind-delta
             // (robust if the edge advances between publish tick and seek; collapses to clockTarget = target - shift).
@@ -1185,7 +1189,7 @@ public final class AetherEngine: ObservableObject {
             if softwareHost != nil, nativeHost == nil {
                 EngineLog.emit("[AetherEngine] SW live seek target=\(target)", category: .engine)
                 await softwareHost?.seek(to: target)
-                guard seekGeneration == seekGen else { return }
+                guard loadGeneration == loadGen, seekGeneration == seekGen else { return }
                 clock.currentTime = target
                 clock.sourceTime = target
                 state = .playing
@@ -1200,7 +1204,7 @@ public final class AetherEngine: ObservableObject {
             nativeClockSeconds = clockTarget
             clock.currentTime = target
             await nativeHost?.seek(to: clockTarget)
-            guard seekGeneration == seekGen else { return }
+            guard loadGeneration == loadGen, seekGeneration == seekGen else { return }
             nativeClockSeconds = clockTarget
             clock.currentTime = target
             clock.sourceTime = target

--- a/Sources/AetherEngine/Audio/AudioBridge.swift
+++ b/Sources/AetherEngine/Audio/AudioBridge.swift
@@ -78,6 +78,15 @@ final class AudioBridge: @unchecked Sendable {
     /// (~4608 @48kHz); EAC3 decodes 1536 samples/packet, so without the FIFO we'd hit -22 EINVAL on the first send.
     private var fifo: OpaquePointer?
 
+    /// Serializes the public mutators (feed/flush/startSegment/noteTimelineJump/close) against each
+    /// other. On a producer restart whose old pump did not exit within the 5s budget (slow/remote
+    /// source), the abandoned pump can still be inside feed() while the restart thread calls
+    /// startSegment() on this otherwise lock-free bridge; concurrent libswresample/libavcodec calls on
+    /// the same contexts are a data race. Uncontended in the normal single-pump case. Mirrors
+    /// AudioDecoder.stateLock. Diagnostic reads (fifoSampleCount/liveBytes) stay lock-free; the engine
+    /// lifecycle (restartLock ref-handoff + waitForFinish-gated cleanup) forecloses their races.
+    private let opLock = NSLock()
+
     /// PCM intermediate format end-to-end (resampler -> FIFO -> encoder). S16 for lossy sources (EAC3/AC3);
     /// S32 @ bits_per_raw_sample=24 for lossless sources (TrueHD, DTS-HD MA, FLAC, ALAC, raw 24/32-bit PCM) so
     /// FLAC output stays bit-perfect (S16 would dither away the bottom 8 bits, audible in quiet passages).
@@ -333,6 +342,8 @@ final class AudioBridge: @unchecked Sendable {
     }
 
     func close() {
+        opLock.lock()
+        defer { opLock.unlock() }
         cleanup()
     }
 
@@ -397,6 +408,8 @@ final class AudioBridge: @unchecked Sendable {
     /// encoder PTS off the next decoded frame's pts. Caller (VideoSegmentProvider) invokes before each fragment's
     /// audio so A/V timestamps stay aligned across muxer fragment boundaries.
     func startSegment() {
+        opLock.lock()
+        defer { opLock.unlock() }
         if let f = fifo {
             av_audio_fifo_reset(f)
         }
@@ -418,6 +431,8 @@ final class AudioBridge: @unchecked Sendable {
     /// drain only emits FULL frames and nothing sent the encoder its EOF frame). Returns the tail packets; caller
     /// writes them via the same muxer path. Call once at pump EOF before muxer finalize. Not meaningful for live.
     func flush() -> [UnsafeMutablePointer<AVPacket>] {
+        opLock.lock()
+        defer { opLock.unlock() }
         guard let dec = decoderCtx, let enc = encoderCtx,
               let swr = swrCtx, let fifoPtr = fifo else { return [] }
         var results: [UnsafeMutablePointer<AVPacket>] = []
@@ -463,6 +478,8 @@ final class AudioBridge: @unchecked Sendable {
     /// (splice overlap) are clamped, the counter never rewinds. Called on the pump thread (same as feed). FIFO
     /// leftover (< one frame) is stamped post-jump; that error is one-shot, bounded by one frame (~32 ms).
     func noteTimelineJump(deltaSeconds: Double) {
+        opLock.lock()
+        defer { opLock.unlock() }
         guard deltaSeconds > 0, encoderTimeBase.den > 0 else { return }
         let samples = Int64((deltaSeconds * Double(encoderTimeBase.den)).rounded())
         nextEncoderPTS += samples
@@ -500,6 +517,8 @@ final class AudioBridge: @unchecked Sendable {
     /// Decode one source packet, resample, buffer, encode. Returns 0+ encoded packets, ownership transferred to
     /// the caller (must av_packet_free after muxing). PTS is in encoderTimeBase units; the muxer rescales during writePacket.
     func feed(packet: UnsafePointer<AVPacket>) throws -> [UnsafeMutablePointer<AVPacket>] {
+        opLock.lock()
+        defer { opLock.unlock() }
         guard let dec = decoderCtx,
               let enc = encoderCtx,
               let swr = swrCtx,

--- a/Sources/AetherEngine/Audio/AudioDecoder.swift
+++ b/Sources/AetherEngine/Audio/AudioDecoder.swift
@@ -175,6 +175,35 @@ final class AudioDecoder: @unchecked Sendable {
         #endif
     }
 
+    /// Drain at source EOF: send a NULL packet to flush the decoder's internal delay frames into the
+    /// accumulator, then force-emit the residual (< minSamplesPerBuffer) tail that the gated decode()
+    /// path never emits. Without this the final ~21ms+ of every audio-only title was dropped (flush()
+    /// discards pending). Mirrors AudioBridge.flush(). Call once at demuxer EOF, before flush()/close().
+    func drain() -> [CMSampleBuffer] {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        guard let ctx = codecContext else { return [] }
+        var results: [CMSampleBuffer] = []
+
+        avcodec_send_packet(ctx, nil)
+        var frame: UnsafeMutablePointer<AVFrame>? = av_frame_alloc()
+        defer { av_frame_free(&frame) }
+        if let f = frame {
+            while avcodec_receive_frame(ctx, f) >= 0 {
+                if swrContext == nil {
+                    if !initResamplerFromFrame(f) { continue }
+                }
+                appendFrameToPending(f)
+                if pendingSampleCount >= Self.minSamplesPerBuffer {
+                    if let sampleBuffer = emitPending() { results.append(sampleBuffer) }
+                }
+            }
+        }
+        // Force-emit whatever is left below the coalescing threshold (emitPending only needs > 0 samples).
+        if let sampleBuffer = emitPending() { results.append(sampleBuffer) }
+        return results
+    }
+
     func close() {
         stateLock.lock()
         defer { stateLock.unlock() }

--- a/Sources/AetherEngine/Audio/AudioPlaybackHost.swift
+++ b/Sources/AetherEngine/Audio/AudioPlaybackHost.swift
@@ -346,6 +346,19 @@ final class AudioPlaybackHost {
             }
 
             guard let packet else {
+                // Drain decoder-delay frames + the sub-threshold tail and enqueue them before flush()
+                // discards pending; extend the high-water mark so the playthrough wait below covers the
+                // tail. flush() alone dropped the final ~21ms+ of every audio-only title.
+                if let aDec = audioDecoder, let aOut = audioOutput,
+                   seekGeneration() == seenSeekGeneration {
+                    let tail = aDec.drain()
+                    for buf in tail { aOut.enqueue(sampleBuffer: buf) }
+                    if let last = tail.last {
+                        let end = CMTimeGetSeconds(CMSampleBufferGetPresentationTimeStamp(last))
+                            + CMTimeGetSeconds(CMSampleBufferGetDuration(last))
+                        if end.isFinite, end > lastEnqueuedEnd { lastEnqueuedEnd = end }
+                    }
+                }
                 audioDecoder?.flush()
                 // Demuxer EOF is NOT end-of-track: renderer still has up to maxBufferAhead seconds queued.
                 // Wait for the clock to play through before signaling end, else host advances seconds early.

--- a/Sources/AetherEngine/Demuxer/AVIOReader.swift
+++ b/Sources/AetherEngine/Demuxer/AVIOReader.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 import Libavformat
 import Libavutil
 
@@ -254,8 +255,21 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
         }
     }
 
-    private var isClosed = false
-    private var isFullyClosed = false
+    // Close flags written on the teardown thread (markClosed / fullyClose) and read on the demux
+    // thread plus the URLSession delegate threads (persistent-connection callbacks). Backed by a
+    // leaf unfair lock so every access is synchronized; the bare Bools were a TSan-confirmed data
+    // race (markClosed write vs appendPersistentData read). The lock is only ever held for the
+    // get/set itself (never across another lock), so it cannot invert with winCond/streamLock.
+    private let isClosedLock = OSAllocatedUnfairLock<Bool>(initialState: false)
+    private var isClosed: Bool {
+        get { isClosedLock.withLock { $0 } }
+        set { isClosedLock.withLock { $0 = newValue } }
+    }
+    private let isFullyClosedLock = OSAllocatedUnfairLock<Bool>(initialState: false)
+    private var isFullyClosed: Bool {
+        get { isFullyClosedLock.withLock { $0 } }
+        set { isFullyClosedLock.withLock { $0 = newValue } }
+    }
 
     /// Wall-clock deadline for reads. Armed by `beginReadDeadline` to abort
     /// a `avformat_seek_file` that degrades into a linear scan when MKV Cues

--- a/Sources/AetherEngine/Native/SoftwarePlaybackHost.swift
+++ b/Sources/AetherEngine/Native/SoftwarePlaybackHost.swift
@@ -457,8 +457,12 @@ final class SoftwarePlaybackHost {
         }
         clockArmed = true
 
-        // Reposition cursor to newest keyframe at or before target (eviction keeps ring keyframe-aligned).
-        let seq = ring.seq(forKeyframeAtOrBefore: targetSource) ?? ring.seqBounds.first
+        // Reposition cursor to the newest keyframe at or before target. If the target precedes every
+        // retained keyframe, fall to the EARLIEST keyframe, not seqBounds.first, which can be a mid-GOP
+        // leading entry before the ring's first eviction and would decode as garbage until the next keyframe.
+        let seq = ring.seq(forKeyframeAtOrBefore: targetSource)
+            ?? ring.firstKeyframeSeq()
+            ?? ring.seqBounds.first
         setFeedCursor(seq)
         EngineLog.emit(
             "[SWHost] DVR rewind: targetSession=\(String(format: "%.2f", targetSession)) "

--- a/Sources/AetherEngine/Video/HLSVideoEngine.swift
+++ b/Sources/AetherEngine/Video/HLSVideoEngine.swift
@@ -116,12 +116,16 @@ public final class HLSVideoEngine: @unchecked Sendable {
     public func attachNativeSubtitleStores(count: Int, languages: [String?] = []) {
         guard count > 0 else { return }
         let stores = (0..<count).map { _ in NativeSubtitleCueStore() }
+        let langs = (0..<count).map { i in i < languages.count ? languages[i] : nil }
+        // Guard the session arrays under restartLock: a runtime attach (this call, host thread) otherwise
+        // races the pump thread iterating them in handleVideoShiftKnown and makeProducer's read (#55).
+        restartLock.lock()
         nativeSubtitleCueStoresForSession = stores
-        nativeSubtitleLanguagesForSession = (0..<count).map { i in
-            i < languages.count ? languages[i] : nil
-        }
-        producer?.subtitleCueStores = stores
-        producer?.nativeSubtitleLanguages = nativeSubtitleLanguagesForSession
+        nativeSubtitleLanguagesForSession = langs
+        let prod = producer
+        restartLock.unlock()
+        prod?.subtitleCueStores = stores
+        prod?.nativeSubtitleLanguages = langs
     }
 
     /// Attach one store per non-bitmap subtitle track from the engine's demuxer (#55, all-tracks).
@@ -1151,8 +1155,13 @@ public final class HLSVideoEngine: @unchecked Sendable {
         let seconds = shiftPts == Int64.min ? 0 : Double(shiftPts) * sourceVideoTbSeconds
         setPlaylistShiftSeconds(seconds)
         // Refresh every native subtitle store's shift so cuesInWindow stays on the correct AVPlayer
-        // axis after a restart (matroska seek can land past the planned keyframe, #55).
-        nativeSubtitleCueStoresForSession.forEach { $0.setShiftSeconds(seconds) }
+        // axis after a restart (matroska seek can land past the planned keyframe, #55). Snapshot under
+        // restartLock: this runs on the pump thread and the array is reassigned by attach* on another
+        // thread, so iterating the live array would race a CoW reassignment.
+        restartLock.lock()
+        let stores = nativeSubtitleCueStoresForSession
+        restartLock.unlock()
+        stores.forEach { $0.setShiftSeconds(seconds) }
         onPlaylistShiftChanged?(seconds)
     }
 

--- a/Sources/AetherEngine/Video/PacketRingBuffer.swift
+++ b/Sources/AetherEngine/Video/PacketRingBuffer.swift
@@ -140,6 +140,17 @@ final class PacketRingBuffer {
             .map { firstSeq + $0 }
     }
 
+    /// Sequence of the EARLIEST retained keyframe, or nil if the ring holds no keyframe yet. DVR reseed
+    /// floor when a target precedes every keyframe: seeding seqBounds.first (firstSeq) can land mid-GOP,
+    /// since leading entries appended before the first eviction are not guaranteed keyframe-aligned.
+    func firstKeyframeSeq() -> Int? {
+        lock.lock()
+        defer { lock.unlock() }
+        return entries.indices
+            .first(where: { entries[$0].isKeyframe })
+            .map { firstSeq + $0 }
+    }
+
     // MARK: - Diagnostics
 
     var oldestPts: Double? {

--- a/Sources/AetherEngineSMB/SMBIOReader.swift
+++ b/Sources/AetherEngineSMB/SMBIOReader.swift
@@ -17,9 +17,22 @@ public final class SMBIOReader: IOReader, @unchecked Sendable {
     // per the IOReader contract; no lock needed.
     private var position: Int64 = 0
     private var didClose = false
-    // `inFlight` is written on the demux thread (read()) and read on a
-    // different thread (cancel()), so it needs its own lock.
-    private let inFlightLock = OSAllocatedUnfairLock<Task<Void, Never>?>(initialState: nil)
+    /// Per-read in-flight state, published so cancel() (a different thread) can both cancel the
+    /// background work and, crucially, unblock read()'s semaphore wait. AMSMB2's libsmb2 read is
+    /// not cancellation-aware (only an internal ~60s timeout resolves the continuation), so
+    /// task.cancel() alone could not wake the wait and teardown blocked up to 60s; cancel() now
+    /// signals the semaphore directly and read() aborts.
+    private final class Inflight: @unchecked Sendable {
+        let task: Task<Void, Never>
+        let semaphore: DispatchSemaphore
+        var cancelled = false
+        init(task: Task<Void, Never>, semaphore: DispatchSemaphore) {
+            self.task = task
+            self.semaphore = semaphore
+        }
+    }
+    // Written on the demux thread (read()), read/mutated on a different thread (cancel()); guarded.
+    private let inFlightLock = OSAllocatedUnfairLock<Inflight?>(initialState: nil)
 
     /// `AVSEEK_SIZE` from FFmpeg: return total size, do not move.
     private let avseekSize: Int32 = 65536
@@ -41,9 +54,17 @@ public final class SMBIOReader: IOReader, @unchecked Sendable {
             catch { outcome.result = .failure(error) }
             semaphore.signal()
         }
-        inFlightLock.withLock { $0 = task }
+        inFlightLock.withLock { $0 = Inflight(task: task, semaphore: semaphore) }
         semaphore.wait()
-        inFlightLock.withLock { $0 = nil }
+        // cancel() may have signalled to unblock teardown while the libsmb2 read is still running.
+        // In that case do NOT read `outcome`: the background Task may still be writing it (the
+        // semaphore's happens-before edge only covers the Task's own signal). Abort with -1 instead.
+        let wasCancelled = inFlightLock.withLock { state -> Bool in
+            let c = state?.cancelled ?? false
+            state = nil
+            return c
+        }
+        if wasCancelled { return -1 }
 
         switch outcome.result {
         case .failure:
@@ -72,8 +93,11 @@ public final class SMBIOReader: IOReader, @unchecked Sendable {
     }
 
     public func cancel() {
-        let task = inFlightLock.withLock { $0 }
-        task?.cancel()
+        inFlightLock.withLock { state in
+            state?.cancelled = true
+            state?.task.cancel()
+            state?.semaphore.signal()   // wake read()'s wait; the libsmb2 op drains in the background
+        }
     }
 
     public func makeIndependentReader() -> IOReader? {


### PR DESCRIPTION
The remaining bug-audit findings that touch playback state machines, plus two concurrency fixes. All verified off-device (full unit suite green, ASan clean, ThreadSanitizer clean on every exercised path, DVR/live harness identical to main = no regression).

State-machine fixes:
- **fix(core)** guard live seek finalize on loadGeneration (drop a superseded live seek onto a torn-down session; mirrors the VOD guard).
- **fix(smb)** SMBIOReader.cancel() signals the read semaphore so teardown does not wait out the ~60s AMSMB2 timeout.
- **fix(subtitles)** guard the native cue-store arrays under restartLock against the pump thread.
- **fix(audio)** AudioDecoder.drain() at EOF so the final tail is not dropped (mirrors AudioBridge.flush).
- **fix(dvr)** PacketRingBuffer.firstKeyframeSeq(): seed the DVR feeder at a real keyframe when the target precedes the ring.

Concurrency fixes:
- **fix(audio)** internal NSLock serializing AudioBridge feed/flush/startSegment/noteTimelineJump/close (restart dual-feeder race; never held across blocking I/O, so no waitForFinish deadlock).
- **fix(demuxer)** AVIOReader close flags (isClosed/isFullyClosed) backed by a leaf unfair lock (persistent-connection teardown data race; found off-device via TSan, pre-existing on main, post-fix TSan = 0 races).

Off-device verification: 79 unit tests pass; ASan clean (audio/seektest/dvr/extract); TSan clean (audio/customio/seektest + post-fix dvr); engine and Sodalite build clean with strict concurrency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)