### PR TITLE
fix(player): delete packet ring scratch directory on a background queue.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ the public-API contract.
 
 ## [Unreleased]
 
+### Fixed
+
+- **PacketRingBuffer.close() now deletes on a background queue.** PacketRingBuffer.close() is now idempotent and dispatches scratch-directory removal to a background queue so filesystem I/O never blocks the caller. This was causing 5–30 s stalls on long live TV streams on close.
+
 ## [5.8.6] - 2026-07-18
 
 ([release notes](https://github.com/superuser404notfound/AetherEngine/releases/tag/5.8.6))

--- a/Sources/AetherEngine/Video/PacketRingBuffer.swift
+++ b/Sources/AetherEngine/Video/PacketRingBuffer.swift
@@ -36,6 +36,7 @@ final class PacketRingBuffer: @unchecked Sendable {
     private var firstSeq: Int = 0
     private var counter: Int = 0
     private var edge: Double = -.infinity
+    private var closed: Bool = false
 
     // MARK: - Init / close
 
@@ -44,19 +45,22 @@ final class PacketRingBuffer: @unchecked Sendable {
         self.scratch = scratch
     }
 
+    /// Idempotent teardown. State is cleared synchronously so the ring is immediately
+    /// unusable; the scratch-directory removal is dispatched to a background queue so
+    /// filesystem I/O never blocks the caller.
     func close() {
         lock.lock()
-        let toDelete = entries.map(\.fileURL)
+        guard !closed else { lock.unlock(); return }
+        closed = true
         entries.removeAll(keepingCapacity: false)
         edge = -.infinity
         counter = 0
         firstSeq = 0
         lock.unlock()
 
-        for url in toDelete {
-            try? FileManager.default.removeItem(at: url)
+        DispatchQueue.global(qos: .userInitiated).async { [scratch] in
+            try? FileManager.default.removeItem(at: scratch)
         }
-        try? FileManager.default.removeItem(at: scratch)  // best-effort; may have stale files from a previous partial write
     }
 
     // MARK: - Writer


### PR DESCRIPTION
## Summary

Make PacketRingBuffer.close() idempotent and dispatch scratch-directory removal to a background queue so filesystem I/O never blocks the caller (5–30 s stalls on long live TV streams with O(n) per-file deletion).

Ensures exiting a live channel on a frontend doesn't block the UI for multiple seconds.

Closes #136

## What changed

* Filesystem delete is executed off a user initiated queue on `PacketRingBuffer.close()`.

## Test plan

- Device / OS: Apple 4k TV (3rd gen) 26.5
- Source media (container / video codec + profile / audio / HDR-DV):
- Result: No blocking on exiting stream and channels can be switched promptly from a UI (Sodalite).

## Checklist

- [ ] `CHANGELOG.md` updated
- [ ] Commit messages follow Conventional Commits (`feat(...)`, `fix(...)`, `chore(...)`)
- [ ] The fix lives in the engine, not in a host-side workaround
- [ ] Public API changes are intentional and documented
