### PR TITLE
feat: let stop() preserve display criteria

### DIFF
--- a/Sources/AetherEngine/AetherEngine.swift
+++ b/Sources/AetherEngine/AetherEngine.swift
@@ -2253,8 +2253,8 @@ public final class AetherEngine: ObservableObject {
         await seek(to: seconds)
     }
 
-    public func stop() {
-        stopInternal()
+    public func stop(resetDisplayCriteria: Bool = true) {
+        stopInternal(resetDisplayCriteria: resetDisplayCriteria)
         state = .idle
         clock.currentTime = 0
         clock.bufferedPosition = 0


### PR DESCRIPTION
Clearing `preferredDisplayCriteria` during a same-mode handoff seems to make tvOS drop to SDR and immediately switch back to Dolby Vision.

This exposes `resetDisplayCriteria` on public `stop()`, defaulting to `true`, so existing behavior stays unchanged while callers can preserve the current mode when the next item matches.

I tested this on a real Apple TV with a Dolby Vision → Dolby Vision handoff, and it avoided the extra switch there.
