### PR TITLE
fix(seek): re-anchor producer for far-forward seeks above retained scrub bands (#141)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ the public-API contract.
 
 ## [Unreleased]
 
+### Fixed
+
+- **A far-forward VOD seek above a retained scrub band no longer parks in 30 s serve timeouts into item death; the producer re-anchors at the target immediately.** Reported geometry: a scripted 600 s scrub left its segment band resident under the retention budget, the producer was later re-anchored at ~302 s, and a fourth seek targeted 640 s, just above the dead band's top. Two layers misread that. The segment server's forward-wait branch trusted the resident maximum as "the producer is about to write this" and parked the request for the target segment (three 30 s cache-miss timeouts; the third tore the connection into `-1017` / `failedToPlayToEndTime` item death and a stage-2 reload, correct target state only ~108 s after the seek command). And the 8 s seek-deadline path (#129) preserved the "progressing" producer because the old position still had forward buffer, blind to the target sitting ~330 s beyond what the march could reach inside the consumer's timeout budget. The forward-wait branch now keys on the active producer's write front (its high water since restart, or its anchor before the first write) instead of the resident maximum, so a request beyond the reachable window re-anchors the producer at once; and the seek-deadline backstop now also re-anchors a progressing producer whose march cannot reach the pending seek target (starvation is no longer the only trigger). Reported by cmcpherson274 (#141).
+
 ## [5.9.0] - 2026-07-19
 
 ([release notes](https://github.com/superuser404notfound/AetherEngine/releases/tag/5.9.0))

--- a/Sources/AetherEngine/AetherEngine.swift
+++ b/Sources/AetherEngine/AetherEngine.swift
@@ -2336,17 +2336,28 @@ public final class AetherEngine: ObservableObject {
                 }
                 let wasStarved = seekIsWedged(
                     renderedTime: avpReal, bufferedEnd: host.bufferedEnd)
+                // AE#141: a progressing producer is only worth preserving when its march can
+                // actually deliver the pending target. A far-forward target beyond coverage
+                // (640 s target, march at ~316 s) rides 3x30 s serve timeouts into item death
+                // if left to "land late"; the old-position buffer health cannot see that.
+                let targetBeyondCoverage: Bool = {
+                    guard let target = pendingRecoverySeekClockTarget,
+                          let session = nativeVideoSession else { return false }
+                    return !session.producerCoversPlaylistTime(target)
+                }()
+                let needsReanchor = Self.shouldReanchorProducerAfterSeekDeadline(
+                    isStarved: wasStarved, targetBeyondProducerCoverage: targetBeyondCoverage)
                 nativeClockSeconds = avpReal
                 // currentTime on the 0-based display axis (AE#105 origin); sourceTime stays source PTS for subs.
                 clock.currentTime = PresentationAxis.display(sourcePTS: avpReal + playlistShiftSeconds,
                                                              origin: sourcePresentationOrigin)
                 clock.sourceTime = avpReal + playlistShiftSeconds
                 setProgrammaticSeek(inFlight: false, target: nil)
-                reconcileNativeSeekTransport(host: host, isStarved: wasStarved)
+                reconcileNativeSeekTransport(host: host, isStarved: needsReanchor)
                 let recoveryAnchor = Self.recoveryAnchorPosition(
                     frozenPosition: avpReal, pendingSeekTarget: pendingRecoverySeekClockTarget,
                     currentRendered: avpReal)
-                if Self.shouldReanchorProducerAfterSeekDeadline(isStarved: wasStarved) {
+                if needsReanchor {
                     reanchorProducerToPlaylistTime(recoveryAnchor)
                     // The playhead will jump when the restarted producer lets the pending seek land.
                     reanchorSubtitleOverlays()
@@ -2355,12 +2366,17 @@ public final class AetherEngine: ObservableObject {
                 // pendingRecoverySeekClockTarget deliberately survives this reconcile: the UI
                 // clock gives up the phantom target, but recovery keeps aiming there until rendered
                 // output reaches it or organic playback proves AVPlayer abandoned the seek.
+                let reason = wasStarved
+                    ? "starved"
+                    : (targetBeyondCoverage
+                        ? "old position still buffered, target beyond producer coverage"
+                        : "old position still buffered")
                 EngineLog.emit(
                     "[AetherEngine] seek did not land within \(Self.nativeSeekReconcileBudgetSeconds)s "
-                    + "(\(wasStarved ? "starved" : "old position still buffered"), "
+                    + "(\(reason), "
                     + "rendered=\(String(format: "%.2f", avpReal))s "
                     + "buffered=\(String(format: "%.2f", host.bufferedEnd))s); reconciled clock"
-                    + (wasStarved
+                    + (needsReanchor
                         ? " and re-anchored producer at \(String(format: "%.2f", recoveryAnchor))s"
                         : " without restarting the progressing producer"),
                     category: .engine
@@ -2428,8 +2444,12 @@ public final class AetherEngine: ObservableObject {
         }
     }
 
-    nonisolated static func shouldReanchorProducerAfterSeekDeadline(isStarved: Bool) -> Bool {
-        isStarved
+    /// #129 kept a progressing producer at the seek deadline (restarting discards useful fill);
+    /// AE#141 narrows that: preservation only pays when the march can reach the pending target.
+    nonisolated static func shouldReanchorProducerAfterSeekDeadline(
+        isStarved: Bool, targetBeyondProducerCoverage: Bool
+    ) -> Bool {
+        isStarved || targetBeyondProducerCoverage
     }
 
     nonisolated static func shouldCatchUpDeadlineLanding(

--- a/Sources/AetherEngine/Video/HLSVideoEngine.swift
+++ b/Sources/AetherEngine/Video/HLSVideoEngine.swift
@@ -1777,6 +1777,16 @@ public final class HLSVideoEngine: @unchecked Sendable {
         return min(max(lo - 1, 0), segmentPlan.count - 1)
     }
 
+    /// AE#141: whether the active producer's march can plausibly deliver the segment covering
+    /// playlist time `seconds` without a re-anchor. The seek-deadline path asks this before
+    /// preserving a "progressing" producer: progress toward a region the pending target is not
+    /// in is not worth preserving (640 s target, march at ~316 s: 3x30 s serve timeouts ride to
+    /// item death long before the march arrives). `true` with no provider (nothing to judge).
+    func producerCoversPlaylistTime(_ seconds: Double) -> Bool {
+        guard let prov = provider else { return true }
+        return prov.activeMarchCovers(segmentIndexForPlaylistTime(seconds))
+    }
+
     /// #93 restart latency: phase split for the "restart took" line, so a slow restart names the
     /// phase that ate the time (old-pump stop wait, wedged-reopen, demuxer seek, producer build).
     nonisolated static func restartPhaseSummary(

--- a/Sources/AetherEngine/Video/VideoSegmentProvider.swift
+++ b/Sources/AetherEngine/Video/VideoSegmentProvider.swift
@@ -116,6 +116,9 @@ final class VideoSegmentProvider: HLSSegmentProvider, @unchecked Sendable {
     /// Hard cap on riding an in-flight restart (#93 residual): a fetch waits past the fixed
     /// budget while a restart is genuinely executing, but never indefinitely.
     private let repositionRideCapSeconds: TimeInterval
+    /// Blocking wait for a forward request the active producer is about to write (test-injectable;
+    /// production stays at 30 s, matching AVPlayer's serve patience before it retries).
+    private let forwardBackpressureWaitSeconds: TimeInterval
     /// #93 round 3: a VOD serve still running at this age signals `onSlow` so the server can emit
     /// an early chunked header, keeping time-to-first-byte under AVPlayer's ~3.5 s -12889 window.
     private let slowServeThresholdSeconds: TimeInterval
@@ -155,6 +158,7 @@ final class VideoSegmentProvider: HLSSegmentProvider, @unchecked Sendable {
         repositionWaitSlice: TimeInterval = 8.0,
         sparseHoleWaitSlice: TimeInterval = 2.0,
         repositionRideCapSeconds: TimeInterval = 90.0,
+        forwardBackpressureWaitSeconds: TimeInterval = 30.0,
         slowServeThresholdSeconds: TimeInterval = 2.0,
         nativeSubtitleStores: [NativeSubtitleCueStore] = [],
         nativeSubtitleLanguages: [String?] = [],
@@ -184,6 +188,7 @@ final class VideoSegmentProvider: HLSSegmentProvider, @unchecked Sendable {
         self.repositionWaitSlice = repositionWaitSlice
         self.sparseHoleWaitSlice = sparseHoleWaitSlice
         self.repositionRideCapSeconds = repositionRideCapSeconds
+        self.forwardBackpressureWaitSeconds = forwardBackpressureWaitSeconds
         self.slowServeThresholdSeconds = slowServeThresholdSeconds
         self.nativeSubStores = nativeSubtitleStores
         self.nativeSubLanguages = nativeSubtitleLanguages
@@ -438,8 +443,14 @@ final class VideoSegmentProvider: HLSSegmentProvider, @unchecked Sendable {
                 }
                 needsRestart = true
             } else {
-                // r.1 < index <= r.1 + forwardWaitWindow: producer about to write; backpressure-wait.
-                needsRestart = false
+                // r.1 < index <= r.1 + forwardWaitWindow: only backpressure-wait when the ACTIVE
+                // producer's march front is actually near. The resident max alone is not that
+                // signal: retained scrub bands (#93 budget) from a dead producer can sit far above
+                // the active march (AE#141: band 150-158 from a 600 s scrub, producer re-anchored
+                // at 75; the request for seg159 parked 3x30 s into -1017 item death while the
+                // march was ~2 minutes away). highWater is reset per provider-fired restart, so
+                // max(highWater, lastRestartIndex) tracks the active producer's front.
+                needsRestart = index > activeMarchFront + Self.forwardWaitWindow
             }
         } else {
             // Empty cache: cold start (producer at lastRestartIndex, hasn't written yet) vs. big scrub
@@ -508,7 +519,7 @@ final class VideoSegmentProvider: HLSSegmentProvider, @unchecked Sendable {
             return logServed(index: index, bytes: nil, totalStart: totalStart, restarted: true)
         }
 
-        let bytes = cache.fetch(index: index, timeout: 30.0)
+        let bytes = cache.fetch(index: index, timeout: forwardBackpressureWaitSeconds)
         return logServed(index: index, bytes: bytes, totalStart: totalStart, restarted: needsRestart)
     }
 
@@ -531,6 +542,20 @@ final class VideoSegmentProvider: HLSSegmentProvider, @unchecked Sendable {
     private func activeProducerCovers(_ index: Int) -> Bool {
         guard let base = activeProducerBase?() else { return false }
         return base <= index && index - base <= Self.forwardWaitWindow
+    }
+
+    /// The active producer's write front: the highest index written since its restart (highWater
+    /// is reset per provider-fired restart) or its restart anchor before the first write (AE#141).
+    private var activeMarchFront: Int {
+        max(cache.highestStoredIndex, lastRestartIndex)
+    }
+
+    /// AE#141: whether the active producer's march can plausibly deliver `index` without a
+    /// re-anchor — at or behind its anchor-to-front span, or within the forward-wait window
+    /// ahead of the front. The engine's seek-deadline backstop asks this before preserving a
+    /// "progressing" producer whose march would never reach the pending seek target.
+    func activeMarchCovers(_ index: Int) -> Bool {
+        index >= lastRestartIndex && index <= activeMarchFront + Self.forwardWaitWindow
     }
 
     private var currentSegmentCount: Int {

--- a/Tests/AetherEngineTests/Issue141FarForwardSeekTests.swift
+++ b/Tests/AetherEngineTests/Issue141FarForwardSeekTests.swift
@@ -1,0 +1,147 @@
+import Testing
+import Foundation
+@testable import AetherEngine
+
+/// AE#141: a far-forward seek above a retained stale scrub band parked 3x30 s into item death.
+/// The forward-wait branch (r.1 < index <= r.1 + forwardWaitWindow) read the resident max as "the
+/// producer is about to write this", but with #93 retention the resident max can belong to a DEAD
+/// producer's band (600 s scrub left seg150-158) while the active producer marches far below
+/// (re-anchored at 75, front ~79). The request for seg159 must re-anchor the producer, not
+/// backpressure-wait on a march that is ~2 minutes away.
+struct Issue141FarForwardSeekTests {
+
+    private final class Recorder: @unchecked Sendable {
+        private let lock = NSLock()
+        private var fired: [Int] = []
+        func record(_ idx: Int) { lock.lock(); fired.append(idx); lock.unlock() }
+        var all: [Int] { lock.lock(); defer { lock.unlock() }; return fired }
+    }
+
+    private func segments(_ n: Int) -> [HLSVideoEngine.Segment] {
+        (0..<n).map { i in
+            HLSVideoEngine.Segment(startPts: Int64(i) * 4000, endPts: Int64(i + 1) * 4000,
+                                   startSeconds: Double(i) * 4.0, durationSeconds: 4.0)
+        }
+    }
+
+    private func makeProvider(cache: SegmentCache, recorder: Recorder,
+                              producerBase: Int?, initialRestartIndex: Int,
+                              storeOnRestart: Bool = false,
+                              backpressureWait: TimeInterval = 0.3) -> VideoSegmentProvider {
+        VideoSegmentProvider(
+            cache: cache, segments: segments(200), codecsString: "hvc1", supplementalCodecs: nil,
+            resolution: (3840, 2160), videoRange: .sdr, frameRate: 24.0, hdcpLevel: nil,
+            sourceBitrate: 60_000_000,
+            restartHandler: { [weak cache] idx in
+                recorder.record(idx)
+                if storeOnRestart {
+                    cache?.store(index: idx, data: Data(repeating: 0x41, count: 8))
+                }
+            },
+            restartActivity: { false },
+            activeProducerBase: { producerBase },
+            initialRestartIndex: initialRestartIndex,
+            repositionWaitSlice: 0.05,
+            repositionRideCapSeconds: 5.0,
+            forwardBackpressureWaitSeconds: backpressureWait
+        )
+    }
+
+    /// The device geometry from the report: stale band 150-158 (dead 600 s-scrub producer),
+    /// active producer re-anchored at 75 with march front 79. AVPlayer's request for seg159
+    /// (the 640 s target) sat exactly in the forward-wait window above the stale band and
+    /// parked 30 s with restarted=false, three times, into -1017 item death.
+    @Test("a forward request above a stale band re-anchors the producer instead of parking")
+    func farForwardAboveStaleBandRestartsInsteadOfParking() {
+        // Device shape: VOD sessions run with the #93 retention budget, which is what keeps the
+        // dead band resident. Without it, window pruning evicts the band and hides the bug.
+        let cache = SegmentCache(forwardWindow: 60, backwardWindow: 60,
+                                 retentionBudgetBytes: 512 * 1024 * 1024)
+        defer { cache.close() }
+        let recorder = Recorder()
+        // Dead gen-1 band: written by an earlier producer, still resident under the retention budget.
+        for i in 150...158 { cache.store(index: i, data: Data(repeating: 0xA1, count: 8)) }
+        // Gen-3 provider-fired restart at 75 reset the high water; the active producer then wrote 75-79.
+        cache.resetHighWaterForRestart()
+        for i in 75...79 { cache.store(index: i, data: Data(repeating: 0xA3, count: 8)) }
+        let provider = makeProvider(cache: cache, recorder: recorder,
+                                    producerBase: 75, initialRestartIndex: 75,
+                                    storeOnRestart: true)
+
+        let start = DispatchTime.now()
+        let served = provider.mediaSegment(at: 159)
+        let elapsed = Double(DispatchTime.now().uptimeNanoseconds - start.uptimeNanoseconds) / 1e9
+
+        #expect(served != nil)
+        #expect(recorder.all == [159])
+        #expect(elapsed < 2.0)
+    }
+
+    /// Healthy forward catch-up must keep its backpressure-wait: single march band, AVPlayer
+    /// requests one past the active producer's front, the march delivers moments later. No restart.
+    @Test("catch-up one past the active march front still backpressure-waits")
+    func forwardCatchupStillBackpressureWaits() {
+        let cache = SegmentCache(forwardWindow: 60, backwardWindow: 60,
+                                 retentionBudgetBytes: 512 * 1024 * 1024)
+        defer { cache.close() }
+        let recorder = Recorder()
+        for i in 30...40 { cache.store(index: i, data: Data(repeating: 0xB2, count: 8)) }
+        // Kernel-scheduled thread, not a GCD timer: oversubscribed CI runners starve
+        // global-queue timers past short wait slices (see SegmentFetchWaitTests).
+        Thread.detachNewThread {
+            Thread.sleep(forTimeInterval: 0.05)
+            cache.store(index: 41, data: Data(repeating: 0xB3, count: 8))
+        }
+        let provider = makeProvider(cache: cache, recorder: recorder,
+                                    producerBase: 30, initialRestartIndex: 30,
+                                    backpressureWait: 1.0)
+
+        let served = provider.mediaSegment(at: 41)
+
+        #expect(served != nil)
+        #expect(recorder.all.isEmpty)
+    }
+}
+
+/// AE#141: the march-coverage predicate the engine's seek-deadline backstop keys on.
+extension Issue141FarForwardSeekTests {
+    @Test("march coverage spans anchor to front plus the forward-wait window")
+    func marchCoverageSpans() {
+        let cache = SegmentCache(forwardWindow: 60, backwardWindow: 60,
+                                 retentionBudgetBytes: 512 * 1024 * 1024)
+        defer { cache.close() }
+        let recorder = Recorder()
+        // Dead band above, then a provider-fired-restart-shaped reset and an active march 75-79.
+        for i in 150...158 { cache.store(index: i, data: Data(repeating: 0xC1, count: 8)) }
+        cache.resetHighWaterForRestart()
+        for i in 75...79 { cache.store(index: i, data: Data(repeating: 0xC2, count: 8)) }
+        let provider = makeProvider(cache: cache, recorder: recorder,
+                                    producerBase: 75, initialRestartIndex: 75)
+
+        // Anchor-to-front span and the forward-wait window ahead of the front are covered.
+        #expect(provider.activeMarchCovers(75))
+        #expect(provider.activeMarchCovers(79))
+        #expect(provider.activeMarchCovers(87))   // front 79 + window 8
+        // Beyond the window (the 640 s target, seg159) and behind the anchor are not.
+        #expect(!provider.activeMarchCovers(88))
+        #expect(!provider.activeMarchCovers(159))
+        #expect(!provider.activeMarchCovers(74))
+    }
+
+    @Test("before its first write a restarted producer covers its anchor window")
+    func marchCoverageColdStart() {
+        let cache = SegmentCache(forwardWindow: 60, backwardWindow: 60,
+                                 retentionBudgetBytes: 512 * 1024 * 1024)
+        defer { cache.close() }
+        let recorder = Recorder()
+        for i in 150...158 { cache.store(index: i, data: Data(repeating: 0xC3, count: 8)) }
+        cache.resetHighWaterForRestart()
+        let provider = makeProvider(cache: cache, recorder: recorder,
+                                    producerBase: 75, initialRestartIndex: 75)
+
+        #expect(provider.activeMarchCovers(75))
+        #expect(provider.activeMarchCovers(83))   // anchor 75 + window 8, no writes yet
+        #expect(!provider.activeMarchCovers(84))
+        #expect(!provider.activeMarchCovers(74))
+    }
+}

--- a/Tests/AetherEngineTests/RecoverySeekTargetTests.swift
+++ b/Tests/AetherEngineTests/RecoverySeekTargetTests.swift
@@ -53,10 +53,19 @@ struct RecoverySeekTargetTests {
         #expect(AetherEngine.isPendingSeekStale(progressWhilePending: 3.5))
     }
 
-    @Test("deadline recovery restarts only a starved producer")
+    @Test("deadline recovery restarts a starved producer or one that cannot reach the target")
     func deadlineRestartDecision() {
-        #expect(AetherEngine.shouldReanchorProducerAfterSeekDeadline(isStarved: true))
-        #expect(!AetherEngine.shouldReanchorProducerAfterSeekDeadline(isStarved: false))
+        #expect(AetherEngine.shouldReanchorProducerAfterSeekDeadline(
+            isStarved: true, targetBeyondProducerCoverage: false))
+        // AE#141: a progressing producer whose march cannot reach the pending target must be
+        // re-anchored; "healthy at the old position" rode 3x30 s serve timeouts into item death.
+        #expect(AetherEngine.shouldReanchorProducerAfterSeekDeadline(
+            isStarved: false, targetBeyondProducerCoverage: true))
+        #expect(AetherEngine.shouldReanchorProducerAfterSeekDeadline(
+            isStarved: true, targetBeyondProducerCoverage: true))
+        // #129: a healthy march filling toward a reachable target keeps its progress.
+        #expect(!AetherEngine.shouldReanchorProducerAfterSeekDeadline(
+            isStarved: false, targetBeyondProducerCoverage: false))
         #expect(AetherEngine.shouldReanchorSubtitlesOnLateSeekLanding(
             alreadyReanchored: false
         ))


### PR DESCRIPTION
## Summary

Fixes #141: a far-forward VOD seek whose target sat just above a retained (dead) scrub band's resident top parked in three 30 s cache-miss serve timeouts, tore the loopback connection into `-1017` / `failedToPlayToEndTime` item death, and only reached the requested target via stage-2 reload roughly 108 s after the seek command.

## Root cause

The reporter's scripted sequence (600 s, 30 s, 302 s, 640 s) built exactly the one geometry the serve path trusts blindly:

1. The 600 s seek re-anchored the producer at seg150; its band (segments ~150-158) stayed resident under the #93 retention budget after later seeks moved the producer away.
2. The 302 s seek re-anchored the producer at seg75 through the provider's restart branch, which resets the cache high water; by the 640 s seek the active march front was ~seg79 (~316 s).
3. The 640 s seek made AVPlayer request seg159, which fell in the forward-wait window just above the dead band's top (`r.1 < index <= r.1 + 8`). That branch read the resident max as "the producer is about to write this" and parked the request in the 30 s backpressure fetch with no restart, three times. The gen 1-3 seeks all took branches that DO check the active producer (out-of-range, interior-hole coverage), which is why only the fourth seek died.
4. The 8 s seek-deadline path (#129) declined its backstop restart too: `seekIsWedged` saw 6.5 s of forward buffer at the old position (healthy, progressing) and "reconciled the clock without restarting the progressing producer". The target sat ~330 s beyond the march; at that bitrate the sequential fill needs ~2 minutes, far past the consumer's 3x30 s budget, so a late landing was structurally impossible.

## Fix

Two layers, matching the two misreads:

- **VideoSegmentProvider (primary):** the forward-wait branch now keys on the active producer's write front, `max(highWater since restart, lastRestartIndex)`, instead of the resident maximum. A request beyond `front + forwardWaitWindow` re-anchors the producer immediately. In normal single-band operation the front equals `r.1`, so healthy catch-up backpressure is unchanged.
- **Seek-deadline backstop (AetherEngine):** `shouldReanchorProducerAfterSeekDeadline` now also re-anchors when the pending seek target lies beyond active march coverage (`producerCoversPlaylistTime` -> `activeMarchCovers`). Starvation is no longer the only trigger; a healthy march filling toward a reachable target still keeps its progress (#129 semantics preserved).

The deadline log line now names the third case (`old position still buffered, target beyond producer coverage ... and re-anchored producer at ...`), so a recurrence is directly attributable in reporter logs.

## Testing

- New `Issue141FarForwardSeekTests`: device geometry red-to-green (restart fires instead of a 30 s park; with the stale band resident under a retention budget, the pre-fix code parks the full injected wait and serves nil), healthy catch-up still backpressure-waits with no restart, and the `activeMarchCovers` span (anchor-to-front + window, cold-start anchor window, behind-anchor and beyond-window excluded).
- `RecoverySeekTargetTests` pins the extended deadline decision table (starved, target-beyond-coverage, both, neither).
- The 30 s forward backpressure wait is injectable for tests; the production default is unchanged.
- Full suite: 734 Swift Testing + 311 XCTest tests green, Swift 6 strict concurrency clean, tvOS Simulator build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NAPCg4tCDdSqkK6tPkNptw
