### PR TITLE
SubtitleFrameCompositor: subtitles inside sample-buffer PiP windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ the public-API contract.
 
 ## [Unreleased]
 
+## [5.14.0] - 2026-07-20
+
+([release notes](https://github.com/superuser404notfound/AetherEngine/releases/tag/5.14.0))
+
+### Added
+
+- **Subtitles render inside sample-buffer PiP windows: the software path composites active cues into decoded frames while `pictureInPictureActive`.** The system PiP window renders only the display layer, so host-drawn overlays never reach it; a new `SubtitleFrameCompositor` caches one overlay per cue-set change (text cues in a readable default look via CoreText, bitmap cues width-aligned center-anchored per their PGS/DVB canvas) and GPU-composites it into a pooled buffer of the source pixel format inside the renderer's flush path. Outside PiP nothing changes (fullscreen subtitle drawing stays with the host); any compositing failure passes the original frame through. Covered by `SubtitleFrameCompositorTests` including a synthetic-buffer integration test.
+
 ## [5.13.0] - 2026-07-20
 
 ([release notes](https://github.com/superuser404notfound/AetherEngine/releases/tag/5.13.0))

--- a/Sources/AetherEngine/AetherEngine+Loading.swift
+++ b/Sources/AetherEngine/AetherEngine+Loading.swift
@@ -898,6 +898,14 @@ extension AetherEngine {
         // SW-PiP: publish the bridge once the session owns its layer (the layer object is stable for
         // the session; the host attaches it to the view and, on PiP start, to the system window).
         softwarePiPSource = SoftwarePiPSource(layer: host.displayLayer, isLive: isLive, engine: self)
+        // SW-PiP Phase C: mirror the published cues (primary + secondary) into the renderer's frame
+        // compositor; the PiP flag gates actual drawing (fullscreen stays host-overlay-only).
+        Publishers.CombineLatest($subtitleCues, $secondarySubtitleCues)
+            .sink { [weak self, weak host] primary, secondary in
+                guard let self, let host else { return }
+                host.updateSubtitleCompositor(cues: primary + secondary, enabled: self.pictureInPictureActive)
+            }
+            .store(in: &softwareCancellables)
         // #131: no demuxable CC track on the SW path either: arm an A53 tap fed by decoded-frame
         // side data. Same lazy synthetic-track surfacing as the producer path.
         // Same synthetic-entry exclusion as setupClosedCaptionTapIfNeeded (via `demuxableClosedCaptionTrack`):

--- a/Sources/AetherEngine/AetherEngine.swift
+++ b/Sources/AetherEngine/AetherEngine.swift
@@ -212,6 +212,9 @@ public final class AetherEngine: ObservableObject {
     /// the keepalive policy + pause-safety read it.
     public var pictureInPictureActive = false {
         didSet {
+            // SW-PiP Phase C: flip the frame compositor with the PiP state so subtitles appear in the
+            // window and never double-draw under the fullscreen host overlay.
+            softwareHost?.updateSubtitleCompositor(cues: subtitleCues + secondarySubtitleCues, enabled: pictureInPictureActive)
             #if os(tvOS)
             // PiP window closed while backgrounded: nothing keeps the app running anymore, so run the
             // wedge-safe teardown now, before idle suspension (mirrors the iOS pause-while-backgrounded path).

--- a/Sources/AetherEngine/Native/SoftwarePlaybackHost.swift
+++ b/Sources/AetherEngine/Native/SoftwarePlaybackHost.swift
@@ -59,6 +59,11 @@ final class SoftwarePlaybackHost {
     /// point it uses for `AVPlayerLayer`.
     var displayLayer: AVSampleBufferDisplayLayer { renderer.displayLayer }
 
+    /// SW-PiP Phase C: engine-fed cue mirror + PiP gate for the renderer's frame compositor.
+    func updateSubtitleCompositor(cues: [SubtitleCue], enabled: Bool) {
+        renderer.subtitleCompositor.update(cues: cues, enabled: enabled)
+    }
+
     // MARK: - Internals
 
     private let renderer: SampleBufferRenderer
@@ -674,6 +679,7 @@ final class SoftwarePlaybackHost {
         isPlaying = false
         timeTimer?.cancel()
         timeTimer = nil
+        renderer.subtitleCompositor.reset()
 
         dvrRing?.close()
         dvrRing = nil

--- a/Sources/AetherEngine/Renderer/SampleBufferRenderer.swift
+++ b/Sources/AetherEngine/Renderer/SampleBufferRenderer.swift
@@ -31,6 +31,10 @@ final class SampleBufferRenderer: @unchecked Sendable {
 
     private(set) var displayLayer: AVSampleBufferDisplayLayer
 
+    /// SW-PiP Phase C: composites active subtitle cues into frames while PiP is active (the system
+    /// window renders only this layer, the host overlay cannot reach it).
+    let subtitleCompositor = SubtitleFrameCompositor()
+
     /// B-frame reorder buffer (4 frames): collects decoder output, flushes to display layer in ascending PTS order. Third tuple slot carries per-frame HDR10+ T.35 SEI bytes, paired through the reorder to kCMSampleAttachmentKey_HDR10PlusPerFrameData.
     private let reorderLock = NSLock()
     private var reorderBuffer: [(CVPixelBuffer, CMTime, Data?)] = []
@@ -194,7 +198,8 @@ final class SampleBufferRenderer: @unchecked Sendable {
     // MARK: - Internal
 
     private func flushFrame(pixelBuffer: CVPixelBuffer, pts: CMTime, hdr10PlusData: Data?) {
-        guard let sampleBuffer = createSampleBuffer(from: pixelBuffer, pts: pts) else {
+        let outputBuffer = subtitleCompositor.composite(pixelBuffer, ptsSeconds: pts.seconds)
+        guard let sampleBuffer = createSampleBuffer(from: outputBuffer, pts: pts) else {
             return
         }
         // HDR10+ attachment overrides any payload baked into the bitstream (VT may strip per-frame SEI on decode).

--- a/Sources/AetherEngine/Renderer/SubtitleFrameCompositor.swift
+++ b/Sources/AetherEngine/Renderer/SubtitleFrameCompositor.swift
@@ -42,4 +42,168 @@ final class SubtitleFrameCompositor: @unchecked Sendable {
         let y = frameCenterY + (position.minY - canvasCenterY) * scale
         return CGRect(x: x, y: y, width: position.width * scale, height: position.height * scale)
     }
+
+    // MARK: - State
+
+    private let lock = NSLock()
+    private var cues: [SubtitleCue] = []
+    private var enabled = false
+    /// Cache key of the overlay currently rendered (active cue ids); nil = no overlay cached.
+    private var cachedCueIDs: [Int]?
+    private var cachedOverlay: CIImage?
+    private var loggedFailure = false
+
+    private lazy var ciContext = CIContext(options: [.cacheIntermediates: false])
+    private var pool: CVPixelBufferPool?
+    private var poolFormat: (width: Int, height: Int, pixelFormat: OSType)?
+
+    /// Any thread; called by the engine when its published cues or the PiP flag change.
+    func update(cues: [SubtitleCue], enabled: Bool) {
+        lock.lock()
+        self.cues = cues
+        self.enabled = enabled
+        lock.unlock()
+    }
+
+    /// Render thread. Returns the input buffer untouched on passthrough or ANY failure.
+    func composite(_ buffer: CVPixelBuffer, ptsSeconds: Double) -> CVPixelBuffer {
+        lock.lock()
+        let enabled = self.enabled
+        let cues = self.cues
+        lock.unlock()
+        guard enabled else { return buffer }
+
+        let active = Self.activeCues(in: cues, at: ptsSeconds)
+        guard !active.isEmpty else {
+            lock.lock(); cachedCueIDs = nil; cachedOverlay = nil; lock.unlock()
+            return buffer
+        }
+
+        let width = CVPixelBufferGetWidth(buffer)
+        let height = CVPixelBufferGetHeight(buffer)
+        let overlay: CIImage
+        lock.lock()
+        let cacheHit = cachedCueIDs == active.map(\.id) ? cachedOverlay : nil
+        lock.unlock()
+        if let cacheHit {
+            overlay = cacheHit
+        } else {
+            guard let rendered = Self.renderOverlay(for: active, frameWidth: CGFloat(width), frameHeight: CGFloat(height)) else {
+                logFailureOnce("overlay render failed")
+                return buffer
+            }
+            overlay = CIImage(cgImage: rendered)
+            lock.lock()
+            cachedCueIDs = active.map(\.id)
+            cachedOverlay = overlay
+            lock.unlock()
+        }
+
+        guard let output = dequeueBuffer(width: width, height: height, pixelFormat: CVPixelBufferGetPixelFormatType(buffer)) else {
+            logFailureOnce("pool exhausted")
+            return buffer
+        }
+        let base = CIImage(cvPixelBuffer: buffer)
+        let composited = overlay.composited(over: base)
+        ciContext.render(composited, to: output, bounds: CGRect(x: 0, y: 0, width: width, height: height), colorSpace: CGColorSpace(name: CGColorSpace.itur_709))
+        return output
+    }
+
+    /// One CGImage per cue-set change: text cues bottom-up in the default look, image cues at their
+    /// canvas-mapped rects. CG coordinate origin is bottom-left; layout values are top-left based,
+    /// so y flips via frameHeight.
+    nonisolated static func renderOverlay(for cues: [SubtitleCue], frameWidth: CGFloat, frameHeight: CGFloat) -> CGImage? {
+        guard let ctx = CGContext(
+            data: nil, width: Int(frameWidth), height: Int(frameHeight),
+            bitsPerComponent: 8, bytesPerRow: 0,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else { return nil }
+
+        let layout = textLayout(frameWidth: frameWidth, frameHeight: frameHeight)
+        var textBaselineFromBottom = layout.bottomMargin
+
+        for cue in cues {
+            switch cue.body {
+            case .image(let image):
+                let rectTopLeft = imageRect(position: image.position, canvasSize: image.canvasSize, frameWidth: frameWidth, frameHeight: frameHeight)
+                let rect = CGRect(x: rectTopLeft.minX, y: frameHeight - rectTopLeft.maxY, width: rectTopLeft.width, height: rectTopLeft.height)
+                ctx.draw(image.cgImage, in: rect)
+            case .text(let text):
+                drawTextBlock(text, in: ctx, layout: layout, frameWidth: frameWidth, baselineFromBottom: &textBaselineFromBottom)
+            case .richText(let runs):
+                let flat = runs.map(\.text).joined()
+                drawTextBlock(flat, in: ctx, layout: layout, frameWidth: frameWidth, baselineFromBottom: &textBaselineFromBottom)
+            }
+        }
+        return ctx.makeImage()
+    }
+
+    private nonisolated static func drawTextBlock(_ text: String, in ctx: CGContext, layout: TextLayout, frameWidth: CGFloat, baselineFromBottom: inout CGFloat) {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        let font = CTFontCreateWithName("HelveticaNeue-Medium" as CFString, layout.fontSize, nil)
+        for line in trimmed.split(separator: "\n").reversed() {
+            let attributes: [CFString: Any] = [
+                kCTFontAttributeName: font,
+                kCTForegroundColorAttributeName: CGColor(red: 1, green: 1, blue: 1, alpha: 1)
+            ]
+            guard let attributed = CFAttributedStringCreate(kCFAllocatorDefault, String(line) as CFString, attributes as CFDictionary) else { continue }
+            let ctLine = CTLineCreateWithAttributedString(attributed)
+            let bounds = CTLineGetBoundsWithOptions(ctLine, .useOpticalBounds)
+            let pad = layout.fontSize * 0.4
+            let boxWidth = min(bounds.width + pad * 2, layout.maxTextWidth)
+            let boxHeight = bounds.height + pad
+            let boxX = (frameWidth - boxWidth) / 2
+            let boxY = baselineFromBottom - pad / 2
+
+            ctx.setFillColor(CGColor(red: 0, green: 0, blue: 0, alpha: 0.6))
+            ctx.fill(CGRect(x: boxX, y: boxY, width: boxWidth, height: boxHeight).insetBy(dx: -2, dy: -2))
+            ctx.textPosition = CGPoint(x: boxX + pad, y: baselineFromBottom + pad / 2 - bounds.minY)
+            CTLineDraw(ctLine, ctx)
+            baselineFromBottom += boxHeight + layout.fontSize * 0.2
+        }
+    }
+
+    private func dequeueBuffer(width: Int, height: Int, pixelFormat: OSType) -> CVPixelBuffer? {
+        if poolFormat?.width != width || poolFormat?.height != height || poolFormat?.pixelFormat != pixelFormat {
+            let attrs: [CFString: Any] = [
+                kCVPixelBufferWidthKey: width,
+                kCVPixelBufferHeightKey: height,
+                kCVPixelBufferPixelFormatTypeKey: pixelFormat,
+                kCVPixelBufferIOSurfacePropertiesKey: [:] as CFDictionary
+            ]
+            var newPool: CVPixelBufferPool?
+            CVPixelBufferPoolCreate(kCFAllocatorDefault, [kCVPixelBufferPoolMinimumBufferCountKey: 3] as CFDictionary, attrs as CFDictionary, &newPool)
+            pool = newPool
+            poolFormat = (width, height, pixelFormat)
+        }
+        guard let pool else { return nil }
+        var out: CVPixelBuffer?
+        CVPixelBufferPoolCreatePixelBuffer(kCFAllocatorDefault, pool, &out)
+        return out
+    }
+
+    private func logFailureOnce(_ reason: String) {
+        lock.lock()
+        let first = !loggedFailure
+        loggedFailure = true
+        lock.unlock()
+        if first {
+            EngineLog.emit("[SubtitleCompositor] degraded to passthrough: \(reason)", category: .swPlayback)
+        }
+    }
+
+    /// Session teardown: drop cache and pool.
+    func reset() {
+        lock.lock()
+        cues = []
+        enabled = false
+        cachedCueIDs = nil
+        cachedOverlay = nil
+        pool = nil
+        poolFormat = nil
+        loggedFailure = false
+        lock.unlock()
+    }
 }

--- a/Sources/AetherEngine/Renderer/SubtitleFrameCompositor.swift
+++ b/Sources/AetherEngine/Renderer/SubtitleFrameCompositor.swift
@@ -1,0 +1,45 @@
+import CoreGraphics
+import CoreImage
+import CoreText
+import CoreVideo
+import Foundation
+
+/// SW-PiP Phase C: composites active subtitle cues into decoded software-path frames so the system
+/// PiP window (which renders only the sample-buffer layer) shows subtitles. Enabled ONLY while
+/// pictureInPictureActive; fullscreen subtitles stay with the host's on-frame overlay. Playback wins
+/// over subtitles: every failure path returns the original buffer untouched.
+final class SubtitleFrameCompositor: @unchecked Sendable {
+
+    struct TextLayout: Equatable {
+        let fontSize: CGFloat
+        let bottomMargin: CGFloat
+        let maxTextWidth: CGFloat
+    }
+
+    /// Plain window check; cue times and SW frame PTS share the source axis.
+    nonisolated static func activeCues(in cues: [SubtitleCue], at seconds: Double) -> [SubtitleCue] {
+        cues.filter { $0.startTime <= seconds && seconds < $0.endTime }
+    }
+
+    /// Default look: readable in a small window, resolution-independent.
+    nonisolated static func textLayout(frameWidth: CGFloat, frameHeight: CGFloat) -> TextLayout {
+        TextLayout(
+            fontSize: frameHeight * 0.05,
+            bottomMargin: frameHeight * 0.06,
+            maxTextWidth: frameWidth * 0.9
+        )
+    }
+
+    /// Canvas -> frame mapping per the SubtitleImage contract: width-aligned, center-anchored
+    /// vertically (a cropped rip's canvas can be taller than the coded video); .zero canvas means
+    /// canvas == frame.
+    nonisolated static func imageRect(position: CGRect, canvasSize: CGSize, frameWidth: CGFloat, frameHeight: CGFloat) -> CGRect {
+        guard canvasSize != .zero, canvasSize.width > 0 else { return position }
+        let scale = frameWidth / canvasSize.width
+        let frameCenterY = frameHeight / 2
+        let canvasCenterY = canvasSize.height / 2
+        let x = position.minX * scale
+        let y = frameCenterY + (position.minY - canvasCenterY) * scale
+        return CGRect(x: x, y: y, width: position.width * scale, height: position.height * scale)
+    }
+}

--- a/Tests/AetherEngineTests/SubtitleFrameCompositorTests.swift
+++ b/Tests/AetherEngineTests/SubtitleFrameCompositorTests.swift
@@ -1,0 +1,52 @@
+import Testing
+import CoreGraphics
+@testable import AetherEngine
+
+@Suite("Subtitle frame compositor logic")
+struct SubtitleFrameCompositorTests {
+    private func cue(_ id: Int, _ start: Double, _ end: Double) -> SubtitleCue {
+        SubtitleCue(id: id, startTime: start, endTime: end, body: .text("line \(id)"))
+    }
+
+    @Test("active cue selection is a plain window check on the source axis")
+    func activeCueWindow() {
+        let cues = [cue(1, 0, 4), cue(2, 3, 8), cue(3, 10, 12)]
+        #expect(SubtitleFrameCompositor.activeCues(in: cues, at: 3.5).map(\.id) == [1, 2])
+        #expect(SubtitleFrameCompositor.activeCues(in: cues, at: 9.0).isEmpty)
+        #expect(SubtitleFrameCompositor.activeCues(in: cues, at: 10.0).map(\.id) == [3])
+        #expect(SubtitleFrameCompositor.activeCues(in: cues, at: 12.0).isEmpty)
+    }
+
+    @Test("text layout scales with frame height and keeps a safe bottom margin")
+    func textLayoutScales() {
+        let layout = SubtitleFrameCompositor.textLayout(frameWidth: 1920, frameHeight: 1080)
+        #expect(abs(layout.fontSize - 54) < 0.5)
+        #expect(abs(layout.bottomMargin - 64.8) < 0.5)
+        #expect(abs(layout.maxTextWidth - 1728) < 0.5)
+    }
+
+    @Test("bitmap cue maps width-aligned and center-anchored from its canvas onto the frame")
+    func bitmapCanvasMapping() {
+        // Canvas 1920x1280 (taller than video), video frame 1280x720: scale by width (1280/1920),
+        // vertical center anchored (canvas center -> frame center).
+        let rect = SubtitleFrameCompositor.imageRect(
+            position: CGRect(x: 660, y: 1100, width: 600, height: 100),
+            canvasSize: CGSize(width: 1920, height: 1280),
+            frameWidth: 1280, frameHeight: 720
+        )
+        #expect(abs(rect.width - 400) < 0.5)
+        #expect(abs(rect.minX - 440) < 0.5)
+        // canvas y 1100 is 460 below canvas center (640); frame center 360 + 460*(2/3) = 666.67
+        #expect(abs(rect.minY - 666.67) < 1.0)
+    }
+
+    @Test("bitmap cue with unknown canvas treats canvas as the frame")
+    func bitmapUnknownCanvas() {
+        let rect = SubtitleFrameCompositor.imageRect(
+            position: CGRect(x: 100, y: 200, width: 300, height: 50),
+            canvasSize: .zero,
+            frameWidth: 1920, frameHeight: 1080
+        )
+        #expect(rect == CGRect(x: 100, y: 200, width: 300, height: 50))
+    }
+}

--- a/Tests/AetherEngineTests/SubtitleFrameCompositorTests.swift
+++ b/Tests/AetherEngineTests/SubtitleFrameCompositorTests.swift
@@ -1,5 +1,6 @@
 import Testing
 import CoreGraphics
+import CoreVideo
 @testable import AetherEngine
 
 @Suite("Subtitle frame compositor logic")
@@ -48,5 +49,45 @@ struct SubtitleFrameCompositorTests {
             frameWidth: 1920, frameHeight: 1080
         )
         #expect(rect == CGRect(x: 100, y: 200, width: 300, height: 50))
+    }
+
+    @Test("composite draws into the cue region and passthrough returns the input instance")
+    func compositeSyntheticBuffer() throws {
+        let compositor = SubtitleFrameCompositor()
+        var pb: CVPixelBuffer?
+        let attrs: [CFString: Any] = [kCVPixelBufferIOSurfacePropertiesKey: [:] as CFDictionary]
+        CVPixelBufferCreate(kCFAllocatorDefault, 640, 360, kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange, attrs as CFDictionary, &pb)
+        let buffer = try #require(pb)
+        // Fill luma with 0 (black) so drawn subtitle pixels are detectable.
+        CVPixelBufferLockBaseAddress(buffer, [])
+        if let luma = CVPixelBufferGetBaseAddressOfPlane(buffer, 0) {
+            memset(luma, 0, CVPixelBufferGetBytesPerRowOfPlane(buffer, 0) * CVPixelBufferGetHeightOfPlane(buffer, 0))
+        }
+        CVPixelBufferUnlockBaseAddress(buffer, [])
+
+        // Disabled: passthrough must be the same instance.
+        compositor.update(cues: [SubtitleCue(id: 1, startTime: 0, endTime: 10, body: .text("HELLO"))], enabled: false)
+        #expect(compositor.composite(buffer, ptsSeconds: 5) === buffer)
+
+        // Enabled with an active cue: output keeps the format and the bottom region gains bright pixels.
+        compositor.update(cues: [SubtitleCue(id: 1, startTime: 0, endTime: 10, body: .text("HELLO"))], enabled: true)
+        let out = compositor.composite(buffer, ptsSeconds: 5)
+        #expect(CVPixelBufferGetPixelFormatType(out) == kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange)
+        #expect(out !== buffer)
+        CVPixelBufferLockBaseAddress(out, [.readOnly])
+        var maxLuma: UInt8 = 0
+        if let luma = CVPixelBufferGetBaseAddressOfPlane(out, 0) {
+            let bpr = CVPixelBufferGetBytesPerRowOfPlane(out, 0)
+            // Scan the bottom third where the text box lands.
+            for row in 240..<360 {
+                let p = luma.advanced(by: row * bpr).assumingMemoryBound(to: UInt8.self)
+                for col in 0..<640 { maxLuma = max(maxLuma, p[col]) }
+            }
+        }
+        CVPixelBufferUnlockBaseAddress(out, [.readOnly])
+        #expect(maxLuma > 100)
+
+        // No active cue at this PTS: passthrough again.
+        #expect(compositor.composite(buffer, ptsSeconds: 20) === buffer)
     }
 }


### PR DESCRIPTION
The system PiP window renders only the display layer, so host-drawn overlays never reach it. A new `SubtitleFrameCompositor` caches one overlay per cue-set change (text cues in a readable default look via CoreText, bitmap cues width-aligned center-anchored per their PGS/DVB canvas) and GPU-composites it into a pooled buffer of the source pixel format inside the renderer's flush path, gated on `pictureInPictureActive` so fullscreen subtitle drawing stays with the host. Any compositing failure passes the original frame through (playback wins). Covered by `SubtitleFrameCompositorTests` incl. a synthetic 420v integration test; full suite 793 green, tvOS sim build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NAPCg4tCDdSqkK6tPkNptw