### PR TITLE
SoftwarePiPSource: sample-buffer PiP bridge for the software path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ the public-API contract.
 
 ## [Unreleased]
 
+## [5.13.0] - 2026-07-20
+
+([release notes](https://github.com/superuser404notfound/AetherEngine/releases/tag/5.13.0))
+
+### Added
+
+- **`SoftwarePiPSource`: a published sample-buffer PiP bridge for the software path.** Hosts building system PiP for SW-routed codecs (dav1d AV1/VP9 and friends) need the display layer plus transport answers on the enqueued frames' PTS axis (source axis); both are engine knowledge, so the engine now publishes `softwarePiPSource` (the `currentAVPlayer` analog) carrying the `AVSampleBufferDisplayLayer`, `timeRange()`, `isPaused`, `setPlaying(_:)`, and `skip(by:)`, with AVKit staying host-side. The background policy keeps SW video decoding alive while `pictureInPictureActive` (the window needs frames) instead of dropping to audio-only; without PiP, background behavior is unchanged. Covered by `SoftwarePiPSourceTests` and the extended `BackgroundKeepaliveTests`.
+
 ## [5.12.0] - 2026-07-20
 
 ([release notes](https://github.com/superuser404notfound/AetherEngine/releases/tag/5.12.0))

--- a/Sources/AetherEngine/AetherEngine+Loading.swift
+++ b/Sources/AetherEngine/AetherEngine+Loading.swift
@@ -895,6 +895,9 @@ extension AetherEngine {
             self?.publishLiveWindow(edgeSessionTime: edge)
         }
         self.softwareHost = host
+        // SW-PiP: publish the bridge once the session owns its layer (the layer object is stable for
+        // the session; the host attaches it to the view and, on PiP start, to the system window).
+        softwarePiPSource = SoftwarePiPSource(layer: host.displayLayer, isLive: isLive, engine: self)
         // #131: no demuxable CC track on the SW path either: arm an A53 tap fed by decoded-frame
         // side data. Same lazy synthetic-track surfacing as the producer path.
         // Same synthetic-entry exclusion as setupClosedCaptionTapIfNeeded (via `demuxableClosedCaptionTrack`):

--- a/Sources/AetherEngine/AetherEngine.swift
+++ b/Sources/AetherEngine/AetherEngine.swift
@@ -240,6 +240,9 @@ public final class AetherEngine: ObservableObject {
     /// AE#158: set by load() when the running item must survive until the new master attaches (PiP
     /// next-episode handover); consumed and reset by the loopback host.load callsite (inPlaceSwap).
     var pendingInPlaceItemHandover = false
+    /// SW-PiP bridge, the software-path analog of `currentAVPlayer`: set when a SW session has its
+    /// display layer, nil on teardown. Hosts build their sample-buffer PiP ContentSource from it.
+    @Published public internal(set) var softwarePiPSource: SoftwarePiPSource?
     #if os(iOS) || os(tvOS)
     /// True between didEnterBackground and didBecomeActive; gates the pause-while-backgrounded teardown
     /// (iOS) and the PiP-closed-while-backgrounded teardown (tvOS).
@@ -274,6 +277,20 @@ public final class AetherEngine: ObservableObject {
     /// keeps the old item attached through the load gap and swaps in place once the new master is ready.
     nonisolated static func shouldHandOverItemInPlace(pipActive: Bool, priorBackendWasNative: Bool) -> Bool {
         pipActive && priorBackendWasNative
+    }
+
+    /// SW-PiP: playable range for the sample-buffer PiP UI on the PTS axis of the enqueued frames
+    /// (the source axis; sourceTime = currentTime + container start offset). Live or unknown
+    /// duration reports indefinite so the window shows live UI instead of a bogus scrubber.
+    nonisolated static func softwarePiPTimeRange(isLive: Bool, sourceTime: Double, currentTime: Double, duration: Double) -> CMTimeRange {
+        guard !isLive, duration.isFinite, duration > 0 else {
+            return CMTimeRange(start: .negativeInfinity, duration: .positiveInfinity)
+        }
+        let sourceStart = sourceTime - currentTime
+        return CMTimeRange(
+            start: CMTime(seconds: sourceStart, preferredTimescale: 600),
+            duration: CMTime(seconds: duration, preferredTimescale: 600)
+        )
     }
 
     /// What to do with the active video pipeline when the app enters the background. Pure so the lifecycle
@@ -2948,6 +2965,7 @@ public final class AetherEngine: ObservableObject {
 
         softwareCancellables.removeAll()
         softwareHost?.stop()
+        softwarePiPSource = nil
         softwareHost = nil
 
         // Clear audioHost so music<->video handoffs start from a clean slate; the engine is a process-wide

--- a/Sources/AetherEngine/AetherEngine.swift
+++ b/Sources/AetherEngine/AetherEngine.swift
@@ -284,15 +284,21 @@ public final class AetherEngine: ObservableObject {
         case teardownVideo           // release the video pipeline before idle suspension
     }
 
-    /// - keepVideoAlive: result of shouldKeepVideoAlive. Pass false on tvOS (the wedge-safe unconditional teardown).
+    /// - keepVideoAlive: result of shouldKeepVideoAlive / shouldKeepVideoAliveTV.
+    /// - pipActive: a live PiP window renders the SW layer's frames, so the SW host must keep
+    ///   decoding video in background instead of dropping to audio-only (SW-PiP Phase A).
     nonisolated static func backgroundAction(
         isAudioBackend: Bool,
         hasSoftwareHost: Bool,
         keepVideoAlive: Bool,
+        pipActive: Bool,
         state: PlaybackState
     ) -> BackgroundAction {
         if isAudioBackend { return .doNothing }
-        if keepVideoAlive { return hasSoftwareHost ? .enterSoftwareAudioOnly : .doNothing }
+        if keepVideoAlive {
+            if hasSoftwareHost { return pipActive ? .doNothing : .enterSoftwareAudioOnly }
+            return .doNothing
+        }
         guard state == .playing || state == .paused else { return .doNothing }
         return .teardownVideo
     }
@@ -3071,6 +3077,7 @@ public final class AetherEngine: ObservableObject {
                     isAudioBackend: self.audioAVPlayerActive || self.audioHost != nil,
                     hasSoftwareHost: self.softwareHost != nil,
                     keepVideoAlive: keepAlive,
+                    pipActive: self.pictureInPictureActive,
                     state: self.state
                 )
                 switch Self.backgroundStep(
@@ -3271,6 +3278,7 @@ public final class AetherEngine: ObservableObject {
             isAudioBackend: audioAVPlayerActive || audioHost != nil,
             hasSoftwareHost: softwareHost != nil,
             keepVideoAlive: keepAlive,
+            pipActive: pictureInPictureActive,
             state: state
         )
     }

--- a/Sources/AetherEngine/Native/SoftwarePiPSource.swift
+++ b/Sources/AetherEngine/Native/SoftwarePiPSource.swift
@@ -1,0 +1,46 @@
+import AVFoundation
+import CoreMedia
+
+/// SW-PiP bridge (Sodalite SW-PiP Phase A): everything a host needs to build an
+/// AVPictureInPictureController ContentSource around the software path, WITHOUT AVKit entering the
+/// engine. The analog of `currentAVPlayer` for sample-buffer PiP: the layer plus the four transport
+/// answers backing AVPictureInPictureSampleBufferPlaybackDelegate. Time answers live here because
+/// the enqueued frames' PTS axis (source axis, synchronizer clock) is engine knowledge.
+@MainActor
+public final class SoftwarePiPSource {
+    public let layer: AVSampleBufferDisplayLayer
+    let isLive: Bool
+    private weak var engine: AetherEngine?
+
+    init(layer: AVSampleBufferDisplayLayer, isLive: Bool, engine: AetherEngine) {
+        self.layer = layer
+        self.isLive = isLive
+        self.engine = engine
+    }
+
+    /// Playable range on the enqueued frames' PTS axis (source axis). Live sources report an
+    /// indefinite range so the window shows live UI.
+    public func timeRange() -> CMTimeRange {
+        guard let engine else {
+            return CMTimeRange(start: .negativeInfinity, duration: .positiveInfinity)
+        }
+        return AetherEngine.softwarePiPTimeRange(
+            isLive: isLive,
+            sourceTime: engine.sourceTime,
+            currentTime: engine.currentTime,
+            duration: engine.duration
+        )
+    }
+
+    public var isPaused: Bool { engine?.state != .playing }
+
+    public func setPlaying(_ playing: Bool) {
+        if playing { engine?.play() } else { engine?.pause() }
+    }
+
+    public func skip(by seconds: Double) {
+        guard let engine else { return }
+        let target = max(0, engine.currentTime + seconds)
+        Task { await engine.seek(to: target) }
+    }
+}

--- a/Tests/AetherEngineTests/BackgroundKeepaliveTests.swift
+++ b/Tests/AetherEngineTests/BackgroundKeepaliveTests.swift
@@ -29,29 +29,29 @@ struct BackgroundKeepaliveTests {
 
     @Test("audio backend is always spared")
     func audioBackendSpared() {
-        #expect(AetherEngine.backgroundAction(isAudioBackend: true, hasSoftwareHost: false, keepVideoAlive: false, state: .playing) == .doNothing)
-        #expect(AetherEngine.backgroundAction(isAudioBackend: true, hasSoftwareHost: true, keepVideoAlive: true, state: .playing) == .doNothing)
+        #expect(AetherEngine.backgroundAction(isAudioBackend: true, hasSoftwareHost: false, keepVideoAlive: false, pipActive: false, state: .playing) == .doNothing)
+        #expect(AetherEngine.backgroundAction(isAudioBackend: true, hasSoftwareHost: true, keepVideoAlive: true, pipActive: false, state: .playing) == .doNothing)
     }
 
     @Test("native keepalive leaves the session alone")
     func nativeKeepaliveLeavesAlone() {
-        #expect(AetherEngine.backgroundAction(isAudioBackend: false, hasSoftwareHost: false, keepVideoAlive: true, state: .playing) == .doNothing)
+        #expect(AetherEngine.backgroundAction(isAudioBackend: false, hasSoftwareHost: false, keepVideoAlive: true, pipActive: false, state: .playing) == .doNothing)
     }
 
     @Test("software host kept alive enters audio-only")
     func softwareEntersAudioOnly() {
-        #expect(AetherEngine.backgroundAction(isAudioBackend: false, hasSoftwareHost: true, keepVideoAlive: true, state: .playing) == .enterSoftwareAudioOnly)
+        #expect(AetherEngine.backgroundAction(isAudioBackend: false, hasSoftwareHost: true, keepVideoAlive: true, pipActive: false, state: .playing) == .enterSoftwareAudioOnly)
     }
 
     @Test("teardown video when not kept alive and playing or paused")
     func teardownWhenNotKeptAlive() {
-        #expect(AetherEngine.backgroundAction(isAudioBackend: false, hasSoftwareHost: false, keepVideoAlive: false, state: .playing) == .teardownVideo)
-        #expect(AetherEngine.backgroundAction(isAudioBackend: false, hasSoftwareHost: true, keepVideoAlive: false, state: .paused) == .teardownVideo)
+        #expect(AetherEngine.backgroundAction(isAudioBackend: false, hasSoftwareHost: false, keepVideoAlive: false, pipActive: false, state: .playing) == .teardownVideo)
+        #expect(AetherEngine.backgroundAction(isAudioBackend: false, hasSoftwareHost: true, keepVideoAlive: false, pipActive: false, state: .paused) == .teardownVideo)
     }
 
     @Test("do nothing when idle or loading (nothing to tear down)")
     func doNothingWhenNotPlayable() {
-        #expect(AetherEngine.backgroundAction(isAudioBackend: false, hasSoftwareHost: false, keepVideoAlive: false, state: .loading) == .doNothing)
+        #expect(AetherEngine.backgroundAction(isAudioBackend: false, hasSoftwareHost: false, keepVideoAlive: false, pipActive: false, state: .loading) == .doNothing)
     }
 
     @Test("tvOS: an active PiP window keeps the video pipeline alive")
@@ -67,5 +67,15 @@ struct BackgroundKeepaliveTests {
     @Test("tvOS: master disable overrides PiP")
     func tvDisabledOverridesPiP() {
         #expect(AetherEngine.shouldKeepVideoAliveTV(enabled: false, pipActive: true) == false)
+    }
+
+    @Test("software host kept alive WITH PiP keeps video (the window needs frames)")
+    func softwareKeepsVideoInPiP() {
+        #expect(AetherEngine.backgroundAction(isAudioBackend: false, hasSoftwareHost: true, keepVideoAlive: true, pipActive: true, state: .playing) == .doNothing)
+    }
+
+    @Test("software host kept alive WITHOUT PiP still drops to audio-only")
+    func softwareAudioOnlyWithoutPiP() {
+        #expect(AetherEngine.backgroundAction(isAudioBackend: false, hasSoftwareHost: true, keepVideoAlive: true, pipActive: false, state: .playing) == .enterSoftwareAudioOnly)
     }
 }

--- a/Tests/AetherEngineTests/SoftwarePiPSourceTests.swift
+++ b/Tests/AetherEngineTests/SoftwarePiPSourceTests.swift
@@ -1,0 +1,35 @@
+import Testing
+import CoreMedia
+@testable import AetherEngine
+
+/// SW-PiP Phase A: the sample-buffer PiP UI needs the playable range on the PTS axis of the
+/// enqueued frames, which is the SOURCE axis (sourceTime = currentTime + source offset).
+@Suite("Software PiP time range")
+struct SoftwarePiPSourceTests {
+    @Test("VOD zero-based source: range starts at 0 for the full duration")
+    func vodZeroBased() {
+        let r = AetherEngine.softwarePiPTimeRange(isLive: false, sourceTime: 12.0, currentTime: 12.0, duration: 3600)
+        #expect(abs(r.start.seconds - 0) < 0.001)
+        #expect(abs(r.duration.seconds - 3600) < 0.001)
+    }
+
+    @Test("VOD with source offset: range starts at the container start PTS")
+    func vodWithOffset() {
+        let r = AetherEngine.softwarePiPTimeRange(isLive: false, sourceTime: 152.5, currentTime: 2.5, duration: 600)
+        #expect(abs(r.start.seconds - 150.0) < 0.001)
+        #expect(abs(r.duration.seconds - 600) < 0.001)
+    }
+
+    @Test("live: indefinite range")
+    func liveIndefinite() {
+        let r = AetherEngine.softwarePiPTimeRange(isLive: true, sourceTime: 500, currentTime: 100, duration: 0)
+        #expect(r.start == .negativeInfinity)
+        #expect(r.duration == .positiveInfinity)
+    }
+
+    @Test("unknown duration falls back to indefinite")
+    func unknownDurationIndefinite() {
+        let r = AetherEngine.softwarePiPTimeRange(isLive: false, sourceTime: 5, currentTime: 5, duration: 0)
+        #expect(r.start == .negativeInfinity)
+    }
+}


### PR DESCRIPTION
Hosts building system PiP for SW-routed codecs (dav1d AV1/VP9 and friends) need the display layer plus transport answers on the enqueued frames' PTS axis (source axis); both are engine knowledge. The engine now publishes `softwarePiPSource` (the `currentAVPlayer` analog) carrying the `AVSampleBufferDisplayLayer`, `timeRange()`, `isPaused`, `setPlaying(_:)`, and `skip(by:)`, with AVKit staying host-side. The background policy keeps SW video decoding alive while `pictureInPictureActive` (the window needs frames) instead of dropping to audio-only; without PiP, background behavior is unchanged. Covered by `SoftwarePiPSourceTests` and the extended `BackgroundKeepaliveTests`; full suite 788 green, tvOS sim build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NAPCg4tCDdSqkK6tPkNptw