### PR TITLE
Fall back to SPS frame_mbs_only_flag when demuxer field_order is UNKNOWN (#150)

### DIFF
--- a/Sources/AetherEngine/AetherEngine.swift
+++ b/Sources/AetherEngine/AetherEngine.swift
@@ -1907,10 +1907,30 @@ public final class AetherEngine: ObservableObject {
         // can deinterlace it; tvOS AVPlayer does not. Decision is pure and unit-tested in
         // VideoRoutingPolicyTests. deint=interlaced passes progressive frames through untouched, so a
         // mis-signalled progressive stream only pays an unnecessary SW decode, never a wrong deinterlace.
+        // #150: some live TS channels are interlaced at the SPS level (frame_mbs_only_flag=0) but the
+        // demuxer's field_order probe stays UNKNOWN, silently defeating the #107 rule; consult the SPS
+        // from codecpar extradata as the tie-breaker.
+        var spsIndicatesInterlaced = false
+        if detectedCodecID == AV_CODEC_ID_H264, detectedFieldOrder == AV_FIELD_UNKNOWN,
+           probeOpened,
+           let vStream = probe.stream(at: probe.videoStreamIndex),
+           let codecpar = vStream.pointee.codecpar,
+           let extradata = codecpar.pointee.extradata, codecpar.pointee.extradata_size > 0 {
+            let bytes = Array(UnsafeBufferPointer(start: extradata, count: Int(codecpar.pointee.extradata_size)))
+            spsIndicatesInterlaced = VideoRoutingPolicy.spsIndicatesInterlaced(extradata: bytes)
+            if spsIndicatesInterlaced {
+                EngineLog.emit(
+                    "[AetherEngine] fieldOrder=UNKNOWN but SPS frame_mbs_only_flag=0; "
+                    + "treating as interlaced for routing (#150)",
+                    category: .engine
+                )
+            }
+        }
         var useSoftwarePath = VideoRoutingPolicy.requiresSoftwarePath(
             codecID: detectedCodecID,
             fieldOrder: detectedFieldOrder,
-            av1Available: VTCapabilityProbe.av1Available
+            av1Available: VTCapabilityProbe.av1Available,
+            spsIndicatesInterlaced: spsIndicatesInterlaced
         )
         // #2: an H.264 / HEVC format AVPlayer accepts at the HLS CODECS level but VideoToolbox can't
         // hardware-decode (H.264 High 4:2:2/4:4:4/High-10, HEVC Rext on Intel Macs / older Apple TV) reaches

--- a/Sources/AetherEngine/Decoder/VideoRoutingPolicy.swift
+++ b/Sources/AetherEngine/Decoder/VideoRoutingPolicy.swift
@@ -13,10 +13,15 @@ enum VideoRoutingPolicy {
 
     /// True when a video codec must use the software decode path (SoftwarePlaybackHost) instead of
     /// native AVPlayer. `av1Available` is `VTCapabilityProbe.av1Available` (HW AV1 decode support).
+    /// #150: `spsIndicatesInterlaced` (SPS frame_mbs_only_flag == 0) breaks the tie when the demuxer's
+    /// field_order probe stays UNKNOWN; a concrete PROGRESSIVE probe analyzed actual frames and wins.
+    /// A false positive only costs an unnecessary SW decode (deint=interlaced passes progressive
+    /// frames through untouched), never a wrong deinterlace.
     static func requiresSoftwarePath(
         codecID: AVCodecID,
         fieldOrder: AVFieldOrder,
-        av1Available: Bool
+        av1Available: Bool,
+        spsIndicatesInterlaced: Bool = false
     ) -> Bool {
         switch codecID {
         case AV_CODEC_ID_AV1:
@@ -25,10 +30,19 @@ enum VideoRoutingPolicy {
              AV_CODEC_ID_MPEG2VIDEO, AV_CODEC_ID_VC1:
             return true
         case AV_CODEC_ID_H264:
-            return interlacedFieldOrders.contains(fieldOrder)
+            if interlacedFieldOrders.contains(fieldOrder) { return true }
+            return fieldOrder == AV_FIELD_UNKNOWN && spsIndicatesInterlaced
         default:
             return false
         }
+    }
+
+    /// #150: pure extradata classifier feeding `spsIndicatesInterlaced`. Accepts Annex-B (MPEG-TS) and
+    /// avcC (MP4/MKV) extradata; anything unparseable classifies as not-interlaced so a missing or
+    /// malformed config never forces the software path.
+    static func spsIndicatesInterlaced(extradata: [UInt8]) -> Bool {
+        guard let sps = H264SPS.spsNAL(fromExtradata: extradata) else { return false }
+        return H264SPS.frameMbsOnly(fromNAL: sps) == false
     }
 
     /// Second-stage gate (#2): a codec that passed `requiresSoftwarePath` as native (H.264 / HEVC) but whose

--- a/Sources/AetherEngine/Video/H264SPS.swift
+++ b/Sources/AetherEngine/Video/H264SPS.swift
@@ -5,6 +5,33 @@ enum H264SPS {
 
     /// Parse cropped dimensions from a raw SPS NAL (with 1-byte NAL header, e.g. 0x67). Returns nil on malformed input.
     static func dimensions(fromNAL nal: [UInt8]) -> (width: Int, height: Int)? {
+        parse(fromNAL: nal).map { ($0.width, $0.height) }
+    }
+
+    /// frame_mbs_only_flag from a raw SPS NAL. false = the stream may code interlaced pictures (PAFF or
+    /// MBAFF). #150: consulted as routing fallback when the demuxer's field_order probe stays UNKNOWN.
+    static func frameMbsOnly(fromNAL nal: [UInt8]) -> Bool? {
+        parse(fromNAL: nal)?.frameMbsOnly
+    }
+
+    /// First SPS NAL (incl. 1-byte header) from codecpar extradata, accepting both layouts: Annex-B
+    /// (MPEG-TS, start-code delimited) and avcC (MP4/MKV, configurationVersion byte 0x01 then
+    /// length-prefixed parameter sets). Returns nil when neither layout yields an SPS.
+    static func spsNAL(fromExtradata extradata: [UInt8]) -> [UInt8]? {
+        guard extradata.count > 1 else { return nil }
+        if extradata[0] == 0x01 {
+            // avcC: version, profile, compat, level, lengthSizeMinusOne, numSPS (low 5 bits), then
+            // per-SPS 2-byte length + NAL.
+            guard extradata.count > 8, (extradata[5] & 0x1f) >= 1 else { return nil }
+            let len = (Int(extradata[6]) << 8) | Int(extradata[7])
+            guard len > 0, extradata.count >= 8 + len else { return nil }
+            let nal = Array(extradata[8..<(8 + len)])
+            return (nal[0] & 0x1f) == 7 ? nal : nil
+        }
+        return extradata.withUnsafeBufferPointer { extractSPSandPPS(fromAnnexB: $0)?.sps }
+    }
+
+    private static func parse(fromNAL nal: [UInt8]) -> (width: Int, height: Int, frameMbsOnly: Bool)? {
         guard nal.count > 1, (nal[0] & 0x1f) == 7 else { return nil }
         let rbsp = unescape(Array(nal[1...]))  // strip NAL header + emulation-prevention (00 00 03 -> 00 00)
         var r = BitReader(rbsp)
@@ -75,7 +102,7 @@ enum H264SPS {
         }
 
         guard width > 0, height > 0 else { return nil }
-        return (width, height)
+        return (width, height, frameMbsOnly)
     }
 
     /// Scan Annex-B for the first SPS (NAL type 7) and PPS (NAL type 8), returned with their 1-byte NAL header.

--- a/Tests/AetherEngineTests/H264SPSTests.swift
+++ b/Tests/AetherEngineTests/H264SPSTests.swift
@@ -84,4 +84,48 @@ final class H264SPSTests: XCTestCase {
         XCTAssertEqual(H264SPS.dimensions(fromNAL: got!.sps)?.width, 1280)
         XCTAssertFalse(withBuf(au) { H264SPS.containsIDR(fromAnnexB: $0) }) // but no IDR -> gate stays closed
     }
+
+    // MARK: - #150 frame_mbs_only_flag fallback
+
+    // Main profile 4.0, 1920x1080, frame_mbs_only=0, mb_adaptive=0 (PAFF) - the reporter's channel shape.
+    private var spsInterlaced1080i: [UInt8] { hex("674d4028eca03c0223ed") }
+
+    func testInterlacedSPSParsesDimensionsAndFrameMbsOnlyFalse() {
+        let dim = H264SPS.dimensions(fromNAL: spsInterlaced1080i)
+        XCTAssertEqual(dim?.width, 1920)
+        XCTAssertEqual(dim?.height, 1080)
+        XCTAssertEqual(H264SPS.frameMbsOnly(fromNAL: spsInterlaced1080i), false)
+    }
+
+    func testProgressiveSPSFrameMbsOnlyTrue() {
+        XCTAssertEqual(H264SPS.frameMbsOnly(fromNAL: sps720), true)
+    }
+
+    func testFrameMbsOnlyRejectsNonSPS() {
+        XCTAssertNil(H264SPS.frameMbsOnly(fromNAL: hex("68efbcb0"))) // PPS
+        XCTAssertNil(H264SPS.frameMbsOnly(fromNAL: []))
+    }
+
+    func testSPSNALFromAnnexBExtradata() {
+        let extradata = annexB([spsInterlaced1080i, pps])
+        let sps = H264SPS.spsNAL(fromExtradata: extradata)
+        XCTAssertEqual(sps, spsInterlaced1080i)
+    }
+
+    func testSPSNALFromAvcCExtradata() {
+        var avcc: [UInt8] = [0x01, 0x4d, 0x40, 0x28, 0xff, 0xe1]
+        avcc += [UInt8(spsInterlaced1080i.count >> 8), UInt8(spsInterlaced1080i.count & 0xff)]
+        avcc += spsInterlaced1080i
+        avcc += [0x01, UInt8(pps.count >> 8), UInt8(pps.count & 0xff)]
+        avcc += pps
+        let sps = H264SPS.spsNAL(fromExtradata: avcc)
+        XCTAssertEqual(sps, spsInterlaced1080i)
+    }
+
+    func testSPSNALRejectsGarbageOrEmpty() {
+        XCTAssertNil(H264SPS.spsNAL(fromExtradata: []))
+        XCTAssertNil(H264SPS.spsNAL(fromExtradata: [0xde, 0xad, 0xbe, 0xef]))
+        XCTAssertNil(H264SPS.spsNAL(fromExtradata: [0x01, 0x4d])) // truncated avcC header
+        XCTAssertNil(H264SPS.spsNAL(fromExtradata: annexB([pps]))) // params without SPS
+    }
 }

--- a/Tests/AetherEngineTests/VideoRoutingPolicyTests.swift
+++ b/Tests/AetherEngineTests/VideoRoutingPolicyTests.swift
@@ -42,6 +42,69 @@ struct VideoRoutingPolicyTests {
             codecID: AV_CODEC_ID_AV1, fieldOrder: AV_FIELD_PROGRESSIVE, av1Available: true))
     }
 
+    // MARK: - #150 SPS frame_mbs_only fallback for UNKNOWN field order
+
+    @Test("UNKNOWN field order + SPS frame_mbs_only=0 routes to software")
+    func unknownFieldOrderSPSInterlacedSoftware() {
+        #expect(VideoRoutingPolicy.requiresSoftwarePath(
+            codecID: AV_CODEC_ID_H264, fieldOrder: AV_FIELD_UNKNOWN, av1Available: true,
+            spsIndicatesInterlaced: true))
+    }
+
+    @Test("UNKNOWN field order without SPS interlace signal stays native")
+    func unknownFieldOrderNoSPSSignalNative() {
+        #expect(!VideoRoutingPolicy.requiresSoftwarePath(
+            codecID: AV_CODEC_ID_H264, fieldOrder: AV_FIELD_UNKNOWN, av1Available: true,
+            spsIndicatesInterlaced: false))
+    }
+
+    @Test("concrete PROGRESSIVE probe wins over SPS interlaced-capable flag")
+    func progressiveProbeWinsOverSPS() {
+        // frame_mbs_only=0 only means the stream MAY code interlaced pictures; a demuxer probe that
+        // analyzed actual frames and concluded progressive is the stronger signal.
+        #expect(!VideoRoutingPolicy.requiresSoftwarePath(
+            codecID: AV_CODEC_ID_H264, fieldOrder: AV_FIELD_PROGRESSIVE, av1Available: true,
+            spsIndicatesInterlaced: true))
+    }
+
+    @Test("concrete interlaced field orders ignore the SPS parameter")
+    func concreteInterlacedIgnoresSPSParameter() {
+        #expect(VideoRoutingPolicy.requiresSoftwarePath(
+            codecID: AV_CODEC_ID_H264, fieldOrder: AV_FIELD_TT, av1Available: true,
+            spsIndicatesInterlaced: false))
+    }
+
+    @Test("non-H.264 codecs ignore the SPS parameter")
+    func otherCodecsIgnoreSPSParameter() {
+        #expect(!VideoRoutingPolicy.requiresSoftwarePath(
+            codecID: AV_CODEC_ID_HEVC, fieldOrder: AV_FIELD_UNKNOWN, av1Available: true,
+            spsIndicatesInterlaced: true))
+    }
+
+    @Test("spsIndicatesInterlaced classifies Annex-B and avcC extradata")
+    func spsIndicatesInterlacedFromExtradata() {
+        let sc: [UInt8] = [0, 0, 0, 1]
+        let spsInterlaced: [UInt8] = [0x67, 0x4d, 0x40, 0x28, 0xec, 0xa0, 0x3c, 0x02, 0x23, 0xed]
+        let spsProgressive: [UInt8] = [
+            0x67, 0x64, 0x00, 0x1f, 0xac, 0xd9, 0x40, 0x50, 0x05, 0xbb, 0x01, 0x6a, 0x02, 0x04,
+            0x02, 0x80, 0x00, 0x00, 0x03, 0x00, 0x80, 0x00, 0x00, 0x1e, 0x07, 0x8c, 0x18, 0xcb,
+        ]
+        let pps: [UInt8] = [0x68, 0xef, 0xbc, 0xb0]
+
+        #expect(VideoRoutingPolicy.spsIndicatesInterlaced(extradata: sc + spsInterlaced + sc + pps))
+        #expect(!VideoRoutingPolicy.spsIndicatesInterlaced(extradata: sc + spsProgressive + sc + pps))
+
+        var avcc: [UInt8] = [0x01, 0x4d, 0x40, 0x28, 0xff, 0xe1]
+        avcc += [0x00, UInt8(spsInterlaced.count)]
+        avcc += spsInterlaced
+        avcc += [0x01, 0x00, UInt8(pps.count)]
+        avcc += pps
+        #expect(VideoRoutingPolicy.spsIndicatesInterlaced(extradata: avcc))
+
+        #expect(!VideoRoutingPolicy.spsIndicatesInterlaced(extradata: []))
+        #expect(!VideoRoutingPolicy.spsIndicatesInterlaced(extradata: [0xde, 0xad]))
+    }
+
     // MARK: - #2 undecodable-format second-stage gate
 
     @Test("H.264 / HEVC that VideoToolbox can't HW-decode falls back to software")


