### PR TITLE
fix: bound stalled seeks and recover sparse cache holes

### DIFF
--- a/Sources/AetherEngine/AetherEngine+Loading.swift
+++ b/Sources/AetherEngine/AetherEngine+Loading.swift
@@ -36,6 +36,39 @@ extension AetherEngine {
         }
     }
 
+    /// A deadline-expired seek remains alive inside AVPlayer. Its current-time publication arrives
+    /// before rendered-time; while the recovery target is pending, the first publication is held.
+    /// Settle the public clock from the rendered frame when that late landing retires the target so
+    /// a paused landing does not wait forever for another periodic clock tick.
+    @discardableResult
+    func settleRecoveryClockIfRenderedTargetLanded(
+        rendered: Double,
+        shift: Double,
+        completionRenderedTimePublished: Bool
+    ) -> Bool {
+        guard pendingRecoverySeekDeadlineExpired,
+              let pending = pendingRecoverySeekClockTarget,
+              Self.pendingSeekHasRenderedLandingEvidence(
+                  rendered: rendered,
+                  target: pending,
+                  initialRendered: pendingSeekInitialRenderedPosition,
+                  completionRenderedTimePublished: completionRenderedTimePublished
+              ) else {
+            return false
+        }
+        if Self.shouldReanchorSubtitlesOnLateSeekLanding(
+            alreadyReanchored: pendingRecoverySeekSubtitlesReanchored
+        ) {
+            reanchorSubtitleOverlays()
+        }
+        setPendingRecoverySeekTarget(nil)
+        clock.currentTime = PresentationAxis.display(
+            sourcePTS: rendered + shift,
+            origin: sourcePresentationOrigin
+        )
+        return true
+    }
+
     /// #123: publish `sourceTime` at seek finalize. `sourceTime` is the on-screen frame (#49), not the
     /// scrub target. Settle it onto the landed `target` (source PTS) only when the frame is actually
     /// presented; while the player is still buffering toward the target (a queued-burst chase on heavy
