### PR TITLE
Seed the seek-landing PGS line from any decoded composition (#143)

### DIFF
--- a/Sources/AetherEngine/AetherEngine+Subtitles.swift
+++ b/Sources/AetherEngine/AetherEngine+Subtitles.swift
@@ -365,8 +365,9 @@ extension AetherEngine {
         // #100: a PGS event whose cues start well behind the playhead is a catch-up replay; its
         // open-ended placeholder window would cover the playhead the instant it inserts and flash
         // stale history through the overlay until the successor trims it. Hold it instead.
-        // #112: a self-contained composition (acquisition point / epoch start) during a reconstruction pass is
-        // the current line and publishes immediately (see PGSStaleArrivalGate.admit).
+        // #112/#143: during a reconstruction pass any decoded composition at/behind the playhead becomes the
+        // held active-line candidate, emitted once when the decode reaches the playhead (see
+        // PGSStaleArrivalGate.admitDuringReconstruction).
         let admitted = pgsStaleArrivalGates[channel, default: PGSStaleArrivalGate()]
             .admit(cues: event.cues, isPGS: event.isPGS,
                    isSelfContained: event.isSelfContainedPGS, playhead: sourceTime)

--- a/Sources/AetherEngine/Subtitles/Issue100PGSStaleArrival.swift
+++ b/Sources/AetherEngine/Subtitles/Issue100PGSStaleArrival.swift
@@ -31,7 +31,8 @@ struct PGSStaleArrivalGate {
     /// candidate active line. Held, not published. Publishing every self-contained composition in the lead-in as
     /// it decoded scrolled ~24 s of history through the frozen overlay (ijuniorfu: "the subtitles keep changing
     /// while paused"). Emitted as the single active line when the decode reaches the playhead (a composition at or
-    /// after it arrives), or dropped/superseded by a newer one first.
+    /// after it arrives), or dropped/superseded by a newer one first. #143: seeded from ANY decoded composition,
+    /// not only self-contained ones; see `admitDuringReconstruction`.
     private(set) var reconstructionCandidate: SubtitleCue?
 
     init(staleEpsilonSeconds: Double = 5.0) {
@@ -43,7 +44,17 @@ struct PGSStaleArrivalGate {
     /// Resolve the held event against its successor's trim point. Returns the cues to publish
     /// NOW: the held cues trimmed to `trimAt`, filtered to those whose true window covers the
     /// playhead. History that ended before the playhead is dropped.
+    ///
+    /// #143: the trim also closes the reconstruction candidate's open window. Every PGS composition
+    /// AND clear broadcasts its start as `pgsTrimAt`, but a clear carries no cues and never reaches
+    /// `admit`; without this trim a line the author cleared before the playhead keeps its open
+    /// placeholder window and resurrects as the "active" line at pass end.
     mutating func resolveHeld(trimAt: Double, playhead: Double) -> [SubtitleCue] {
+        if let candidate = reconstructionCandidate,
+           candidate.startTime < trimAt, candidate.endTime > trimAt {
+            reconstructionCandidate = SubtitleCue(id: candidate.id, startTime: candidate.startTime,
+                                                  endTime: trimAt, body: candidate.body)
+        }
         guard !heldCues.isEmpty else { return [] }
         let resolved = heldCues.map { cue in
             SubtitleCue(id: cue.id, startTime: cue.startTime,
@@ -77,11 +88,19 @@ struct PGSStaleArrivalGate {
     /// active line and publish nothing, so the lead-in's earlier lines never scroll through the frozen overlay.
     /// The first composition at or after the playhead ends the pass: the active line (the candidate, or a
     /// just-decoded composition at the playhead) is emitted once, together with any cues ahead of the playhead
-    /// (future, stored but not yet shown). The candidate is seeded only from a self-contained composition (one the
-    /// decoder can render standalone); once seeded, any later composition at/behind the playhead refines it.
+    /// (future, stored but not yet shown).
+    ///
+    /// #143: the candidate is seeded from ANY decoded composition behind the playhead. Requiring a self-contained
+    /// composition (Acquisition Point / Epoch Start) for the FIRST seed dropped the seek-landing line on AP-less/
+    /// sparse-authored streams: every lead-in composition is Normal there, so no candidate was ever seeded and the
+    /// landing-span line, forced cues included, stayed dark until the next authored composition. A composition
+    /// that decoded at all is renderable (the drain decoder is rebuilt fresh at the backscan start, so a set whose
+    /// references are missing fails decode and never gets here), and the steady-state path outside reconstruction
+    /// already publishes Normal compositions unconditionally. `isSelfContained` stays on the signature: callers
+    /// keep reporting the PCS classification, which the epoch-start-aware backscan direction would need.
     private mutating func admitDuringReconstruction(cues: [SubtitleCue], isSelfContained: Bool, playhead: Double) -> [SubtitleCue] {
         let newestBehind = cues.filter { $0.startTime <= playhead }.max(by: { $0.startTime < $1.startTime })
-        if let newestBehind, isSelfContained || reconstructionCandidate != nil,
+        if let newestBehind,
            reconstructionCandidate.map({ newestBehind.startTime >= $0.startTime }) ?? true {
             reconstructionCandidate = newestBehind
         }

--- a/Tests/AetherEngineTests/Issue143PGSLandingLineTests.swift
+++ b/Tests/AetherEngineTests/Issue143PGSLandingLineTests.swift
@@ -1,0 +1,137 @@
+import Foundation
+import CoreGraphics
+import Testing
+@testable import AetherEngine
+
+/// #143 (cmcpherson274): a seek landing mid-cue (or exactly on a display-set start boundary) on a
+/// PGS stream WITHOUT acquisition points never re-showed the landing line, forced cues included,
+/// until the next authored composition arrived. On sparse dialogue the blackout ran tens of seconds.
+///
+/// Root cause: the reconstruction pass seeded its active-line candidate only from a self-contained
+/// composition (Acquisition Point / Epoch Start). On AP-less/sparse-authored streams every lead-in
+/// composition is Normal, so no candidate was ever seeded and the landing-span line was silently
+/// discarded; the pass-ending composition (the NEXT line) published fine, which is why "first new
+/// cue after seek" instruments looked clean.
+///
+/// The fix seeds the candidate from ANY successfully decoded composition behind the playhead. A
+/// composition that decodes at all is renderable by definition (a fresh drain decoder has no stale
+/// state; a state-dependent set with missing references fails decode and never reaches the gate),
+/// and the steady-state path outside reconstruction already publishes Normal compositions without a
+/// self-contained check. Companion fix: every PGS composition and clear broadcasts its start as
+/// `pgsTrimAt`; that trim now also closes the candidate's open window, so a line authored to be
+/// gone by the playhead (a clear in the lead-in) cannot resurrect at pass end.
+struct Issue143PGSLandingLineTests {
+
+    private func imageCue(id: Int, start: Double, end: Double = 4_296_178) -> SubtitleCue {
+        let ctx = CGContext(data: nil, width: 1, height: 1, bitsPerComponent: 8, bytesPerRow: 4,
+                            space: CGColorSpaceCreateDeviceRGB(),
+                            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue)!
+        return SubtitleCue(id: id, startTime: start, endTime: end,
+                           body: .image(SubtitleImage(cgImage: ctx.makeImage()!, position: .zero)))
+    }
+
+    @Test("AP-less lead-in: the landing-span line seeds the candidate and publishes at pass end")
+    func aplessLandingLinePublishes() {
+        var gate = PGSStaleArrivalGate()
+        gate.reconstructing = true
+        // Normal-state composition (no acquisition point anywhere in the lead-in) 8 s behind the
+        // landing, still open at the playhead. Held as candidate, published once the decode reaches
+        // the playhead.
+        #expect(gate.admit(cues: [imageCue(id: 1, start: 92)], isPGS: true,
+                           isSelfContained: false, playhead: 100).isEmpty)
+        let out = gate.admit(cues: [imageCue(id: 2, start: 106)], isPGS: true,
+                             isSelfContained: false, playhead: 100)
+        #expect(out.map(\.id).sorted() == [1, 2])
+        #expect(gate.reconstructing == false)
+        #expect(!gate.hasHeld)
+    }
+
+    @Test("boundary landing with the tick playhead already past the boundary still paints the landing line")
+    func boundaryLandingWithAdvancedPlayhead() {
+        var gate = PGSStaleArrivalGate()
+        gate.reconstructing = true
+        // Seek lands exactly on the display set's start (120.0) but the drain tick's playhead has
+        // advanced a few frames by the time the backscan decodes it, turning it into the mid-cue
+        // shape. The reporter measured this variant dropping the line 13/14 batteries.
+        #expect(gate.admit(cues: [imageCue(id: 1, start: 120.0)], isPGS: true,
+                           isSelfContained: false, playhead: 120.3).isEmpty)
+        let out = gate.admit(cues: [imageCue(id: 2, start: 126)], isPGS: true,
+                             isSelfContained: false, playhead: 120.3)
+        #expect(out.map(\.id).sorted() == [1, 2])
+    }
+
+    @Test("AP-less lead-in does not scroll: only the newest line behind the playhead publishes")
+    func aplessLeadInNoScroll() {
+        var gate = PGSStaleArrivalGate()
+        gate.reconstructing = true
+        let p = 100.0
+        // The #112 no-scroll invariant must hold for Normal compositions exactly as it does for
+        // acquisition points: nothing publishes until the pass ends, then only the newest.
+        #expect(gate.admit(cues: [imageCue(id: 1, start: 78)], isPGS: true,
+                           isSelfContained: false, playhead: p).isEmpty)
+        #expect(gate.admit(cues: [imageCue(id: 2, start: 85)], isPGS: true,
+                           isSelfContained: false, playhead: p).isEmpty)
+        #expect(gate.admit(cues: [imageCue(id: 3, start: 92)], isPGS: true,
+                           isSelfContained: false, playhead: p).isEmpty)
+        let out = gate.admit(cues: [imageCue(id: 4, start: 106)], isPGS: true,
+                             isSelfContained: false, playhead: p)
+        #expect(out.map(\.id).sorted() == [3, 4])
+    }
+
+    @Test("a clear in the lead-in ends the candidate: the cleared line does not resurrect at pass end")
+    func clearedLineDoesNotResurrect() {
+        var gate = PGSStaleArrivalGate()
+        gate.reconstructing = true
+        // Line at 90 followed by an authored clear at 95; the viewer lands at 100 during silence.
+        _ = gate.admit(cues: [imageCue(id: 1, start: 90)], isPGS: true,
+                       isSelfContained: false, playhead: 100)
+        // The clear composition carries no cues; its pgsTrimAt is the only thing that reaches the
+        // gate. It must close the candidate's open placeholder window.
+        #expect(gate.resolveHeld(trimAt: 95, playhead: 100).isEmpty)
+        let out = gate.admit(cues: [imageCue(id: 2, start: 106)], isPGS: true,
+                             isSelfContained: false, playhead: 100)
+        #expect(out.map(\.id) == [2])
+    }
+
+    @Test("acquisition-point content: a cleared candidate does not resurrect either")
+    func clearedSelfContainedCandidateDoesNotResurrect() {
+        var gate = PGSStaleArrivalGate()
+        gate.reconstructing = true
+        // Same shape with an acquisition point: this hole predates #143 (the candidate ignored
+        // clears entirely) and is locked here for AP-full content too.
+        _ = gate.admit(cues: [imageCue(id: 1, start: 90)], isPGS: true,
+                       isSelfContained: true, playhead: 100)
+        #expect(gate.resolveHeld(trimAt: 95, playhead: 100).isEmpty)
+        let out = gate.admit(cues: [imageCue(id: 2, start: 106)], isPGS: true,
+                             isSelfContained: true, playhead: 100)
+        #expect(out.map(\.id) == [2])
+    }
+
+    @Test("a clear ahead of the playhead closes the emitted landing line at the clear, not the successor")
+    func aheadClearClosesEmittedLine() {
+        var gate = PGSStaleArrivalGate()
+        gate.reconstructing = true
+        // Landing line open at the playhead, authored to end at 103 (clear), next line at 130.
+        _ = gate.admit(cues: [imageCue(id: 1, start: 92)], isPGS: true,
+                       isSelfContained: false, playhead: 100)
+        #expect(gate.resolveHeld(trimAt: 103, playhead: 100).isEmpty)
+        let out = gate.admit(cues: [imageCue(id: 2, start: 130)], isPGS: true,
+                             isSelfContained: false, playhead: 100)
+        let landing = out.first { $0.id == 1 }
+        #expect(landing != nil)
+        #expect(landing?.endTime == 103)
+    }
+
+    @Test("a later composition still refines a candidate seeded from a Normal composition")
+    func normalSeedRefinedByNewerComposition() {
+        var gate = PGSStaleArrivalGate()
+        gate.reconstructing = true
+        _ = gate.admit(cues: [imageCue(id: 1, start: 80)], isPGS: true,
+                       isSelfContained: false, playhead: 100)
+        _ = gate.admit(cues: [imageCue(id: 2, start: 95)], isPGS: true,
+                       isSelfContained: false, playhead: 100)
+        let out = gate.admit(cues: [imageCue(id: 3, start: 110)], isPGS: true,
+                             isSelfContained: false, playhead: 100)
+        #expect(out.map(\.id).sorted() == [2, 3])
+    }
+}