### PR DESCRIPTION
Fixes #150.

## Problem

Some interlaced live H.264 channels are interlaced at the SPS level (frame_mbs_only_flag=0) but the demuxer's field-order probe returns UNKNOWN instead of TT/BB/TB/BT. The #107 routing rule only consults field_order, so these channels stayed on native VideoToolbox decode, which does not deinterlace, producing a persistent green colour cast from the first frame.

## Fix

- `H264SPS`: expose `frameMbsOnly(fromNAL:)` (the parser already walked the flag for dimensions) and `spsNAL(fromExtradata:)`, which accepts both extradata layouts, Annex-B (MPEG-TS) and avcC (MP4/MKV).
- `VideoRoutingPolicy.requiresSoftwarePath` gains `spsIndicatesInterlaced`, consulted only when field_order is UNKNOWN. A concrete PROGRESSIVE probe (which analyzed actual frames) still wins over the SPS capability flag. New pure helper `spsIndicatesInterlaced(extradata:)` classifies extradata.
- `AetherEngine.load` computes the fallback from codecpar extradata and logs `fieldOrder=UNKNOWN but SPS frame_mbs_only_flag=0; treating as interlaced for routing (#150)` when it fires.

Safety: a false positive (interlaced-capable SPS carrying progressive frames) only pays an unnecessary software decode. The SW decoder gates bwdif per frame on AV_FRAME_FLAG_INTERLACED from the slice headers, so progressive frames pass through untouched. Unparseable or missing extradata classifies as not-interlaced and keeps the native path.

## Tests

- Interlaced Main-profile 1920x1080 SPS fixture (frame_mbs_only=0, PAFF, the reporter's channel shape), validated against the existing `dimensions` parser.
- `frameMbsOnly` true/false/nil cases, SPS extraction from Annex-B and avcC extradata, garbage rejection.
- Routing matrix: UNKNOWN+SPS-interlaced routes software, UNKNOWN without signal stays native (unchanged default), PROGRESSIVE wins over SPS, concrete field orders and non-H.264 codecs ignore the new parameter.
- Full suite: 762 tests in 129 suites green, strict-concurrency=complete build clean, tvOS Simulator build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NAPCg4tCDdSqkK6tPkNptw