### PR TITLE
Land MKV TrackTimestampScale tracks on the coherent segment axis (#145)

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "c6db777fc87f55f659bbf6aa75c12ff579a271fe898fbd15778a55bb771885a4",
+  "originHash" : "c4c0edd109d648f25715de570364b0d8baa80810bfc0f6ad588ecb7e2b326c1d",
   "pins" : [
     {
       "identity" : "ffmpegbuild",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/superuser404notfound/FFmpegBuild",
       "state" : {
-        "revision" : "45ce3027149a50951ed2da17328b0166710e88af",
-        "version" : "2.1.1"
+        "revision" : "5e8babf6dfbf5578f1bf579b9594803d38df79c5",
+        "version" : "2.1.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
         // No network stack, we use custom AVIO + URLSession for HTTP streams.
         // Resolved over Git rather than a local path so consumers (and
         // Xcode Cloud) can build without a sibling FFmpegBuild checkout.
-        .package(url: "https://github.com/superuser404notfound/FFmpegBuild", from: "2.1.1"),  // 2.1.1: pgssubdec Epoch-Continue retain (#142); 2.1.0: yadif_videotoolbox + hwupload (Metal GPU deinterlace); 2.0.0: dynamic frameworks (LGPL), zvbi GPL excision
+        .package(url: "https://github.com/superuser404notfound/FFmpegBuild", from: "2.1.2"),  // 2.1.2: matroska TrackTimestampScale clamp (#145); 2.1.1: pgssubdec Epoch-Continue retain (#142); 2.1.0: yadif_videotoolbox + hwupload (Metal GPU deinterlace); 2.0.0: dynamic frameworks (LGPL), zvbi GPL excision
         // Pure-Swift SMB2 client (MIT) that speaks the protocol over
         // NWConnection. Replaces AMSMB2/libsmb2, which EPERMs on tvOS/iOS.
         // Pinned to the 0.3.x minor: SMBClient is pre-1.0 with an actively

--- a/Tests/AetherEngineTests/Issue145MatroskaTrackTimestampScaleTests.swift
+++ b/Tests/AetherEngineTests/Issue145MatroskaTrackTimestampScaleTests.swift
@@ -1,0 +1,187 @@
+import Foundation
+import Testing
+import Libavcodec
+@testable import AetherEngine
+
+/// #145 (cmcpherson274): an MKV whose subtitle track carries TrackTimestampScale != 1 came out on a
+/// HYBRID timestamp axis: cue pts = cluster timestamp + (in-cluster relative timestamp x TTS),
+/// which is neither the unscaled (cluster + rel) nor the fully scaled ((cluster + rel) x TTS) axis.
+/// Consequences on a TTS=2.0 fixture: cue starts shifted by relTs x (TTS - 1) per cluster (12->14 s,
+/// 24.5->29 s), packets arrived non-monotonic in storage order (a late-rel cue in cluster N landing
+/// past an early-rel clear in cluster N+1), and a stale fade outlived its authored clear. All of it
+/// silent: right pixels, wrong times, no warning.
+///
+/// Root cause is inherited from FFmpeg's matroska demuxer (n8.1.2 and master): read_header bakes the
+/// track's TrackTimestampScale into the stream time_base (segment scale x TTS) but the block parser
+/// divides only the CLUSTER component by TTS (`cluster_time / track->time_scale + block_time`), so
+/// the relative component ends up scaled and the cluster component does not.
+///
+/// The fix (FFmpegBuild patch_ffmpeg_matroska_tts) clamps any TrackTimestampScale != 1.0 to 1.0 at
+/// read_header with a warning, extending FFmpeg's own existing `< 0.01` clamp. That lands every
+/// track on the coherent, unscaled segment axis (cluster + rel): the axis the file's clusters are
+/// stored on, monotonic in storage order, and in sync with the file's other tracks. Full spec
+/// scaling was rejected deliberately: RFC 9559 deprecates the element (maxver 3), matroska.org
+/// documents that most readers ignore it, and a real-world TTS != 1 is almost always muxer damage
+/// where full scaling would desync the track from its siblings instead of playing it correctly.
+struct Issue145MatroskaTrackTimestampScaleTests {
+
+    /// One authored subtitle event: absolute time = cluster + rel (both ms on the segment axis).
+    fileprivate struct Event {
+        let clusterMs: Int
+        let relMs: Int
+        let durationMs: Int
+        var authoredSeconds: Double { Double(clusterMs + relMs) / 1000.0 }
+        var authoredDurationSeconds: Double { Double(durationMs) / 1000.0 }
+    }
+
+    /// Mirrors the reporter's fixture shape: 5 s clusters, a late-rel cue in the 20 s cluster
+    /// (authored 24.5 s) followed by an early-rel event in the 25 s cluster. On the hybrid axis with
+    /// TTS=2 those emit as 29 s then 25 s: shifted AND non-monotonic.
+    private static let events: [Event] = [
+        Event(clusterMs: 0, relMs: 2000, durationMs: 1000),
+        Event(clusterMs: 5000, relMs: 2000, durationMs: 1000),
+        Event(clusterMs: 10_000, relMs: 2000, durationMs: 1000),
+        Event(clusterMs: 20_000, relMs: 4500, durationMs: 500),
+        Event(clusterMs: 25_000, relMs: 0, durationMs: 1000),
+    ]
+
+    private func demuxSubtitleTimes(_ mkv: Data) throws -> [(pts: Double, duration: Double)] {
+        let demuxer = Demuxer()
+        try demuxer.open(reader: DataIOReader(data: mkv), formatHint: "matroska")
+        defer { demuxer.close() }
+        guard let stream = demuxer.stream(at: 0) else {
+            Issue.record("fixture stream missing")
+            return []
+        }
+        let tb = stream.pointee.time_base
+        let tick = Double(tb.num) / Double(tb.den)
+        var out: [(pts: Double, duration: Double)] = []
+        while let pkt = try demuxer.readPacket() {
+            var toFree: UnsafeMutablePointer<AVPacket>? = pkt
+            defer { trackedPacketFree(&toFree) }
+            guard pkt.pointee.stream_index == 0, pkt.pointee.pts != Int64.min else { continue }
+            out.append((Double(pkt.pointee.pts) * tick, Double(pkt.pointee.duration) * tick))
+        }
+        return out
+    }
+
+    @Test("TTS=2.0 track demuxes on the authored segment axis, not the hybrid axis")
+    func scaledTrackKeepsAuthoredTimes() throws {
+        let packets = try demuxSubtitleTimes(MatroskaTTSFixture.make(trackTimestampScale: 2.0,
+                                                                     events: Self.events))
+        #expect(packets.count == Self.events.count)
+        for (packet, event) in zip(packets, Self.events) {
+            #expect(abs(packet.pts - event.authoredSeconds) < 0.0005,
+                    "cue authored at \(event.authoredSeconds)s emitted at \(packet.pts)s")
+            #expect(abs(packet.duration - event.authoredDurationSeconds) < 0.0005,
+                    "duration authored \(event.authoredDurationSeconds)s emitted \(packet.duration)s")
+        }
+    }
+
+    @Test("TTS=2.0 track emits monotonic pts in storage order")
+    func scaledTrackStaysMonotonic() throws {
+        let packets = try demuxSubtitleTimes(MatroskaTTSFixture.make(trackTimestampScale: 2.0,
+                                                                     events: Self.events))
+        let times = packets.map(\.pts)
+        #expect(times == times.sorted(),
+                "storage order must stay monotonic on a coherent axis, got \(times)")
+    }
+
+    @Test("TTS=2.0 file demuxes identically to the TTS-less control")
+    func scaledTrackMatchesControl() throws {
+        let control = try demuxSubtitleTimes(MatroskaTTSFixture.make(trackTimestampScale: nil,
+                                                                     events: Self.events))
+        let scaled = try demuxSubtitleTimes(MatroskaTTSFixture.make(trackTimestampScale: 2.0,
+                                                                    events: Self.events))
+        #expect(control.count == scaled.count)
+        for (c, s) in zip(control, scaled) {
+            #expect(abs(c.pts - s.pts) < 0.0005, "control \(c.pts)s vs scaled \(s.pts)s")
+            #expect(abs(c.duration - s.duration) < 0.0005)
+        }
+    }
+}
+
+/// Minimal in-memory Matroska writer: one S_TEXT/UTF8 subtitle track, one BlockGroup (Block +
+/// BlockDuration) per event, one Cluster per distinct cluster timestamp. Sizes are always encoded
+/// as 8-byte EBML vints so nesting needs no length backpatching.
+private enum MatroskaTTSFixture {
+
+    private static func vintSize(_ n: Int) -> [UInt8] {
+        var bytes: [UInt8] = [0x01]
+        for shift in stride(from: 48, through: 0, by: -8) {
+            bytes.append(UInt8((n >> shift) & 0xFF))
+        }
+        return bytes
+    }
+
+    private static func element(_ id: [UInt8], _ payload: [UInt8]) -> [UInt8] {
+        id + vintSize(payload.count) + payload
+    }
+
+    private static func uint(_ v: Int) -> [UInt8] {
+        var bytes: [UInt8] = []
+        var v = v
+        repeat {
+            bytes.insert(UInt8(v & 0xFF), at: 0)
+            v >>= 8
+        } while v > 0
+        return bytes
+    }
+
+    private static func float64(_ v: Double) -> [UInt8] {
+        let bits = v.bitPattern
+        return (0..<8).map { UInt8((bits >> (56 - 8 * UInt64($0))) & 0xFF) }
+    }
+
+    private static func string(_ s: String) -> [UInt8] { Array(s.utf8) }
+
+    static func make(trackTimestampScale: Double?, events: [Event]) -> Data {
+        let header = element([0x1A, 0x45, 0xDF, 0xA3],
+                             element([0x42, 0x86], uint(1)) +          // EBMLVersion
+                             element([0x42, 0xF7], uint(1)) +          // EBMLReadVersion
+                             element([0x42, 0xF2], uint(4)) +          // EBMLMaxIDLength
+                             element([0x42, 0xF3], uint(8)) +          // EBMLMaxSizeLength
+                             element([0x42, 0x82], string("matroska")) +
+                             element([0x42, 0x87], uint(4)) +          // DocTypeVersion
+                             element([0x42, 0x85], uint(2)))           // DocTypeReadVersion
+
+        let info = element([0x15, 0x49, 0xA9, 0x66],
+                           element([0x2A, 0xD7, 0xB1], uint(1_000_000)) +  // TimestampScale: 1 ms
+                           element([0x44, 0x89], float64(30_000)) +        // Duration (ticks)
+                           element([0x4D, 0x80], string("aether-#145")) +
+                           element([0x57, 0x41], string("aether-#145")))
+
+        var trackFields: [UInt8] = []
+        trackFields += element([0xD7], uint(1))          // TrackNumber
+        trackFields += element([0x73, 0xC5], uint(1))    // TrackUID
+        trackFields += element([0x83], uint(0x11))       // TrackType: subtitle
+        trackFields += element([0x9C], uint(0))          // FlagLacing
+        trackFields += element([0x86], string("S_TEXT/UTF8"))
+        if let tts = trackTimestampScale {
+            trackFields += element([0x23, 0x31, 0x4F], float64(tts))  // TrackTimestampScale
+        }
+        let tracks = element([0x16, 0x54, 0xAE, 0x6B], element([0xAE], trackFields))
+
+        var clusters: [UInt8] = []
+        let grouped = Dictionary(grouping: events, by: \.clusterMs).sorted { $0.key < $1.key }
+        for (clusterMs, clusterEvents) in grouped {
+            var body = element([0xE7], uint(clusterMs))  // Cluster Timestamp
+            for event in clusterEvents.sorted(by: { $0.relMs < $1.relMs }) {
+                let block: [UInt8] = [0x81,                             // track number vint
+                                      UInt8((event.relMs >> 8) & 0xFF),
+                                      UInt8(event.relMs & 0xFF),        // int16 relative timestamp
+                                      0x00]                             // flags
+                                     + string("line @\(clusterMs + event.relMs)ms")
+                body += element([0xA0],                                 // BlockGroup
+                                element([0xA1], block) +                // Block
+                                element([0x9B], uint(event.durationMs)))  // BlockDuration
+            }
+            clusters += element([0x1F, 0x43, 0xB6, 0x75], body)
+        }
+
+        let segment = element([0x18, 0x53, 0x80, 0x67], info + tracks + clusters)
+        return Data(header + segment)
+    }
+
+    typealias Event = Issue145MatroskaTrackTimestampScaleTests.Event
+}


### PR DESCRIPTION
Fixes #145.

### Root cause

Inherited from FFmpeg's matroska demuxer (n8.1.2 and current master, line-identical). `matroska_read_header` bakes the track's `TrackTimestampScale` (TTS) into the stream time_base (`segment scale x TTS`), but `matroska_parse_block` divides only the CLUSTER component of each block timestamp by it:

```c
avpriv_set_pts_info(st, 64, matroska->time_scale * track->time_scale, 1000*1000*1000);
...
uint64_t timecode_cluster_in_track_tb = (double) cluster_time / track->time_scale;
timecode = timecode_cluster_in_track_tb + block_time - track->codec_delay_in_track_tb;
```

In seconds that is `cluster + rel x TTS`: the reporter's hybrid axis, exactly. It reproduces every measured number in the report (12->14 s, 24.5->29 s, per-cluster error bound `clusterSpan x (TTS - 1)`), the non-monotonic storage-order arrival (a late-rel block in cluster N overtakes an early-rel block in cluster N+1: the 29 s cue before the 25 s clear), and, downstream, the stale fade outliving its authored clear. Packet durations are additionally off by a factor of TTS (segment-tick durations interpreted in the TTS-scaled time base). All of it silent.

### Fix (FFmpegBuild 2.1.2, `patch_ffmpeg_matroska_tts`)

`matroskadec.c` now clamps any `TrackTimestampScale != 1.0` to 1.0 with an `AV_LOG_WARNING` carrying the ignored value, extending upstream's own `< 0.01` clamp in the same spot. Every track lands on the coherent, unscaled segment axis (`cluster + rel`): monotonic in storage order and in sync with the file's sibling tracks. The engine cannot fix this host-side even in principle: libavformat does not export the track's TTS (it only bakes it into the time base), so the demuxer is the root-cause layer.

Why clamp instead of full spec scaling (`(cluster + rel) x TTS`):

- RFC 9559 deprecates the element (maxver 3; it must not appear in Matroska v4).
- matroska.org documents that "a lot of Matroska readers don't take the TrackTimestampScale value in account", so a non-1.0 value in the wild is almost always muxer damage, not intent.
- Full scaling would desync the track from its siblings (the element's legacy purpose is per-track speed adjustment); for damaged files that turns a subtle mistiming into a catastrophic one.
- The clamp is a strict no-op for TTS = 1.0, i.e. effectively all real-world Matroska (the rebuild changed only Libavformat binaries; the full suite is byte-for-byte unaffected).

### TDD

`Issue145MatroskaTrackTimestampScaleTests`: a minimal in-memory Matroska writer (one S_TEXT/UTF8 track, BlockGroup + BlockDuration, 5 s clusters mirroring the reporter's fixture shape) demuxed through the engine's `Demuxer`.

- RED on FFmpegBuild 2.1.1: emitted 4.0 / 9.0 / 14.0 / 29.0 / 25.0 s for authored 2.0 / 7.0 / 12.0 / 24.5 / 25.0 s; durations x2; non-monotonic. All three tests fail with exactly the reported shifts.
- GREEN on 2.1.2: authored times, authored durations, monotonic, and the TTS=2.0 file demuxes identically to the TTS-less control.

### Verification

- Full suite: 747 Swift Testing + 311 XCTest tests pass.
- `-strict-concurrency=complete` build clean.
- tvOS Simulator build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NAPCg4tCDdSqkK6tPkNptw