### PR TITLE
chore(concurrency): zero out strict-concurrency + deprecation warnings

### DIFF
--- a/Sources/AetherEngine/Decoder/VideoDecoderTypes.swift
+++ b/Sources/AetherEngine/Decoder/VideoDecoderTypes.swift
@@ -10,7 +10,9 @@ typealias DecodedFrameHandler = (CVPixelBuffer, CMTime, Data?) -> Void
 
 /// Common video decoder protocol. SoftwareVideoDecoder (libavcodec, AV1/VP9) and
 /// HardwareVideoDecoder (VTDecompressionSession, HEVC) both conform; the host swaps per codec without rewiring the demux loop.
-protocol VideoDecodingPipeline: AnyObject {
+// Sendable: both conformers (SoftwareVideoDecoder, HardwareVideoDecoder) are @unchecked Sendable
+// (internally lock-guarded), so `any VideoDecodingPipeline` is safe to capture in @Sendable closures.
+protocol VideoDecodingPipeline: AnyObject, Sendable {
     var onFrame: DecodedFrameHandler? { get set }
     var onFirstHDR10PlusDetected: (() -> Void)? { get set }
     var skipUntilPTS: CMTime? { get set }

--- a/Sources/AetherEngine/Diagnostics/FFmpegLogBridge.swift
+++ b/Sources/AetherEngine/Diagnostics/FFmpegLogBridge.swift
@@ -39,7 +39,9 @@ enum FFmpegLogBridge {
                                        &printPrefixState)
         }
 
-        var line = String(cString: buf)
+        // buf is a NUL-terminated CChar buffer from av_log_format_line2; decode up to the NUL as
+        // UTF-8 (String(cString:) is deprecated).
+        var line = String(decoding: buf.prefix(while: { $0 != 0 }).map { UInt8(bitPattern: $0) }, as: UTF8.self)
         if line.hasSuffix("\n") { line.removeLast() }  // av_log_format_line2 always appends \n
         if line.isEmpty { return }
 

--- a/Sources/AetherEngine/Native/NativeAVPlayerHost.swift
+++ b/Sources/AetherEngine/Native/NativeAVPlayerHost.swift
@@ -147,7 +147,6 @@ final class NativeAVPlayerHost {
                    let underlying = nsErr.userInfo[NSUnderlyingErrorKey] as? NSError {
                     EngineLog.emit("[NativeAVPlayerHost] #\(sid) item.error.underlying=\(underlying.domain)/\(underlying.code) '\(underlying.localizedDescription)'", category: .engine)
                 }
-                Self.dumpAssetTracks(item.asset, sid: sid, reason: "item.failed")
                 // Poll full errorLog on .failed (notification observer misses synchronous entries during replaceCurrentItem).
                 if let log = item.errorLog() {
                     EngineLog.emit("[NativeAVPlayerHost] #\(sid) errorLog dump: \(log.events.count) events", category: .engine)
@@ -169,27 +168,12 @@ final class NativeAVPlayerHost {
                 } else {
                     EngineLog.emit("[NativeAVPlayerHost] #\(sid) accessLog dump: <nil>", category: .engine)
                 }
-                // For HLS, asset.tracks is empty; item.tracks shows what AVPlayer built from the playlist before init.mp4 parse.
-                EngineLog.emit("[NativeAVPlayerHost] #\(sid) item.tracks count=\(item.tracks.count)", category: .engine)
-                for (idx, itrack) in item.tracks.enumerated() {
-                    let mediaType = itrack.assetTrack?.mediaType.rawValue ?? "?"
-                    let fdesc = itrack.assetTrack?.formatDescriptions.first
-                    let fourCC: String
-                    if let cm = fdesc {
-                        // swiftlint:disable:next force_cast
-                        let cmDesc = cm as! CMFormatDescription
-                        let code = CMFormatDescriptionGetMediaSubType(cmDesc)
-                        let b: [UInt8] = [
-                            UInt8((code >> 24) & 0xff),
-                            UInt8((code >> 16) & 0xff),
-                            UInt8((code >> 8) & 0xff),
-                            UInt8(code & 0xff),
-                        ]
-                        fourCC = String(bytes: b.map { ($0 >= 0x20 && $0 < 0x7f) ? $0 : 0x2e }, encoding: .ascii) ?? "????"
-                    } else {
-                        fourCC = "<no fdesc>"
-                    }
-                    EngineLog.emit("[NativeAVPlayerHost] #\(sid)   item.tracks[\(idx)] mediaType=\(mediaType) fourCC=\(fourCC) enabled=\(itrack.isEnabled)", category: .engine)
+                // AVAsset/AVAssetTrack track info is load-based + main-actor in current SDKs; dump it off
+                // the KVO callback on the main actor (HLS asset.tracks is empty; item.tracks shows what
+                // AVPlayer built from the playlist before init.mp4 parse).
+                Task { @MainActor in
+                    await Self.dumpAssetTracks(item.asset, sid: sid, reason: "item.failed")
+                    await Self.dumpFailedItemTracks(item, sid: sid)
                 }
                 EngineLog.emit("[NativeAVPlayerHost] #\(sid) item.presentationSize=\(item.presentationSize)", category: .engine)
                 EngineLog.emit("[NativeAVPlayerHost] #\(sid) item.seekableTimeRanges.count=\(item.seekableTimeRanges.count)", category: .engine)
@@ -199,8 +183,10 @@ final class NativeAVPlayerHost {
                 EngineLog.emit("[NativeAVPlayerHost] #\(sid) item.appliesPerFrameHDRDisplayMetadata=\(item.appliesPerFrameHDRDisplayMetadata)", category: .engine)
             } else if item.status == .readyToPlay {
                 // HLS: asset.tracks is empty; dump item.tracks for audio codec/layout. Route not warned yet: stereo-idle sinks (Continuous Audio off) read ch=2 until first .playing (issue #24).
-                Self.dumpPlayerItemTracks(item, sid: sid)
-                Self.dumpAudioRoute(sid: sid, phase: "readyToPlay, route may still be negotiating")
+                Task { @MainActor in
+                    await Self.dumpPlayerItemTracks(item, sid: sid)
+                    Self.dumpAudioRoute(sid: sid, phase: "readyToPlay, route may still be negotiating")
+                }
             }
 
             Task { @MainActor in
@@ -350,7 +336,7 @@ final class NativeAVPlayerHost {
 
         // Explicitly load each key separately: AVPlayerItem(asset:)+KVO was observed stuck in .unknown (build-123), and separate awaits let DrHurt's "1 success, 3 failures" pattern identify which key -1008 hits.
         let urlStr = url.absoluteString
-        Task {
+        Task { @MainActor in
             for key in ["isPlayable", "tracks", "duration"] {
                 do {
                     // Use the value returned by the async load instead of re-reading the deprecated
@@ -370,7 +356,7 @@ final class NativeAVPlayerHost {
                         EngineLog.emit("[NativeAVPlayerHost] #\(sid) asset.load(\(key)) underlying=\(underlying.domain)/\(underlying.code) '\(underlying.localizedDescription)'", category: .engine)
                     }
                     // Dump partial track info even on failure: DrHurt's -1008 stall still surfaces the FourCC (hev1 vs hvc1, dvhe vs dvh1).
-                    Self.dumpAssetTracks(asset, sid: sid, reason: "asset.load(\(key)).failed")
+                    await Self.dumpAssetTracks(asset, sid: sid, reason: "asset.load(\(key)).failed")
                     return
                 }
             }
@@ -567,11 +553,14 @@ final class NativeAVPlayerHost {
     }
 
     /// Dump asset URL + track FourCCs on .failed and asset.load failure; d9b8aa5 added the asset.load path because item.status never went .failed in DrHurt's P5 MKV session.
-    nonisolated private static func dumpAssetTracks(_ asset: AVAsset, sid: Int, reason: String) {
+    // async: AVAsset.tracks and AVAssetTrack.formatDescriptions/isEnabled/isPlayable are load-based in
+    // current SDKs (the synchronous accessors are deprecated). @MainActor (implicit on this @MainActor
+    // type) so the AVAsset/AVAssetTrack reads stay on the main actor.
+    private static func dumpAssetTracks(_ asset: AVAsset, sid: Int, reason: String) async {
         if let urlAsset = asset as? AVURLAsset {
             EngineLog.emit("[NativeAVPlayerHost] #\(sid) asset.url=\(urlAsset.url.absoluteString) (\(reason))", category: .engine)
         }
-        let tracks = asset.tracks
+        let tracks = (try? await asset.load(.tracks)) ?? []
         if tracks.isEmpty {
             EngineLog.emit("[NativeAVPlayerHost] #\(sid) asset.tracks empty (\(reason))", category: .engine)
             return
@@ -579,8 +568,7 @@ final class NativeAVPlayerHost {
         for track in tracks {
             let fourcc: String
             var extra = ""
-            if let fmt = track.formatDescriptions.first {
-                let cm = fmt as! CMFormatDescription
+            if let cm = (try? await track.load(.formatDescriptions))?.first {
                 fourcc = fourccString(CMFormatDescriptionGetMediaSubType(cm))
                 if track.mediaType == .audio {
                     extra = " " + audioFormatDescription(cm)
@@ -588,12 +576,14 @@ final class NativeAVPlayerHost {
             } else {
                 fourcc = "?"
             }
-            EngineLog.emit("[NativeAVPlayerHost] #\(sid) asset.track type=\(track.mediaType.rawValue) codec='\(fourcc)' enabled=\(track.isEnabled) playable=\(track.isPlayable)\(extra) (\(reason))", category: .engine)
+            let enabled = (try? await track.load(.isEnabled)) ?? false
+            let playable = (try? await track.load(.isPlayable)) ?? false
+            EngineLog.emit("[NativeAVPlayerHost] #\(sid) asset.track type=\(track.mediaType.rawValue) codec='\(fourcc)' enabled=\(enabled) playable=\(playable)\(extra) (\(reason))", category: .engine)
         }
     }
 
     /// Dump item.tracks at readyToPlay (HLS: asset.tracks is empty; item.tracks has the resolved list after playlist+init.mp4 parse). Channel layout tag diagnoses multichannel-routing path.
-    nonisolated private static func dumpPlayerItemTracks(_ item: AVPlayerItem, sid: Int) {
+    private static func dumpPlayerItemTracks(_ item: AVPlayerItem, sid: Int) async {
         let tracks = item.tracks
         if tracks.isEmpty {
             EngineLog.emit("[NativeAVPlayerHost] #\(sid) item.tracks empty (readyToPlay)", category: .engine)
@@ -603,8 +593,7 @@ final class NativeAVPlayerHost {
             guard let assetTrack = itemTrack.assetTrack else { continue }
             let fourcc: String
             var extra = ""
-            if let fmt = assetTrack.formatDescriptions.first {
-                let cm = fmt as! CMFormatDescription
+            if let cm = (try? await assetTrack.load(.formatDescriptions))?.first {
                 fourcc = fourccString(CMFormatDescriptionGetMediaSubType(cm))
                 if assetTrack.mediaType == .audio {
                     extra = " " + audioFormatDescription(cm)
@@ -631,6 +620,34 @@ final class NativeAVPlayerHost {
     }
 
     /// Compact video track summary: dimensions + color attachments (primaries/transfer/matrix). Mismatch vs source-side codecpar signals DV/HDR signaling didn't survive the muxer.
+    /// Dump item.tracks on .failed (FourCC per track). Async: AVAssetTrack.formatDescriptions is
+    /// load-based; assetTrack access is main-actor.
+    private static func dumpFailedItemTracks(_ item: AVPlayerItem, sid: Int) async {
+        EngineLog.emit("[NativeAVPlayerHost] #\(sid) item.tracks count=\(item.tracks.count)", category: .engine)
+        for (idx, itrack) in item.tracks.enumerated() {
+            let assetTrack = itrack.assetTrack
+            let mediaType = assetTrack?.mediaType.rawValue ?? "?"
+            var fdesc: CMFormatDescription?
+            if let assetTrack {
+                fdesc = (try? await assetTrack.load(.formatDescriptions))?.first
+            }
+            let fourCC: String
+            if let cm = fdesc {
+                let code = CMFormatDescriptionGetMediaSubType(cm)
+                let b: [UInt8] = [
+                    UInt8((code >> 24) & 0xff),
+                    UInt8((code >> 16) & 0xff),
+                    UInt8((code >> 8) & 0xff),
+                    UInt8(code & 0xff),
+                ]
+                fourCC = String(bytes: b.map { ($0 >= 0x20 && $0 < 0x7f) ? $0 : 0x2e }, encoding: .ascii) ?? "????"
+            } else {
+                fourCC = "<no fdesc>"
+            }
+            EngineLog.emit("[NativeAVPlayerHost] #\(sid)   item.tracks[\(idx)] mediaType=\(mediaType) fourCC=\(fourCC) enabled=\(itrack.isEnabled)", category: .engine)
+        }
+    }
+
     nonisolated private static func videoFormatDescription(_ fmt: CMFormatDescription) -> String {
         var parts: [String] = []
         let dims = CMVideoFormatDescriptionGetDimensions(fmt)

--- a/Sources/AetherEngine/Native/NativeAVPlayerHost.swift
+++ b/Sources/AetherEngine/Native/NativeAVPlayerHost.swift
@@ -272,9 +272,12 @@ final class NativeAVPlayerHost {
             object: item,
             queue: .main
         ) { [weak self] _ in
-            guard let self = self, let event = self.playerItem?.errorLog()?.events.last else { return }
-            let comment = event.errorComment ?? "no comment"
-            EngineLog.emit("[NativeAVPlayerHost] #\(sid) errorLog code=\(event.errorStatusCode) domain=\(event.errorDomain) uri=\(event.uri ?? "-") '\(comment)'", category: .engine)
+            // Delivered on .main (queue: .main above), so assert MainActor to reach @MainActor state.
+            MainActor.assumeIsolated {
+                guard let self = self, let event = self.playerItem?.errorLog()?.events.last else { return }
+                let comment = event.errorComment ?? "no comment"
+                EngineLog.emit("[NativeAVPlayerHost] #\(sid) errorLog code=\(event.errorStatusCode) domain=\(event.errorDomain) uri=\(event.uri ?? "-") '\(comment)'", category: .engine)
+            }
         }
         notificationObservers.append(errLogObs)
 
@@ -284,11 +287,14 @@ final class NativeAVPlayerHost {
             object: item,
             queue: .main
         ) { [weak self] _ in
-            guard let self = self,
-                  self.accessLogCount < 5,
-                  let event = self.playerItem?.accessLog()?.events.last else { return }
-            self.accessLogCount += 1
-            EngineLog.emit("[NativeAVPlayerHost] #\(sid) accessLog uri=\(event.uri ?? "-") server=\(event.serverAddress ?? "-") bytes=\(event.numberOfBytesTransferred) reqs=\(event.numberOfMediaRequests)", category: .engine)
+            // Delivered on .main (queue: .main above), so assert MainActor to reach @MainActor state.
+            MainActor.assumeIsolated {
+                guard let self = self,
+                      self.accessLogCount < 5,
+                      let event = self.playerItem?.accessLog()?.events.last else { return }
+                self.accessLogCount += 1
+                EngineLog.emit("[NativeAVPlayerHost] #\(sid) accessLog uri=\(event.uri ?? "-") server=\(event.serverAddress ?? "-") bytes=\(event.numberOfBytesTransferred) reqs=\(event.numberOfMediaRequests)", category: .engine)
+            }
         }
         notificationObservers.append(accessLogObs)
 
@@ -347,18 +353,14 @@ final class NativeAVPlayerHost {
         Task {
             for key in ["isPlayable", "tracks", "duration"] {
                 do {
-                    switch key {
-                    case "isPlayable": _ = try await asset.load(.isPlayable)
-                    case "tracks":     _ = try await asset.load(.tracks)
-                    case "duration":   _ = try await asset.load(.duration)
-                    default: continue
-                    }
+                    // Use the value returned by the async load instead of re-reading the deprecated
+                    // synchronous accessor (asset.isPlayable / .tracks / .duration).
                     let detail: String
                     switch key {
-                    case "isPlayable": detail = "value=\(asset.isPlayable)"
-                    case "tracks":     detail = "count=\(asset.tracks.count)"
-                    case "duration":   detail = "seconds=\(asset.duration.seconds)"
-                    default: detail = "-"
+                    case "isPlayable": detail = "value=\(try await asset.load(.isPlayable))"
+                    case "tracks":     detail = "count=\(try await asset.load(.tracks).count)"
+                    case "duration":   detail = "seconds=\(try await asset.load(.duration).seconds)"
+                    default: continue
                     }
                     EngineLog.emit("[NativeAVPlayerHost] #\(sid) asset.load(\(key)) ok url=\(urlStr) \(detail)", category: .engine)
                 } catch {
@@ -565,7 +567,7 @@ final class NativeAVPlayerHost {
     }
 
     /// Dump asset URL + track FourCCs on .failed and asset.load failure; d9b8aa5 added the asset.load path because item.status never went .failed in DrHurt's P5 MKV session.
-    private static func dumpAssetTracks(_ asset: AVAsset, sid: Int, reason: String) {
+    nonisolated private static func dumpAssetTracks(_ asset: AVAsset, sid: Int, reason: String) {
         if let urlAsset = asset as? AVURLAsset {
             EngineLog.emit("[NativeAVPlayerHost] #\(sid) asset.url=\(urlAsset.url.absoluteString) (\(reason))", category: .engine)
         }
@@ -591,7 +593,7 @@ final class NativeAVPlayerHost {
     }
 
     /// Dump item.tracks at readyToPlay (HLS: asset.tracks is empty; item.tracks has the resolved list after playlist+init.mp4 parse). Channel layout tag diagnoses multichannel-routing path.
-    private static func dumpPlayerItemTracks(_ item: AVPlayerItem, sid: Int) {
+    nonisolated private static func dumpPlayerItemTracks(_ item: AVPlayerItem, sid: Int) {
         let tracks = item.tracks
         if tracks.isEmpty {
             EngineLog.emit("[NativeAVPlayerHost] #\(sid) item.tracks empty (readyToPlay)", category: .engine)
@@ -629,7 +631,7 @@ final class NativeAVPlayerHost {
     }
 
     /// Compact video track summary: dimensions + color attachments (primaries/transfer/matrix). Mismatch vs source-side codecpar signals DV/HDR signaling didn't survive the muxer.
-    private static func videoFormatDescription(_ fmt: CMFormatDescription) -> String {
+    nonisolated private static func videoFormatDescription(_ fmt: CMFormatDescription) -> String {
         var parts: [String] = []
         let dims = CMVideoFormatDescriptionGetDimensions(fmt)
         parts.append("dim=\(dims.width)x\(dims.height)")
@@ -732,7 +734,7 @@ final class NativeAVPlayerHost {
     }
 
     /// Dump audio route channel capability post-load (route renegotiates on asset load; pre-load poll is stale). outputNumberOfChannels is the actual LPCM limit; EAC3/Atmos bypasses it via bitstream tunnel.
-    private static func dumpAudioRoute(sid: Int, phase: String) {
+    nonisolated private static func dumpAudioRoute(sid: Int, phase: String) {
         #if os(iOS) || os(tvOS)
         let session = AVAudioSession.sharedInstance()
         let out = session.outputNumberOfChannels
@@ -754,7 +756,7 @@ final class NativeAVPlayerHost {
     }
 
     /// Read sr/ch/bits/layoutTag from CMAudioFormatDescription. Layout tag diagnoses where downmix occurs: unknown/stereo tag = AVPlayer parse layer; correct 7.1 tag = route/soundbar layer.
-    private static func audioFormatDescription(_ fmt: CMFormatDescription) -> String {
+    nonisolated private static func audioFormatDescription(_ fmt: CMFormatDescription) -> String {
         var parts: [String] = []
         if let asbdPtr = CMAudioFormatDescriptionGetStreamBasicDescription(fmt) {
             let asbd = asbdPtr.pointee

--- a/Sources/AetherEngine/Native/SoftwarePlaybackHost.swift
+++ b/Sources/AetherEngine/Native/SoftwarePlaybackHost.swift
@@ -491,8 +491,8 @@ final class SoftwarePlaybackHost {
         let tbSec = pkt.isVideo ? videoTimeBaseSeconds : audioTimeBaseSeconds
         guard tbSec > 0, !pkt.bytes.isEmpty else { return false }
 
-        guard var avPkt: UnsafeMutablePointer<AVPacket>? = trackedPacketAlloc(),
-              let p = avPkt else { return false }
+        guard let p = trackedPacketAlloc() else { return false }
+        var avPkt: UnsafeMutablePointer<AVPacket>? = p
         defer { trackedPacketFree(&avPkt) }
 
         if av_new_packet(p, Int32(pkt.bytes.count)) < 0 { return false }

--- a/Sources/AetherEngine/Video/PacketRingBuffer.swift
+++ b/Sources/AetherEngine/Video/PacketRingBuffer.swift
@@ -1,7 +1,9 @@
 import Foundation
 
 /// Keyframe-indexed disk-spooled DVR ring buffer. Eviction is keyframe-aligned (retained span always starts at a decodable keyframe). Bytes stored as flat files under a scratch dir; in-RAM index holds only metadata; `Data(contentsOf:,.alwaysMapped)` keeps RSS flat. NSLock guards the index (demux-thread appends, seek-thread reads).
-final class PacketRingBuffer {
+// Thread-safe: all mutable state is guarded by `lock` (NSLock), so it is safe to share across the
+// demux/seek/feeder threads and capture in @Sendable closures.
+final class PacketRingBuffer: @unchecked Sendable {
 
     // MARK: - Public types
 

--- a/Sources/AetherEngine/Video/SegmentCache.swift
+++ b/Sources/AetherEngine/Video/SegmentCache.swift
@@ -5,7 +5,9 @@ import Foundation
 /// Reads use .alwaysMapped (kernel pages in/out under memory pressure). Window:
 /// [currentTargetIndex - backwardWindow, currentTargetIndex + forwardWindow].
 /// The producer pauses via awaitFetchHighWater once forwardWindow ahead of target.
-final class SegmentCache {
+// Thread-safe: all mutable state is guarded by `condition` (NSCondition), so it is safe to share
+// across the producer/provider threads and capture in @Sendable closures.
+final class SegmentCache: @unchecked Sendable {
 
     private let condition = NSCondition()
 


### PR DESCRIPTION
Behavior-preserving warning cleanup. AetherEngine now builds with **zero warnings** under `swift build -Xswiftc -strict-concurrency=complete` (was 27 unique).

- Mark PacketRingBuffer / SegmentCache `@unchecked Sendable` (both fully lock-guarded) and VideoDecodingPipeline `Sendable` (conformers already @unchecked Sendable) -> clears the non-Sendable @Sendable-closure capture warnings (ring / cacheRef / vDec).
- NativeAVPlayerHost: `MainActor.assumeIsolated` in the two `queue:.main` observers; diagnostic track-dumps refactored to `@MainActor async` with `await load(.x)` (AVAsset/AVAssetTrack sync accessors are deprecated + main-actor-isolated), dispatched from MainActor Tasks; asset.load diagnostic uses the awaited value.
- FFmpegLogBridge: `String(decoding:as:)` instead of deprecated `String(cString:)`.
- SoftwarePlaybackHost: drop a redundant optional annotation that made a guard-let always succeed.

Only behavioral nuance: the NativeAVPlayerHost track-info **diagnostic log lines** now emit asynchronously (slightly later / reordered vs surrounding sync lines); content unchanged, no playback path affected.

Verified: 79 unit tests pass, strict + normal build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)