### PR TITLE
fix(disc): fold multi-clip Blu-ray titles onto a contiguous timeline (#105)

### DIFF
--- a/Sources/AetherEngine/Demuxer/Demuxer.swift
+++ b/Sources/AetherEngine/Demuxer/Demuxer.swift
@@ -163,9 +163,39 @@ public final class Demuxer: @unchecked Sendable {
     private(set) var discTitles: [DiscTitle] = []
     private(set) var selectedDiscTitleIndex: Int = 0
 
+    /// Per-clip presentation-offset spans for a selected multi-clip Blu-ray title (empty otherwise). When
+    /// non-empty, `readPacket` and `indexedKeyframes` fold each clip's timestamps onto one contiguous
+    /// timeline so the playhead does not leap at clip boundaries (AE#105). Guarded by `accessLock`.
+    private var clipTimeline: [ClipSpan] = []
+    /// Last clip index resolved from a packet byte position; reused when a packet reports pos < 0
+    /// (reads are sequential, so the clip only advances). Guarded by `accessLock`.
+    private var lastClipIndex: Int = 0
+
     private func adoptDiscInfo(_ info: DiscInfo) {
         discTitles = info.titles
         selectedDiscTitleIndex = info.selectedTitleIndex
+        clipTimeline = info.clipTimeline
+        lastClipIndex = 0
+    }
+
+    /// Seconds to subtract from a raw source timestamp of a packet/index entry at byte position `pos`,
+    /// attributing it to its clip via `clipTimeline`. 0 when normalization is off or `pos` is in clip 0.
+    /// Must be called under `accessLock`.
+    private func clipSubtractSeconds(forPos pos: Int64) -> Double {
+        guard !clipTimeline.isEmpty else { return 0 }
+        let idx = ClipSpan.index(forPos: pos, in: clipTimeline, fallback: lastClipIndex)
+        lastClipIndex = idx
+        return clipTimeline[idx].subtractSeconds
+    }
+
+    /// Fold a raw timestamp onto the contiguous presentation timeline given its byte position and time base.
+    /// Must be called under `accessLock`.
+    private func normalizedTimestamp(_ ts: Int64, pos: Int64, timeBase: AVRational) -> Int64 {
+        guard ts != Int64.min, !clipTimeline.isEmpty else { return ts }
+        let sub = clipSubtractSeconds(forPos: pos)
+        guard sub != 0, timeBase.num > 0, timeBase.den > 0 else { return ts }
+        let subTicks = Int64((sub * Double(timeBase.den) / Double(timeBase.num)).rounded())
+        return ts &- subTicks
     }
 
     /// True once a disc structure (BD/DVD/UDF) was recognized at open. Disc sources concat
@@ -704,6 +734,7 @@ public final class Demuxer: @unchecked Sendable {
         }
         let count = avformat_index_get_entries_count(stream)
         guard count > 0 else { return [] }
+        let tb = stream.pointee.time_base
         var result: [Int64] = []
         result.reserveCapacity(Int(count))
         for i in 0..<count {
@@ -711,7 +742,9 @@ public final class Demuxer: @unchecked Sendable {
             // AVINDEX_KEYFRAME = 0x0001
             if entry.pointee.flags & 0x0001 != 0,
                entry.pointee.timestamp != Int64.min {
-                result.append(entry.pointee.timestamp)
+                // Fold each entry onto the contiguous timeline (multi-clip disc) so the segment plan
+                // built from these IRAP positions matches the normalized packets (AE#105).
+                result.append(normalizedTimestamp(entry.pointee.timestamp, pos: entry.pointee.pos, timeBase: tb))
             }
         }
         return result
@@ -731,6 +764,20 @@ public final class Demuxer: @unchecked Sendable {
                 return nil
             }
             throw DemuxerError.readFailed(code: ret)
+        }
+        if !clipTimeline.isEmpty, let pkt = packet {
+            let si = Int(pkt.pointee.stream_index)
+            if si >= 0, si < Int(ctx.pointee.nb_streams), let st = ctx.pointee.streams[si] {
+                let sub = clipSubtractSeconds(forPos: pkt.pointee.pos)
+                if sub != 0 {
+                    let tb = st.pointee.time_base
+                    if tb.num > 0, tb.den > 0 {
+                        let subTicks = Int64((sub * Double(tb.den) / Double(tb.num)).rounded())
+                        if pkt.pointee.pts != Int64.min { pkt.pointee.pts &-= subTicks }
+                        if pkt.pointee.dts != Int64.min { pkt.pointee.dts &-= subTicks }
+                    }
+                }
+            }
         }
         return packet
     }

--- a/Sources/AetherEngine/Disc/BDTitleSelector.swift
+++ b/Sources/AetherEngine/Disc/BDTitleSelector.swift
@@ -46,7 +46,24 @@ enum BDTitleSelector {
                     DiscChapter(id: i, startTicks: start)
                 }
                 return DiscTitle(id: index, durationTicks: playlist.durationTicks,
-                                 chapters: chapters, bdClipIDs: playlist.clipIDs)
+                                 chapters: chapters, bdClipIDs: playlist.clipIDs,
+                                 bdClipSubtractTicks: clipSubtractTicks(playlist))
             }
