### PR TITLE
fix(hls): prime mp4 moov with a parsed audio packet on backward-seek muxer restart (#92)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ the public-API contract.
 
 ## [Unreleased]
 
+### Fixed
+
+- **E-AC-3/AC-3/TrueHD no longer wedge the fragmented-mp4 muxer on an out-of-cache backward seek (#94).** Under `+delay_moov` the mp4 muxer writes `moov` lazily on the first flush, and for AC-3/E-AC-3/TrueHD the audio sample entry (`dac3`/`dec3`/`dmlp`) can only be built from a parsed audio packet — so a first `moov` flush that fires video-only errors `-22` ("Cannot write moov atom before EAC3 packets parsed"), the segment cut fails, and the fresh muxer the producer builds at a backward-seek restart is retried forever (AVPlayer 503 → forever-loading spinner). `MP4SegmentMuxer` now latches at init whether the audio codec needs a parsed packet and, scoped to those codecs only, guards the #64 RAM-cap interim flush and proactively primes `moov` with the first audio packet. AAC and every other codec keep the stock path (no early flush, full RAM-cap bound), so there is no audio-dropout regression.
+
 ## [4.8.0] - 2026-06-30
 
 ### Added

--- a/Sources/AetherEngine/Video/MP4SegmentMuxer.swift
+++ b/Sources/AetherEngine/Video/MP4SegmentMuxer.swift
@@ -130,6 +130,17 @@ final class MP4SegmentMuxer {
     /// +delay_moov: first cut may need a second av_write_frame(nil) because FFmpeg can split
     /// ftyp+moov and moof+mdat across calls; gate ensures it only fires once.
     private var moovFlushed: Bool = false
+    /// EAC3/AC-3 moov-wedge guard (#92 follow-up): latched once the first audio packet is written so
+    /// the first moov flush can never fire before FFmpeg has parsed an audio packet — mov_write_moov
+    /// builds the E-AC-3 `dec3` / AC-3 `dac3` (and TrueHD `dmlp`) sample-entry box from a parsed packet,
+    /// and flushing moov video-only errors -22 "Cannot write moov atom before EAC3 packets parsed" and
+    /// wedges the muxer.
+    private var audioPacketWritten: Bool = false
+    /// True only when the audio codec's mp4 sample entry requires a PARSED packet before moov can be
+    /// written (AC-3 `dac3`, E-AC-3 `dec3`, TrueHD `dmlp`). AAC and other codecs build their sample entry
+    /// from codecpar alone, so they never wedge — and gating the #64 RAM-cap flush on them would needlessly
+    /// weaken that memory bound. Latched at init from the audio codec_id.
+    private let audioNeedsParsedPacketForMoov: Bool
     /// Latched when the next staging file open fails; producer must stop the pump.
     private(set) var isWedged: Bool = false
     /// Latched after avformat_write_header; mp4 muxer rewrites time_base to its own pick
@@ -178,6 +189,16 @@ final class MP4SegmentMuxer {
         self.currentSegmentIndex = initialSegmentIndex
         self.sessionDir = sessionDir
         self.haveAudio = audio != nil
+        // Only AC-3 / E-AC-3 / TrueHD build their mp4 sample entry from a parsed packet (dac3/dec3/dmlp),
+        // so only they can hit the "moov before audio parsed" wedge and need the #64-flush guard.
+        if let audioCodecID = audio?.codecpar.pointee.codec_id {
+            self.audioNeedsParsedPacketForMoov =
+                audioCodecID == AV_CODEC_ID_AC3 ||
+                audioCodecID == AV_CODEC_ID_EAC3 ||
+                audioCodecID == AV_CODEC_ID_TRUEHD
+        } else {
+            self.audioNeedsParsedPacketForMoov = false
+        }
 
         let firstPath = Self.stagingPath(forSegmentIndex: initialSegmentIndex,
                                          in: sessionDir)
@@ -515,12 +536,14 @@ final class MP4SegmentMuxer {
         packet.pointee.pts = clean.pts
         packet.pointee.dts = clean.dts
 
+        let streamIndex = packet.pointee.stream_index
+
         // #64 mid-segment flush bound: cap libavformat's interleaver RAM on a very long segment
         // (degenerate sparse-keyframe plan, or an audio stream that decodes to nothing) by emitting a
         // moof+mdat into the current staging file before the buffered span grows without bound. Tracked
         // on the video output stream only; audio/subtitle packets ride along and are force-drained by the
         // flush. Flush BEFORE writing the triggering packet so it opens a fresh window.
-        if packet.pointee.stream_index == videoOutputStreamIndex, packet.pointee.dts != Int64.min {
+        if streamIndex == videoOutputStreamIndex, packet.pointee.dts != Int64.min {
             let dts = packet.pointee.dts
             if fragmentWindowFirstVideoDts == Int64.min {
                 fragmentWindowFirstVideoDts = dts
@@ -537,7 +560,33 @@ final class MP4SegmentMuxer {
         // av_write_frame was tried as a leak hypothesis; no impact on 8 MB/s mallocMB growth
         // (leak was Data(d) dispatch_data aliasing in AVIOReader). Reverted to interleaved for
         // cross-stream DTS monotonicity and audio+video re-ordering via libavformat.
-        return av_interleaved_write_frame(ctx, packet)
+        let rc = av_interleaved_write_frame(ctx, packet)
+
+        // EAC3/AC-3/TrueHD moov-wedge guard (#92 follow-up). Under +delay_moov the first fragment flush
+        // writes moov lazily, and FFmpeg's mp4 muxer can only build the AC-3/E-AC-3/TrueHD dac3/dec3/dmlp
+        // sample-entry box once it has PARSED an audio packet. On a mid-file backward seek the producer
+        // tears down and rebuilds a FRESH muxer at the restart segment; if that muxer's first moov flush
+        // (a #64 RAM-cap flush, or the first segment cut) fires before any audio packet is written,
+        // mov_write_moov errors -22 "Cannot write moov atom before EAC3 packets parsed", the cut fails, and
+        // the segment is retried forever (AVPlayer 503 -> forever-loading). AAC never hits this (its sample
+        // entry needs no parsed packet). Fix has two parts: (1) latch that an audio packet has been written;
+        // (2) in the video-leads-audio case — the first audio packet arrives after a video packet is already
+        // in the fragment window — proactively flush so moov is emitted WITH a parsed audio packet present
+        // rather than waiting for the first cut. In the common backward-seek path the #74 pregate buffer
+        // replays captured audio BEFORE the first video look-behind packet, so fragmentWindowFirstVideoDts
+        // is still unset here and this proactive arm is skipped — moov is instead primed correctly at the
+        // first cut, which already holds the audio in the interleaver. Idempotent once moovFlushed. Audio
+        // routing/placement is untouched, so no audio dropouts. The proactive flush is scoped to
+        // AC-3/E-AC-3/TrueHD (audioNeedsParsedPacketForMoov): AAC (and every other codec) never wedges and
+        // must keep the exact stock code path — no extra early fragment flush — so nothing perturbs its audio.
+        if streamIndex == audioOutputStreamIndex {
+            audioPacketWritten = true
+            if audioNeedsParsedPacketForMoov, !moovFlushed, fragmentWindowFirstVideoDts != Int64.min {
+                flushPendingFragment()
+            }
+        }
+
+        return rc
     }
 
     /// Emit a moof+mdat for everything buffered into the CURRENT staging file, without rotating the fd or
@@ -546,6 +595,14 @@ final class MP4SegmentMuxer {
     /// ftyp+moov under +delay_moov, populating init.mp4 early instead of only at the (far-off) first cut.
     private func flushPendingFragment() {
         guard let ctx = formatContext, headerWritten, fd >= 0 else { return }
+        // EAC3/AC-3/TrueHD moov-wedge guard (#92 follow-up): never let a video-only flush emit moov while
+        // an audio stream whose sample entry needs a parsed packet is declared but no audio packet has been
+        // written yet — mov_write_moov needs a parsed AC-3/E-AC-3/TrueHD packet for its dac3/dec3/dmlp box
+        // (see writePacket). Scoped to those codecs so AAC (which never wedges) keeps the full #64 RAM-cap
+        // bound. Skipping an interim #64 RAM-cap flush is harmless (the interleaver window just grows a
+        // little longer); the first audio packet primes moov here or at the first cut (which already holds
+        // the audio in the interleaver).
+        if audioNeedsParsedPacketForMoov, !audioPacketWritten, !moovFlushed { return }
         _ = av_interleaved_write_frame(ctx, nil)
         _ = av_write_frame(ctx, nil)
         if !moovFlushed {


### PR DESCRIPTION
## Summary

Follow-up to #92. Fixes an E-AC-3/AC-3 (and TrueHD) **moov-before-audio-parsed wedge** that can strand the fragmented-mp4 muxer in a permanent "forever-loading" state after a mid-file **backward seek** that lands out of the segment cache.

## Root cause

`MP4SegmentMuxer` runs one long-lived mp4 `AVFormatContext` with `+empty_moov+default_base_moof+frag_custom+delay_moov`. Under `+delay_moov`, `moov` is written lazily on the first `av_write_frame(ctx, nil)`.

FFmpeg's mp4 muxer builds the AC-3/E-AC-3/TrueHD sample-entry box (`dac3`/`dec3`/`dmlp`) from a **parsed audio packet** — it cannot emit `moov` for these codecs from `codecpar` alone (see `movenc.c` `mov_write_dec3_tag` / `handle_eac3`). So if the first `moov` flush fires **video-only**, `mov_write_moov` returns `-22`:

```
Cannot write moov atom before EAC3 packets parsed.
```

The cut then fails, the muxer wedges, and the segment is retried forever -> AVPlayer 503 -> forever-loading spinner.

On a backward seek out of cache, the producer rebuilds a **fresh** muxer at the restart segment. If that muxer's first `moov` flush -- either the `#64` RAM-cap interim `flushPendingFragment()` or the first segment cut -- fires before any audio packet is written, it hits this. **AAC never triggers it** (its sample entry needs no parsed packet).

## What changed

- Latch `audioPacketWritten` once the first audio packet is written.
- Latch `audioNeedsParsedPacketForMoov` at init from the audio `codec_id` (AC-3/E-AC-3/TrueHD) — the only codecs whose sample entry needs a parsed packet.
- Gate the `#64` RAM-cap interim `flushPendingFragment()` on those latches, so AAC (and every other codec) keeps its full RAM-cap bound and the stock code path.
- In the video-leads-audio case, for those codecs only, proactively flush on the first audio packet so `moov` is emitted with a parsed audio packet present.

The **first segment cut is intentionally left unguarded**: if audio never arrives, `moov` must still be attempted (fail-as-before) rather than deferred forever -- guarding the cut too would convert the wedge into a *guaranteed* permanent stall. Audio routing/placement is untouched (no dropout regression).

## Reproducibility (honest caveat)

This is **hard to reproduce on demand** and I could not capture a live before/after. The original triggering file's identity was lost (temp log GC'd). On the unpatched build, the closest-duration-match E-AC-3/HEVC file played through **93 producer restarts / 50 out-of-cache backward seeks with zero wedges**, because in the normal seek path audio reaches the interleaver 4-30 ms after each restart and beats the first cut. The wedge needs the narrow case where a full segment of video (coarse interleave) or an audio-absent region precedes the first audio packet at the restart point.

So I am offering this as a **low-risk guard against a real, mechanism-confirmed crash class** -- it can only reduce the wedge surface and does not alter the healthy path. Happy to adjust or hold if you would prefer an issue-first discussion.

## Test plan

- **Device / OS:** Apple TV 4K (3rd generation, AppleTV14,1), tvOS 27.0 (build 24J5305f)
- **Source media:** HEVC video + E-AC-3 (Dolby Digital Plus) audio, delivered through the host app's in-process loopback HLS (AetherEngine on tvOS)
- **Result:** On the patched build, repeated out-of-cache backward seeks across ~50 producer restarts play through with no muxer wedge / forever-loading spinner and **no audio dropout**; AAC playback is unchanged (stock path). Host `swift build` and the tvOS device build both pass. See the Reproducibility caveat above — the wedge could not be reproduced on demand even on the *unpatched* build, so this is a mechanism-confirmed guard rather than a captured before/after.

Verification detail:
- Mechanism independently verified against FFmpeg `movenc.c` (the `dec3`/`dac3` refusal path) and against the vendored `Libavformat.xcframework` binary strings.
- Confirmed a fresh `MP4SegmentMuxer` is allocated per restart (the latches reset correctly), the change is single-threaded on the producer's serial pump queue, and audio routing/placement is untouched.

## Checklist

- [x] `CHANGELOG.md` updated
- [x] Commit messages follow Conventional Commits (`fix(hls):`, `docs(changelog):`)
- [x] The fix lives in the engine, not in a host-side workaround
- [x] No public API changes (the two new muxer latches are `internal`/`private`)
