### PR TITLE
fix(disc): rebase multi-clip Blu-ray playhead onto the 0-based display axis (#105)

### DIFF
--- a/Sources/AetherEngine/AetherEngine+Loading.swift
+++ b/Sources/AetherEngine/AetherEngine+Loading.swift
@@ -25,7 +25,10 @@ extension AetherEngine {
             playlistShiftSeconds = active.shift
         }
         if pendingRecoverySeekClockTarget == nil {
-            clock.currentTime = value + playlistShiftSeconds
+            // AE#105: fold the disc's clip-0 STC base back out so the published playhead sits on the same
+            // 0-based axis as the MPLS duration (origin 0 for normal/live -> no-op).
+            clock.currentTime = PresentationAxis.display(sourcePTS: value + playlistShiftSeconds,
+                                                         origin: sourcePresentationOrigin)
         }
         // Live edge must fold with the same playlistShiftSeconds as the playhead; opposite sign would make behindLiveSeconds meaningless.
         if isLive {
@@ -211,10 +214,16 @@ extension AetherEngine {
                 let prevShift = self.playlistShiftSeconds
                 let delta = seconds - prevShift
                 self.playlistShiftSeconds = seconds
+                // AE#105: a disc title's raw source PTS starts at clip 0's STC base (= this constant VOD shift)
+                // while its duration is the 0-based MPLS/IFO playlist length. Anchor the display origin to that
+                // base so the published playhead is 0-based like the total. Normal/live sources keep origin 0
+                // (their public axis already equals source PTS), so this whole change is a no-op off disc.
+                self.sourcePresentationOrigin = (!self.discTitles.isEmpty && !self.isLive) ? seconds : 0
                 // Seed seam history: activateAt=-.infinity covers the full output timeline from the start.
                 self.liveShiftSeams = [(activateAt: -.infinity, shift: seconds)]
-                // Re-fold immediately so currentTime (source PTS) doesn't lag the next periodic tick.
-                self.clock.currentTime = self.nativeClockSeconds + seconds
+                // Re-fold immediately so currentTime doesn't lag the next periodic tick (origin-corrected).
+                self.clock.currentTime = PresentationAxis.display(sourcePTS: self.nativeClockSeconds + seconds,
+                                                                  origin: self.sourcePresentationOrigin)
                 // sourceTime re-folds on next $renderedTime tick; keeping it there tracks the rendered picture, not the optimistic clock (#49).
                 // #65 diag: every VOD producer (re)start collapses the seam history to one entry here. If `delta`
                 // is non-zero while AVPlayer still holds old-epoch buffer (avBufAhead > 0), the buffered bytes
@@ -225,6 +234,7 @@ extension AetherEngine {
                     "[AetherEngine] #65 VOD shift published: \(String(format: "%.3f", seconds))s "
                     + "(prev \(String(format: "%.3f", prevShift))s, delta \(String(format: "%.3f", delta))s, "
                     + "changed=\(abs(delta) > 0.001 ? "YES" : "no")) seams->1 "
+                    + "presentationOrigin=\(String(format: "%.3f", self.sourcePresentationOrigin))s "
                     + "rawClock=\(String(format: "%.2f", self.nativeClockSeconds))s "
                     + "avBufAhead=\(String(format: "%.2f", self.avPlayerBufferAheadSeconds()))s",
                     category: .session
@@ -234,8 +244,11 @@ extension AetherEngine {
         session.onSeekStateChanged = { [weak self] inFlight, playlistTime in
             Task { @MainActor in
                 guard let self = self else { return }
-                // Fold playlist-axis segment time onto source-PTS axis for seekTarget/currentTime (#38). nil clears without disturbing the last value.
-                let target = playlistTime.map { $0 + self.playlistShiftSeconds }
+                // Fold playlist-axis segment time onto the published display axis (#38); the origin keeps a disc
+                // scrub target 0-based like currentTime (0 off disc). nil clears without disturbing the last value.
+                let target = playlistTime.map {
+                    PresentationAxis.display(sourcePTS: $0 + self.playlistShiftSeconds, origin: self.sourcePresentationOrigin)
+                }
                 self.setNativeScrubSeek(inFlight: inFlight, target: target)
             }
         }
@@ -540,8 +553,11 @@ extension AetherEngine {
                 let shift = self.liveShiftSeams.last(where: { value >= $0.activateAt })?.shift
                     ?? self.playlistShiftSeconds
                 self.clock.sourceTime = value + shift
-                // bufferedPosition = end of AVPlayer's contiguous loadedTimeRanges, folded the same way. Clamp so it never trails the rendered frame (#54).
-                self.clock.bufferedPosition = max(value + shift, host.bufferedEnd + shift)
+                // bufferedPosition = end of AVPlayer's contiguous loadedTimeRanges, folded the same way. Clamp so
+                // it never trails the rendered frame (#54). Drawn against the 0-based duration, so map onto the
+                // display axis to keep the buffer bar aligned with currentTime (0 off disc). AE#105.
+                self.clock.bufferedPosition = PresentationAxis.display(
+                    sourcePTS: max(value + shift, host.bufferedEnd + shift), origin: self.sourcePresentationOrigin)
             }
             .store(in: &nativeCancellables)
         startLiveWindowTimer(host: host)

--- a/Sources/AetherEngine/AetherEngine.swift
+++ b/Sources/AetherEngine/AetherEngine.swift
@@ -508,6 +508,16 @@ public final class AetherEngine: ObservableObject {
     /// onPlaylistShiftChanged can re-derive currentTime immediately on shift change. Unused on SW/audio (shift 0).
     var nativeClockSeconds: Double = 0
 
+    /// Source PTS that maps to display-time 0 for the SELECTED source. 0 for normal files and live (their
+    /// public seconds axis already coincides with source PTS). For a disc title it equals the (constant) VOD
+    /// `playlistShiftSeconds` = clip 0's STC base, because a disc title publishes its `duration` from the
+    /// MPLS/IFO playlist on a 0-based axis while the raw source PTS starts at that base (599s / 4199s on the
+    /// TRON multi-clip titles, AE#105). Subtracted from the published `currentTime`/`seekTarget` and added back
+    /// to the `seek` input so the scrubber position, total, seek and resume all live on the same 0-based axis
+    /// the producer already anchors `startPosition` on (`segmentIndexForPlaylistTime`), while `sourceTime`
+    /// stays true source PTS for subtitle-cue alignment. Reset to 0 on load/stop; set in onPlaylistShiftChanged.
+    var sourcePresentationOrigin: Double = 0
+
     /// Diagnostics only. Reads HLSVideoEngine's videoShiftPts synchronously, bypassing the async
     /// onPlaylistShiftChanged relay. A persistent gap vs `playlistShiftSeconds` means the clock is folding
     /// with a stale shift (AetherEngine#49 divergence). Poll alongside `frameAhead` when tracing divergence.
@@ -1851,9 +1861,11 @@ public final class AetherEngine: ObservableObject {
             setProgrammaticSeek(inFlight: false, target: nil)
             return
         }
-        // Convert source-PTS target to AVPlayer's HLS clock (source - playlistShiftSeconds).
-        // SW/audio hosts run on source time (shift 0), so the conversion is a no-op there.
-        let clockTarget = target - playlistShiftSeconds
+        // Convert the (display-axis) target to AVPlayer's HLS clock. The origin re-adds a disc title's clip-0
+        // STC base so `target` (0-based, matching duration) lands on the source-PTS shift the producer subtracts,
+        // i.e. clockTarget == the 0-based playlist time (AE#105). Origin 0 off disc, so this stays
+        // `target - playlistShiftSeconds` for normal VOD; SW/audio hosts run on source time (shift 0), no-op.
+        let clockTarget = PresentationAxis.source(displayTime: target, origin: sourcePresentationOrigin) - playlistShiftSeconds
         let gen = loadGeneration
         // Publish the native-path seek target up front so the scrub clock snaps immediately (#37); the host
         // suppresses periodic-observer reads until landing. SW/audio hosts resolve synchronously and write
@@ -1896,7 +1908,9 @@ public final class AetherEngine: ObservableObject {
                     // evict the target's segments from retention).
                     let avpReal = host.renderedTime
                     nativeClockSeconds = avpReal
-                    clock.currentTime = avpReal + playlistShiftSeconds
+                    // currentTime on the 0-based display axis (AE#105 origin); sourceTime stays source PTS for subs.
+                    clock.currentTime = PresentationAxis.display(sourcePTS: avpReal + playlistShiftSeconds,
+                                                                 origin: sourcePresentationOrigin)
                     clock.sourceTime = avpReal + playlistShiftSeconds
                     setProgrammaticSeek(inFlight: false, target: nil)
                     // Hand state to AVPlayer's ACTUAL transport status, not the phantom .playing the normal
@@ -1938,10 +1952,12 @@ public final class AetherEngine: ObservableObject {
         setPendingRecoverySeekTarget(nil)
         nativeClockSeconds = clockTarget
         clock.currentTime = target
-        clock.sourceTime = target
+        // sourceTime + subtitle re-arm need true source PTS; map the display target back (0 off disc). AE#105.
+        let landedSourcePTS = PresentationAxis.source(displayTime: target, origin: sourcePresentationOrigin)
+        clock.sourceTime = landedSourcePTS
 
         // #100 + #96: the playhead jumped; re-anchor the overlay subtitle readers at the landed source-PTS.
-        rearmEmbeddedSubtitleReaders(atSourceTime: target)
+        rearmEmbeddedSubtitleReaders(atSourceTime: landedSourcePTS)
 
         // Seek has physically landed.
         state = .playing
@@ -2028,6 +2044,7 @@ public final class AetherEngine: ObservableObject {
         clock.currentTime = 0
         clock.bufferedPosition = 0
         clock.progress = 0
+        sourcePresentationOrigin = 0  // AE#105: clear disc display-origin so the next source starts on a clean axis.
         // Clear session state; without this, metadata/track lists/format/pendingExternalMetadata from the
         // previous session survive until the next load and bleed into unrelated sessions.
         duration = 0

--- a/Sources/AetherEngine/PresentationAxis.swift
+++ b/Sources/AetherEngine/PresentationAxis.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// Converts between the two time axes a session exposes (AE#105).
+///
+/// - **Source-PTS axis**: the timestamps the decoder/producer/subtitle readers work in. For a normal file
+///   this starts at ~0; for a Blu-ray/DVD title it starts at clip 0's STC base (the TRON multi-clip titles
+///   start at 599s / 4199s), because the raw m2ts/VOB clocks are not zero-based.
+/// - **Display axis**: the 0-based `[0, duration]` axis the scrubber shows and the host seeks against. A disc
+///   title's `duration` is the 0-based MPLS/IFO playlist length, so the published playhead must match it.
+///
+/// `sourcePresentationOrigin` is the source PTS that maps to display-0 (0 for normal/live, clip 0's base for a
+/// disc title). These helpers keep every public playhead/seek conversion in one place so the sign is obvious
+/// and unit-testable; `sourceTime` and the internal producer/subtitle axes stay on the source-PTS axis.
+enum PresentationAxis {
+    /// Published playhead / seek-target on the 0-based display axis, from a source-PTS value.
+    /// Inverse of `source(displayTime:origin:)`. Identity when `origin == 0`.
+    static func display(sourcePTS: Double, origin: Double) -> Double {
+        sourcePTS - origin
+    }
+
+    /// Source PTS from a 0-based display value (host seek input, resume position).
+    /// Inverse of `display(sourcePTS:origin:)`. Identity when `origin == 0`.
+    static func source(displayTime: Double, origin: Double) -> Double {
+        displayTime + origin
+    }
+}

--- a/Tests/AetherEngineTests/Issue105PresentationAxisTests.swift
+++ b/Tests/AetherEngineTests/Issue105PresentationAxisTests.swift
@@ -1,0 +1,83 @@
+import XCTest
+@testable import AetherEngine
+
+/// AE#105 round 5: the multi-clip fold made the intra-title timeline contiguous, but the published playhead
+/// still sat in the disc's source-PTS domain (clip 0's STC base) while `duration` was the 0-based MPLS length,
+/// so the scrubber showed 10:04 / 1:10:14 on 0:35 / 0:41 titles. `PresentationAxis` + `sourcePresentationOrigin`
+/// map the published playhead / seek target onto the same 0-based axis as the duration, leaving `sourceTime`
+/// (subtitle-cue alignment) on the source-PTS axis. These cover the pure axis arithmetic; the clock wiring is
+/// device-verified on the real disc.
+final class Issue105PresentationAxisTests: XCTestCase {
+
+    // Concrete geometry from the reporter's test.t.log.txt / screenshots.
+    private let eightClipBase0 = 599.917    // "Title 4", 8 clips, duration 0:35 -> scrubber showed 10:04
+    private let twoClipBase0 = 4_199.917    // "Title 3", 2 clips, duration 0:41 -> scrubber showed 1:10:14
+
+    // MARK: - Display axis (published playhead / seek target)
+
+    /// The exact reporter numbers: a source-PTS playhead of base0 + elapsed must publish as `elapsed` (0-based),
+    /// not base0 + elapsed. 604s on the 8-clip title -> 4.083s; 4214s on the 2-clip title -> 14.083s.
+    func test_discOriginRebasesReporterPlayheadToZeroBased() {
+        XCTAssertEqual(PresentationAxis.display(sourcePTS: 604.0, origin: eightClipBase0), 4.083, accuracy: 0.01)
+        XCTAssertEqual(PresentationAxis.display(sourcePTS: 4_214.0, origin: twoClipBase0), 14.083, accuracy: 0.01)
+    }
+
+    /// The published playhead must never exceed the 0-based duration (the "ball pinned at the end" symptom).
+    func test_discPlayheadStaysWithinZeroBasedDuration() {
+        let duration = 35.285                       // 8-clip title MPLS duration
+        // Playhead near the end of the title: source PTS = base0 + 35.0.
+        let display = PresentationAxis.display(sourcePTS: eightClipBase0 + 35.0, origin: eightClipBase0)
+        XCTAssertEqual(display, 35.0, accuracy: 0.001)
+        XCTAssertLessThanOrEqual(display, duration)
+    }
+
+    /// Normal files and live use origin 0, so the display axis is byte-identical to the source axis (no-op).
+    func test_zeroOriginIsIdentity() {
+        for pts in [0.0, 12.5, 3_600.0, 7_508.9] {
+            XCTAssertEqual(PresentationAxis.display(sourcePTS: pts, origin: 0), pts, accuracy: 0.0)
+            XCTAssertEqual(PresentationAxis.source(displayTime: pts, origin: 0), pts, accuracy: 0.0)
+        }
+    }
+
+    // MARK: - Round trip (host seek in / playhead out are inverses)
+
+    func test_displaySourceRoundTrip() {
+        for origin in [0.0, eightClipBase0, twoClipBase0] {
+            for value in [0.0, 4.083, 35.0, 41.6] {
+                let source = PresentationAxis.source(displayTime: value, origin: origin)
+                XCTAssertEqual(PresentationAxis.display(sourcePTS: source, origin: origin), value, accuracy: 1e-9)
+            }
+        }
+    }
+
+    // MARK: - Seek clock target (display target -> AVPlayer's 0-based HLS clock)
+
+    /// Replicates `seek(to:)`: clockTarget = source(displayTarget, origin) - playlistShiftSeconds. For a disc,
+    /// origin == the constant shift == base0, so a 0-based display target lands on the SAME 0-based playlist
+    /// clock AVPlayer runs on (never the negative value the old `target - shift` produced). Off disc it stays
+    /// `target - shift`.
+    private func clockTarget(displayTarget: Double, shift: Double, origin: Double) -> Double {
+        PresentationAxis.source(displayTime: displayTarget, origin: origin) - shift
+    }
+
+    func test_discSeekTargetMapsToZeroBasedPlaylistClock() {
+        // Disc: origin == shift == base0. Scrub to 0:20 must seek AVPlayer to itemAxis 20s, not 20 - 599 < 0.
+        let shift = eightClipBase0, origin = eightClipBase0
+        XCTAssertEqual(clockTarget(displayTarget: 20.0, shift: shift, origin: origin), 20.0, accuracy: 0.001)
+        XCTAssertEqual(clockTarget(displayTarget: 0.0, shift: shift, origin: origin), 0.0, accuracy: 0.001)
+    }
+
+    func test_oldFormulaWouldSeekNegativeOnDisc() {
+        // Guards the regression this fixes: without the origin, scrubbing a disc seeks to a negative clock.
+        let shift = eightClipBase0
+        let brokenClockTarget = 20.0 - shift            // the pre-fix `target - playlistShiftSeconds`
+        XCTAssertLessThan(brokenClockTarget, 0)
+    }
+
+    func test_nonDiscSeekTargetIsUnchanged() {
+        // Normal VOD: origin 0, so clockTarget == target - shift exactly as before this change.
+        let shift = 0.4                                  // a small head-of-stream offset
+        XCTAssertEqual(clockTarget(displayTarget: 30.0, shift: shift, origin: 0),
+                       30.0 - shift, accuracy: 1e-9)
+    }
+}


### PR DESCRIPTION
## Problem

Round 4 (`95aef3a`) made the multi-clip fold contiguous, but the reporter still saw the playhead sitting far past the total on the short TRON titles: **10:04 on a 0:35 title, 1:10:14 on a 0:41 title, ball pinned at the end.**

That was never the fold. A disc title publishes its `duration` from the 0-based MPLS/IFO playlist, while the engine kept publishing `currentTime` on the source-PTS axis, which for a disc starts at clip 0's STC base (599s / 4199s). Position and total lived in different domains, so the playhead overshot the bar and seek clamped to a negative clock.

The producer already anchors `startPosition` on the 0-based playlist axis (`segmentIndexForPlaylistTime`) and the subtitle reader already expects a 0-based resume offset (`currentShiftSeconds = playlistShiftSeconds + subtitleStreamStartSeconds`), so the source-PTS `currentTime` was also feeding reload/resume the wrong domain (audio-switch/recovery reload resumed offset by base0; subtitle reload doubled base0 into its shift).

## Fix

Introduce `sourcePresentationOrigin`: the source PTS that maps to display-0. It is 0 for normal files and live (their public axis already equals source PTS) and clip 0's STC base for a disc title (captured from the constant VOD shift in `onPlaylistShiftChanged`).

`PresentationAxis.display/source` convert the published playhead, seek target, buffered frontier and seek input by that origin, so the scrubber, total, seek and resume all sit on the same 0-based axis as the duration. `sourceTime` and the internal producer/subtitle axes stay on source PTS for cue alignment. **Off disc the origin is 0, so every conversion is a no-op and normal/live playback is byte-identical.**

## Tests / gates

- `Issue105PresentationAxisTests` (+7): reporter's 604s/4214s playheads rebasing to 4.083s/14.083s, seek target landing on a 0-based playlist clock instead of a negative one, zero-origin identity for normal VOD, display/source round trip.
- Full suite 437 pass, XCTest disc suite 30 pass, `-strict-concurrency=complete` clean, tvOS-Sim + iOS-Sim BUILD SUCCEEDED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)