+    }
+
+    /// Per-clip amount to subtract from a raw source timestamp (45 kHz ticks) so each PlayItem continues
+    /// contiguously from the previous one on the title's presentation timeline, with clip 0 left untouched
+    /// (offset 0). For clip k: `inTime[k] - inTime[0] - cumulativeBefore[k]`. Derivation: clip k's presented
+    /// content must land at `inTime[0] + cumulativeBefore[k] + (raw - inTime[k])`, so the constant to remove
+    /// from `raw` is `inTime[k] - inTime[0] - cumulativeBefore[k]`. Nil when the playlist carried no per-clip
+    /// timing (older parse / malformed), leaving normalization disabled. See AE#105.
+    static func clipSubtractTicks(_ playlist: MPLSPlaylist) -> [Int64]? {
+        let inT = playlist.inTimes
+        let cumB = playlist.cumulativeBefore
+        guard inT.count == playlist.clipIDs.count, cumB.count == playlist.clipIDs.count,
+              let first = inT.first else { return nil }
+        return inT.indices.map { k in
+            Int64(bitPattern: inT[k]) - Int64(bitPattern: first) - Int64(bitPattern: cumB[k])
+        }
     }
 }

--- a/Sources/AetherEngine/Disc/DiscMetadata.swift
+++ b/Sources/AetherEngine/Disc/DiscMetadata.swift
@@ -46,19 +46,55 @@ struct DiscTitle: Sendable, Equatable {
     let chapters: [DiscChapter]
     /// Blu-ray: the m2ts clip basenames to concatenate for this title (exactly one of the resolution keys is set).
     let bdClipIDs: [String]?
+    /// Blu-ray: per-clip amount to SUBTRACT from a raw source timestamp, 45 kHz ticks, parallel to `bdClipIDs`.
+    /// Each m2ts clip carries its own STC, so a multi-clip title's concatenated source jumps at every clip
+    /// boundary. Subtracting this per-clip offset folds every clip onto one contiguous presentation timeline
+    /// that continues from clip 0 (whose offset is always 0, so the plan/anchor/seeks stay untouched). See
+    /// `Demuxer.readPacket` normalization and AE#105.
+    let bdClipSubtractTicks: [Int64]?
     /// DVD: the title-set number whose VOBs back this title.
     let dvdVTSN: Int?
     /// DVD: the title number within its VTS.
     let dvdTitleNumber: Int?
 
     init(id: Int, durationTicks: UInt64, chapters: [DiscChapter] = [],
-         bdClipIDs: [String]? = nil, dvdVTSN: Int? = nil, dvdTitleNumber: Int? = nil) {
+         bdClipIDs: [String]? = nil, bdClipSubtractTicks: [Int64]? = nil,
+         dvdVTSN: Int? = nil, dvdTitleNumber: Int? = nil) {
         self.id = id
         self.durationTicks = durationTicks
         self.chapters = chapters
         self.bdClipIDs = bdClipIDs
+        self.bdClipSubtractTicks = bdClipSubtractTicks
         self.dvdVTSN = dvdVTSN
         self.dvdTitleNumber = dvdTitleNumber
+    }
+}
+
+/// One clip's span inside a `ConcatIOReader` stream, plus how far to pull its timestamps back so the clip
+/// continues contiguously from the previous one. Built once at disc recognition for the SELECTED title and
+/// applied per packet by `Demuxer` (attributing packets to clips by their byte position). Empty / all-zero
+/// for single-clip titles and non-disc sources, where it is a no-op. See AE#105.
+struct ClipSpan: Sendable, Equatable {
+    /// Byte offset in the concatenated stream where this clip's bytes begin.
+    let concatByteStart: Int64
+    /// Seconds to subtract from a raw source timestamp of a packet in this clip (0 for the first clip).
+    let subtractSeconds: Double
+}
+
+extension ClipSpan {
+    /// Index of the clip span containing byte position `pos` (the last span whose `concatByteStart` <= pos).
+    /// `pos < 0` (a packet / index entry that reported no byte position) returns `fallback` clamped into
+    /// range, since reads are sequential and the clip only advances. Empty list returns `fallback`.
+    static func index(forPos pos: Int64, in spans: [ClipSpan], fallback: Int) -> Int {
+        guard !spans.isEmpty else { return fallback }
+        if pos < 0 { return min(max(fallback, 0), spans.count - 1) }
+        var lo = 0
+        var hi = spans.count
+        while lo < hi {
+            let mid = lo + (hi - lo) / 2
+            if spans[mid].concatByteStart <= pos { lo = mid + 1 } else { hi = mid }
+        }
+        return max(0, lo - 1)
     }
 }
 