@@ -582,6 +615,8 @@ extension AetherEngine {
         host.$renderedTime
             .sink { [weak self] value in
                 guard let self = self else { return }
+                let shift = self.liveShiftSeams.last(where: { value >= $0.activateAt })?.shift
+                    ?? self.playlistShiftSeconds
                 // #93 PiP skips: AVKit-side seeks never reach the engine seek API; a far rendered-
                 // time jump is the engine-visible signal to re-anchor the subtitle readers.
                 if Self.isSubtitleReanchorJump(from: self.renderedPositionMirror.get(), to: value) {
@@ -591,9 +626,12 @@ extension AetherEngine {
                 // reaches its neighbourhood) or goes stale (organic progress far from it, i.e.
                 // AVPlayer abandoned the seek and playback runs elsewhere).
                 if let pending = self.pendingRecoverySeekClockTarget {
-                    if Self.pendingSeekLanded(rendered: value, target: pending) {
-                        self.setPendingRecoverySeekTarget(nil)
-                    } else {
+                    if !self.settleRecoveryClockIfRenderedTargetLanded(
+                        rendered: value,
+                        shift: shift,
+                        completionRenderedTimePublished:
+                            self.nativeHost?.latestSeekRenderedTimePublished ?? false
+                    ) {
                         let prev = self.lastRenderedForPendingSeek
                         if value > prev, value - prev < 1.0 {
                             self.pendingSeekProgressAccum += (value - prev)
@@ -612,8 +650,6 @@ extension AetherEngine {
                 }
                 // #65: mirror AVPlayer's rendered (playlist-axis) position for off-main wedge re-anchoring.
                 self.renderedPositionMirror.set(value)
-                let shift = self.liveShiftSeams.last(where: { value >= $0.activateAt })?.shift
-                    ?? self.playlistShiftSeconds
                 self.clock.sourceTime = value + shift
                 // bufferedPosition = the disk SegmentCache read-ahead frontier (origin -> disk), which is
                 // what the Network Buffer setting controls, expressed on the display axis as the playhead

--- a/Sources/AetherEngine/AetherEngine.swift
+++ b/Sources/AetherEngine/AetherEngine.swift
@@ -819,6 +819,15 @@ public final class AetherEngine: ObservableObject {
     /// the target's neighbourhood, on organic playback progress elsewhere (stale: AVPlayer
     /// abandoned the seek), and on load reset / stop.
     var pendingRecoverySeekClockTarget: Double? = nil
+    /// The rendered-time sink owns clock/subtitle finalization only after the bounded seek wait
+    /// expires. Ordinary in-flight seeks remain owned by their normal continuation.
+    var pendingRecoverySeekDeadlineExpired = false
+    /// True when a starved deadline already reset subtitle discontinuity state before the pending
+    /// seek landed. Healthy late landings perform that reset in the rendered-time sink instead.
+    var pendingRecoverySeekSubtitlesReanchored = false
+    /// Rendered frame parked on screen when the current native seek began. Distinguishes a genuine
+    /// late landing from a short seek whose unchanged old frame is already within the 5 s window.
+    var pendingSeekInitialRenderedPosition: Double = 0
     /// Off-main mirror of `pendingRecoverySeekClockTarget` so the session's wedge re-anchor can aim
     /// the producer at the pending target (#93 retest). Kept in sync via `setPendingRecoverySeekTarget`.
     let recoverySeekTargetMirror = AtomicOptionalDouble()
@@ -828,7 +837,12 @@ public final class AetherEngine: ObservableObject {
     /// Single write path for the recovery seek intent: the MainActor field and its off-main mirror
     /// must never diverge (a stale mirror would teleport a wedge re-anchor to a retired target).
     func setPendingRecoverySeekTarget(_ target: Double?) {
+        pendingRecoverySeekDeadlineExpired = false
+        pendingRecoverySeekSubtitlesReanchored = false
         pendingRecoverySeekClockTarget = target
+        if target == nil {
+            pendingSeekInitialRenderedPosition = 0
+        }
         recoverySeekTargetMirror.set(target)
     }
     nonisolated static let pendingSeekLandedEpsilon: Double = 5.0
@@ -859,6 +873,30 @@ public final class AetherEngine: ObservableObject {
     /// Pure decision: rendered output near the target means the seek effectively landed.
     nonisolated static func pendingSeekLanded(rendered: Double, target: Double) -> Bool {
         abs(rendered - target) < pendingSeekLandedEpsilon
+    }
+
+    nonisolated static func pendingSeekHasRenderedLandingEvidence(
+        rendered: Double,
+        target: Double,
+        initialRendered: Double,
+        completionRenderedTimePublished: Bool
+    ) -> Bool {
+        guard pendingSeekLanded(rendered: rendered, target: target) else { return false }
+        if completionRenderedTimePublished { return true }
+
+        let initialDistance = abs(initialRendered - target)
+        let currentDistance = abs(rendered - target)
+        guard abs(rendered - initialRendered) > 0.1 else { return false }
+        if initialDistance < pendingSeekLandedEpsilon {
+            return currentDistance <= 0.5
+        }
+        return true
+    }
+
+    nonisolated static func shouldReanchorSubtitlesOnLateSeekLanding(
+        alreadyReanchored: Bool
+    ) -> Bool {
+        !alreadyReanchored
     }
 
     /// Pure decision: organic playback progress far from the target means AVPlayer abandoned the
@@ -1121,6 +1159,60 @@ public final class AetherEngine: ObservableObject {
     /// playing, and keeps `engineStateIsPlaying` honest so the reassert only fires on real stalls.
     nonisolated static func seekFinalizeState(transportIntentIsPlaying: Bool) -> PlaybackState {
         transportIntentIsPlaying ? .playing : .paused
+    }
+
+    /// Reconcile native seek completion while the regular time-control sink was gated by `.seeking`.
+    /// Live AVPlayer status captures an external play that superseded older engine pause intent; a
+    /// live pause wins unless the bounded stall-recovery policy deliberately reasserts playback.
+    nonisolated static func seekRecoveredState(
+        transportIntentIsPlaying: Bool,
+        statusIsPaused: Bool,
+        shouldReassertPausedStatus: Bool
+    ) -> PlaybackState {
+        if statusIsPaused {
+            guard transportIntentIsPlaying, shouldReassertPausedStatus else {
+                return .paused
+            }
+        }
+        return .playing
+    }
+
+    /// Apply the same transport reconciliation after a normal native seek landing and after a
+    /// deadline recovery. A starved deadline opens the bounded reassert window; a stable pause on a
+    /// healthy path is treated as an external AVKit / MediaRemote command. When recovery overrides a
+    /// spurious pause, replay play() because the paused KVO was consumed while state was `.seeking`.
+    private func reconcileNativeSeekTransport(
+        host: NativeAVPlayerHost,
+        isStarved: Bool
+    ) {
+        let now = Date()
+        if isStarved, now >= stallRecoveryWindowUntil {
+            stallRecoveryWindowUntil = now.addingTimeInterval(Self.stallRecoveryWindowSeconds)
+            stallRecoveryReasserts = 0
+        }
+        let liveStatus = host.liveTimeControlStatus
+        let statusIsPaused = liveStatus == .paused
+        let transportIntentIsPlaying = host.transportIntentIsPlaying
+        let shouldReassertPausedStatus = Self.shouldReassertPlayDuringRecovery(
+            statusIsPaused: statusIsPaused,
+            engineStateIsPlaying: transportIntentIsPlaying,
+            now: now,
+            windowUntil: stallRecoveryWindowUntil,
+            reasserts: stallRecoveryReasserts
+        )
+        let recoveredState = Self.seekRecoveredState(
+            transportIntentIsPlaying: transportIntentIsPlaying,
+            statusIsPaused: statusIsPaused,
+            shouldReassertPausedStatus: shouldReassertPausedStatus
+        )
+        state = recoveredState
+        isBuffering = recoveredState == .playing
+            && liveStatus == .waitingToPlayAtSpecifiedRate
+        if shouldReassertPausedStatus {
+            stallRecoveryReasserts += 1
+            playIntentMirror.set(true)
+            host.play()
+        }
     }
 
     /// #123: whether a seek landing (host completion + engine finalize) may settle `sourceTime` /
@@ -2104,7 +2196,11 @@ public final class AetherEngine: ObservableObject {
             clock.currentTime = target
             clock.sourceTime = target
             // publishLiveWindow on the next tick recomputes behindLiveSeconds.
-            state = .playing
+            if let nativeHost {
+                reconcileNativeSeekTransport(host: nativeHost, isStarved: false)
+            } else {
+                state = .playing
+            }
             setProgrammaticSeek(inFlight: false, target: nil)
             return
         }
@@ -2134,7 +2230,9 @@ public final class AetherEngine: ObservableObject {
             // never lands and the recovery chain must aim here, not at the frozen clock.
             setPendingRecoverySeekTarget(clockTarget)
             pendingSeekProgressAccum = 0
-            lastRenderedForPendingSeek = nativeHost?.renderedTime ?? 0
+            let renderedAtSeekStart = nativeHost?.renderedTime ?? 0
+            pendingSeekInitialRenderedPosition = renderedAtSeekStart
+            lastRenderedForPendingSeek = renderedAtSeekStart
             // Await real AVPlayer landing so isSeeking spans it (#37/#38), but bound the wait (#65): a seek
             // AVPlayer can never land (producer-wedge starvation) must not leave the optimistic clock latched
             // forever. A normal/slow-but-buffering seek lands or keeps buffering well within the budget.
@@ -2144,50 +2242,74 @@ public final class AetherEngine: ObservableObject {
                 // Deadline expired. Only the surviving (winning) generation reconciles; a superseded seek
                 // returns at the guard below and lets the newer seek own the final state.
                 guard loadGeneration == gen, seekGeneration == seekGen else { return }
-                if let host = nativeHost,
-                   host.isEffectivelyPlaying, // #65: a paused seek lands while paused and is not a wedge; only reconcile a starved seek the player actually wants to play
-                   seekIsWedged(renderedTime: host.renderedTime, bufferedEnd: host.bufferedEnd) {
-                    // Genuine wedge: snap the clock back to AVPlayer's REAL rendered position (not the
-                    // unreachable optimistic target). The producer, unlike the clock, keeps aiming at
-                    // the TARGET (#93 retest): after a hard zero-tolerance seek AVPlayer only requests
-                    // media at the target, so a re-anchor on the frozen position would pull the producer
-                    // away from the window the seek's own restart just anchored (and its refill can
-                    // evict the target's segments from retention).
-                    let avpReal = host.renderedTime
-                    nativeClockSeconds = avpReal
-                    // currentTime on the 0-based display axis (AE#105 origin); sourceTime stays source PTS for subs.
-                    clock.currentTime = PresentationAxis.display(sourcePTS: avpReal + playlistShiftSeconds,
-                                                                 origin: sourcePresentationOrigin)
-                    clock.sourceTime = avpReal + playlistShiftSeconds
-                    setProgrammaticSeek(inFlight: false, target: nil)
-                    // Hand state to AVPlayer's ACTUAL transport status, not the phantom .playing the normal
-                    // finalize forces nor the stuck .seeking we entered with: the $timeControlStatus sink is
-                    // gated on state already being .playing/.paused, so leaving .seeking would latch it there
-                    // forever even after the producer re-anchor recovers playback.
-                    state = (host.timeControlStatus == .paused) ? .paused : .playing
-                    isBuffering = host.timeControlStatus == .waitingToPlayAtSpecifiedRate
-                    let recoveryAnchor = Self.recoveryAnchorPosition(
-                        frozenPosition: avpReal, pendingSeekTarget: pendingRecoverySeekClockTarget,
-                        currentRendered: avpReal)
-                    reanchorProducerToPlaylistTime(recoveryAnchor)
-                    // #96/#112 rework: the playhead jumped without a normal seek landing (we return
-                    // here), so reset the subtitle gates/CC tap now; the drainer's jump detection
-                    // re-decodes around the recovery target on its next tick.
-                    reanchorSubtitleOverlays()
-                    // pendingRecoverySeekClockTarget deliberately survives this reconcile: the UI
-                    // clock gives up the phantom target, the recovery intent does not.
+                guard let host = nativeHost else {
                     EngineLog.emit(
-                        "[AetherEngine] #65 seek did not land within \(Self.nativeSeekReconcileBudgetSeconds)s "
-                        + "and AVPlayer is starved (rendered=\(String(format: "%.2f", avpReal))s "
-                        + "buffered=\(String(format: "%.2f", host.bufferedEnd))s); reconciled clock to rendered "
-                        + "position, producer + recovery keep aiming at "
-                        + "\(String(format: "%.2f", clockTarget))s",
+                        "[AetherEngine] seek deadline expired after native host teardown",
                         category: .engine
                     )
                     return
                 }
-                // Slow-but-buffering: preserve the #37/#38 await-real-landing contract.
-                await nativeHost?.seek(to: clockTarget)
+                pendingRecoverySeekDeadlineExpired = true
+                // Eight seconds is a hard interactive cap. A second unbounded AVPlayer seek could
+                // inherit repeated 20 s source stalls and leave the caller suspended for 40+ s.
+                // Keep the original pending seek alive. Re-anchor only a starved producer; a
+                // healthy-but-slow producer is already filling toward the target and restarting it
+                // would throw away useful progress.
+                let avpReal = host.renderedTime
+                // The deadline continuation and AVPlayer completion are both MainActor jobs. If the
+                // completion published renderedTime first, its sink still saw deadlineExpired=false.
+                // Catch that ordering now; otherwise the later publication will settle through the sink.
+                if Self.shouldCatchUpDeadlineLanding(
+                    renderedTimePublished: host.latestSeekRenderedTimePublished
+                ),
+                   settleRecoveryClockIfRenderedTargetLanded(
+                       rendered: avpReal,
+                       shift: playlistShiftSeconds,
+                       completionRenderedTimePublished: true
+                   ) {
+                    nativeClockSeconds = avpReal
+                    clock.sourceTime = avpReal + playlistShiftSeconds
+                    setProgrammaticSeek(inFlight: false, target: nil)
+                    reconcileNativeSeekTransport(host: host, isStarved: false)
+                    EngineLog.emit(
+                        "[AetherEngine] seek landed while deadline ownership transferred; "
+                        + "reconciled from rendered \(String(format: "%.2f", avpReal))s",
+                        category: .engine
+                    )
+                    return
+                }
+                let wasStarved = seekIsWedged(
+                    renderedTime: avpReal, bufferedEnd: host.bufferedEnd)
+                nativeClockSeconds = avpReal
+                // currentTime on the 0-based display axis (AE#105 origin); sourceTime stays source PTS for subs.
+                clock.currentTime = PresentationAxis.display(sourcePTS: avpReal + playlistShiftSeconds,
+                                                             origin: sourcePresentationOrigin)
+                clock.sourceTime = avpReal + playlistShiftSeconds
+                setProgrammaticSeek(inFlight: false, target: nil)
+                reconcileNativeSeekTransport(host: host, isStarved: wasStarved)
+                let recoveryAnchor = Self.recoveryAnchorPosition(
+                    frozenPosition: avpReal, pendingSeekTarget: pendingRecoverySeekClockTarget,
+                    currentRendered: avpReal)
+                if Self.shouldReanchorProducerAfterSeekDeadline(isStarved: wasStarved) {
+                    reanchorProducerToPlaylistTime(recoveryAnchor)
+                    // The playhead will jump when the restarted producer lets the pending seek land.
+                    reanchorSubtitleOverlays()
+                    pendingRecoverySeekSubtitlesReanchored = true
+                }
+                // pendingRecoverySeekClockTarget deliberately survives this reconcile: the UI
+                // clock gives up the phantom target, but recovery keeps aiming there until rendered
+                // output reaches it or organic playback proves AVPlayer abandoned the seek.
+                EngineLog.emit(
+                    "[AetherEngine] seek did not land within \(Self.nativeSeekReconcileBudgetSeconds)s "
+                    + "(\(wasStarved ? "starved" : "old position still buffered"), "
+                    + "rendered=\(String(format: "%.2f", avpReal))s "
+                    + "buffered=\(String(format: "%.2f", host.bufferedEnd))s); reconciled clock"
+                    + (wasStarved
+                        ? " and re-anchored producer at \(String(format: "%.2f", recoveryAnchor))s"
+                        : " without restarting the progressing producer"),
+                    category: .engine
+                )
+                return
             }
         }
         // Guard: stop/load during the await tore the session down; writing clock state would publish a phantom.
@@ -2213,7 +2335,11 @@ public final class AetherEngine: ObservableObject {
         // after a paused scrub and the #93 recovery reassert can't misread the paused landing as a
         // spurious pause and call host.play(). A seek on any non-native host keeps the prior
         // `.playing` default (those paths do not carry the durable intent and are not affected).
-        state = Self.seekFinalizeState(transportIntentIsPlaying: nativeHost?.transportIntentIsPlaying ?? true)
+        if let nativeHost {
+            reconcileNativeSeekTransport(host: nativeHost, isStarved: false)
+        } else {
+            state = .playing
+        }
         setProgrammaticSeek(inFlight: false, target: nil)
     }
 
@@ -2233,18 +2359,27 @@ public final class AetherEngine: ObservableObject {
         }
     }
 
-    /// #65: re-base the loopback producer onto AVPlayer's real (playlist-axis) position after a seek-deadline
-    /// wedge reconcile, so the segments AVPlayer is starved for get produced. requestRestart does blocking
-    /// teardown (old.stop + waitForFinish up to 5s) and is designed to run off-main, so dispatch it detached.
+    /// Re-base the loopback producer onto the recovery position after a seek deadline, so the
+    /// segments AVPlayer is waiting for get produced. requestRestart does blocking teardown
+    /// (old.stop + waitForFinish up to 5s) and is designed to run off-main, so dispatch it detached.
     private func reanchorProducerToPlaylistTime(_ seconds: Double) {
         guard let session = nativeVideoSession else { return }
         Task.detached {
             let idx = session.segmentIndexForPlaylistTime(seconds)
-            // #79: authoritative re-anchor. `seconds` is AVPlayer's REAL rendered position (the clock was
-            // just reconciled to it), so it must win the coalescer over any stale in-flight scrub target.
-            // Without this a burst-tail scrub overrode it and the producer stayed ~1600s off the playhead.
+            // Authoritative re-anchor: deadline recovery must win the coalescer over any stale
+            // in-flight scrub target.
             session.requestRestart(at: idx, authoritative: true)
         }
+    }
+
+    nonisolated static func shouldReanchorProducerAfterSeekDeadline(isStarved: Bool) -> Bool {
+        isStarved
+    }
+
+    nonisolated static func shouldCatchUpDeadlineLanding(
+        renderedTimePublished: Bool
+    ) -> Bool {
+        renderedTimePublished
     }
 
     /// Deprecated alias. The engine clock is now unified onto source PTS; prefer `seek(to:)` in new code.

--- a/Sources/AetherEngine/Native/NativeAVPlayerHost.swift
+++ b/Sources/AetherEngine/Native/NativeAVPlayerHost.swift
@@ -56,6 +56,10 @@ final class NativeAVPlayerHost {
 
     /// Suppresses currentTime publishing while a seek is in flight; the loopback source lands seeks seconds after the call, so the observer would otherwise bounce the clock back through the pre-seek position (issue #37).
     private(set) var seekInFlight: Bool = false
+    /// Set immediately before the latest seek completion publishes renderedTime. Deadline recovery
+    /// uses this as authoritative presented-frame evidence when that publication wins the MainActor
+    /// queue race against the resumed deadline continuation.
+    private(set) var latestSeekRenderedTimePublished = false
 
     // MARK: - Output
 
@@ -579,8 +583,10 @@ final class NativeAVPlayerHost {
     // MARK: - Playback control
 
     var isEffectivelyPlaying: Bool { avPlayer.timeControlStatus != .paused }
+    var liveTimeControlStatus: AVPlayer.TimeControlStatus { avPlayer.timeControlStatus }
 
-    /// #122: durable transport intent (the last play/pause/setRate command), untouched by a seek.
+    /// #122: durable engine-routed transport intent (the last play/pause/setRate command), untouched
+    /// by a seek. External AVKit / MediaRemote commands are reflected by `timeControlStatus` instead.
     /// Unlike `isEffectivelyPlaying` (instantaneous, momentarily `.paused`/`.waitingToPlay` right
     /// after a landing) this survives a scrub, so the engine's seek finalize can land a paused
     /// scrub paused instead of forcing `.playing`.
@@ -647,6 +653,7 @@ final class NativeAVPlayerHost {
         seekGeneration &+= 1
         let gen = seekGeneration
         seekInFlight = true
+        latestSeekRenderedTimePublished = false
         let resumeGuard = SeekResumeGuard()
         return await withCheckedContinuation { (cont: CheckedContinuation<Bool, Never>) in
             if let deadlineSeconds, deadlineSeconds > 0 {
@@ -683,6 +690,7 @@ final class NativeAVPlayerHost {
                             // frame; the observer settles it to the target when playback resumes.
                             if AetherEngine.seekLandingSettlesToTarget(
                                 bufferingTowardTarget: self.isBufferingTowardSeekTarget) {
+                                self.latestSeekRenderedTimePublished = true
                                 self.renderedTime = landed
                             }
                         }

--- a/Sources/AetherEngine/Video/VideoSegmentProvider.swift
+++ b/Sources/AetherEngine/Video/VideoSegmentProvider.swift
@@ -109,6 +109,9 @@ final class VideoSegmentProvider: HLSSegmentProvider, @unchecked Sendable {
     /// Slice is generous enough to absorb a cold 4K-HDR first-GOP decode. Instance lets so the
     /// wait shape is testable without 8 s sleeps (#93 residual).
     private let repositionWaitSlice: TimeInterval
+    /// A cache index range can be sparse after scrubbing. Wait only when the active producer can
+    /// actually fill an interior hole; otherwise restart immediately instead of burning this slice.
+    private let sparseHoleWaitSlice: TimeInterval
     private static let repositionMaxWaits = 3
     /// Hard cap on riding an in-flight restart (#93 residual): a fetch waits past the fixed
     /// budget while a restart is genuinely executing, but never indefinitely.
@@ -150,6 +153,7 @@ final class VideoSegmentProvider: HLSSegmentProvider, @unchecked Sendable {
         activeProducerBase: (() -> Int?)? = nil,
         initialRestartIndex: Int = 0,
         repositionWaitSlice: TimeInterval = 8.0,
+        sparseHoleWaitSlice: TimeInterval = 2.0,
         repositionRideCapSeconds: TimeInterval = 90.0,
         slowServeThresholdSeconds: TimeInterval = 2.0,
         nativeSubtitleStores: [NativeSubtitleCueStore] = [],
@@ -178,6 +182,7 @@ final class VideoSegmentProvider: HLSSegmentProvider, @unchecked Sendable {
         self.activeProducerBase = activeProducerBase
         self._lastRestartIndex = initialRestartIndex
         self.repositionWaitSlice = repositionWaitSlice
+        self.sparseHoleWaitSlice = sparseHoleWaitSlice
         self.repositionRideCapSeconds = repositionRideCapSeconds
         self.slowServeThresholdSeconds = slowServeThresholdSeconds
         self.nativeSubStores = nativeSubtitleStores
@@ -424,10 +429,12 @@ final class VideoSegmentProvider: HLSSegmentProvider, @unchecked Sendable {
             } else if index > r.1 + Self.forwardWaitWindow {
                 needsRestart = true
             } else if index >= r.0 && index <= r.1 {
-                // Producer might still be writing this index forward
-                // from its current write head. Wait briefly first.
-                if let waited = cache.fetch(index: index, timeout: 2.0) {
-                    return logServed(index: index, bytes: waited, totalStart: totalStart, restarted: false)
+                // min...max is not proof of residency: retained scrub bands leave interior holes.
+                // Only wait when the active producer can actually march into this index.
+                if activeProducerCovers(index),
+                   let waited = cache.fetch(index: index, timeout: sparseHoleWaitSlice) {
+                    return logServed(
+                        index: index, bytes: waited, totalStart: totalStart, restarted: false)
                 }
                 needsRestart = true
             } else {
@@ -466,10 +473,7 @@ final class VideoSegmentProvider: HLSSegmentProvider, @unchecked Sendable {
                     // covers (base <= index <= base + forward window) never fires OR backstops:
                     // the march will deliver it, and the backstop killed a 75%-complete capture
                     // on device while a forward-march neighbor got its healthy producer restarted.
-                    let producerCovers: Bool = {
-                        guard let base = activeProducerBase?() else { return false }
-                        return base <= index && index - base <= Self.forwardWaitWindow
-                    }()
+                    let producerCovers = activeProducerCovers(index)
                     // A request superseded by a NEWER declared target is an orphan of a skip
                     // storm: AVPlayer's newest request is what it actually wants (the same
                     // newest-wins semantics the coalescer applies to immediate restarts).
@@ -522,6 +526,11 @@ final class VideoSegmentProvider: HLSSegmentProvider, @unchecked Sendable {
             )
         }
         return bytes
+    }
+
+    private func activeProducerCovers(_ index: Int) -> Bool {
+        guard let base = activeProducerBase?() else { return false }
+        return base <= index && index - base <= Self.forwardWaitWindow
     }
 
     private var currentSegmentCount: Int {

--- a/Tests/AetherEngineTests/Issue37RecoveryClockHoldTests.swift
+++ b/Tests/AetherEngineTests/Issue37RecoveryClockHoldTests.swift
@@ -41,4 +41,34 @@ struct Issue37RecoveryClockHoldTests {
         engine.applyNativeHostClockTick(634.0)
         #expect(engine.clock.currentTime == 634.0)
     }
+
+    @Test("a late paused landing settles the public clock while retiring recovery intent")
+    func latePausedLandingSettlesClock() throws {
+        let engine = try AetherEngine()
+        engine.clock.currentTime = 40.0
+        engine.setPendingRecoverySeekTarget(120.0)
+
+        // Before the bounded wait expires, the normal seek continuation owns finalization.
+        #expect(!engine.settleRecoveryClockIfRenderedTargetLanded(
+            rendered: 120.0,
+            shift: 0,
+            completionRenderedTimePublished: true
+        ))
+        engine.pendingRecoverySeekDeadlineExpired = true
+        #expect(!engine.settleRecoveryClockIfRenderedTargetLanded(
+            rendered: 80.0,
+            shift: 0,
+            completionRenderedTimePublished: false
+        ))
+        #expect(engine.pendingRecoverySeekClockTarget == 120.0)
+        #expect(engine.clock.currentTime == 40.0)
+
+        #expect(engine.settleRecoveryClockIfRenderedTargetLanded(
+            rendered: 120.0,
+            shift: 0,
+            completionRenderedTimePublished: true
+        ))
+        #expect(engine.pendingRecoverySeekClockTarget == nil)
+        #expect(engine.clock.currentTime == 120.0)
+    }
 }

--- a/Tests/AetherEngineTests/RecoverySeekTargetTests.swift
+++ b/Tests/AetherEngineTests/RecoverySeekTargetTests.swift
@@ -52,4 +52,93 @@ struct RecoverySeekTargetTests {
         // unrelated stall cannot teleport to a minutes-old target.
         #expect(AetherEngine.isPendingSeekStale(progressWhilePending: 3.5))
     }
+
+    @Test("deadline recovery restarts only a starved producer")
+    func deadlineRestartDecision() {
+        #expect(AetherEngine.shouldReanchorProducerAfterSeekDeadline(isStarved: true))
+        #expect(!AetherEngine.shouldReanchorProducerAfterSeekDeadline(isStarved: false))
+        #expect(AetherEngine.shouldReanchorSubtitlesOnLateSeekLanding(
+            alreadyReanchored: false
+        ))
+        #expect(!AetherEngine.shouldReanchorSubtitlesOnLateSeekLanding(
+            alreadyReanchored: true
+        ))
+    }
+
+    @Test("a published completion is the authoritative deadline catch-up signal")
+    func completionPublicationDecision() {
+        #expect(AetherEngine.shouldCatchUpDeadlineLanding(renderedTimePublished: true))
+        #expect(!AetherEngine.shouldCatchUpDeadlineLanding(renderedTimePublished: false))
+    }
+
+    @Test("a short seek needs rendered movement or completion evidence")
+    func shortSeekLandingEvidence() {
+        #expect(!AetherEngine.pendingSeekHasRenderedLandingEvidence(
+            rendered: 40,
+            target: 43,
+            initialRendered: 40,
+            completionRenderedTimePublished: false
+        ))
+        #expect(AetherEngine.pendingSeekHasRenderedLandingEvidence(
+            rendered: 43,
+            target: 43,
+            initialRendered: 40,
+            completionRenderedTimePublished: false
+        ))
+        #expect(AetherEngine.pendingSeekHasRenderedLandingEvidence(
+            rendered: 40,
+            target: 43,
+            initialRendered: 40,
+            completionRenderedTimePublished: true
+        ))
+    }
+
+    @MainActor
+    @Test("starting or clearing a recovery target resets deadline lifecycle state")
+    func targetLifecycleReset() throws {
+        let engine = try AetherEngine()
+        engine.setPendingRecoverySeekTarget(42)
+        engine.pendingRecoverySeekDeadlineExpired = true
+        engine.pendingRecoverySeekSubtitlesReanchored = true
+
+        // A superseding seek to the same target is still a new lifecycle.
+        engine.setPendingRecoverySeekTarget(42)
+        #expect(!engine.pendingRecoverySeekDeadlineExpired)
+        #expect(!engine.pendingRecoverySeekSubtitlesReanchored)
+
+        engine.pendingRecoverySeekDeadlineExpired = true
+        engine.pendingRecoverySeekSubtitlesReanchored = true
+        engine.setPendingRecoverySeekTarget(nil)
+        #expect(!engine.pendingRecoverySeekDeadlineExpired)
+        #expect(!engine.pendingRecoverySeekSubtitlesReanchored)
+    }
+
+    @Test("seek recovery reasserts only pauses covered by the bounded recovery policy")
+    func recoveredStateDecision() {
+        #expect(AetherEngine.seekRecoveredState(
+            transportIntentIsPlaying: false,
+            statusIsPaused: false,
+            shouldReassertPausedStatus: true
+        ) == .playing)
+        #expect(AetherEngine.seekRecoveredState(
+            transportIntentIsPlaying: false,
+            statusIsPaused: true,
+            shouldReassertPausedStatus: true
+        ) == .paused)
+        #expect(AetherEngine.seekRecoveredState(
+            transportIntentIsPlaying: true,
+            statusIsPaused: true,
+            shouldReassertPausedStatus: false
+        ) == .paused)
+        #expect(AetherEngine.seekRecoveredState(
+            transportIntentIsPlaying: true,
+            statusIsPaused: true,
+            shouldReassertPausedStatus: true
+        ) == .playing)
+        #expect(AetherEngine.seekRecoveredState(
+            transportIntentIsPlaying: true,
+            statusIsPaused: false,
+            shouldReassertPausedStatus: false
+        ) == .playing)
+    }
 }

