### PR TITLE
fix(subtitles): gate synthetic PGS END flush on a complete object (#112)

### DIFF
--- a/Sources/AetherEngine/Decoder/EmbeddedSubtitleDecoder.swift
+++ b/Sources/AetherEngine/Decoder/EmbeddedSubtitleDecoder.swift
@@ -90,12 +90,17 @@ final class EmbeddedSubtitleDecoder {
 
         var sub = AVSubtitle()
         var gotSub: Int32 = 0
-        let ret = decodeWithFixups(ctx: ctx, pkt: packet, sub: &sub, gotSub: &gotSub)
+        var fixedPayload: [UInt8]? = nil
+        let ret = decodeWithFixups(ctx: ctx, pkt: packet, sub: &sub, gotSub: &gotSub, capturedPayload: &fixedPayload)
 
-        // Some MKV converters drop the PGS trailing END (0x80); feed a synthetic one to flush accumulated state.
+        // Some MKV converters drop the PGS trailing END (0x80); feed a synthetic one to flush accumulated
+        // state. Gate it (#112): only when the decoded payload already carries a complete object and no END
+        // of its own. A split-M2TS intermediate packet (PCS/PDS ahead of the ODS) would otherwise force a
+        // compose against an object that is not defined yet ("Invalid object id", once per display set).
         if gotSub == 0,
            ctx.pointee.codec_id == AV_CODEC_ID_HDMV_PGS_SUBTITLE,
-           packet.pointee.size > 30 {
+           packet.pointee.size > 30,
+           Self.pgsPayloadWarrantsSyntheticEnd(for: packet, fixedPayload: fixedPayload) {
             var endBytes: [UInt8] = [0x80, 0x00, 0x00,
                                      0, 0, 0, 0, 0, 0, 0, 0, 0,
                                      0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -226,13 +231,60 @@ final class EmbeddedSubtitleDecoder {
             || id == AV_CODEC_ID_XSUB
     }
 
+    /// Issue #112: decide whether a PGS payload that decoded with gotSub==0 warrants the synthetic
+    /// END flush. True ONLY when the payload already carries a complete object (an ODS whose
+    /// last-in-sequence flag is set) and no END segment of its own: the MKV-converter case the flush
+    /// targets (a full display set missing its trailing 0x80). It excludes the split-M2TS intermediate
+    /// packet (PCS/PDS before the ODS), where forcing a compose references an object that is not
+    /// defined yet and logs "Invalid object id".
+    ///
+    /// Payload layout: a run of `[type:1][length:2 BE][body:length]` segments (0x14 PDS, 0x15 ODS,
+    /// 0x16 PCS, 0x17 WDS, 0x80 END). Walked defensively; any malformed length ends the scan without a
+    /// read past `count`.
+    static func pgsPayloadWarrantsSyntheticEnd(_ base: UnsafePointer<UInt8>?, count: Int) -> Bool {
+        guard let base, count >= 3 else { return false }
+        var i = 0
+        var sawCompleteObject = false
+        while i + 3 <= count {
+            let type = base[i]
+            let len = (Int(base[i + 1]) << 8) | Int(base[i + 2])
+            let bodyStart = i + 3
+            if type == 0x80 { return false }   // real END present: the decoder emits on its own.
+            if type == 0x15,                   // ODS: complete only when the last-in-sequence bit is set.
+               len >= 4,
+               bodyStart + 3 < count {
+                // ODS body = object_id[2] + version[1] + sequence_flag[1]; 0x40 = last, 0xC0 = only.
+                if (base[bodyStart + 3] & 0x40) != 0 { sawCompleteObject = true }
+            }
+            let next = bodyStart + len
+            if next <= i { break }             // zero/negative advance guard.
+            i = next
+        }
+        return sawCompleteObject
+    }
+
+    /// Pick the bytes actually decoded (`fixedPayload` for stripped/inflated paths, else the raw
+    /// packet) and run the #112 synthetic-END gate over them.
+    private static func pgsPayloadWarrantsSyntheticEnd(
+        for packet: UnsafeMutablePointer<AVPacket>,
+        fixedPayload: [UInt8]?
+    ) -> Bool {
+        if let fixedPayload {
+            return fixedPayload.withUnsafeBufferPointer {
+                pgsPayloadWarrantsSyntheticEnd($0.baseAddress, count: $0.count)
+            }
+        }
+        return pgsPayloadWarrantsSyntheticEnd(packet.pointee.data, count: Int(packet.pointee.size))
+    }
+
     // MARK: - Decode fixups
 
     private func decodeWithFixups(
         ctx: UnsafeMutablePointer<AVCodecContext>,
         pkt: UnsafeMutablePointer<AVPacket>,
         sub: UnsafeMutablePointer<AVSubtitle>,
-        gotSub: UnsafeMutablePointer<Int32>
+        gotSub: UnsafeMutablePointer<Int32>,
+        capturedPayload: inout [UInt8]?
     ) -> Int32 {
         guard let data = pkt.pointee.data, pkt.pointee.size > 2 else {
             return avcodec_decode_subtitle2(ctx, sub, gotSub, pkt)
@@ -242,6 +294,7 @@ final class EmbeddedSubtitleDecoder {
         if data[0] == 0x78,
            data[1] == 0x01 || data[1] == 0x5E || data[1] == 0x9C || data[1] == 0xDA {
             if let decompressed = inflateZlibBlock(data, size: Int(pkt.pointee.size)) {
+                capturedPayload = decompressed
                 return decodeWithReplacedPayload(
                     ctx: ctx, pkt: pkt, payload: decompressed,
                     sub: sub, gotSub: gotSub
@@ -253,6 +306,7 @@ final class EmbeddedSubtitleDecoder {
         if pkt.pointee.size > 18,
            data[0] == 0x1F, data[1] == 0x8B {
             if let decompressed = inflateGzipBlock(data, size: Int(pkt.pointee.size)) {
+                capturedPayload = decompressed
                 return decodeWithReplacedPayload(
                     ctx: ctx, pkt: pkt, payload: decompressed,
                     sub: sub, gotSub: gotSub
@@ -265,6 +319,8 @@ final class EmbeddedSubtitleDecoder {
         if isPGS,
            pkt.pointee.size > 10,
            data[0] == 0x50, data[1] == 0x47 {
+            capturedPayload = Array(UnsafeBufferPointer(start: data.advanced(by: 10),
+                                                        count: Int(pkt.pointee.size) - 10))
             return decodeWithStrippedPrefix(ctx: ctx, pkt: pkt, prefix: 10, sub: sub, gotSub: gotSub)
         }
 

--- a/Tests/AetherEngineTests/PGSSyntheticEndGateTests.swift
+++ b/Tests/AetherEngineTests/PGSSyntheticEndGateTests.swift
@@ -1,0 +1,101 @@
+import Testing
+import Foundation
+@testable import AetherEngine
+
+/// Issue #112: the synthetic PGS END flush (added for MKV converters that drop the trailing
+/// 0x80 END segment) assumed every packet carries a COMPLETE display set. On a Blu-ray M2TS the
+/// mpegts demuxer splits one display set across several PES packets (PCS | PDS | ODS | END), so
+/// the flush fired on the intermediate PCS/PDS packet BEFORE the ODS arrived and forced a compose
+/// against an object that was not defined yet: `[pgssub] Invalid object id 0`, once per display
+/// set. The gate now only warrants a synthetic END when the payload already carries a complete
+/// object (an ODS with the last-in-sequence flag) and no real END of its own.
+struct PGSSyntheticEndGateTests {
+
+    // PGS segment: [type:1][length:2 BE][body...]
+    private func seg(_ type: UInt8, _ body: [UInt8]) -> [UInt8] {
+        [type, UInt8((body.count >> 8) & 0xFF), UInt8(body.count & 0xFF)] + body
+    }
+
+    // Segment type constants.
+    private let PDS: UInt8 = 0x14
+    private let ODS: UInt8 = 0x15
+    private let PCS: UInt8 = 0x16
+    private let WDS: UInt8 = 0x17
+    private let END: UInt8 = 0x80
+
+    // ODS body = object_id[2] + version[1] + sequence_flag[1] + (data). 0x40 = last, 0x80 = first, 0xC0 = only.
+    private func ods(seqFlag: UInt8) -> [UInt8] {
+        seg(ODS, [0x00, 0x00, 0x00, seqFlag, 0x00, 0x00, 0x00, 0x00])
+    }
+
+    private func warrants(_ payload: [UInt8]) -> Bool {
+        payload.withUnsafeBufferPointer {
+            EmbeddedSubtitleDecoder.pgsPayloadWarrantsSyntheticEnd($0.baseAddress, count: $0.count)
+        }
+    }
+
+    // MARK: - The bug: intermediate M2TS fragment must NOT flush
+
+    @Test("PCS + PDS with no object (the split-M2TS intermediate packet) does not warrant a flush")
+    func intermediateFragmentDoesNotFlush() {
+        let payload = seg(PCS, Array(repeating: 0x01, count: 16)) + seg(PDS, Array(repeating: 0x02, count: 20))
+        #expect(payload.count > 30)          // clears the caller's size gate
+        #expect(warrants(payload) == false)  // but no complete object yet -> no premature compose
+    }
+
+    @Test("a PCS-only packet does not warrant a flush")
+    func pcsOnlyDoesNotFlush() {
+        #expect(warrants(seg(PCS, Array(repeating: 0x01, count: 32))) == false)
+    }
+
+    @Test("a partial (first-but-not-last) object fragment does not warrant a flush")
+    func firstObjectFragmentDoesNotFlush() {
+        // Large bitmaps split across ODS segments; composing on the first fragment is unsafe.
+        #expect(warrants(seg(PCS, [0x01]) + ods(seqFlag: 0x80)) == false)
+    }
+
+    // MARK: - The MKV case a9b493a targeted: complete block, dropped END -> flush
+
+    @Test("a complete display set missing only its END warrants a flush")
+    func completeSetMissingEndFlushes() {
+        let payload = seg(PCS, [0x01, 0x02]) + seg(WDS, [0x03]) + seg(PDS, [0x04, 0x05])
+            + ods(seqFlag: 0x40)   // last fragment -> object complete
+        #expect(warrants(payload) == true)
+    }
+
+    @Test("an only-fragment object (first+last) warrants a flush")
+    func onlyObjectFragmentFlushes() {
+        #expect(warrants(seg(PCS, [0x01]) + ods(seqFlag: 0xC0)) == true)
+    }
+
+    // MARK: - A real END present -> the decoder emits naturally, never synthesize
+
+    @Test("a payload that already contains an END never warrants a synthetic one")
+    func realEndSuppressesFlush() {
+        let payload = seg(PCS, [0x01]) + seg(PDS, [0x02]) + ods(seqFlag: 0x40) + seg(END, [])
+        #expect(warrants(payload) == false)
+    }
+
+    @Test("END even after a complete object still suppresses the synthetic flush")
+    func endAfterObjectSuppresses() {
+        #expect(warrants(ods(seqFlag: 0xC0) + seg(END, [])) == false)
+    }
+
+    // MARK: - Degenerate inputs
+
+    @Test("empty payload does not warrant a flush")
+    func emptyDoesNotFlush() {
+        #expect(warrants([]) == false)
+    }
+
+    @Test("a truncated header does not warrant a flush and does not crash")
+    func truncatedHeaderSafe() {
+        #expect(warrants([0x15, 0x00]) == false)
+    }
+
+    @Test("a segment claiming a length past the buffer end does not crash")
+    func overlongLengthSafe() {
+        // ODS header claims 255 body bytes but only 2 follow.
+        #expect(warrants([ODS, 0x00, 0xFF, 0x01, 0x02]) == false)
+    }
+}


### PR DESCRIPTION
## Problem

Selecting a PGS subtitle track on a Blu-ray logs `[pgssub] Invalid object id 0` persistently (once per display set), reported by ijuniorfu on AetherPlayer/macOS (#112).

## Root cause

The synthetic END flush (a9b493a) feeds a 3-byte `0x80` END after any PGS packet that decoded with `gotSub=0` and `>30` bytes, to rescue MKV converters that strip the trailing END from each display set. That assumed **every packet carries a complete display set** (only the terminator missing).

On a Blu-ray M2TS the mpegts demuxer splits one display set across several PES packets (`PCS | WDS | PDS | ODS | END`). The flush then fired on the **PCS/PDS intermediate packet, before the ODS arrived**, forcing `pgssubdec` to compose against an object not yet defined: `Invalid object id 0`, once per display set. Unlike a seek-into-mid-epoch artifact, it never self-heals because it re-triggers on every set.

## Fix

Gate the flush: synthesize the END only when the decoded payload already carries a **complete object** (an ODS whose last-in-sequence flag is set) and **no END** of its own.

- Still rescues the MKV case (a full block missing only its END).
- Never fires on a split-M2TS fragment, so the referenced object is always defined before the forced compose.
- Walks the *effective* payload (raw TS, or the stripped/inflated buffer for PG-PES and zlib/gzip Matroska), so it is correct across every delivery path.
- Can only **remove** premature composes: correct cases (real END present, or complete object present) are byte-identical.

## Tests

New `PGSSyntheticEndGateTests` unit-tests the pure segment-walk gate against the split-M2TS fragment, the MKV missing-END block, split-ODS fragments, a real END, and malformed lengths. Full suite (447) green; strict-concurrency and tvOS-Simulator builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)