@@ -75,6 +111,18 @@ struct DiscInfo: Sendable {
     let formatHint: String
     let titles: [DiscTitle]
     let selectedTitleIndex: Int
+    /// Per-clip presentation-offset spans for the SELECTED multi-clip Blu-ray title, sorted by
+    /// `concatByteStart`. Empty for single-clip / DVD / non-disc sources (Demuxer normalization no-ops).
+    let clipTimeline: [ClipSpan]
+
+    init(reader: IOReader, formatHint: String, titles: [DiscTitle], selectedTitleIndex: Int,
+         clipTimeline: [ClipSpan] = []) {
+        self.reader = reader
+        self.formatHint = formatHint
+        self.titles = titles
+        self.selectedTitleIndex = selectedTitleIndex
+        self.clipTimeline = clipTimeline
+    }
 
     var selectedTitle: DiscTitle? {
         titles.indices.contains(selectedTitleIndex) ? titles[selectedTitleIndex] : nil

--- a/Sources/AetherEngine/Disc/DiscReader.swift
+++ b/Sources/AetherEngine/Disc/DiscReader.swift
@@ -65,21 +65,34 @@ enum DiscReader {
         let selected = titles[selectedIndex]
         let streamDir = (try? udf.list(path: ["BDMV", "STREAM"])) ?? []
         var allExtents: [(offset: Int64, length: Int64)] = []
-        for clip in selected.bdClipIDs ?? [] {
+        // One ClipSpan per resolved clip: byte start in the concat stream + how far to pull its
+        // timestamps back so it continues contiguously from clip 0 (AE#105 multi-clip position drift).
+        var clipTimeline: [ClipSpan] = []
+        let subTicks = selected.bdClipSubtractTicks ?? []
+        for (k, clip) in (selected.bdClipIDs ?? []).enumerated() {
             guard let e = streamDir.first(where: { $0.name == "\(clip).m2ts" }),
                   let exts = try? udf.extents(of: e) else { continue }
+            let byteStart = allExtents.reduce(Int64(0)) { $0 + max(0, $1.length) }
+            let subSeconds = k < subTicks.count ? Double(subTicks[k]) / discTickRate : 0
+            clipTimeline.append(ClipSpan(concatByteStart: byteStart, subtractSeconds: subSeconds))
             allExtents += exts
         }
         guard !allExtents.isEmpty else {
             EngineLog.emit("[disc] selected title \(selectedIndex) clips=\(selected.bdClipIDs ?? []) but resolved no m2ts extents in BDMV/STREAM (\(streamDir.count) entries); cannot build stream", category: .demux)
             return nil
         }
+        // Only a multi-clip title with a real (non-zero) offset needs normalization; a single clip is a no-op.
+        if clipTimeline.count < 2 || !clipTimeline.contains(where: { $0.subtractSeconds != 0 }) {
+            clipTimeline = []
+        }
         let totalBytes = allExtents.reduce(Int64(0)) { $0 + max(0, $1.length) }
-        EngineLog.emit("[disc] Blu-ray recognized: \(titles.count) title(s), selected \(selectedIndex) clips=\(selected.bdClipIDs ?? []) m2ts-extents=\(allExtents.count) bytes=\(totalBytes)", category: .demux)
+        EngineLog.emit("[disc] Blu-ray recognized: \(titles.count) title(s), selected \(selectedIndex) clips=\(selected.bdClipIDs ?? []) m2ts-extents=\(allExtents.count) bytes=\(totalBytes) clipSpans=\(clipTimeline.count)", category: .demux)
         storeRecognition(cacheKey: cacheKey, selectTitleID: selectTitleID,
-                         formatHint: "mpegts", titles: titles, selectedIndex: selectedIndex, extents: allExtents)
+                         formatHint: "mpegts", titles: titles, selectedIndex: selectedIndex,
+                         extents: allExtents, clipTimeline: clipTimeline)
         return DiscInfo(reader: ConcatIOReader(base: reader, extents: allExtents),
-                        formatHint: "mpegts", titles: titles, selectedTitleIndex: selectedIndex)
+                        formatHint: "mpegts", titles: titles, selectedTitleIndex: selectedIndex,
+                        clipTimeline: clipTimeline)
     }
 
     /// Memoize a successful recognition so a re-open of the same source (track switch on a remote ISO)
@@ -87,11 +100,12 @@ enum DiscReader {
     private static func storeRecognition(
         cacheKey: String?, selectTitleID: Int?,
         formatHint: String, titles: [DiscTitle], selectedIndex: Int,
-        extents: [(offset: Int64, length: Int64)]
+        extents: [(offset: Int64, length: Int64)], clipTimeline: [ClipSpan] = []
     ) {
         guard let cacheKey else { return }
         let recognition = DiscRecognition(formatHint: formatHint, titles: titles,
-                                          selectedTitleIndex: selectedIndex, extents: extents)
+                                          selectedTitleIndex: selectedIndex, extents: extents,
+                                          clipTimeline: clipTimeline)
         DiscRecognitionCache.store(key: cacheKey, selectTitleID: selectTitleID, recognition)
         // The probe opens with selectTitleID == nil (default title), but the rest of the engine
         // references that same title by its resolved id (== selectedIndex): reloads and the subtitle
@@ -131,7 +145,8 @@ enum DiscReader {
         if let cacheKey, let cached = DiscRecognitionCache.lookup(key: cacheKey, selectTitleID: selectTitleID) {
             return DiscInfo(reader: ConcatIOReader(base: reader, extents: cached.extents),
                             formatHint: cached.formatHint, titles: cached.titles,
-                            selectedTitleIndex: cached.selectedTitleIndex)
+                            selectedTitleIndex: cached.selectedTitleIndex,
+                            clipTimeline: cached.clipTimeline)
         }
         guard looksLikeISO9660(reader) else { return try wrapBluRay(reader, selectTitleID: selectTitleID, cacheKey: cacheKey) }
         let iso: ISO9660Reader

--- a/Sources/AetherEngine/Disc/DiscRecognitionCache.swift
+++ b/Sources/AetherEngine/Disc/DiscRecognitionCache.swift
@@ -9,6 +9,18 @@ struct DiscRecognition: Sendable {
     let titles: [DiscTitle]
     let selectedTitleIndex: Int
     let extents: [(offset: Int64, length: Int64)]
+    /// Per-clip presentation-offset spans for the selected multi-clip Blu-ray title; empty otherwise.
+    /// Cached so a re-open (subtitle side demuxer, reload) rebuilds the same normalized timeline (AE#105).
+    let clipTimeline: [ClipSpan]
+
+    init(formatHint: String, titles: [DiscTitle], selectedTitleIndex: Int,
+         extents: [(offset: Int64, length: Int64)], clipTimeline: [ClipSpan] = []) {
+        self.formatHint = formatHint
+        self.titles = titles
+        self.selectedTitleIndex = selectedTitleIndex
+        self.extents = extents
+        self.clipTimeline = clipTimeline
+    }
 }
 
 /// Memoizes `DiscReader.wrap` per source identity + selected title.

--- a/Sources/AetherEngine/Disc/MPLSParser.swift
+++ b/Sources/AetherEngine/Disc/MPLSParser.swift
@@ -3,6 +3,13 @@ import Foundation
 struct MPLSPlaylist: Equatable {
     let clipIDs: [String]
     let durationTicks: UInt64
+    /// Per-PlayItem in_time on the clip's STC, 45 kHz ticks, parallel to `clipIDs`. A clip's presented
+    /// frames begin at this STC value, so it is the origin used to fold each clip onto the title's
+    /// contiguous presentation timeline (AE#105 multi-clip position drift).
+    var inTimes: [UInt64] = []
+    /// Presentation offset of each PlayItem's start, 45 kHz ticks relative to the title's start (sum of the
+    /// durations of all earlier PlayItems), parallel to `clipIDs`.
+    var cumulativeBefore: [UInt64] = []
     /// Entry-mark chapter starts, 45 kHz ticks relative to the title's start, sorted ascending. Empty when
     /// the playlist declares no PlayListMark section (or only link-point marks). See `parseChapterStarts` (#67).
     var chapterStartTicks: [UInt64] = []
@@ -38,7 +45,9 @@ enum MPLSParser {
         }
         guard !clips.isEmpty else { return nil }
         let chapters = parseChapterStarts(data, inTimes: inTimes, cumulativeBefore: cumulativeBefore)
-        return MPLSPlaylist(clipIDs: clips, durationTicks: ticks, chapterStartTicks: chapters)
+        return MPLSPlaylist(clipIDs: clips, durationTicks: ticks,
+                            inTimes: inTimes, cumulativeBefore: cumulativeBefore,
+                            chapterStartTicks: chapters)
     }
 
     /// Parse the PlayListMark section (header offset 12 = PlayListMarkStartAddress) into title-relative chapter

--- a/Tests/AetherEngineTests/BDDiscReaderTests.swift
+++ b/Tests/AetherEngineTests/BDDiscReaderTests.swift
@@ -27,6 +27,7 @@ final class BDDiscReaderTests: XCTestCase {
         XCTAssertEqual(info.formatHint, "mpegts")
         XCTAssertEqual(info.titles.count, 1)  // single-playlist fixture -> one title
         XCTAssertEqual(info.selectedTitleIndex, 0)
+        XCTAssertTrue(info.clipTimeline.isEmpty)  // AE#105: single-clip title needs no normalization (no-op)
         var buf = [UInt8](repeating: 0, count: 5)
         _ = buf.withUnsafeMutableBufferPointer { info.reader.read($0.baseAddress, size: 5) }
         XCTAssertEqual(buf, [0x00,0x00,0x00,0x00,0x47])

--- a/Tests/AetherEngineTests/BDTitleSelectorTests.swift
+++ b/Tests/AetherEngineTests/BDTitleSelectorTests.swift
@@ -91,4 +91,42 @@ final class BDTitleSelectorTests: XCTestCase {
         XCTAssertFalse(BDTitleSelector.isRepeatedClipDecoy(branching))
         XCTAssertTrue(BDTitleSelector.isRepeatedClipDecoy(decoyPlaylist()))
     }
+
+    // MARK: - Per-clip presentation offsets (AE#105)
+
+    func test_clipSubtractTicksFoldsClipsContiguously() {
+        // Two clips whose STC both start at 0: clip0 runs 0..90000, clip1 (raw 0-based) must be pulled
+        // forward to continue at 90000, i.e. subtract -90000 (normalized = raw - (-90000)).
+        let pl = MPLSPlaylist(clipIDs: ["00001", "00002"], durationTicks: 270_000,
+                              inTimes: [0, 0], cumulativeBefore: [0, 90_000])
+        XCTAssertEqual(BDTitleSelector.clipSubtractTicks(pl), [0, -90_000])
+    }
+
+    func test_clipSubtractTicksMatchesObservedDiscontinuity() {
+        // AE#105 reporter's title: clip0 in_time ~4199.9s, clip1 in_time ~96043s, clip0 duration ~40s.
+        // The subtract for clip1 must equal the source PTS jump (the ~91803s ledger drift) so the
+        // normalized playhead stays contiguous instead of leaping to ~1:10:xx.
+        let i0: UInt64 = 189_000_000        // 4200.0s * 45000
+        let i1: UInt64 = 4_321_935_000      // 96043.0s * 45000
+        let dur0: UInt64 = 1_800_000        // 40.0s * 45000
+        let pl = MPLSPlaylist(clipIDs: ["00055", "00048"], durationTicks: dur0 + 90_000,
+                              inTimes: [i0, i1], cumulativeBefore: [0, dur0])
+        let sub = try! XCTUnwrap(BDTitleSelector.clipSubtractTicks(pl))
+        XCTAssertEqual(sub[0], 0)
+        // 4321935000 - 189000000 - 1800000 = 4131135000 ticks = 91803.0s (matches the observed drift).
+        XCTAssertEqual(sub[1], 4_131_135_000)
+        XCTAssertEqual(Double(sub[1]) / 45000.0, 91_803.0, accuracy: 0.001)
+    }
+
+    func test_clipSubtractTicksNilWhenTimingAbsent() {
+        // A playlist parsed without per-clip timing (older parse / malformed) disables normalization.
+        let pl = MPLSPlaylist(clipIDs: ["00001", "00002"], durationTicks: 270_000)
+        XCTAssertNil(BDTitleSelector.clipSubtractTicks(pl))
+    }
+
+    func test_clipSubtractTicksSingleClipIsZero() {
+        let pl = MPLSPlaylist(clipIDs: ["00001"], durationTicks: 90_000,
+                              inTimes: [12_345], cumulativeBefore: [0])
+        XCTAssertEqual(BDTitleSelector.clipSubtractTicks(pl), [0])
+    }
 }

--- a/Tests/AetherEngineTests/Issue105MultiClipTimelineTests.swift
+++ b/Tests/AetherEngineTests/Issue105MultiClipTimelineTests.swift
@@ -1,0 +1,67 @@
+import XCTest
+@testable import AetherEngine
+
+/// AE#105: a multi-clip Blu-ray title concatenates m2ts clips that each carry their own STC, so the raw
+/// source PTS leaps at every clip boundary. The demuxer folds each clip onto one contiguous presentation
+/// timeline by subtracting a per-clip offset, attributing packets to clips by byte position. These cover
+/// the pure pieces of that transform (the end-to-end packet rewrite is device-verified on the real disc).
+final class Issue105MultiClipTimelineTests: XCTestCase {
+
+    // MARK: - Byte-position -> clip attribution (ClipSpan.index)
+
+    func test_indexAttributesByByteBoundary() {
+        let spans = [ClipSpan(concatByteStart: 0, subtractSeconds: 0),
+                     ClipSpan(concatByteStart: 1_000, subtractSeconds: 5),
+                     ClipSpan(concatByteStart: 2_000, subtractSeconds: 9)]
+        XCTAssertEqual(ClipSpan.index(forPos: 0, in: spans, fallback: 0), 0)
+        XCTAssertEqual(ClipSpan.index(forPos: 999, in: spans, fallback: 0), 0)
+        XCTAssertEqual(ClipSpan.index(forPos: 1_000, in: spans, fallback: 0), 1)   // boundary belongs to the new clip
+        XCTAssertEqual(ClipSpan.index(forPos: 1_500, in: spans, fallback: 0), 1)
+        XCTAssertEqual(ClipSpan.index(forPos: 2_000, in: spans, fallback: 0), 2)
+        XCTAssertEqual(ClipSpan.index(forPos: 9_999, in: spans, fallback: 0), 2)
+    }
+
+    func test_indexNegativePosUsesFallback() {
+        // A packet / index entry that reports no byte position keeps the last clip (reads are sequential).
+        let spans = [ClipSpan(concatByteStart: 0, subtractSeconds: 0),
+                     ClipSpan(concatByteStart: 1_000, subtractSeconds: 5)]
+        XCTAssertEqual(ClipSpan.index(forPos: -1, in: spans, fallback: 1), 1)
+        XCTAssertEqual(ClipSpan.index(forPos: -1, in: spans, fallback: 9), 1)   // clamped into range
+    }
+
+    func test_indexEmptyReturnsFallback() {
+        XCTAssertEqual(ClipSpan.index(forPos: 500, in: [], fallback: 3), 3)
+    }
+
+    // MARK: - Normalized timeline is contiguous
+
+    /// Replicates the Demuxer's per-packet transform (subtract the clip's seconds converted to the stream
+    /// time base) and asserts the two-clip title presents one contiguous 90 kHz timeline instead of leaping
+    /// to ~1:10:xx at the boundary (the reported symptom).
+    func test_normalizationYieldsContiguousTimeline() {
+        let tbDen = 90_000, tbNum = 1
+        let clip1SubSeconds = 91_803.0     // BDTitleSelector.clipSubtractTicks -> 4_131_135_000 / 45000
+        let spans = [ClipSpan(concatByteStart: 0, subtractSeconds: 0),
+                     ClipSpan(concatByteStart: 1_000_000, subtractSeconds: clip1SubSeconds)]
+
+        func normalized(rawPts: Int64, pos: Int64) -> Int64 {
+            let idx = ClipSpan.index(forPos: pos, in: spans, fallback: 0)
+            let sub = spans[idx].subtractSeconds
+            guard sub != 0 else { return rawPts }
+            let subTicks = Int64((sub * Double(tbDen) / Double(tbNum)).rounded())
+            return rawPts - subTicks
+        }
+
+        // Last frame of clip0 (its byte range) and first frame of clip1 (raw PTS jumps by +91803s).
+        let clip0LastRaw: Int64 = 381_600_000      // 4240.0s
+        let clip1FirstRaw: Int64 = 8_643_870_000   // 96043.0s
+        let clip0LastNorm = normalized(rawPts: clip0LastRaw, pos: 500_000)
+        let clip1FirstNorm = normalized(rawPts: clip1FirstRaw, pos: 1_000_000)
+
+        // Clip0 is untouched; clip1 is pulled back to continue right where clip0 ended (~4240s), not 96043s.
+        XCTAssertEqual(clip0LastNorm, 381_600_000)
+        XCTAssertEqual(Double(clip1FirstNorm) / 90_000.0, 4240.0, accuracy: 0.01)
+        // Without normalization the boundary gap is ~91803s; with it, sub-second.
+        XCTAssertLessThan(abs(Double(clip1FirstNorm - clip0LastNorm) / 90_000.0), 0.5)
+    }
+}

--- a/Tests/AetherEngineTests/MPLSParserTests.swift
+++ b/Tests/AetherEngineTests/MPLSParserTests.swift
@@ -41,6 +41,15 @@ final class MPLSParserTests: XCTestCase {
         XCTAssertEqual(pl.durationTicks, 270000)
     }
 
+    // AE#105: per-clip in_time and cumulative presentation offset are retained (parallel to clipIDs) so a
+    // multi-clip title can fold each clip's discontinuous STC onto one contiguous presentation timeline.
+    func test_retainsPerClipInTimesAndCumulativeOffsets() {
+        // makeMPLS: item0 in=0/out=90000 (dur 90000), item1 in=0/out=180000 (dur 180000).
+        let pl = try! XCTUnwrap(MPLSParser.parse(makeMPLS()))
+        XCTAssertEqual(pl.inTimes, [0, 0])
+        XCTAssertEqual(pl.cumulativeBefore, [0, 90000])   // item1 starts after item0's 90000-tick duration
+    }
+
     func test_rejectsBadMagic() {
         XCTAssertNil(MPLSParser.parse(Array("NOPE0200".utf8) + [UInt8](repeating: 0, count: 40)))
     }


### PR DESCRIPTION
## Problem (AE#105, round 3)

After R1 (decoy playlist) and R2 (MPLS duration / follow-selected-title) were confirmed by the reporter, the **playhead position** was still wrong on multi-clip titles: title 3 (0:00:42) read `1:10:14`, title 4 (0:00:35) read `10:04`, the ball pinned at the end, and title 3 again showed a blank frame.

## Root cause

A multi-clip Blu-ray title concatenates m2ts clips that each carry their own STC, so the raw source PTS leaps at every clip boundary (the reporter's title 3 jumped ~91803s at its trailing clip: `#65 ledger seg-10 drift=91803.676s`). The engine uses a single constant `videoShiftPts` anchored on clip 0; the live timeline-rebase that absorbs such jumps (`HLSSegmentProducer.swift:1444`) is gated `isLive`, so VOD/disc inherits the jump. `outputTfdt = source - shift` then shows the raw source seconds, and post-boundary packets route past the plan into a blank frame. R2's duration fix corrected only the scrubber total and the plan, not the position.

## Fix

The demuxer folds each clip onto one contiguous presentation timeline. MPLS already carries per-clip `in_time` and cumulative duration; from those the title selector computes a per-clip subtract offset (clip 0 = 0, so the plan/anchor/seeks in clip 0 stay untouched), disc recognition pairs each offset with the clip's byte span in the concat stream, and `readPacket` / `indexedKeyframes` attribute every packet and index entry to its clip by byte position (`pkt.pos` / `entry.pos`) and subtract that clip's offset. Active only for multi-clip BD titles; single-clip, main feature, DVD, and non-disc sources are a no-op.

Chose demuxer normalization over enabling the VOD producer-rebase: it fixes the concatenation seam itself, so the plan, producer, still extractor, and subtitle side-demuxer all see one clean timeline, and it leaves the regression-prone producer restart/tfdt code untouched.

## Tests / builds

- `BDTitleSelectorTests.clipSubtractTicks` (+4, incl. the reporter's observed 91803s drift), `Issue105MultiClipTimelineTests` (+4: byte-position attribution, contiguous-timeline assertion), `MPLSParserTests` per-clip retention (+1), `BDDiscReaderTests` single-clip no-op (+1).
- Full disc suite green; strict-concurrency, tvOS-Sim, and iOS-Sim builds green.

Known residual (out of scope): a cold seek directly into a tiny trailing clip maps imperfectly (av_seek across the discontinuity); sequential playback is fully correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)