--- a/Tests/AetherEngineTests/SegmentFetchWaitTests.swift
+++ b/Tests/AetherEngineTests/SegmentFetchWaitTests.swift
@@ -372,7 +372,11 @@ extension SegmentFetchWaitTests {
         let recorder = Recorder()
         cache.store(index: 0, data: Data(repeating: 0x10, count: 8))
         cache.store(index: 50, data: Data(repeating: 0x50, count: 8))
-        DispatchQueue.global().asyncAfter(deadline: .now() + 0.02) {
+        // Use a kernel-scheduled thread rather than a GCD timer: the macOS CI runner
+        // can starve global-queue timers past this test's 500 ms wait slice when the
+        // Swift Testing suites run concurrently.
+        Thread.detachNewThread {
+            Thread.sleep(forTimeInterval: 0.05)
             cache.store(index: 40, data: Data(repeating: 0x40, count: 8))
         }
         let provider = makeCoverageProvider(

--- a/Tests/AetherEngineTests/SegmentFetchWaitTests.swift
+++ b/Tests/AetherEngineTests/SegmentFetchWaitTests.swift
@@ -270,15 +270,23 @@ extension SegmentFetchWaitTests {
 /// #93 residual: an index the ACTIVE producer covers must never be fired or backstopped away.
 extension SegmentFetchWaitTests {
     private func makeCoverageProvider(cache: SegmentCache, recorder: Recorder,
-                                      producerBase: Int?) -> VideoSegmentProvider {
+                                      producerBase: Int?,
+                                      sparseHoleWaitSlice: TimeInterval = 2.0,
+                                      storeOnRestart: Bool = false) -> VideoSegmentProvider {
         VideoSegmentProvider(
             cache: cache, segments: segments(60), codecsString: "hvc1", supplementalCodecs: nil,
             resolution: (1920, 1080), videoRange: .sdr, frameRate: 24.0, hdcpLevel: nil,
             sourceBitrate: 8_000_000,
-            restartHandler: { idx in recorder.record(idx) },
+            restartHandler: { [weak cache] idx in
+                recorder.record(idx)
+                if storeOnRestart {
+                    cache?.store(index: idx, data: Data(repeating: 0x55, count: 8))
+                }
+            },
             restartActivity: { false },
             activeProducerBase: { producerBase },
             repositionWaitSlice: 0.05,
+            sparseHoleWaitSlice: sparseHoleWaitSlice,
             repositionRideCapSeconds: 5.0
         )
     }
@@ -334,6 +342,47 @@ extension SegmentFetchWaitTests {
         storeAbove(cache, range: 55...58)
         _ = provider.mediaSegment(at: 40)
         #expect(recorder.all == [40])
+    }
+
+    @Test("an interior sparse-cache hole restarts immediately when the producer cannot reach it")
+    func sparseHoleOutsideCoverageRestartsImmediately() {
+        let cache = SegmentCache(forwardWindow: 60, backwardWindow: 60)
+        defer { cache.close() }
+        let recorder = Recorder()
+        cache.store(index: 0, data: Data(repeating: 0x10, count: 8))
+        cache.store(index: 50, data: Data(repeating: 0x50, count: 8))
+        let provider = makeCoverageProvider(
+            cache: cache, recorder: recorder, producerBase: 55,
+            sparseHoleWaitSlice: 2.0, storeOnRestart: true)
+
+        let start = DispatchTime.now()
+        let served = provider.mediaSegment(at: 40)
+        let elapsed = Double(
+            DispatchTime.now().uptimeNanoseconds - start.uptimeNanoseconds) / 1e9
+
+        #expect(served != nil)
+        #expect(recorder.all == [40])
+        #expect(elapsed < 0.5)
+    }
+
+    @Test("an interior sparse-cache hole waits when the active producer covers it")
+    func sparseHoleInsideCoverageWaits() {
+        let cache = SegmentCache(forwardWindow: 60, backwardWindow: 60)
+        defer { cache.close() }
+        let recorder = Recorder()
+        cache.store(index: 0, data: Data(repeating: 0x10, count: 8))
+        cache.store(index: 50, data: Data(repeating: 0x50, count: 8))
+        DispatchQueue.global().asyncAfter(deadline: .now() + 0.02) {
+            cache.store(index: 40, data: Data(repeating: 0x40, count: 8))
+        }
+        let provider = makeCoverageProvider(
+            cache: cache, recorder: recorder, producerBase: 38,
+            sparseHoleWaitSlice: 0.5)
+
+        let served = provider.mediaSegment(at: 40)
+
+        #expect(served != nil)
+        #expect(recorder.all.isEmpty)
     }
 }
 


### PR DESCRIPTION
I ran into cases where native seeks could leave the caller waiting for a long time, plus interior cache holes that waited even when the active producer couldn't fill them.

This bounds the seek wait, restarts only when the producer appears genuinely starved, and reconciles transport state, clocks, and subtitles if the original seek lands later. It also skips the sparse-hole wait when producer coverage says a restart is needed.

I tested the main behavior on a real Apple TV with network-backed media and added focused engine tests for the recovery paths. There are several timing-sensitive cases here, so I'd appreciate another set of eyes on the logic.

Related context: #65, #79, and #93. This is additional hardening around the same seek-recovery paths.
