### PR TITLE
fix(disc): trust MPLS title duration and follow selected title for stills (#105)

### DIFF
--- a/Sources/AetherEngine/Demuxer/Demuxer.swift
+++ b/Sources/AetherEngine/Demuxer/Demuxer.swift
@@ -182,6 +182,24 @@ public final class Demuxer: @unchecked Sendable {
         discTitles.indices.contains(selectedDiscTitleIndex) ? discTitles[selectedDiscTitleIndex].id : nil
     }
 
+    /// Authoritative playlist/IFO duration of the selected disc title, or nil when there is no disc
+    /// title or its duration is unparsed (ticks 0). This is trusted over FFmpeg's container estimate
+    /// (see `duration`).
+    var selectedDiscTitleDurationSeconds: Double? {
+        guard discTitles.indices.contains(selectedDiscTitleIndex) else { return nil }
+        let ticks = discTitles[selectedDiscTitleIndex].durationTicks
+        return ticks > 0 ? Double(ticks) / discTickRate : nil
+    }
+
+    /// Pick the trustworthy duration for a disc-backed source. FFmpeg's mpegts estimate over
+    /// concatenated multi-clip Blu-ray m2ts with discontinuous PTS is unreliable (AE#105: a 42s title
+    /// probed as 25.5h, a 35s title as 5s), so the MPLS/IFO playlist duration wins whenever it is
+    /// present (> 0). Non-disc sources (`discTitle == nil`) keep the container estimate verbatim.
+    static func effectiveDurationSeconds(discTitle: Double?, container: Double) -> Double {
+        if let discTitle, discTitle > 0 { return discTitle }
+        return container
+    }
+
     /// Open a media URL and probe its streams.
     /// - Parameters:
     ///   - extraHeaders: Attached to every HTTP request (ignored for file:// URLs).
@@ -432,9 +450,13 @@ public final class Demuxer: @unchecked Sendable {
     }
 
     var duration: Double {
-        guard let ctx = formatContext else { return 0 }
-        let dur = ctx.pointee.duration
-        return dur > 0 ? Double(dur) / Double(AV_TIME_BASE) : 0
+        let container: Double = {
+            guard let ctx = formatContext else { return 0 }
+            let dur = ctx.pointee.duration
+            return dur > 0 ? Double(dur) / Double(AV_TIME_BASE) : 0
+        }()
+        // A disc title's MPLS/IFO duration overrides FFmpeg's unreliable mpegts estimate (AE#105).
+        return Self.effectiveDurationSeconds(discTitle: selectedDiscTitleDurationSeconds, container: container)
     }
 
     /// AVFormatContext.bit_rate in bps, or 0 if unknown. Used by

--- a/Sources/AetherEngine/FrameExtractor/AetherEngine+FrameExtractor.swift
+++ b/Sources/AetherEngine/FrameExtractor/AetherEngine+FrameExtractor.swift
@@ -62,7 +62,11 @@ extension AetherEngine {
                                   yieldWhile: sessionYieldSignal())
         }
         guard let url = loadedURL else { return nil }
+        // For a disc image, pin the extractor to the currently-selected title so stills follow the
+        // title switch instead of always decoding the default one (AE#105). The host rebuilds the
+        // extractor when the disc title changes.
         return FrameExtractor(url: url, httpHeaders: loadedOptions.httpHeaders,
+                              selectTitleID: activeDiscTitleID,
                               yieldWhile: sessionYieldSignal())
     }
 

