### PR TITLE
fix(io): fail closed when an HLS playlist is misrouted onto the raw live path (#140)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ the public-API contract.
 
 ## [Unreleased]
 
+## [5.9.0] - 2026-07-19
+
+([release notes](https://github.com/superuser404notfound/AetherEngine/releases/tag/5.9.0))
+
+### Fixed
+
+- **Handing an HLS playlist (`.m3u8`) URL to `load(isLive:)` on the generic path no longer hangs forever with no error.** The documented HLS entry points (`LoadOptions.nativeRemoteHLS` and `HLSLiveIngestReader`) were bypassed, so the playlist URL routed onto the raw-byte live reader. A live origin serves the finite `#EXTM3U` body at HTTP 200 and closes the connection, which the endless-feed reader read as a dropped live stream and reconnected, re-fetching the same body forever. Those reconnects looked productive (a full body at 200, and every `find_stream_info` probe seek reset the unproductive-reconnect streak), so the reconnect give-up counters (#71) never tripped, `avformat_open_input` never returned, and `load()` sat at `.loading` with no terminal state (reporter saw 262 reconnect cycles over 5.75 minutes). The raw-byte reader now inspects the first bytes of a live source and fails closed when they are an HLS playlist tag (a raw media container never opens with `#`; TS syncs on `0x47`), before the reconnect loop is ever entered. Reported by cmcpherson274 (#140).
+
+### Added
+
+- **`AetherEngineError.hlsPlaylistOnRawLivePath`.** `load()` now throws this typed, catchable error (with an actionable `LocalizedError` description) when an `.m3u8` playlist is misrouted onto the raw live path, pointing the caller at `LoadOptions.nativeRemoteHLS` / `HLSLiveIngestReader` instead of looping silently.
+
 ## [5.8.9] - 2026-07-19
 
 ([release notes](https://github.com/superuser404notfound/AetherEngine/releases/tag/5.8.9))

--- a/Sources/AetherEngine/AetherEngine.swift
+++ b/Sources/AetherEngine/AetherEngine.swift
@@ -1611,6 +1611,7 @@ public final class AetherEngine: ObservableObject {
         // would strip the successor's abort handle.
         defer { if inFlightProbeDemuxer === probe { inFlightProbeDemuxer = nil } }
         var probeOpened = false
+        var probeFailure: Error?
         do {
             // Detach avformat_open_input + find_stream_info off @MainActor (~6 s on a slow CDN).
             // AetherEngine#10: a @MainActor async body without a suspension point blocks the main thread
@@ -1655,6 +1656,7 @@ public final class AetherEngine: ObservableObject {
             // Ownership transfers to loadNative/loadSoftware, which adopt the probe for reuse
             // or open fresh if the probe failed.
         } catch {
+            probeFailure = error
             EngineLog.emit("[AetherEngine] probe failed (\(error)); proceeding without criteria", category: .engine)
         }
 
@@ -1671,6 +1673,15 @@ public final class AetherEngine: ObservableObject {
         if case .custom = source, !probeOpened {
             state = .error("Failed to load: custom source probe failed")
             throw DemuxerError.openFailed(code: -1)
+        }
+
+        // AE#140: an HLS playlist URL misrouted onto the raw-byte live path. The AVIOReader detected the
+        // #EXTM3U body and failed closed instead of looping its endless-feed reconnect forever. Surface a
+        // typed, actionable rejection so the host routes m3u8 through LoadOptions.nativeRemoteHLS or
+        // HLSLiveIngestReader, not the generic isLive raw path.
+        if let readerError = probeFailure as? AVIOReaderError, case .hlsPlaylistOnRawLivePath = readerError {
+            state = .error("HLS playlist supplied to the raw live path. Use LoadOptions.nativeRemoteHLS or HLSLiveIngestReader for m3u8 sources.")
+            throw AetherEngineError.hlsPlaylistOnRawLivePath
         }
 
         // Live fail-fast: a failed probe means the AVIOReader burned its full reconnect budget.
@@ -3146,7 +3157,19 @@ public final class AetherEngine: ObservableObject {
 
 // MARK: - Errors
 
-public enum AetherEngineError: Error {
+public enum AetherEngineError: Error, LocalizedError {
     case noVideoStream
     case noAudioStream
+    /// AE#140: an HLS playlist URL (m3u8) was handed to `load(isLive:)` on the generic raw-byte path.
+    /// Route m3u8 sources through `LoadOptions.nativeRemoteHLS` or `HLSLiveIngestReader` instead.
+    case hlsPlaylistOnRawLivePath
+
+    public var errorDescription: String? {
+        switch self {
+        case .noVideoStream: return "No video stream in source"
+        case .noAudioStream: return "No audio stream in source"
+        case .hlsPlaylistOnRawLivePath:
+            return "HLS playlist supplied to the raw live path. Use LoadOptions.nativeRemoteHLS or HLSLiveIngestReader for m3u8 sources."
+        }
+    }
 }

--- a/Sources/AetherEngine/Demuxer/AVIOReader.swift
+++ b/Sources/AetherEngine/Demuxer/AVIOReader.swift
@@ -363,6 +363,20 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
             // probeFileSize() round-trip (and its HEAD fallback, the request some origins 429).
             startPersistentConnection(at: 0, boundedTo: boundedInitialFetch)
             let gotData = awaitFirstPersistentData()
+            // AE#140: an HLS playlist URL misrouted onto the raw-byte live path. A live origin serves the
+            // finite #EXTM3U body at HTTP 200 and closes the connection; the endless-feed reader then
+            // re-fetches that body forever. Those reconnects look PRODUCTIVE (a full body at 200, and every
+            // find_stream_info probe seek resets the unproductive streak via seekReconnect), so the #71
+            // give-up counters never trip, avformat_open_input never returns, and load() hangs with no
+            // terminal state. Fail closed here, before the reconnect loop is ever entered: a raw media
+            // container never begins with '#' (TS syncs on 0x47; MP4/MKV open with binary box/EBML markers),
+            // so an #EXTM3U prefix is an unambiguous misroute. The host is pointed at the HLS entry points.
+            if isLive, gotData, Self.bodyBeginsWithHLSPlaylistTag(firstWindowPrefix()) {
+                EngineLog.emit("[AVIOReader] HLS playlist body on the raw live path (AE#140); failing closed. Use LoadOptions.nativeRemoteHLS or HLSLiveIngestReader for m3u8 sources.", category: .demux)
+                markClosed()
+                close()
+                throw AVIOReaderError.hlsPlaylistOnRawLivePath
+            }
             var tookFallback = false
             if !isLive {
                 // Atomically decide, under winCond, whether the optimistic connection resolved
@@ -434,6 +448,31 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
         let gotData = !window.isEmpty
         winCond.unlock()
         return gotData
+    }
+
+    /// Snapshot up to `max` leading bytes of the first window (open-time, before any read has consumed
+    /// it, so `winStart == 0`). winCond-guarded like every other window access. Used only by the AE#140
+    /// misroute check; returns [] if no data has arrived.
+    private func firstWindowPrefix(max: Int = 16) -> [UInt8] {
+        winCond.lock()
+        defer { winCond.unlock() }
+        let n = Swift.min(max, window.count)
+        return n > 0 ? Array(window.prefix(n)) : []
+    }
+
+    /// True when a body's leading bytes are the HLS playlist tag `#EXTM3U`, tolerating a UTF-8 BOM and
+    /// leading ASCII whitespace. A raw media container never opens with '#', so this is an unambiguous
+    /// signal that an m3u8 playlist was handed to the raw-byte reader (AE#140). Static + internal so the
+    /// classifier is unit-tested without a live origin.
+    static func bodyBeginsWithHLSPlaylistTag(_ bytes: [UInt8]) -> Bool {
+        var i = 0
+        if bytes.count >= 3, bytes[0] == 0xEF, bytes[1] == 0xBB, bytes[2] == 0xBF { i = 3 }
+        while i < bytes.count, bytes[i] == 0x20 || bytes[i] == 0x09 || bytes[i] == 0x0A || bytes[i] == 0x0D {
+            i += 1
+        }
+        let tag = Array("#EXTM3U".utf8)
+        guard bytes.count - i >= tag.count else { return false }
+        return Array(bytes[i..<(i + tag.count)]) == tag
     }
 
     /// Under a single winCond critical section: snapshot whether the optimistic open-time
@@ -2249,12 +2288,16 @@ enum AVIOReaderError: Error, CustomStringConvertible {
     case allocationFailed
     case noResponse
     case requestTimeout
+    /// AE#140: an HLS playlist body arrived on the raw-byte live reader (misroute). Surfaced to load()
+    /// so it can fail closed with a typed rejection instead of looping the endless-feed reconnect.
+    case hlsPlaylistOnRawLivePath
 
     var description: String {
         switch self {
         case .allocationFailed: return "Failed to allocate AVIO buffer"
         case .noResponse: return "No response from server"
         case .requestTimeout: return "Request timed out"
+        case .hlsPlaylistOnRawLivePath: return "HLS playlist supplied to the raw live path"
         }
     }
 }

--- a/Tests/AetherEngineTests/AVIOReaderHLSMisrouteTests.swift
+++ b/Tests/AetherEngineTests/AVIOReaderHLSMisrouteTests.swift
@@ -1,0 +1,67 @@
+import Testing
+import Foundation
+@testable import AetherEngine
+
+/// AE#140: `load(url: m3u8, options: LoadOptions(isLive: true))` without `nativeRemoteHLS` routes the
+/// playlist URL onto the raw-byte live reader. The origin serves the finite #EXTM3U body at HTTP 200 and
+/// closes; the endless-feed reader then re-fetches it forever (productive-looking reconnects the #71
+/// give-up counters can't catch), so avformat_open_input never returns and load() hangs with no terminal
+/// state. AVIOReader now classifies the first bytes and fails closed before entering the reconnect loop.
+/// These cover the classifier in isolation (no network): a raw media container never opens with '#', so an
+/// #EXTM3U prefix is an unambiguous misroute.
+struct AVIOReaderHLSMisrouteTests {
+
+    private func bytes(_ string: String) -> [UInt8] { Array(string.utf8) }
+
+    @Test("Media playlist body is detected")
+    func mediaPlaylist() {
+        let body = "#EXTM3U\n#EXT-X-VERSION:3\n#EXT-X-TARGETDURATION:6\n#EXTINF:6.0,\nseg0.ts\n"
+        #expect(AVIOReader.bodyBeginsWithHLSPlaylistTag(bytes(body)))
+    }
+
+    @Test("Master playlist body is detected")
+    func masterPlaylist() {
+        let body = "#EXTM3U\n#EXT-X-STREAM-INF:BANDWIDTH=800000\nvariant.m3u8\n"
+        #expect(AVIOReader.bodyBeginsWithHLSPlaylistTag(bytes(body)))
+    }
+
+    @Test("UTF-8 BOM before the tag is tolerated")
+    func bomPrefix() {
+        var b: [UInt8] = [0xEF, 0xBB, 0xBF]
+        b.append(contentsOf: bytes("#EXTM3U\n"))
+        #expect(AVIOReader.bodyBeginsWithHLSPlaylistTag(b))
+    }
+
+    @Test("Leading whitespace before the tag is tolerated")
+    func leadingWhitespace() {
+        #expect(AVIOReader.bodyBeginsWithHLSPlaylistTag(bytes("  \n\t#EXTM3U\n")))
+    }
+
+    @Test("MPEG-TS sync bytes are not a playlist")
+    func mpegTSSync() {
+        // TS packets sync on 0x47; the raw live path this guards is exactly the TS case.
+        let ts: [UInt8] = [0x47, 0x40, 0x00, 0x10, 0x00, 0x00, 0x00, 0x00]
+        #expect(!AVIOReader.bodyBeginsWithHLSPlaylistTag(ts))
+    }
+
+    @Test("MP4 ftyp box is not a playlist")
+    func mp4Ftyp() {
+        let mp4: [UInt8] = [0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70] // ....ftyp
+        #expect(!AVIOReader.bodyBeginsWithHLSPlaylistTag(mp4))
+    }
+
+    @Test("A bare #EXTINF without the #EXTM3U header is not matched")
+    func extinfWithoutHeader() {
+        #expect(!AVIOReader.bodyBeginsWithHLSPlaylistTag(bytes("#EXTINF:6.0,\nseg0.ts\n")))
+    }
+
+    @Test("A truncated #EXT prefix is not matched")
+    func truncatedPrefix() {
+        #expect(!AVIOReader.bodyBeginsWithHLSPlaylistTag(bytes("#EXT")))
+    }
+
+    @Test("Empty body is not a playlist")
+    func emptyBody() {
+        #expect(!AVIOReader.bodyBeginsWithHLSPlaylistTag([]))
+    }
+}


### PR DESCRIPTION
Fixes #140.

## Problem

`load(url: m3u8, options: LoadOptions(isLive: true))` **without** `nativeRemoteHLS` bypasses both documented HLS entry points (`loadRemoteHLS` / `HLSLiveIngestReader`) and routes the playlist URL onto the raw-byte live reader (`AVIOReader`, endless-feed mode).

A live origin serves the finite ~497-byte `#EXTM3U` body at HTTP 200 and closes the connection. The endless-feed reader read that as a dropped live stream and reconnected, re-fetching the same body forever. The reconnects looked **productive** (a full body at 200, and every `find_stream_info` probe seek reset the unproductive-reconnect streak via `seekReconnect`), so the #71 give-up counters never tripped. `avformat_open_input` never returned, and `load()` sat at `.loading` with **no terminal state** (reporter observed 262 reconnect cycles over 5.75 min). The raw-TS live path fails *closed* correctly because a dead TS source returns a real connection error; a healthy static playlist at HTTP 200 slips past every give-up heuristic.

## Fix

Detect the misroute at the byte source, not in the give-up counters (which are structurally blind to a productive-looking playlist re-serve). After the persistent connection delivers its first window, the reader snapshots the leading bytes and fails closed when they begin with the HLS playlist tag `#EXTM3U` (tolerating a UTF-8 BOM and leading whitespace). A raw media container never opens with `#` (TS syncs on `0x47`; MP4/MKV open with binary box/EBML markers), so the prefix is an unambiguous signal that an m3u8 was handed to the wrong API. The reader throws before the reconnect loop is entered.

`load()` surfaces it as a new typed, catchable **`AetherEngineError.hlsPlaylistOnRawLivePath`** (with an actionable `LocalizedError` description pointing the caller at `nativeRemoteHLS` / `HLSLiveIngestReader`), reusing the existing live fail-closed seam.

## Verification

- **End-to-end** on the exact `.url` + `isLive` misroute via a local static-playlist HTTP fixture: pre-fix hung; post-fix terminates in **0.03s** with the typed error and an actionable `.error` state, no reconnect cycles.
- **Unit tests** cover the byte classifier (media/master playlist, BOM, whitespace, TS sync, MP4 ftyp, bare `#EXTINF`, truncated prefix, empty).
- Full suite: **730 tests pass**. `swift build` (Swift 6 complete concurrency) + tvOS Simulator build green.

## API surface (MINOR)

Adds `public case AetherEngineError.hlsPlaylistOnRawLivePath` and a `LocalizedError` conformance on `AetherEngineError` → 5.9.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)