### PR TITLE
fix(smb): NWConnection-based SMBClient so SMB works on tvOS/iOS

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,21 +1,12 @@
 {
-  "originHash" : "fc22b962aa887705ec43c3de0be41a17c77ade62cad323b0c9ef0d88ae10faf6",
+  "originHash" : "159958c403e07fd446f641ae63b76a1080ff31cc2612f8d2d44ae89397a2c074",
   "pins" : [
-    {
-      "identity" : "amsmb2",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/amosavian/AMSMB2",
-      "state" : {
-        "revision" : "1726aaaf7adf63d7d1d2a0c5d1b0e635028215c0",
-        "version" : "4.0.3"
-      }
-    },
     {
       "identity" : "ffmpegbuild",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/superuser404notfound/FFmpegBuild",
       "state" : {
-        "revision" : "86d985a790cc32b5b9e03d5971c21b6cc6373c60",
+        "revision" : "5329cdd58d000373fc85fd19dc30ddceac6a4985",
         "version" : "1.0.3"
       }
     },
@@ -26,6 +17,15 @@
       "state" : {
         "revision" : "bebab0af0e3633b0002fcc7106ea6fc7ceea8277",
         "version" : "1.0.2"
+      }
+    },
+    {
+      "identity" : "smbclient",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kishikawakatsumi/SMBClient",
+      "state" : {
+        "revision" : "e636c2b2458930770932a36d311ec9d478575b90",
+        "version" : "0.3.1"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -30,7 +30,9 @@ let package = Package(
         // Resolved over Git rather than a local path so consumers (and
         // Xcode Cloud) can build without a sibling FFmpegBuild checkout.
         .package(url: "https://github.com/superuser404notfound/FFmpegBuild", from: "1.0.1"),  // 1.0.2: FFmpeg n8.1.2 + dca_core bitstream filter (#64)
-        .package(url: "https://github.com/amosavian/AMSMB2", from: "4.0.3"),
+        // Pure-Swift SMB2 client (MIT) that speaks the protocol over
+        // NWConnection. Replaces AMSMB2/libsmb2, which EPERMs on tvOS/iOS.
+        .package(url: "https://github.com/kishikawakatsumi/SMBClient", from: "0.3.1"),
         // libdovi (Dolby Vision RPU parser/converter). Resolved over Git like
         // FFmpegBuild so consumers (and Xcode Cloud) build without a sibling
         // LibDovi checkout; the prebuilt xcframework needs no Rust at build time.
@@ -56,7 +58,7 @@ let package = Package(
             name: "AetherEngineSMB",
             dependencies: [
                 "AetherEngine",
-                .product(name: "AMSMB2", package: "AMSMB2"),
+                .product(name: "SMBClient", package: "SMBClient"),
             ],
             path: "Sources/AetherEngineSMB"
         ),

--- a/Package.swift
+++ b/Package.swift
@@ -32,7 +32,9 @@ let package = Package(
         .package(url: "https://github.com/superuser404notfound/FFmpegBuild", from: "1.0.1"),  // 1.0.2: FFmpeg n8.1.2 + dca_core bitstream filter (#64)
         // Pure-Swift SMB2 client (MIT) that speaks the protocol over
         // NWConnection. Replaces AMSMB2/libsmb2, which EPERMs on tvOS/iOS.
-        .package(url: "https://github.com/kishikawakatsumi/SMBClient", from: "0.3.1"),
+        // Pinned to the 0.3.x minor: SMBClient is pre-1.0 with an actively
+        // moving API, so allow patch updates but not a minor bump.
+        .package(url: "https://github.com/kishikawakatsumi/SMBClient", .upToNextMinor(from: "0.3.1")),
         // libdovi (Dolby Vision RPU parser/converter). Resolved over Git like
         // FFmpegBuild so consumers (and Xcode Cloud) build without a sibling
         // LibDovi checkout; the prebuilt xcframework needs no Rust at build time.

--- a/README.md
+++ b/README.md
@@ -213,6 +213,8 @@ try await engine.load(source: .custom(SMBIOReader(source: smb), formatHint: "mat
 
 Read-only, NTLMv2 / guest auth (no Kerberos). On tvOS the host must declare `NSLocalNetworkUsageDescription` + the local-network entitlement to reach a LAN share. See [`aetherctl smbtest`](docs/cli.md#smbtest) to validate a share from macOS.
 
+Known limitation: SMBClient negotiates only SMB 2.0.2 and 2.1, so there is no SMB3 transport encryption or AES-CMAC signing. Servers configured SMB3-only or with `smb encrypt = required` won't connect (libsmb2 spoke 3.1.1 here, but was itself unusable on tvOS/iOS — see above).
+
 ### Live TV / DVR
 
 ```swift

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Seekable readers support audio-track switching and background reload; embedded s
 
 #### SMB shares (optional `AetherEngineSMB` product)
 
-Playing media off an SMB2/3 share is a ready-made `IOReader`, shipped as a separate product so the SMB dependency ([AMSMB2](https://github.com/amosavian/AMSMB2), LGPL-2.1) only enters consumers that opt in. Add the `AetherEngineSMB` product alongside `AetherEngine`; hosts that do not need SMB link only the core and never pull libsmb2.
+Playing media off an SMB2/3 share is a ready-made `IOReader`, shipped as a separate product so the SMB dependency ([SMBClient](https://github.com/kishikawakatsumi/SMBClient), MIT — pure Swift, `NWConnection`-based) only enters consumers that opt in. Add the `AetherEngineSMB` product alongside `AetherEngine`; hosts that do not need SMB link only the core. The transport is pure Swift over Network.framework rather than libsmb2, which fails with `EPERM` on tvOS/iOS.
 
 ```swift
 import AetherEngineSMB

--- a/Sources/AetherEngineSMB/AetherEngineSMB.swift
+++ b/Sources/AetherEngineSMB/AetherEngineSMB.swift
@@ -1,6 +1,7 @@
 // AetherEngineSMB: opt-in SMB2/3 byte source for AetherEngine.
-// Depends on AMSMB2 (libsmb2, LGPL-2.1). Linked only by consumers that
-// link the AetherEngineSMB product; never enters the core engine binary.
+// Transport is kishikawakatsumi/SMBClient (pure-Swift, MIT, NWConnection-based),
+// linked only by consumers that link the AetherEngineSMB product; it never
+// enters the core engine binary.
 
 /// Marker for the AetherEngineSMB module version surface.
 public enum AetherEngineSMB {

--- a/Sources/AetherEngineSMB/SMBConnection.swift
+++ b/Sources/AetherEngineSMB/SMBConnection.swift
@@ -1,52 +1,84 @@
 import Foundation
-import AMSMB2
+import SMBClient
 
-/// A read-only SMB2/3 byte source over one share + file path, backed by AMSMB2.
-/// There is no public persistent file handle in AMSMB2, so each `read` issues a
-/// fresh `contents(atPath:range:)` that opens/seeks/closes internally.
+/// A read-only SMB2/3 byte source over one share + file path.
+///
+/// The transport is [kishikawakatsumi/SMBClient](https://github.com/kishikawakatsumi/SMBClient):
+/// a pure-Swift SMB2 client that speaks the wire protocol over `NWConnection`
+/// (Network.framework). This replaces the previous AMSMB2/libsmb2 backend, which
+/// failed with POSIX `EPERM` ("Operation not permitted") on the very first
+/// `connectShare` on tvOS (and iOS) — a known, long-standing libsmb2 issue on
+/// those platforms (AMSMB2 #32/#63/#64). A raw `NWConnection` to port 445
+/// completes a full SMB2 handshake on the same device, so an `NWConnection`-based
+/// client works where libsmb2 does not. The public surface here is unchanged, so
+/// `SMBIOReader`, `SMBURL`, and existing callers are untouched.
+///
+/// Concurrency: reads are driven one at a time on the engine's demux thread via
+/// `SMBIOReader`'s semaphore, and `SMBClient`'s `Connection` serialises each
+/// request/response round-trip internally, so `@unchecked Sendable` is safe for
+/// this access pattern (as it was for the AMSMB2 backend).
 public final class SMBConnection: ByteRangeSource, @unchecked Sendable {
     public struct SMBError: Error { public let message: String }
 
-    private let client: SMB2Manager
-    private let path: String
+    private let client: SMBClient
+    private let reader: FileReader
     public let byteSize: Int64
 
-    private init(client: SMB2Manager, path: String, byteSize: Int64) {
+    private init(client: SMBClient, reader: FileReader, byteSize: Int64) {
         self.client = client
-        self.path = path
+        self.reader = reader
         self.byteSize = byteSize
     }
 
-    /// Connect, authenticate (NTLMv2 / guest), tree-connect to `share`, and
-    /// stat `path` for its size. `server` is e.g. `smb://host` or `smb://host:445`.
+    /// Connect, authenticate (NTLMv2 / guest / anonymous), tree-connect to
+    /// `share`, open `path` read-only, and stat it for its size. `server` is
+    /// e.g. `smb://host` or `smb://host:445`.
     public static func connect(
         server: URL, share: String, path: String,
         user: String, password: String, domain: String = ""
     ) async throws -> SMBConnection {
-        let credential = URLCredential(
-            user: user, password: password, persistence: .forSession
-        )
-        guard let client = SMB2Manager(url: server, domain: domain, credential: credential) else {
-            throw SMBError(message: "SMB2Manager init failed for \(server.absoluteString)")
+        guard let host = server.host, !host.isEmpty else {
+            throw SMBError(message: "no host in \(server.absoluteString)")
         }
-        try await client.connectShare(name: share)
+        let client = server.port.map { SMBClient(host: host, port: $0) }
+            ?? SMBClient(host: host)
 
-        let attrs = try await client.attributesOfItem(atPath: path)
-        guard let size = attrs[.fileSizeKey] as? Int64 ?? (attrs[.fileSizeKey] as? Int).map(Int64.init) else {
-            throw SMBError(message: "no fileSizeKey for \(path)")
+        // An empty username means "no explicit account": try guest first, then
+        // fall back to a fully anonymous NTLM session if the server rejects it.
+        // This mirrors the guest/anonymous behaviour of the previous backend.
+        let account = user.isEmpty ? nil : user
+        let secret = password.isEmpty ? nil : password
+        let realm = domain.isEmpty ? nil : domain
+        do {
+            try await client.login(username: account ?? "guest", password: secret, domain: realm)
+        } catch {
+            try await client.login(username: nil, password: nil)
         }
-        return SMBConnection(client: client, path: path, byteSize: size)
+
+        try await client.connectShare(share)
+
+        let reader = client.fileReader(path: path)
+        let size = try await reader.fileSize
+        guard size > 0 else {
+            throw SMBError(message: "SMB file has zero size or could not be stat'd: \(path)")
+        }
+        return SMBConnection(client: client, reader: reader, byteSize: Int64(size))
     }
 
     public func read(at offset: Int64, length: Int) async throws -> Data {
-        guard length > 0, offset < byteSize else { return Data() }
+        guard length > 0, offset >= 0, offset < byteSize else { return Data() }
         let upper = min(offset &+ Int64(length), byteSize)
-        return try await client.contents(atPath: path, range: offset..<upper)
+        let want = UInt32(truncatingIfNeeded: upper - offset)
+        return try await reader.read(offset: UInt64(offset), length: want)
     }
 
     public func close() {
-        // Fire-and-forget disconnect; AMSMB2 has no synchronous close.
+        // Fire-and-forget teardown; SMBClient's close/logoff are async.
+        let reader = self.reader
         let client = self.client
-        Task { try? await client.disconnectShare() }
+        Task {
+            try? await reader.close()
+            try? await client.logoff()
+        }
     }
 }

--- a/Sources/AetherEngineSMB/SMBConnection.swift
+++ b/Sources/AetherEngineSMB/SMBConnection.swift
@@ -46,23 +46,38 @@ public final class SMBConnection: ByteRangeSource, @unchecked Sendable {
         // An empty username means "no explicit account": try guest first, then
         // fall back to a fully anonymous NTLM session if the server rejects it.
         // This mirrors the guest/anonymous behaviour of the previous backend.
+        // The fallback is scoped to the no-account case (`account == nil`): when
+        // an explicit username was supplied, a login failure is a real auth
+        // error and must propagate rather than silently downgrading to an
+        // anonymous session. Callers signal "no account" with an empty username
+        // (see `SMBURL`, which leaves an omitted user empty rather than
+        // substituting "guest" — otherwise this fallback could never fire).
         let account = user.isEmpty ? nil : user
         let secret = password.isEmpty ? nil : password
         let realm = domain.isEmpty ? nil : domain
+
+        // `login` negotiates and opens the NWConnection before it can throw, so
+        // any failure past this point leaves a live socket. Tear it down before
+        // rethrowing so failed connects don't leak a connection until dealloc.
         do {
-            try await client.login(username: account ?? "guest", password: secret, domain: realm)
+            do {
+                try await client.login(username: account ?? "guest", password: secret, domain: realm)
+            } catch where account == nil {
+                try await client.login(username: nil, password: nil)
+            }
+
+            try await client.connectShare(share)
+
+            let reader = client.fileReader(path: path)
+            let size = try await reader.fileSize
+            guard size > 0 else {
+                throw SMBError(message: "SMB file has zero size or could not be stat'd: \(path)")
+            }
+            return SMBConnection(client: client, reader: reader, byteSize: Int64(size))
         } catch {
-            try await client.login(username: nil, password: nil)
+            client.session.disconnect()
+            throw error
         }
-
-        try await client.connectShare(share)
-
-        let reader = client.fileReader(path: path)
-        let size = try await reader.fileSize
-        guard size > 0 else {
-            throw SMBError(message: "SMB file has zero size or could not be stat'd: \(path)")
-        }
-        return SMBConnection(client: client, reader: reader, byteSize: Int64(size))
     }
 
     public func read(at offset: Int64, length: Int) async throws -> Data {
@@ -79,6 +94,9 @@ public final class SMBConnection: ByteRangeSource, @unchecked Sendable {
         Task {
             try? await reader.close()
             try? await client.logoff()
+            // logoff() only ends the SMB session; tear down the underlying TCP
+            // connection too so the socket doesn't linger until dealloc.
+            client.session.disconnect()
         }
     }
 }

--- a/Sources/AetherEngineSMB/SMBIOReader.swift
+++ b/Sources/AetherEngineSMB/SMBIOReader.swift
@@ -18,10 +18,10 @@ public final class SMBIOReader: IOReader, @unchecked Sendable {
     private var position: Int64 = 0
     private var didClose = false
     /// Per-read in-flight state, published so cancel() (a different thread) can both cancel the
-    /// background work and, crucially, unblock read()'s semaphore wait. AMSMB2's libsmb2 read is
-    /// not cancellation-aware (only an internal ~60s timeout resolves the continuation), so
-    /// task.cancel() alone could not wake the wait and teardown blocked up to 60s; cancel() now
-    /// signals the semaphore directly and read() aborts.
+    /// background work and, crucially, unblock read()'s semaphore wait. The underlying SMB read
+    /// is an in-flight network round-trip that task.cancel() may not interrupt promptly (it can
+    /// block until the connection times out), so task.cancel() alone could not reliably wake the
+    /// wait and teardown could stall; cancel() now signals the semaphore directly and read() aborts.
     private final class Inflight: @unchecked Sendable {
         let task: Task<Void, Never>
         let semaphore: DispatchSemaphore
@@ -56,7 +56,7 @@ public final class SMBIOReader: IOReader, @unchecked Sendable {
         }
         inFlightLock.withLock { $0 = Inflight(task: task, semaphore: semaphore) }
         semaphore.wait()
-        // cancel() may have signalled to unblock teardown while the libsmb2 read is still running.
+        // cancel() may have signalled to unblock teardown while the SMB read is still running.
         // In that case do NOT read `outcome`: the background Task may still be writing it (the
         // semaphore's happens-before edge only covers the Task's own signal). Abort with -1 instead.
         let wasCancelled = inFlightLock.withLock { state -> Bool in
@@ -100,12 +100,12 @@ public final class SMBIOReader: IOReader, @unchecked Sendable {
         inFlightLock.withLock { state in
             state?.cancelled = true
             state?.task.cancel()
-            state?.semaphore.signal()   // wake read()'s wait; the libsmb2 op drains in the background
+            state?.semaphore.signal()   // wake read()'s wait; the SMB op drains in the background
         }
     }
 
     public func makeIndependentReader() -> IOReader? {
-        // Range reads are stateless and SMB2Manager is thread safe, so the
+        // Range reads are serialised per connection by SMBClient, so the
         // independent reader shares the connection but never owns its teardown.
         SMBIOReader(source: source, ownsSource: false)
     }

--- a/Sources/AetherEngineSMB/SMBURL.swift
+++ b/Sources/AetherEngineSMB/SMBURL.swift
@@ -1,7 +1,10 @@
 import Foundation
 
 /// Parses an `smb://[user[:password]@]host[:port]/share/path/to/file` URL into
-/// connection parts. Missing credentials default to guest.
+/// connection parts. An omitted username is left empty (not substituted with
+/// "guest"): `SMBConnection.connect` treats an empty username as "no account"
+/// and drives the guest-then-anonymous fallback itself. Substituting "guest"
+/// here would make that fallback unreachable for credential-less URLs.
 public struct SMBURL: Sendable {
     public let server: URL
     public let share: String
@@ -34,7 +37,7 @@ public struct SMBURL: Sendable {
             server: server,
             share: segments[0],
             path: segments.dropFirst().joined(separator: "/"),
-            user: comps.user ?? "guest",
+            user: comps.user ?? "",
             password: comps.password ?? ""
         )
     }

--- a/Sources/aetherctl/SMBTestCommand.swift
+++ b/Sources/aetherctl/SMBTestCommand.swift
@@ -14,7 +14,7 @@ private func smbTestRun(_ args: [String]) async -> Int32 {
     do {
         let u = try SMBURL.parse(rawURL)
         let started = ProcessInfo.processInfo.systemUptime
-        print("connecting to \(u.server.absoluteString) share=\(u.share) path=\(u.path) user=\(u.user)")
+        print("connecting to \(u.server.absoluteString) share=\(u.share) path=\(u.path) user=\(u.user.isEmpty ? "(guest/anonymous)" : u.user)")
         let connection = try await SMBConnection.connect(
             server: u.server, share: u.share, path: u.path,
             user: u.user, password: u.password

--- a/Tests/AetherEngineSMBTests/SMBURLTests.swift
+++ b/Tests/AetherEngineSMBTests/SMBURLTests.swift
@@ -11,9 +11,12 @@ final class SMBURLTests: XCTestCase {
         XCTAssertEqual(u.path, "Movies/film.mkv")
     }
 
-    func testGuestWhenNoCredentials() throws {
+    func testEmptyUserWhenNoCredentials() throws {
+        // An omitted username parses to empty — SMBConnection.connect maps that
+        // to the guest-then-anonymous fallback; the parser must not fabricate
+        // "guest" or that fallback would never fire.
         let u = try SMBURL.parse("smb://nas.local/public/clip.mp4")
-        XCTAssertEqual(u.user, "guest")
+        XCTAssertEqual(u.user, "")
         XCTAssertEqual(u.password, "")
         XCTAssertEqual(u.share, "public")
         XCTAssertEqual(u.path, "clip.mp4")


### PR DESCRIPTION
## What

Swaps `AetherEngineSMB`'s transport from **AMSMB2/libsmb2** to **[kishikawakatsumi/SMBClient](https://github.com/kishikawakatsumi/SMBClient)** — a pure-Swift, MIT, zero-C-dependency SMB2 client built on `NWConnection`. Public API is unchanged.

## Why

The AMSMB2 backend works on macOS but is **dead on tvOS and iOS**: the very first `connectShare` fails with POSIX `EPERM` ("Operation not permitted"), no matter the credentials, network, or thread. It's a known, long-standing libsmb2-on-Apple-mobile issue — AMSMB2 [#32](https://github.com/amosavian/AMSMB2/issues/32), [#63](https://github.com/amosavian/AMSMB2/issues/63), [#64](https://github.com/amosavian/AMSMB2/issues/64), all the same error, all open (the fix in #64 was literally "switch SMB libraries"). For an embeddable A/V engine, tvOS/iOS is exactly where SMB needs to work.

It's **not** the platform blocking SMB. A raw `NWConnection` to port 445 completes a full SMB2 negotiate on the same Apple TV where libsmb2 `EPERM`s. So the fix is to stop using libsmb2 and speak SMB2 over Network.framework instead — which is exactly what SMBClient does.

## How

- `SMBConnection` now drives `SMBClient` (`login` → `connectShare` → `fileReader` → `fileSize`/`read(offset:length:)`).
- Its `fileSize` + ranged-read API maps directly onto the existing `ByteRangeSource` seam, so **the public surface is identical** — `SMBIOReader`, `SMBURL`, and the `aetherctl smbtest` caller are untouched.
- `Package.swift`: drop `amosavian/AMSMB2`, add `kishikawakatsumi/SMBClient` (`from: 0.3.1`). This also **removes the LGPL-2.1 libsmb2 dependency** — SMBClient is MIT.
- Comment / README / module-marker updates to reflect the new transport.

Note: SMBClient's own `Package.swift` doesn't list tvOS in `platforms`, but it's pure Swift and builds/runs fine there (see below). An upstream PR adding `.tvOS` there would be a nice-to-have but isn't required.

## Verification

Tested end-to-end against a real NAS on an **Apple TV (tvOS)**, through the engine's actual `SMBIOReader` path, with a ~85-min 1080p MKV:

| | guest share | password share (NTLMv2) |
| --- | --- | --- |
| connect + login + tree-connect | ✅ | ✅ |
| sequential playback (decoding, correct duration) | ✅ | ✅ |
| seek forward | ✅ | ✅ |
| seek near end | ✅ | ✅ |
| seek backward (the #94 muxer-restart path) | ✅ | ✅ |

- `AetherEngineSMB` builds for **tvOS Simulator** (`xcodebuild`, `BUILD SUCCEEDED`).
- `AetherEngineSMBTests` pass on macOS (`swift test`).

## Compatibility / risk

- No public API changes; opt-in product only, never enters the core engine binary.
- One behavior note: an empty username now tries guest, then falls back to a fully anonymous NTLM session (mirrors the old guest/anonymous behavior).
