### PR TITLE
PGS: render bare Epoch-Continue display sets from retained state (#142)

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "f8a0a226f46c2920eda1c7d082d7e72f57287f0c51dc9b1717c86a82d4f4bcbf",
+  "originHash" : "c6db777fc87f55f659bbf6aa75c12ff579a271fe898fbd15778a55bb771885a4",
   "pins" : [
     {
       "identity" : "ffmpegbuild",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/superuser404notfound/FFmpegBuild",
       "state" : {
-        "revision" : "e8ae797a8ac9b715dfb6805b4929cc9f3e4173f2",
-        "version" : "2.1.0"
+        "revision" : "45ce3027149a50951ed2da17328b0166710e88af",
+        "version" : "2.1.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
         // No network stack, we use custom AVIO + URLSession for HTTP streams.
         // Resolved over Git rather than a local path so consumers (and
         // Xcode Cloud) can build without a sibling FFmpegBuild checkout.
-        .package(url: "https://github.com/superuser404notfound/FFmpegBuild", from: "2.1.0"),  // 2.1.0: yadif_videotoolbox + hwupload (Metal GPU deinterlace); 2.0.0: dynamic frameworks (LGPL), zvbi GPL excision
+        .package(url: "https://github.com/superuser404notfound/FFmpegBuild", from: "2.1.1"),  // 2.1.1: pgssubdec Epoch-Continue retain (#142); 2.1.0: yadif_videotoolbox + hwupload (Metal GPU deinterlace); 2.0.0: dynamic frameworks (LGPL), zvbi GPL excision
         // Pure-Swift SMB2 client (MIT) that speaks the protocol over
         // NWConnection. Replaces AMSMB2/libsmb2, which EPERMs on tvOS/iOS.
         // Pinned to the 0.3.x minor: SMBClient is pre-1.0 with an actively

--- a/Tests/AetherEngineTests/Issue142PGSEpochContinueTests.swift
+++ b/Tests/AetherEngineTests/Issue142PGSEpochContinueTests.swift
@@ -1,0 +1,162 @@
+import Foundation
+import Testing
+import Libavcodec
+@testable import AetherEngine
+
+/// #142: a bare Epoch-Continue display set (PCS+WDS+END, palette and objects referenced from retained
+/// decoder state, no PDS/ODS retransmit) must render from that retained state. Stock FFmpeg pgssubdec
+/// flushes palettes and objects for ANY composition_state != Normal, including 0xC0 Epoch Continue,
+/// so the bare set fails find_palette ("Invalid palette id 0") and is dropped whole; because PGS end
+/// times are closed by the successor cue, the predecessor cue then overstays. FFmpegBuild carries a
+/// pgssubdec patch that skips the flush for Epoch Continue only; Epoch Start and Acquisition Point
+/// keep flushing (both are self-contained restatements by spec, the flush is safe there).
+///
+/// These tests drive the shipped Libavcodec pgssub decoder directly with synthetic display sets, the
+/// same call path EmbeddedSubtitleDecoder uses.
+struct Issue142PGSEpochContinueTests {
+
+    // MARK: - Segment builders (layouts per pgssubdec.c parsers)
+
+    /// A PGS segment run: each segment is [type:1][len:2 BE][body:len].
+    private func segment(type: UInt8, body: [UInt8]) -> [UInt8] {
+        [type, UInt8((body.count >> 8) & 0xFF), UInt8(body.count & 0xFF)] + body
+    }
+
+    /// PCS (0x16): 1920x1080, one composition object referencing object 0 / palette 0 at (100,100).
+    private func pcs(compositionState: UInt8) -> [UInt8] {
+        segment(type: 0x16, body: [
+            0x07, 0x80, 0x04, 0x38,             // width 1920, height 1080
+            0x10,                               // frame rate (opaque to the decoder)
+            0x00, 0x01,                         // composition number
+            compositionState,
+            0x00,                               // palette_update_flag
+            0x00,                               // palette_id 0
+            0x01,                               // one composition object
+            0x00, 0x00,                         // object id 0
+            0x00,                               // window id 0
+            0x00,                               // composition flags (no crop, not forced)
+            0x00, 0x64, 0x00, 0x64,             // x 100, y 100
+        ])
+    }
+
+    /// WDS (0x17): one 8x8 window at (100,100). pgssubdec skips it; present for stream shape fidelity.
+    private var wds: [UInt8] {
+        segment(type: 0x17, body: [0x01, 0x00, 0x00, 0x64, 0x00, 0x64, 0x00, 0x08, 0x00, 0x08])
+    }
+
+    /// PDS (0x14): palette 0 with entry 0 transparent and entry 1 opaque white.
+    private var pds: [UInt8] {
+        segment(type: 0x14, body: [
+            0x00, 0x00,                         // palette id 0, version 0
+            0x00, 0x10, 0x80, 0x80, 0x00,       // entry 0: transparent
+            0x01, 0xEB, 0x80, 0x80, 0xFF,       // entry 1: opaque white
+        ])
+    }
+
+    /// ODS (0x15): object 0, single-segment (first+last), 8x8 bitmap of palette entry 1.
+    /// RLE per line: 0x00 0x88 0x01 (run of 8, color 1) then 0x00 0x00 (end of line) = 5 bytes x 8 lines.
+    private var ods: [UInt8] {
+        let rle = Array(repeating: [0x00, 0x88, 0x01, 0x00, 0x00] as [UInt8], count: 8).flatMap { $0 }
+        return segment(type: 0x15, body: [
+            0x00, 0x00,                         // object id 0
+            0x00,                               // version
+            0xC0,                               // sequence: first and last
+            0x00, 0x00, 0x2C,                   // rle length 44 (40 RLE + 4 dimension bytes)
+            0x00, 0x08, 0x00, 0x08,             // width 8, height 8
+        ] + rle)
+    }
+
+    private var end: [UInt8] { segment(type: 0x80, body: []) }
+
+    /// The anchor: a self-contained Epoch Start display set (PCS+WDS+PDS+ODS+END).
+    private var epochStartSet: [UInt8] { pcs(compositionState: 0x80) + wds + pds + ods + end }
+
+    /// A bare follow-up set: PCS+WDS+END only, palette/objects expected from retained state.
+    private func bareSet(compositionState: UInt8) -> [UInt8] { pcs(compositionState: compositionState) + wds + end }
+
+    // MARK: - Decoder harness
+
+    private func withPGSDecoder(_ body: (UnsafeMutablePointer<AVCodecContext>) -> Void) {
+        guard let codec = avcodec_find_decoder(AV_CODEC_ID_HDMV_PGS_SUBTITLE),
+              let ctx = avcodec_alloc_context3(codec) else {
+            Issue.record("pgssub decoder unavailable")
+            return
+        }
+        guard avcodec_open2(ctx, codec, nil) >= 0 else {
+            Issue.record("avcodec_open2 failed for pgssub")
+            return
+        }
+        body(ctx)
+        var freed: UnsafeMutablePointer<AVCodecContext>? = ctx
+        avcodec_free_context(&freed)
+    }
+
+    @discardableResult
+    private func decode(_ ctx: UnsafeMutablePointer<AVCodecContext>, _ payload: [UInt8],
+                        pts: Int64, into sub: inout AVSubtitle) -> Int32 {
+        var got: Int32 = 0
+        var bytes = payload
+        bytes.withUnsafeMutableBufferPointer { buffer in
+            var packet = AVPacket()
+            packet.data = buffer.baseAddress
+            packet.size = Int32(buffer.count)
+            packet.pts = pts
+            _ = avcodec_decode_subtitle2(ctx, &sub, &got, &packet)
+        }
+        return got
+    }
+
+    // MARK: - Tests
+
+    @Test("a bare Epoch-Continue set renders from retained palette and objects")
+    func bareEpochContinueRendersFromRetainedState() {
+        withPGSDecoder { ctx in
+            var sub = AVSubtitle()
+            #expect(decode(ctx, epochStartSet, pts: 0, into: &sub) == 1)
+            #expect(sub.num_rects == 1)
+            avsubtitle_free(&sub)
+
+            var continued = AVSubtitle()
+            let got = decode(ctx, bareSet(compositionState: 0xC0), pts: 90_000, into: &continued)
+            #expect(got == 1, "bare Epoch-Continue set was dropped (pgssubdec flushed retained state)")
+            if got == 1 {
+                #expect(continued.num_rects == 1)
+                if continued.num_rects == 1, let rect = continued.rects?[0]?.pointee {
+                    #expect(rect.w == 8)
+                    #expect(rect.h == 8)
+                    #expect(rect.x == 100)
+                    #expect(rect.y == 100)
+                }
+                avsubtitle_free(&continued)
+            }
+        }
+    }
+
+    @Test("a bare Normal set already renders from retained state (fixture control)")
+    func bareNormalSetControl() {
+        withPGSDecoder { ctx in
+            var sub = AVSubtitle()
+            #expect(decode(ctx, epochStartSet, pts: 0, into: &sub) == 1)
+            avsubtitle_free(&sub)
+
+            var continued = AVSubtitle()
+            let got = decode(ctx, bareSet(compositionState: 0x00), pts: 90_000, into: &continued)
+            #expect(got == 1, "bare Normal set failed; the synthetic fixture itself is broken")
+            if got == 1 { avsubtitle_free(&continued) }
+        }
+    }
+
+    @Test("a bare Epoch-Start set still flushes and drops (patch stays scoped to Epoch Continue)")
+    func bareEpochStartStillFlushes() {
+        withPGSDecoder { ctx in
+            var sub = AVSubtitle()
+            #expect(decode(ctx, epochStartSet, pts: 0, into: &sub) == 1)
+            avsubtitle_free(&sub)
+
+            var continued = AVSubtitle()
+            let got = decode(ctx, bareSet(compositionState: 0x80), pts: 90_000, into: &continued)
+            #expect(got == 0, "a bare Epoch-Start set must not survive the epoch flush")
+            if got == 1 { avsubtitle_free(&continued) }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #142.

A bare Epoch-Continue display set (PCS+WDS+END, palette/objects referenced from retained decoder state, no PDS/ODS retransmit) was dropped whole with "Invalid palette id 0"; because PGS end times are closed by the successor cue, the predecessor cue overstayed (reporter's 90 s cue ran to the 100 s clear instead of the authored 95 s).

**Root cause** (inherited FFmpeg, verified in n8.1.2 and current master): `pgssubdec.c parse_presentation_segment` flushes retained palettes/objects for ANY `composition_state != Normal`, including `0xC0` Epoch Continue. Per PGS semantics Epoch Continue means the previous epoch continues across a connection point, so retained state stays valid; a bare set references it.

**Fix**: FFmpegBuild 2.1.1 (`patch_ffmpeg_pgssub`) skips the flush for Epoch Continue only. Acquisition Point and Epoch Start are self-contained restatements, their flush stays. This PR bumps the pin and adds `Issue142PGSEpochContinueTests`, which drives the shipped pgssub decoder with synthetic display sets:

- bare Epoch-Continue set renders from retained state (red on 2.1.0, green on 2.1.1)
- bare Normal set control (validates the fixture independent of the patch)
- bare Epoch-Start set still drops (pins the patch's scope)

Full suite: 737 tests green. Strict-concurrency build and tvOS Simulator build verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)