--- a/Sources/AetherEngine/FrameExtractor/FrameDecodeContext.swift
+++ b/Sources/AetherEngine/FrameExtractor/FrameDecodeContext.swift
@@ -18,6 +18,10 @@ final class FrameDecodeContext: @unchecked Sendable {
     /// idle-reopen path can rebuild over the still-alive reader).
     private let reader: IOReader?
     private let formatHint: String?
+    /// For a disc image (Blu-ray / DVD ISO) URL, the title to extract stills from. nil = the default
+    /// (main) title. Threaded into `Demuxer.open` so a still follows the currently-selected disc title
+    /// instead of always decoding the default one (AE#105).
+    private let selectTitleID: Int?
 
     private var demuxer: Demuxer?
     private var codecContext: UnsafeMutablePointer<AVCodecContext>?
@@ -92,11 +96,12 @@ final class FrameDecodeContext: @unchecked Sendable {
         return max(0, duration - clampBackoffSeconds)
     }
 
-    init(url: URL, httpHeaders: [String: String]) {
+    init(url: URL, httpHeaders: [String: String], selectTitleID: Int? = nil) {
         self.url = url
         self.httpHeaders = httpHeaders
         self.reader = nil
         self.formatHint = nil
+        self.selectTitleID = selectTitleID
     }
 
     init(reader: IOReader, formatHint: String?) {
@@ -105,6 +110,7 @@ final class FrameDecodeContext: @unchecked Sendable {
         self.httpHeaders = [:]
         self.reader = reader
         self.formatHint = formatHint
+        self.selectTitleID = nil
     }
 
     deinit {
@@ -147,7 +153,7 @@ final class FrameDecodeContext: @unchecked Sendable {
         if let reader = reader {
             try demuxer.open(reader: reader, formatHint: formatHint, profile: .stillExtraction)
         } else {
-            try demuxer.open(url: url, extraHeaders: httpHeaders, profile: .stillExtraction)
+            try demuxer.open(url: url, extraHeaders: httpHeaders, profile: .stillExtraction, selectTitleID: selectTitleID)
         }
         self.demuxer = demuxer
 

--- a/Sources/AetherEngine/FrameExtractor/FrameExtractor.swift
+++ b/Sources/AetherEngine/FrameExtractor/FrameExtractor.swift
@@ -49,9 +49,13 @@ public actor FrameExtractor {
         self.decodeQueue = DispatchQueue(label: "com.aetherengine.frameextractor", qos: .utility)
     }
 
+    /// `selectTitleID` picks the disc title for a Blu-ray / DVD ISO URL (nil = main title); it lets a
+    /// still follow the currently-selected title instead of always the default one (AE#105). Inert for
+    /// non-disc URLs.
     public init(url: URL, httpHeaders: [String: String] = [:],
+                selectTitleID: Int? = nil,
                 yieldWhile: (@Sendable () -> Bool)? = nil) {
-        self.init(context: FrameDecodeContext(url: url, httpHeaders: httpHeaders),
+        self.init(context: FrameDecodeContext(url: url, httpHeaders: httpHeaders, selectTitleID: selectTitleID),
                   yieldWhile: yieldWhile)
     }
 

--- a/Tests/AetherEngineTests/DemuxerDurationTests.swift
+++ b/Tests/AetherEngineTests/DemuxerDurationTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+@testable import AetherEngine
+
+// AE#105 follow-up: FFmpeg's mpegts duration estimate over concatenated multi-clip Blu-ray m2ts with
+// discontinuous PTS is unreliable (a 42s title probed as 25.5h, a 35s title as 5s). The MPLS/IFO
+// playlist duration is authoritative, so the demuxer prefers it when a disc title supplies one.
+final class DemuxerDurationTests: XCTestCase {
+    func test_prefersDiscTitleDurationOverInflatedContainerEstimate() {
+        // Title probed as 25.5h; MPLS says 42s.
+        XCTAssertEqual(Demuxer.effectiveDurationSeconds(discTitle: 42, container: 91_843.97), 42)
+    }
+
+    func test_prefersDiscTitleDurationOverTruncatedContainerEstimate() {
+        // 8-clip title probed as 5s; MPLS says 35s. Disc duration wins even when it is the larger value.
+        XCTAssertEqual(Demuxer.effectiveDurationSeconds(discTitle: 35, container: 5), 35)
+    }
+
+    func test_fallsBackToContainerWhenDiscTitleDurationUnknown() {
+        // durationTicks 0 (unparsed IFO/MPLS) -> nil disc duration -> keep the container estimate.
+        XCTAssertEqual(Demuxer.effectiveDurationSeconds(discTitle: nil, container: 7508.93), 7508.93)
+        XCTAssertEqual(Demuxer.effectiveDurationSeconds(discTitle: 0, container: 7508.93), 7508.93)
+    }
+
+    func test_nonDiscSourceIsUnaffected() {
+        // Plain file: no disc title, keep the container duration verbatim.
+        XCTAssertEqual(Demuxer.effectiveDurationSeconds(discTitle: nil, container: 123.4), 123.4)
+    }
+}


### PR DESCRIPTION
Follow-up to #108 (decoy-playlist defeat). The reporter re-tested on 0.9.2: the decoy fix works (the disc now recognizes 14 titles and the real 2:05 feature is the main title). Two independent disc bugs then surfaced on the short auxiliary titles they switched to.

## Bug 1: bogus duration on multi-clip disc titles

FFmpeg's mpegts duration estimate over concatenated multi-clip m2ts with discontinuous PTS is unreliable:
- a 42s title probed as **91844s (25.5h)** and built **22961 phantom HLS segments**
- a 35s title probed as **5s**

The scrubber showed the bogus demuxer duration, so total and playhead were inconsistent (25:12:34 / 25:30:43; 10:04 / 0:05). The MPLS/IFO playlist duration is authoritative (the title list already shows it correctly), so `Demuxer.duration` now returns the selected disc title's duration when present, falling back to the container estimate for non-disc sources or an unparsed title. One point corrects the scrubber total, the HLS segment plan, and the still extractor's past-duration clamp. No-op for the main feature (MPLS and container agree within rounding), which also removes the cosmetic 1s TitleInfo vs duration difference.

## Bug 2: stale snapshot on title switch

The full-res still extractor opened its own disc demuxer with **no title id**, so it always decoded the default title regardless of the selected one ("switch to title3, snapshot is still title1's"). `FrameDecodeContext` / `FrameExtractor` now thread a `selectTitleID` into `Demuxer.open(url:)`, and `makeFrameExtractor` pins it to the engine's `activeDiscTitleID`. (The host rebuilds the extractor when the disc title changes.)

## Tests / verification

- `DemuxerDurationTests`: the duration-authority helper (disc duration wins when present, falls back otherwise).
- Full suite: 0 failures. `swift build -Xswiftc -strict-concurrency=complete`: clean. tvOS Simulator build: SUCCEEDED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HFZVoTDayyEfpqrY8ohNyg