### PR DESCRIPTION
Fixes #143.

## Problem

A seek landing mid-cue (or exactly on a display-set start boundary) on a PGS stream without acquisition points never re-shows the landing line, forced cues included, until the next authored composition arrives. On sparse dialogue the blackout runs tens of seconds. Successor cues re-emit normally, so only the line the viewer lands on is lost, which keeps "first new cue after seek" instruments blind to it.

## Root cause

Exactly where the reporter pointed: the #112 reconstruction pass (`PGSStaleArrivalGate.admitDuringReconstruction`) seeded its active-line candidate only from a self-contained composition (Acquisition Point / Epoch Start). On AP-less/sparse-authored streams every lead-in composition is Normal, so no candidate was ever seeded and the landing-span line was silently discarded. The exact-boundary variant collapses into the same shape because the drain tick's playhead has advanced a few frames past the boundary by decode time.

## Fix

Seed the candidate from any successfully decoded composition behind the playhead (the reporter's first suggested direction). A composition that decoded at all is renderable: the drain decoder is rebuilt fresh at the backscan start, so a set with missing palette/object references fails decode and never reaches the gate. The steady-state path outside reconstruction already publishes Normal compositions unconditionally, so the gate was strictly more conservative than the pipeline it feeds with nothing gained.

Companion fix uncovered while widening the seed: `pgsTrimAt` (broadcast by every PGS composition and clear) now also closes the reconstruction candidate's open placeholder window. A clear event carries no cues and never reaches `admit`, so a line the author cleared before the playhead kept its open window and resurrected as the "active" line at pass end. That hole predates this issue for acquisition-point content (proven by the new resurrection test, which fails on main) and would have widened with the new seeding.

The #112 no-scroll invariant is untouched: lead-in compositions are still held, only the single newest line at/behind the playhead emits once the decode reaches the playhead.

`isSelfContained` stays on the gate's signature; callers keep reporting the PCS classification, which the epoch-start-aware backscan direction (the reporter's second suggestion, for content whose landing sets are not standalone-decodable) would need.

## Tests

`Issue143PGSLandingLineTests`, 7 cases: AP-less mid-cue landing, boundary landing with advanced tick playhead, AP-less no-scroll invariant, cleared-line non-resurrection (Normal and acquisition-point variants), ahead-clear trimming the emitted line, candidate refinement from a Normal seed. 6 of 7 fail on main. Full suite: 744 tests green, strict-concurrency=complete clean, tvOS simulator build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NAPCg4tCDdSqkK6tPkNptw