### PR TITLE
In-place AVPlayerItem handover across native loads while PiP is active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ the public-API contract.
 
 ## [Unreleased]
 
+## [5.12.0] - 2026-07-20
+
+([release notes](https://github.com/superuser404notfound/AetherEngine/releases/tag/5.12.0))
+
+### Added
+
+- **A native->native load while a PiP window is active now hands the AVPlayerItem over in place, so system PiP survives next-episode transitions.** The load teardown dropped the running item to nil for the whole load gap (probe, demuxer, fresh loopback session), and the system closes a PiP window whose source layer's player loses its item; the #93 in-PiP recovery reload had already established the same failure mode and the `inPlaceSwap` fix for it. `load()` now computes `shouldHandOverItemInPlace(pipActive:priorBackendWasNative:)`, `stopInternal` defers the item detach (`keepCurrentItem`), and the loopback host.load callsite consumes the armed handover as `inPlaceSwap`: the old item keeps playing until `replaceCurrentItem` swaps in the ready master, transport intent latched. Audio-switch and recovery reloads keep their existing contracts (consume-and-reset). Covered by `PiPItemHandoverTests`. Host adoption: Sodalite re-enables next-episode auto-advance inside the tvOS PiP window. (#158)
+
 ## [5.11.0] - 2026-07-20
 
 ([release notes](https://github.com/superuser404notfound/AetherEngine/releases/tag/5.11.0))

--- a/Sources/AetherEngine/AetherEngine+Loading.swift
+++ b/Sources/AetherEngine/AetherEngine+Loading.swift
@@ -830,11 +830,16 @@ extension AetherEngine {
         // forwardBufferDuration default (4 s): deep buffer lets AVPlayer race to the live edge and hit the transcode warm-up gap head-on (-12888); 4 s PACES consumption. Verified: 8 s worsened startup pause (8-10 s vs ~1 s).
         // Live REJOIN: skip initial seek so AVPlayer picks edge-minus-holdback instead; seek-to-0 against the re-served backlog wedged the reloaded item in waitingToPlay (device repro: tvOS 26, Jellyfin stream.ts). See LiveReloadPolicy.
         lastNativeVideoStartPosition = startPosition ?? 0
+        // AE#158: consume-and-reset so only the load() that armed the handover swaps in place; audio-switch
+        // and recovery reloads keep their own contracts.
+        let inPlaceHandover = pendingInPlaceItemHandover
+        pendingInPlaceItemHandover = false
         host.load(url: playbackURL,
                   startPosition: startPosition,
                   perFrameHDR: true,
                   skipInitialSeek: LiveReloadPolicy.skipInitialSeek(
-                      isLive: isLive, isRejoin: liveRejoin))
+                      isLive: isLive, isRejoin: liveRejoin),
+                  inPlaceSwap: inPlaceHandover)
         forceNativeLegibleDeselectedUntilHostSelects()
     }
 

--- a/Sources/AetherEngine/AetherEngine.swift
+++ b/Sources/AetherEngine/AetherEngine.swift
@@ -237,6 +237,9 @@ public final class AetherEngine: ObservableObject {
 
     /// #127: latest host seek issued while the native item was pre-ready; replayed at readiness.
     var pendingPreReadySeekSeconds: Double?
+    /// AE#158: set by load() when the running item must survive until the new master attaches (PiP
+    /// next-episode handover); consumed and reset by the loopback host.load callsite (inPlaceSwap).
+    var pendingInPlaceItemHandover = false
     #if os(iOS) || os(tvOS)
     /// True between didEnterBackground and didBecomeActive; gates the pause-while-backgrounded teardown
     /// (iOS) and the PiP-closed-while-backgrounded teardown (tvOS).
@@ -264,6 +267,13 @@ public final class AetherEngine: ObservableObject {
     /// unconditional teardown that protects mediaserverd across multi-hour suspensions.
     nonisolated static func shouldKeepVideoAliveTV(enabled: Bool, pipActive: Bool) -> Bool {
         enabled && pipActive
+    }
+
+    /// AE#158: a system PiP window closes the moment its source layer's player drops its item (the #93
+    /// in-PiP recovery reload hit the same nil-item gap), so a native->native load while PiP is active
+    /// keeps the old item attached through the load gap and swaps in place once the new master is ready.
+    nonisolated static func shouldHandOverItemInPlace(pipActive: Bool, priorBackendWasNative: Bool) -> Bool {
+        pipActive && priorBackendWasNative
     }
 
     /// What to do with the active video pipeline when the app enters the background. Pure so the lifecycle
@@ -1518,11 +1528,16 @@ public final class AetherEngine: ObservableObject {
         // registration survives the seam (issue #15). Captured before stopInternal resets playbackBackend;
         // the SW dispatch branch releases it if this source routes software.
         let priorBackendWasNative = (playbackBackend == .native)
+        // AE#158: while a PiP window is live, the running item must survive this load's teardown or the
+        // system closes the window; the loopback host.load callsite finishes the handover (inPlaceSwap).
+        let handOverInPlace = Self.shouldHandOverItemInPlace(pipActive: pictureInPictureActive,
+                                                             priorBackendWasNative: priorBackendWasNative)
+        pendingInPlaceItemHandover = handOverInPlace
         // #128 follow-up: preserve the previous session's display criteria across the load seam. Nil-ing it
         // here bounces the panel through SDR before apply() re-negotiates the same mode on video->video
         // reloads. Sessions that never reach apply() clear a stale criteria via loadDisplayCriteriaAction
         // (audio-only fast path, suppressed hosts); a load() that throws before routing leaves it for stop().
-        stopInternal(resetDisplayCriteria: false, keepNativeHost: priorBackendWasNative)
+        stopInternal(resetDisplayCriteria: false, keepNativeHost: priorBackendWasNative, keepCurrentItem: handOverInPlace)
         // #35/#93: a genuinely new item has not rendered yet; re-arm the cold-startup wedge suspension.
         // Scrub/seek/producer-restart never route through load(), so mid-stream #93 detection stays armed.
         hasRenderedFirstFrameMirror.set(false)
@@ -2876,7 +2891,7 @@ public final class AetherEngine: ObservableObject {
     ///   never settles and burns the full settle timeout (~12 s of
     ///   black-screen latency per audio switch on the old fixed 5 s
     ///   poll; capped at ~2 s since #117, but still worth skipping).
-    func stopInternal(resetDisplayCriteria: Bool = true, keepNativeHost: Bool = false, keepCustomReader: Bool = false) {
+    func stopInternal(resetDisplayCriteria: Bool = true, keepNativeHost: Bool = false, keepCustomReader: Bool = false, keepCurrentItem: Bool = false) {
         // Bump generation to invalidate in-flight load() checkpoints.
         loadGeneration &+= 1
         resumeAfterInterruption = false
@@ -2898,7 +2913,12 @@ public final class AetherEngine: ObservableObject {
         liveTelemetrySampler = nil
         diagnostics.liveTelemetry = nil
         nativeCancellables.removeAll()
-        nativeHost?.tearDown()
+        // AE#158: keepCurrentItem defers the item detach to the next host.load(inPlaceSwap:) so a
+        // system PiP window never sees a nil-item gap across a native->native load. Only meaningful
+        // together with keepNativeHost; load() computes it via shouldHandOverItemInPlace.
+        if !keepCurrentItem {
+            nativeHost?.tearDown()
+        }
         if !keepNativeHost {
             nativeHost = nil
             currentAVPlayer = nil

--- a/Tests/AetherEngineTests/PiPItemHandoverTests.swift
+++ b/Tests/AetherEngineTests/PiPItemHandoverTests.swift
@@ -1,0 +1,16 @@
+import Testing
+@testable import AetherEngine
+
+/// AE#158: a system PiP window closes the moment its source layer's player drops its item, so a
+/// native->native load while PiP is active keeps the running item attached until the new master
+/// swaps in place. See AetherEngine.shouldHandOverItemInPlace.
+@Suite("PiP in-place item handover policy")
+struct PiPItemHandoverTests {
+    @Test("hands over in place only while PiP is active on a native session")
+    func handsOverOnlyForNativePiP() {
+        #expect(AetherEngine.shouldHandOverItemInPlace(pipActive: true, priorBackendWasNative: true) == true)
+        #expect(AetherEngine.shouldHandOverItemInPlace(pipActive: false, priorBackendWasNative: true) == false)
+        #expect(AetherEngine.shouldHandOverItemInPlace(pipActive: true, priorBackendWasNative: false) == false)
+        #expect(AetherEngine.shouldHandOverItemInPlace(pipActive: false, priorBackendWasNative: false) == false)
+    }
+}


### PR DESCRIPTION
Fixes #158. A system PiP window closes the moment its source layer's player drops its item; the load teardown nulled it for the whole load gap (probe, demuxer, fresh loopback session). The #93 in-PiP recovery reload already established the failure mode and the `inPlaceSwap` mechanism. This wires it into the regular load path: `load()` arms `shouldHandOverItemInPlace(pipActive:priorBackendWasNative:)`, `stopInternal` defers the item detach behind the new `keepCurrentItem` parameter, and the loopback `host.load` callsite consumes the armed handover as `inPlaceSwap` (consume-and-reset, so audio-switch and recovery reloads keep their contracts). The old item keeps playing until `replaceCurrentItem` swaps in the ready master with transport intent latched. Covered by `PiPItemHandoverTests`; full suite 782 green, tvOS sim build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NAPCg4tCDdSqkK6tPkNptw