### PR TITLE
External PGS sidecar files load and render (sup demuxer + bitmap cue decode)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ the public-API contract.
 
 ## [Unreleased]
 
+## [5.14.1] - 2026-07-20
+
+([release notes](https://github.com/superuser404notfound/AetherEngine/releases/tag/5.14.1))
+
+### Fixed
+
+- **External PGS subtitle files (raw .sup sidecars, e.g. Jellyfin serving external PGS tracks) now load and render.** Two gaps compounded into a silent no-show on every path: FFmpegBuild lacked the `sup` demuxer (fixed in 2.1.3, now pinned), so `avformat_open_input` rejected the file with `AVERROR_INVALIDDATA`; and the sidecar decode loop extracted only text rects, dropping bitmap rects. The loop now routes bitmap rects through the embedded path's `imageForSubtitleRect` into `.image` cues with PGS end semantics (an open composition ends at the next composition event's PTS instead of a flat 5 s fallback). Also fixes the frame compositor's bitmap placement: `SubtitleImage.position` is normalized against its canvas, and the compositor treated it as absolute pixels. Covered by `SidecarPGSDecodeTests` (real .sup fixture, local-only) and the updated `SubtitleFrameCompositorTests`.
+
 ## [5.14.0] - 2026-07-20
 
 ([release notes](https://github.com/superuser404notfound/AetherEngine/releases/tag/5.14.0))

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/superuser404notfound/FFmpegBuild",
       "state" : {
-        "revision" : "5e8babf6dfbf5578f1bf579b9594803d38df79c5",
-        "version" : "2.1.2"
+        "revision" : "06409cd0b0d833eeb3810c59d42395b9b3c59352",
+        "version" : "2.1.3"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
         // No network stack, we use custom AVIO + URLSession for HTTP streams.
         // Resolved over Git rather than a local path so consumers (and
         // Xcode Cloud) can build without a sibling FFmpegBuild checkout.
-        .package(url: "https://github.com/superuser404notfound/FFmpegBuild", from: "2.1.2"),  // 2.1.2: matroska TrackTimestampScale clamp (#145); 2.1.1: pgssubdec Epoch-Continue retain (#142); 2.1.0: yadif_videotoolbox + hwupload (Metal GPU deinterlace); 2.0.0: dynamic frameworks (LGPL), zvbi GPL excision
+        .package(url: "https://github.com/superuser404notfound/FFmpegBuild", from: "2.1.3"),  // 2.1.3: sup demuxer (raw PGS sidecars); 2.1.2: matroska TrackTimestampScale clamp (#145); 2.1.1: pgssubdec Epoch-Continue retain (#142); 2.1.0: yadif_videotoolbox + hwupload (Metal GPU deinterlace); 2.0.0: dynamic frameworks (LGPL), zvbi GPL excision
         // Pure-Swift SMB2 client (MIT) that speaks the protocol over
         // NWConnection. Replaces AMSMB2/libsmb2, which EPERMs on tvOS/iOS.
         // Pinned to the 0.3.x minor: SMBClient is pre-1.0 with an actively

--- a/Sources/AetherEngine/Decoder/SubtitleDecoder.swift
+++ b/Sources/AetherEngine/Decoder/SubtitleDecoder.swift
@@ -186,6 +186,8 @@ enum SubtitleDecoder {
 
         var cues: [SubtitleCue] = []
         var nextID = 0
+        /// Indices of image cues still "open" (PGS-style: ended by the next composition event).
+        var pendingImageCueIndices: [Int] = []
         var lastPktPTS: Double = 0  // PTS anchor for flush events that have no packet of their own
 
         // Under preserveASSMarkup: keep raw ASS event line (ASSScriptBuilder re-stamps timing); otherwise plain text.
@@ -229,11 +231,32 @@ enum SubtitleDecoder {
                 let startTime = pktPTS + startOffset
                 let endTime = pktPTS + endOffset
 
+                // Bitmap subtitles (external .sup / PGS sidecars, FFmpegBuild >= 2.1.3 sup demuxer):
+                // a composition usually carries end_display_time == 0 and is ended by the NEXT
+                // composition event (a new set or a clear packet), so clamp any still-open image
+                // cues to this packet's PTS before appending the new ones. The 5 s fallback above
+                // only survives for a final composition with no successor.
+                for idx in pendingImageCueIndices where cues[idx].startTime < pktPTS && cues[idx].endTime > pktPTS {
+                    let open = cues[idx]
+                    cues[idx] = SubtitleCue(id: open.id, startTime: open.startTime, endTime: pktPTS, body: open.body)
+                }
+                pendingImageCueIndices.removeAll()
+
                 var lines: [String] = []
+                var images: [SubtitleImage] = []
                 if sub.num_rects > 0, let rects = sub.rects {
                     for i in 0..<Int(sub.num_rects) {
                         guard let rect = rects[i] else { continue }
-                        if let text = lineForRect(rect) {
+                        if rect.pointee.type == SUBTITLE_BITMAP {
+                            // The composition canvas is the codec's coded size (PGS: from the PCS).
+                            if let image = EmbeddedSubtitleDecoder.imageForSubtitleRect(
+                                rect,
+                                videoWidth: Int(codecpar.pointee.width),
+                                videoHeight: Int(codecpar.pointee.height)
+                            ) {
+                                images.append(image)
+                            }
+                        } else if let text = lineForRect(rect) {
                             lines.append(text)
                         }
                     }
@@ -251,6 +274,18 @@ enum SubtitleDecoder {
                         body: .text(merged)
                     ))
                     nextID += 1
+                }
+                if endTime > startTime {
+                    for image in images {
+                        pendingImageCueIndices.append(cues.count)
+                        cues.append(SubtitleCue(
+                            id: nextID,
+                            startTime: startTime,
+                            endTime: endTime,
+                            body: .image(image)
+                        ))
+                        nextID += 1
+                    }
                 }
             }
 

--- a/Sources/AetherEngine/Renderer/SubtitleFrameCompositor.swift
+++ b/Sources/AetherEngine/Renderer/SubtitleFrameCompositor.swift
@@ -30,17 +30,30 @@ final class SubtitleFrameCompositor: @unchecked Sendable {
         )
     }
 
-    /// Canvas -> frame mapping per the SubtitleImage contract: width-aligned, center-anchored
-    /// vertically (a cropped rip's canvas can be taller than the coded video); .zero canvas means
-    /// canvas == frame.
+    /// Canvas -> frame mapping per the SubtitleImage contract: `position` is NORMALIZED against the
+    /// canvas; go to canvas pixels first, then map width-aligned and center-anchored vertically (a
+    /// cropped rip's canvas can be taller than the coded video). A .zero canvas means the position is
+    /// normalized against the video frame itself.
     nonisolated static func imageRect(position: CGRect, canvasSize: CGSize, frameWidth: CGFloat, frameHeight: CGFloat) -> CGRect {
-        guard canvasSize != .zero, canvasSize.width > 0 else { return position }
+        guard canvasSize != .zero, canvasSize.width > 0 else {
+            return CGRect(
+                x: position.minX * frameWidth,
+                y: position.minY * frameHeight,
+                width: position.width * frameWidth,
+                height: position.height * frameHeight
+            )
+        }
+        let px = position.minX * canvasSize.width
+        let py = position.minY * canvasSize.height
         let scale = frameWidth / canvasSize.width
         let frameCenterY = frameHeight / 2
         let canvasCenterY = canvasSize.height / 2
-        let x = position.minX * scale
-        let y = frameCenterY + (position.minY - canvasCenterY) * scale
-        return CGRect(x: x, y: y, width: position.width * scale, height: position.height * scale)
+        return CGRect(
+            x: px * scale,
+            y: frameCenterY + (py - canvasCenterY) * scale,
+            width: position.width * canvasSize.width * scale,
+            height: position.height * canvasSize.height * scale
+        )
     }
 
     // MARK: - State

--- a/Tests/AetherEngineTests/SidecarPGSDecodeTests.swift
+++ b/Tests/AetherEngineTests/SidecarPGSDecodeTests.swift
@@ -1,0 +1,37 @@
+import Testing
+import Foundation
+@testable import AetherEngine
+
+/// External PGS sidecar decode (Jellyfin serves external PGS tracks as raw .sup streams). The
+/// fixture is local-only like the restart-witness clips (extract one with:
+/// `ffmpeg -i <mkv-with-pgs> -map 0:s:0 -c copy Fixtures/external-pgs.sup`); the test skips when
+/// absent (CI). Requires FFmpegBuild >= 2.1.3 (sup demuxer in the allowlist).
+@Suite("Sidecar PGS decode")
+struct SidecarPGSDecodeTests {
+    private var fixtureURL: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()   // AetherEngineTests
+            .deletingLastPathComponent()   // Tests
+            .deletingLastPathComponent()   // repo root
+            .appendingPathComponent("Fixtures")
+            .appendingPathComponent("external-pgs.sup")
+    }
+
+    @Test("raw .sup sidecar decodes into image cues with monotonic timing")
+    func supSidecarDecodes() async throws {
+        guard FileManager.default.fileExists(atPath: fixtureURL.path) else { return }
+        let result = try await SubtitleDecoder.decodeFile(url: fixtureURL, httpHeaders: [:], preserveASSMarkup: false)
+        #expect(!result.cues.isEmpty)
+        var lastStart = -1.0
+        for cue in result.cues {
+            guard case .image(let image) = cue.body else {
+                Issue.record("non-image cue in PGS sidecar")
+                return
+            }
+            #expect(image.cgImage.width > 0)
+            #expect(cue.endTime > cue.startTime)
+            #expect(cue.startTime >= lastStart)
+            lastStart = cue.startTime
+        }
+    }
+}

--- a/Tests/AetherEngineTests/SubtitleFrameCompositorTests.swift
+++ b/Tests/AetherEngineTests/SubtitleFrameCompositorTests.swift
@@ -26,12 +26,13 @@ struct SubtitleFrameCompositorTests {
         #expect(abs(layout.maxTextWidth - 1728) < 0.5)
     }
 
-    @Test("bitmap cue maps width-aligned and center-anchored from its canvas onto the frame")
+    @Test("bitmap cue maps its NORMALIZED position via the canvas, width-aligned center-anchored")
     func bitmapCanvasMapping() {
-        // Canvas 1920x1280 (taller than video), video frame 1280x720: scale by width (1280/1920),
-        // vertical center anchored (canvas center -> frame center).
+        // SubtitleImage.position is normalized against the canvas (see PlayerState). Canvas 1920x1280
+        // (taller than video), video frame 1280x720: canvas pixels = position * canvas, then scale by
+        // width (1280/1920 = 2/3), vertical center anchored (canvas center -> frame center).
         let rect = SubtitleFrameCompositor.imageRect(
-            position: CGRect(x: 660, y: 1100, width: 600, height: 100),
+            position: CGRect(x: 660.0 / 1920.0, y: 1100.0 / 1280.0, width: 600.0 / 1920.0, height: 100.0 / 1280.0),
             canvasSize: CGSize(width: 1920, height: 1280),
             frameWidth: 1280, frameHeight: 720
         )
@@ -41,14 +42,17 @@ struct SubtitleFrameCompositorTests {
         #expect(abs(rect.minY - 666.67) < 1.0)
     }
 
-    @Test("bitmap cue with unknown canvas treats canvas as the frame")
+    @Test("bitmap cue with unknown canvas is normalized against the frame itself")
     func bitmapUnknownCanvas() {
         let rect = SubtitleFrameCompositor.imageRect(
-            position: CGRect(x: 100, y: 200, width: 300, height: 50),
+            position: CGRect(x: 0.1, y: 0.8, width: 0.8, height: 0.15),
             canvasSize: .zero,
             frameWidth: 1920, frameHeight: 1080
         )
-        #expect(rect == CGRect(x: 100, y: 200, width: 300, height: 50))
+        #expect(abs(rect.minX - 192) < 0.5)
+        #expect(abs(rect.minY - 864) < 0.5)
+        #expect(abs(rect.width - 1536) < 0.5)
+        #expect(abs(rect.height - 162) < 0.5)
     }
 
     @Test("composite draws into the cue region and passthrough returns the input instance")


### PR DESCRIPTION
Two compounding gaps made external PGS (.sup) subtitle files a silent no-show on every path: FFmpegBuild lacked the `sup` demuxer (fixed in 2.1.3, now pinned), so `avformat_open_input` rejected the file with `AVERROR_INVALIDDATA`; and the sidecar decode loop extracted only text rects, dropping bitmap rects. The loop now routes bitmap rects through the embedded path's `imageForSubtitleRect` into `.image` cues with PGS end semantics (an open composition ends at the next composition event's PTS instead of the flat 5 s fallback). Also fixes the frame compositor's bitmap placement (`SubtitleImage.position` is normalized against its canvas; the compositor treated it as absolute pixels). `SidecarPGSDecodeTests` decodes a real .sup fixture (local-only, skip-when-absent) and reproduced the exact field failure before the demuxer landed; full suite 794 green, tvOS sim build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NAPCg4tCDdSqkK6tPkNptw