### PR TITLE
fix(disc): defeat repeated-clip decoy playlists in BD title selection (#105)

### DIFF
--- a/Sources/AetherEngine/Disc/BDTitleSelector.swift
+++ b/Sources/AetherEngine/Disc/BDTitleSelector.swift
@@ -6,15 +6,38 @@ enum BDTitleSelector {
     /// leave nothing, the unfiltered set is used so a disc never ends up with zero titles.
     static let minTitleSeconds: Double = 10
 
+    /// A single clip repeated at least this many times, and supplying most of a playlist's PlayItems,
+    /// marks that playlist as a repeated-clip decoy (see `isRepeatedClipDecoy`).
+    static let decoyMinRepeats = 3
+
+    /// Anti-rip Blu-rays pad PLAYLIST with decoy .mpls that reference one short clip dozens or hundreds
+    /// of times, inflating the declared duration to 5+ hours while the demuxer only ever probes the
+    /// first clip's worth of PTS. A decoy is dominated by one repeated clip; a real feature lists
+    /// distinct clips (one, or a handful for seamless branching / multi-angle). Flag a playlist as a
+    /// decoy only when a single clip both repeats past the floor and supplies more than half its
+    /// PlayItems, so light legitimate clip reuse is preserved. (AE#105: TRON: Legacy 4K crowned a clip
+    /// looped 252x over its 2:05 feature under duration-max selection, so scrubs past 76s came back blank.)
+    static func isRepeatedClipDecoy(_ playlist: MPLSPlaylist) -> Bool {
+        let clips = playlist.clipIDs
+        guard clips.count > 1 else { return false }
+        var counts: [String: Int] = [:]
+        for c in clips { counts[c, default: 0] += 1 }
+        guard let maxRepeat = counts.values.max() else { return false }
+        return maxRepeat >= decoyMinRepeats && maxRepeat * 2 > clips.count
+    }
+
     static func selectMainTitle(_ playlists: [MPLSPlaylist]) -> MPLSPlaylist? {
-        playlists.max { $0.durationTicks < $1.durationTicks }
+        let real = playlists.filter { !isRepeatedClipDecoy($0) }
+        let pool = real.isEmpty ? playlists : real
+        return pool.max { $0.durationTicks < $1.durationTicks }
     }
 
     /// All playlists as selectable titles, longest first so id 0 is the main feature (preserving the
-    /// "default plays the main title" behavior). Trivially-short playlists are filtered (see above).
+    /// "default plays the main title" behavior). Trivially-short playlists and repeated-clip decoys are
+    /// filtered (see above); if filtering would leave nothing, the unfiltered set is used.
     static func enumerateTitles(_ playlists: [MPLSPlaylist]) -> [DiscTitle] {
         let minTicks = UInt64(minTitleSeconds * discTickRate)
-        let real = playlists.filter { $0.durationTicks >= minTicks }
+        let real = playlists.filter { $0.durationTicks >= minTicks && !isRepeatedClipDecoy($0) }
         let pool = real.isEmpty ? playlists : real
         return pool.sorted { $0.durationTicks > $1.durationTicks }
             .enumerated()

--- a/Sources/AetherEngine/FrameExtractor/FrameDecodeContext.swift
+++ b/Sources/AetherEngine/FrameExtractor/FrameDecodeContext.swift
@@ -76,6 +76,22 @@ final class FrameDecodeContext: @unchecked Sendable {
     /// a frozen read cannot pin the FrameExtractor's serial decode queue (issue #27).
     static let stillReadDeadlineSeconds: TimeInterval = 8
 
+    /// A still requested more than this many seconds past the demuxer's known duration is treated as
+    /// out of range and clamped (see `clampSeekSeconds`). The grace absorbs rounding on a last-frame scrub.
+    static let pastDurationTolerance: Double = 1.0
+    /// How far inside the end a clamped past-EOF request lands, to reach a safely-decodable frame.
+    static let clampBackoffSeconds: Double = 1.0
+
+    /// Clamp a still-extraction seek target to the demuxer's known duration. Seeking far past EOF
+    /// lands on a garbage/empty frame that decodes "successfully" but is blank (AE#105: a mis-selected
+    /// decoy Blu-ray title whose demuxer knew only 76s while the scrub asked for 611s). Returns the
+    /// request unchanged when the duration is unknown (<= 0) or the request is within tolerance of the
+    /// end; otherwise the last safely-decodable position.
+    static func clampSeekSeconds(requested: Double, duration: Double) -> Double {
+        guard duration > 0, requested > duration + pastDurationTolerance else { return requested }
+        return max(0, duration - clampBackoffSeconds)
+    }
+
     init(url: URL, httpHeaders: [String: String]) {
         self.url = url
         self.httpHeaders = httpHeaders
@@ -229,10 +245,23 @@ final class FrameDecodeContext: @unchecked Sendable {
         // thumbnail gains nothing from it, and snapshot must keep all frames to reach exact PTS.
         ctx.pointee.skip_frame = AVDISCARD_DEFAULT
 
-        demuxer.seek(to: seconds)
+        // Clamp a request past the demuxer's known duration to the last decodable frame: seeking far
+        // past EOF returns a blank garbage frame that still reports success (AE#105). Both the seek and
+        // the forward-decode target below must use the clamped value or snapshot would chase an
+        // unreachable PTS forever.
+        let seekSeconds = Self.clampSeekSeconds(requested: seconds, duration: demuxer.duration)
+        if seekSeconds != seconds {
+            EngineLog.emit(
+                "[FrameExtractor] still past duration: t=\(String(format: "%.2f", seconds))s "
+                + "> duration=\(String(format: "%.2f", demuxer.duration))s; clamped to "
+                + "\(String(format: "%.2f", seekSeconds))s",
+                category: .swPlayback)
+        }
+
+        demuxer.seek(to: seekSeconds)
 
         guard timeBase.num > 0 else { return nil }
-        let targetPTS = Int64((seconds * Double(timeBase.den)) / Double(timeBase.num))
+        let targetPTS = Int64((seekSeconds * Double(timeBase.den)) / Double(timeBase.num))
 
         var frame: UnsafeMutablePointer<AVFrame>? = av_frame_alloc()
         guard frame != nil else { return nil }

--- a/Tests/AetherEngineTests/BDTitleSelectorTests.swift
+++ b/Tests/AetherEngineTests/BDTitleSelectorTests.swift
@@ -50,4 +50,45 @@ final class BDTitleSelectorTests: XCTestCase {
         XCTAssertEqual(titles[0].chapters.map(\.startTicks), [0, 1_350_000, 2_700_000])
         XCTAssertEqual(titles[0].titleInfo().chapterCount, 3)
     }
+
+    // MARK: - Repeated-clip decoy demotion (AE#105)
+
+    // Anti-rip Blu-rays (e.g. TRON: Legacy 4K) pad PLAYLIST with a decoy .mpls that references one
+    // short menu/loop clip hundreds of times, inflating its declared duration to 5+ hours while the
+    // demuxer only ever probes the first clip's ~76s of PTS. Duration-max selection crowned that decoy
+    // as the main title, so scrubbing/snapshots past 76s landed past the demuxer's EOF and came back
+    // blank. The real feature is a single-clip 2:05 title and must win.
+    private func decoyPlaylist() -> MPLSPlaylist {
+        MPLSPlaylist(clipIDs: ["00046"] + Array(repeating: "00038", count: 252),
+                     durationTicks: 872_865_000)  // 5:23:17, but really one looped 76s clip
+    }
+    private func featurePlaylist() -> MPLSPlaylist {
+        MPLSPlaylist(clipIDs: ["00070"], durationTicks: 337_860_000)  // 2:05:08, a single real clip
+    }
+
+    func test_selectMainTitleIgnoresRepeatedClipDecoy() {
+        XCTAssertEqual(BDTitleSelector.selectMainTitle([decoyPlaylist(), featurePlaylist()]),
+                       featurePlaylist())
+    }
+
+    func test_enumerateTitlesDemotesRepeatedClipDecoy() {
+        let titles = BDTitleSelector.enumerateTitles([decoyPlaylist(), featurePlaylist()])
+        XCTAssertEqual(titles.first?.bdClipIDs, ["00070"])          // real feature is the main title (id 0)
+        XCTAssertFalse(titles.contains { $0.bdClipIDs == decoyPlaylist().clipIDs })  // decoy dropped entirely
+    }
+
+    func test_enumerateTitlesKeepsDecoyWhenItIsTheOnlyPlaylist() {
+        // Never leave a disc with zero titles: if every playlist is a decoy, expose them anyway.
+        let titles = BDTitleSelector.enumerateTitles([decoyPlaylist()])
+        XCTAssertEqual(titles.count, 1)
+    }
+
+    func test_isRepeatedClipDecoyToleratesLightClipReuse() {
+        // Seamless-branching / multi-angle titles legitimately reuse a clip a couple of times. A clip
+        // that appears twice in a four-clip title is NOT a decoy; only a single clip dominating the
+        // PlayItem list is.
+        let branching = MPLSPlaylist(clipIDs: ["A", "B", "A", "C"], durationTicks: 5_400_000)
+        XCTAssertFalse(BDTitleSelector.isRepeatedClipDecoy(branching))
+        XCTAssertTrue(BDTitleSelector.isRepeatedClipDecoy(decoyPlaylist()))
+    }
 }

--- a/Tests/AetherEngineTests/FrameDecodeContextClampTests.swift
+++ b/Tests/AetherEngineTests/FrameDecodeContextClampTests.swift
@@ -1,0 +1,36 @@
+import Foundation
+import Testing
+@testable import AetherEngine
+
+/// AE#105: a still requested past the demuxer's known duration otherwise seeks far past EOF and
+/// decodes a blank garbage frame that reports `image=ok`. The seek target is clamped to the last
+/// safely-decodable position. This is defense-in-depth behind the BDTitleSelector decoy fix that
+/// stops a mis-selected decoy title (76s demuxer, 5:23 declared) from being the scrub target at all.
+struct FrameDecodeContextClampTests {
+
+    @Test("a request within the known duration is left untouched")
+    func inRangePassthrough() {
+        #expect(FrameDecodeContext.clampSeekSeconds(requested: 42.0, duration: 76.64) == 42.0)
+        #expect(FrameDecodeContext.clampSeekSeconds(requested: 0.0, duration: 76.64) == 0.0)
+    }
+
+    @Test("a request far past the known duration clamps to just inside the end")
+    func pastDurationClamps() {
+        // The AE#105 case: demuxer duration 76.64s, host scrub asked for 611.25s.
+        let clamped = FrameDecodeContext.clampSeekSeconds(requested: 611.25, duration: 76.64)
+        #expect(clamped < 76.64)
+        #expect(clamped > 0)
+    }
+
+    @Test("an unknown duration (<= 0) disables clamping so normal sources are unaffected")
+    func unknownDurationPassthrough() {
+        #expect(FrameDecodeContext.clampSeekSeconds(requested: 611.25, duration: 0) == 611.25)
+        #expect(FrameDecodeContext.clampSeekSeconds(requested: 5.0, duration: -1) == 5.0)
+    }
+
+    @Test("scrubbing to the very end within tolerance is not treated as past-EOF")
+    func endScrubTolerated() {
+        // Rounding can put the last-frame request a hair past the reported duration; that must not clamp.
+        #expect(FrameDecodeContext.clampSeekSeconds(requested: 76.7, duration: 76.64) == 76.7)
+    }
+}


### PR DESCRIPTION
## Problem

Issue #105: the generated snapshot is a blank image. Reporter's log + screenshots show a Blu-ray ISO (TRON: Legacy 4K, 16 titles):

```
[disc] Blu-ray recognized: 16 titles, selected 0 clips=["00046","00038" x252] m2ts-extents=253
[Demuxer] Opened: 3 streams, duration=76640000 us          <- 76.64s
[FrameExtractor] miss mode=snapshot t=611.25s ... image=ok bytes=0   <- blank
```

The disc's longest-duration `.mpls` references one ~76s menu/loop clip (`00038`) 252 times, inflating its declared duration to 5:23:17 while the demuxer only ever probes the first clip's PTS (76.64s). `BDTitleSelector` ranked titles purely by `durationTicks`, so this decoy crowned the real 2:05 feature (single clip `00070`) as the main/default title. Scrubbing or snapshotting past 76s then seeked past the demuxer's EOF and decoded a blank garbage frame that still reported `image=ok`.

This is not the tone-map path and not the #106 single-connection second-demuxer class.

## Fix

- **`BDTitleSelector`**: `isRepeatedClipDecoy` flags a playlist dominated by one repeated clip (repeats past a floor and supplying more than half its PlayItems). `selectMainTitle` and `enumerateTitles` drop decoys before the duration-max sort, keeping the existing never-leave-zero-titles fallback. Light legitimate clip reuse (seamless branching, multi-angle) is preserved.
- **`FrameDecodeContext`**: `clampSeekSeconds` clamps a still requested past the demuxer's known duration to the last decodable frame instead of seeking past EOF into a blank frame (defense-in-depth behind the selector fix). Both the seek and the snapshot forward-decode target use the clamped value.

## Tests

- `BDTitleSelectorTests`: decoy demotion (real feature becomes the main title), only-decoy fallback, light clip-reuse tolerance.
- `FrameDecodeContextClampTests`: the pure clamp arithmetic (in-range passthrough, past-EOF clamp, unknown-duration passthrough, end-scrub tolerance).

## Verification

- Full suite: 431 tests, 0 failures
- `swift build -Xswiftc -strict-concurrency=complete`: clean
- tvOS Simulator (`xcodebuild -scheme AetherEngine`): BUILD SUCCEEDED

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HFZVoTDayyEfpqrY8ohNyg