### PR TITLE
fix(playback): finish a video-exhausted VOD tail + keep DV on tail resume (#169)

### DIFF
--- a/Sources/AetherEngine/AetherEngine.swift
+++ b/Sources/AetherEngine/AetherEngine.swift
@@ -1333,6 +1333,73 @@ public final class AetherEngine: ObservableObject {
         return currentTime >= duration - endOfMediaEpsilonSeconds
     }
 
+    /// True when a native VOD tick shows the tail-park signature of AetherEngine#169: the final segment
+    /// is loaded to (approximately) the advertised end, yet the playhead sits a hair short of `duration`
+    /// waiting to minimize stalls. The final segment's advertised EXTINF is derived from the container
+    /// duration (`sourceDurationSeconds`), which overshoots the last real video sample whenever the audio
+    /// track runs a few frames longer or the container duration is rounded up; the video renderer then
+    /// has no frame for the last fraction of a second, AVPlayer parks in WaitingToMinimizeStalls, never
+    /// fires didPlayToEndTime, and after ~43 s dies with CoreMediaErrorDomain -12889.
+    ///
+    /// The `loadedEnd` guard is the discriminator against a still-downloading final segment: a playhead
+    /// within the end epsilon but with the media loaded well short of `duration` is a recoverable network
+    /// stall, NOT exhausted video, and must be left to the stall/reload recovery. A live source, an
+    /// actually-playing item, a deliberate pause (not waiting-to-play), and a mid-stream position all fail
+    /// the guards above.
+    nonisolated static func endOfMediaParkTickQualifies(
+        isLive: Bool,
+        duration: Double,
+        playhead: Double,
+        loadedEnd: Double,
+        waitingToPlay: Bool,
+        minimizingStalls: Bool
+    ) -> Bool {
+        guard !isLive, duration > 0 else { return false }
+        guard waitingToPlay, minimizingStalls else { return false }
+        guard isAtEndOfMedia(currentTime: playhead, duration: duration, isLive: isLive) else { return false }
+        return loadedEnd >= duration - endOfMediaEpsilonSeconds
+    }
+
+    /// Rolling count of consecutive 1 Hz native ticks whose tail-park conditions held with a frozen
+    /// playhead. Resets to zero the instant a tick stops qualifying or the playhead advances, so a
+    /// momentary near-end buffering blip that then resumes never accumulates toward completion.
+    nonisolated static func endOfMediaParkFrozenTicks(
+        previous: Int,
+        tickQualifies: Bool,
+        playheadFrozen: Bool
+    ) -> Int {
+        (tickQualifies && playheadFrozen) ? previous + 1 : 0
+    }
+
+    /// Grace before synthesizing end-of-media from a tail park (AetherEngine#169): the park must persist
+    /// this many consecutive 1 Hz ticks so a transient near-end stall that self-recovers is never cut
+    /// short. Three ticks (~3 s) still finishes far faster than the ~43 s AVPlayer takes to surface -12889.
+    nonisolated static let endOfMediaParkGraceTicks: Int = 3
+
+    /// Synthesize organic end-of-media once the tail park has persisted past the grace window.
+    nonisolated static func shouldSynthesizeEndOfMediaFromPark(frozenTicks: Int) -> Bool {
+        frozenTicks >= endOfMediaParkGraceTicks
+    }
+
+    /// Complete a native VOD that parked a hair short of its advertised duration because the final
+    /// segment's video is exhausted (AetherEngine#169): the final segment's EXTINF, derived from the
+    /// container duration, overshoots the last real video sample, so AVPlayer sits in
+    /// WaitingToMinimizeStalls a few frames from the end, never fires didPlayToEndTime, and after ~43 s
+    /// dies with -12889. Fires organic end-of-media through the host's `didReachEnd` so the session
+    /// finishes cleanly (`.ended` -> mark-watched / autoplay-next / dismiss) instead of hanging then
+    /// erroring. The tail numbers are logged so a field trace confirms the mechanism (video ends short
+    /// of the container duration the final EXTINF was built from). Driven from the 1 Hz native tick.
+    @MainActor
+    func synthesizeEndOfMediaFromTailPark(playhead: Double, loadedEnd: Double) {
+        EngineLog.emit(
+            "[AetherEngine] #169 tail park: playhead=\(String(format: "%.3f", playhead))s "
+            + "duration=\(String(format: "%.3f", duration))s loadedEnd=\(String(format: "%.3f", loadedEnd))s; "
+            + "final-segment video exhausted within \(String(format: "%.2f", Self.endOfMediaEpsilonSeconds))s "
+            + "of duration, synthesizing end-of-media",
+            category: .engine)
+        nativeHost?.markEndOfMediaReached()
+    }
+
     /// A VOD seek whose target lands at end-of-media parks at the final frame (AetherEngine#164): it is
     /// not playing, but it is NOT the terminal `.ended` state either. `.ended` (organic completion, #63)
     /// fires the host's end-of-playback handling (mark-watched / autoplay-next / dismiss) and is reserved

--- a/Sources/AetherEngine/AetherEngine.swift
+++ b/Sources/AetherEngine/AetherEngine.swift
@@ -1099,6 +1099,7 @@ public final class AetherEngine: ObservableObject {
         defer { host.startupReadinessGateActive = false }
 
         var attempt = 1
+        var dataWaitRounds = 0
         while true {
             // Attempt 1 plays the item the load path already created; later attempts replay it fresh.
             host.play()
@@ -1112,10 +1113,25 @@ public final class AetherEngine: ObservableObject {
                 outcome: outcome,
                 attempt: attempt,
                 masterAlreadyFellBack: masterFallbackUsed,
-                hasMediaFallbackURL: session.mediaPlaylistURL != nil
+                hasMediaFallbackURL: session.mediaPlaylistURL != nil,
+                dataWaitRounds: dataWaitRounds
             ) {
             case .proceed:
                 return
+
+            case .keepAwaitingData:
+                // #169: the master's first segment (a tail resume anchors it on the final segment) has
+                // not been served yet because it is still being produced over a slow link. That is not a
+                // cold DV/HDCP decode failure; keep the DV master and re-await the SAME item rather than
+                // reloading and falling back to the media playlist (which would needlessly drop DV).
+                dataWaitRounds += 1
+                EngineLog.emit(
+                    "[AetherEngine] #35/#169 readiness gate: master's first segment not served yet "
+                    + "(still producing over a slow link); keeping the DV master and waiting "
+                    + "(data-wait \(dataWaitRounds)/\(StartupReadinessGate.maxDataWaitRounds)) at "
+                    + "\(String(format: "%.2f", position))s",
+                    category: .session)
+                continue
 
             case .reloadMaster:
                 guard let masterURL = session.masterPlaylistURL else {

--- a/Sources/AetherEngine/Diagnostics/LiveTelemetrySampler.swift
+++ b/Sources/AetherEngine/Diagnostics/LiveTelemetrySampler.swift
@@ -46,6 +46,10 @@ struct NativeAVFReadings: Sendable {
     var networkThroughputMbps: Double? = nil
     var networkTransferredBytes: Int64? = nil
     var forwardBufferSeconds: Double? = nil
+    /// Raw (unclamped) loaded-range end, for the #169 tail-park loadedEnd guard. On a resume/seek into
+    /// the tail the playhead jumps ahead of loaded media, so the clamped `forwardBufferSeconds` (>= 0)
+    /// hides that the final segment has not arrived; the decision needs the true loaded end vs duration.
+    var loadedRangeEndSeconds: Double? = nil
     /// Sum over all access-log events, for the [LagDiag] tick-over-tick drop delta.
     var droppedFramesLifetimeSum: Int = 0
     var currentTimeSeconds: Double = .nan
@@ -87,6 +91,15 @@ final class LiveTelemetrySampler {
     private var lagLastClock: Double?
     private var lagLastDroppedSum: Int = 0
 
+    /// #169 tail-park end-of-media synthesis state.
+    private var eomParkFrozenTicks: Int = 0
+    private var eomParkLastPlayhead: Double?
+    private var didSynthesizeEomPark = false
+
+    /// A playhead moving less than this between 1 Hz ticks is "frozen" for #169 (well under a single
+    /// 23.976 fps frame of ~42 ms of legitimate forward progress).
+    private static let eomParkFrozenEpsilonSeconds: Double = 0.05
+
     init(engine: AetherEngine, nativeRead: @escaping NativeRead = LiveTelemetrySampler.batchReadNativeAVF) {
         self.engine = engine
         self.nativeRead = nativeRead
@@ -105,6 +118,9 @@ final class LiveTelemetrySampler {
         sessionStartBytes = 0
         lagLastClock = nil
         lagLastDroppedSum = 0
+        eomParkFrozenTicks = 0
+        eomParkLastPlayhead = nil
+        didSynthesizeEomPark = false
         task = Task { @MainActor [weak self] in
             while !Task.isCancelled {
                 await self?.tick()
@@ -225,6 +241,7 @@ final class LiveTelemetrySampler {
 
         if let readings = nativeReadings {
             emitLagDiag(engine: engine, readings: readings, netMbps: instantBitrateMbps)
+            evaluateEndOfMediaPark(engine: engine, readings: readings)
         }
 
         let snapshot = LiveTelemetry(
@@ -292,6 +309,37 @@ final class LiveTelemetrySampler {
         )
     }
 
+    /// Grace-thresholded synthesis of organic end-of-media when a native VOD parks a hair short of its
+    /// advertised duration with the final segment loaded (AetherEngine#169: the final segment's EXTINF,
+    /// derived from the container duration, overshoots the last real video sample, so AVPlayer sits in
+    /// WaitingToMinimizeStalls a few frames from the end and never fires didPlayToEndTime). Reuses the
+    /// already-read native batch; owns no AVFoundation reads of its own. Fires at most once per session.
+    private func evaluateEndOfMediaPark(engine: AetherEngine, readings: NativeAVFReadings) {
+        guard !didSynthesizeEomPark else { return }
+        let playhead = readings.currentTimeSeconds
+        guard playhead.isFinite else { eomParkFrozenTicks = 0; return }
+        let waitingToPlay = readings.timeControlStatus == .waitingToPlayAtSpecifiedRate
+        let minimizingStalls = readings.reasonForWaitingToPlay == AVPlayer.WaitingReason.toMinimizeStalls.rawValue
+        // Raw loaded end; on a resume/seek into the tail the playhead runs ahead of loaded media, so
+        // default to the playhead (loadedEnd == playhead) which fails the final-segment-loaded guard.
+        let loadedEnd = readings.loadedRangeEndSeconds ?? playhead
+        let qualifies = AetherEngine.endOfMediaParkTickQualifies(
+            isLive: engine.isLive,
+            duration: engine.duration,
+            playhead: playhead,
+            loadedEnd: loadedEnd,
+            waitingToPlay: waitingToPlay,
+            minimizingStalls: minimizingStalls)
+        let frozen = eomParkLastPlayhead.map { abs(playhead - $0) < Self.eomParkFrozenEpsilonSeconds } ?? false
+        eomParkLastPlayhead = playhead
+        eomParkFrozenTicks = AetherEngine.endOfMediaParkFrozenTicks(
+            previous: eomParkFrozenTicks, tickQualifies: qualifies, playheadFrozen: frozen)
+        if AetherEngine.shouldSynthesizeEndOfMediaFromPark(frozenTicks: eomParkFrozenTicks) {
+            didSynthesizeEomPark = true
+            engine.synthesizeEndOfMediaFromTailPark(playhead: playhead, loadedEnd: loadedEnd)
+        }
+    }
+
     /// Hops the AVFoundation batch onto the dedicated read queue and back. The main actor only
     /// suspends here; a stalled mediaserverd reply parks a GCD thread, not the main thread.
     private func readNativeOffMain(player: AVPlayer, item: AVPlayerItem) async -> NativeAVFReadings {
@@ -322,8 +370,11 @@ final class LiveTelemetrySampler {
         readings.currentTimeSeconds = now
         if let last = item.loadedTimeRanges.last?.timeRangeValue {
             let end = CMTimeGetSeconds(CMTimeAdd(last.start, last.duration))
-            if end.isFinite, now.isFinite {
-                readings.forwardBufferSeconds = max(0, end - now)
+            if end.isFinite {
+                readings.loadedRangeEndSeconds = end
+                if now.isFinite {
+                    readings.forwardBufferSeconds = max(0, end - now)
+                }
             }
         }
 

--- a/Sources/AetherEngine/Native/NativeAVPlayerHost.swift
+++ b/Sources/AetherEngine/Native/NativeAVPlayerHost.swift
@@ -608,7 +608,20 @@ final class NativeAVPlayerHost {
             try? await Task.sleep(nanoseconds: tickMs * 1_000_000)
         }
         if let item = playerItem, hasEverPlayed || item.presentationSize != .zero { return .ready }
-        return .timedOut
+        // #169: distinguish an unserved first segment (no media loaded -> still producing over a slow
+        // link, keep waiting) from a served-but-0-tracks master (the cold DV/HDCP decode park).
+        let loaded = playerItem.map { Self.hasLoadedMedia($0.loadedTimeRanges) } ?? false
+        return StartupReadinessGate.timeoutOutcome(hasLoadedMedia: loaded)
+    }
+
+    /// True when the item has any positive-duration loaded range: real media has been served (vs a fresh
+    /// item whose first segment is still being produced). Drives the #169 awaitingData split.
+    nonisolated static func hasLoadedMedia(_ loadedTimeRanges: [NSValue]) -> Bool {
+        for value in loadedTimeRanges {
+            let d = value.timeRangeValue.duration.seconds
+            if d.isFinite && d > 0 { return true }
+        }
+        return false
     }
 
     // MARK: - Playback control

--- a/Sources/AetherEngine/Native/NativeAVPlayerHost.swift
+++ b/Sources/AetherEngine/Native/NativeAVPlayerHost.swift
@@ -667,6 +667,17 @@ final class NativeAVPlayerHost {
         avPlayer.pause()
     }
 
+    /// Synthesize organic end-of-media when the engine determines a tail park is video-exhaustion
+    /// (AetherEngine#169), not a recoverable stall. Sets the same `didReachEnd` the real
+    /// didPlayToEndTime observer sets, so the engine transitions to `.ended` and the host's
+    /// end-of-playback handling (mark-watched / autoplay-next / dismiss) fires exactly as an organic
+    /// finish. Idempotent, and cleared per load in `unloadCurrentItem`.
+    func markEndOfMediaReached() {
+        guard !didReachEnd else { return }
+        EngineLog.emit("[NativeAVPlayerHost] #\(sessionID) synthesized end-of-media (tail park, #169)", category: .engine)
+        didReachEnd = true
+    }
+
     /// Resolve only when the seek physically lands (loopback source lands seeks seconds after the call; issue #37).
     /// seekInFlight suppresses the periodic observer across the wait; only the latest seekGeneration clears it.
     func seek(to seconds: Double) async {

--- a/Sources/AetherEngine/Native/StartupReadinessGate.swift
+++ b/Sources/AetherEngine/Native/StartupReadinessGate.swift
@@ -7,9 +7,16 @@ enum StartupReadiness: Sendable, Equatable {
     case ready
     /// `item.status == .failed` (e.g. -11819 "Cannot Complete Action" / -11868 cold DV handshake).
     case dead
-    /// The settle window elapsed with the item neither ready nor failed: the silent 0-track park
-    /// (`AVPlayerWaitingWithNoItemToPlayReason`, `asset.tracks` empty).
+    /// The settle window elapsed with the item neither ready nor failed, but with media already loaded:
+    /// the silent 0-track park (`AVPlayerWaitingWithNoItemToPlayReason`, `asset.tracks` empty), i.e. the
+    /// cold DV/HDCP decode failure the gate was written for.
     case timedOut
+    /// The settle window elapsed with 0 tracks AND no media loaded yet: the master's first segment has
+    /// not been served, not a decode failure. Resuming into the tail (AetherEngine#169) anchors the
+    /// master on the final segment, still being produced over a slow link; treating this as a cold
+    /// failure would reload and fall back to the media playlist, needlessly dropping DV. The gate waits
+    /// for the first segment's data (bounded) before judging the master dead.
+    case awaitingData
 }
 
 /// Terminal failure thrown when the readiness gate exhausts the master budget and has no media
@@ -28,6 +35,9 @@ enum StartupGateAction: Sendable, Equatable {
     case reloadMaster
     /// Master is not recovering; reload the media playlist once (HDR10 base, no DV upgrade).
     case fallBackToMedia
+    /// The first segment has not been served yet (slow production over a slow link); keep the current
+    /// master and keep waiting rather than misreading unstarted production as a decode failure.
+    case keepAwaitingData
     /// Nothing left to try (no media URL, or already fell back); surface a terminal failure.
     case giveUp
 }
@@ -49,15 +59,36 @@ enum StartupReadinessGate {
     /// created; the remainder are fresh reloads that re-probe the warming link. Two total.
     static let masterAttempts = 2
 
+    /// How many consecutive `awaitingData` settle windows the gate rides while the first segment is still
+    /// being produced, before giving up and treating it as a cold failure. At `startupGateReloadSeconds`
+    /// (3 s) per round this is ~24 s of patience: comfortably longer than a slow-link final-segment
+    /// production (reopen + a ~4 s / ~12 MB fetch), yet bounded so a genuinely wedged producer still
+    /// falls through to reload/fallback instead of waiting forever.
+    static let maxDataWaitRounds = 8
+
+    /// Classify a settle-window timeout: no media loaded means the first segment has not been served
+    /// (slow production, `awaitingData`); media loaded but still 0 tracks is the cold decode park
+    /// (`timedOut`).
+    static func timeoutOutcome(hasLoadedMedia: Bool) -> StartupReadiness {
+        hasLoadedMedia ? .timedOut : .awaitingData
+    }
+
     /// Decide the next action after `attempt` master attempts (1-based) produced `outcome`.
+    /// `dataWaitRounds` counts the consecutive `awaitingData` windows already ridden this gate run.
     static func nextAction(
         outcome: StartupReadiness,
         attempt: Int,
         masterAttempts: Int = masterAttempts,
         masterAlreadyFellBack: Bool,
-        hasMediaFallbackURL: Bool
+        hasMediaFallbackURL: Bool,
+        dataWaitRounds: Int = 0,
+        maxDataWaitRounds: Int = maxDataWaitRounds
     ) -> StartupGateAction {
         if outcome == .ready { return .proceed }
+        // First segment not served yet: keep the current master (DV preserved) and keep waiting, bounded
+        // by the data-wait budget. Only once the budget is spent does an unstarted first segment fall
+        // through to the cold-failure reload/fallback below (a genuinely wedged producer still terminates).
+        if outcome == .awaitingData && dataWaitRounds < maxDataWaitRounds { return .keepAwaitingData }
         if attempt < masterAttempts { return .reloadMaster }
         if !masterAlreadyFellBack && hasMediaFallbackURL { return .fallBackToMedia }
         return .giveUp

--- a/Tests/AetherEngineTests/NearEndOfMediaParkTests.swift
+++ b/Tests/AetherEngineTests/NearEndOfMediaParkTests.swift
@@ -1,0 +1,129 @@
+// End-of-media tail-park completion (AetherEngine#169).
+//
+// A long loopback-HLS VOD's FINAL segment advertises an EXTINF derived from the container duration
+// (`sourceDurationSeconds`), which overshoots the last real video sample when the audio track runs a
+// few frames longer or the container duration is rounded up. The final segment serves and plays, but
+// the video renderer has no frame for the last fraction of a second, so AVPlayer parks in
+// WaitingToMinimizeStalls ~0.1 s from the advertised end, never fires didPlayToEndTime, and after ~43 s
+// dies with CoreMediaErrorDomain -12889. The engine detects this tail park from its 1 Hz native tick
+// and synthesizes organic end-of-media so the session finishes cleanly (mark-watched / autoplay-next)
+// instead of hanging then erroring.
+//
+// These pure cases pin the discriminator: a genuine video-exhausted tail (final segment loaded to the
+// end, playhead frozen a hair short of duration, waiting to minimize stalls) qualifies; a live source,
+// an actually-playing item, a deliberate pause, a mid-stream position, or an unfinished final-segment
+// download (loadedEnd short of duration = a recoverable network stall) do NOT.
+import Foundation
+import Testing
+@testable import AetherEngine
+
+@Suite("End-of-media tail park (#169)")
+struct NearEndOfMediaParkTests {
+
+    // The reporter's exact shape: 48-min DV title, engine.duration 2881.3, park at 2881.202, final
+    // segment loaded right to the advertised end.
+    let duration = 2881.3
+    let parkPlayhead = 2881.202
+    let loadedToEnd = 2881.3
+
+    @Test("A video-exhausted tail park with the final segment fully loaded qualifies")
+    func qualifiesOnExhaustedTail() {
+        #expect(AetherEngine.endOfMediaParkTickQualifies(
+            isLive: false,
+            duration: duration,
+            playhead: parkPlayhead,
+            loadedEnd: loadedToEnd,
+            waitingToPlay: true,
+            minimizingStalls: true))
+    }
+
+    @Test("A live source never qualifies (no fixed end to reach)")
+    func liveNeverQualifies() {
+        #expect(!AetherEngine.endOfMediaParkTickQualifies(
+            isLive: true,
+            duration: duration,
+            playhead: parkPlayhead,
+            loadedEnd: loadedToEnd,
+            waitingToPlay: true,
+            minimizingStalls: true))
+    }
+
+    @Test("An actually-playing item does not qualify")
+    func playingDoesNotQualify() {
+        #expect(!AetherEngine.endOfMediaParkTickQualifies(
+            isLive: false,
+            duration: duration,
+            playhead: parkPlayhead,
+            loadedEnd: loadedToEnd,
+            waitingToPlay: false,
+            minimizingStalls: false))
+    }
+
+    @Test("Waiting for a reason other than minimizing stalls does not qualify")
+    func otherWaitReasonDoesNotQualify() {
+        // e.g. WaitingWhileEvaluatingBufferingRate / no-item-to-play: not the exhausted-video signature.
+        #expect(!AetherEngine.endOfMediaParkTickQualifies(
+            isLive: false,
+            duration: duration,
+            playhead: parkPlayhead,
+            loadedEnd: loadedToEnd,
+            waitingToPlay: true,
+            minimizingStalls: false))
+    }
+
+    @Test("A mid-stream park (playhead far from the end) does not qualify")
+    func midStreamDoesNotQualify() {
+        // Symptom 2's resume-into-tail lands at 2878.5, ~2.8 s from the end: outside the end-of-media
+        // epsilon, so tail completion must not fire (that path needs producer/readiness handling).
+        #expect(!AetherEngine.endOfMediaParkTickQualifies(
+            isLive: false,
+            duration: duration,
+            playhead: 2878.5,
+            loadedEnd: 2877.5,
+            waitingToPlay: true,
+            minimizingStalls: true))
+    }
+
+    @Test("An unfinished final-segment download (loadedEnd short of duration) does not qualify")
+    func unloadedTailDoesNotQualify() {
+        // Resume/seek into the tail (Symptom 2): AVPlayer's currentTime jumps to the target (2881.0,
+        // within the end epsilon) before the final segment downloads, so the raw loaded range still ends
+        // at the previous boundary (~2877.5). That is a recoverable download-in-progress, not exhausted
+        // video; leaving it lets the producer/readiness path serve the final segment.
+        #expect(!AetherEngine.endOfMediaParkTickQualifies(
+            isLive: false,
+            duration: duration,
+            playhead: 2881.0,
+            loadedEnd: 2877.5,   // final segment not yet loaded; well short of duration - 0.5
+            waitingToPlay: true,
+            minimizingStalls: true))
+    }
+
+    @Test("Frozen-tick count accumulates only while a qualifying tick keeps a frozen playhead")
+    func frozenTicksAccumulate() {
+        var ticks = 0
+        // Three consecutive qualifying, frozen ticks.
+        ticks = AetherEngine.endOfMediaParkFrozenTicks(previous: ticks, tickQualifies: true, playheadFrozen: true)
+        #expect(ticks == 1)
+        ticks = AetherEngine.endOfMediaParkFrozenTicks(previous: ticks, tickQualifies: true, playheadFrozen: true)
+        #expect(ticks == 2)
+        ticks = AetherEngine.endOfMediaParkFrozenTicks(previous: ticks, tickQualifies: true, playheadFrozen: true)
+        #expect(ticks == 3)
+    }
+
+    @Test("The frozen-tick count resets when a tick stops qualifying or the playhead advances")
+    func frozenTicksReset() {
+        // A momentary near-end stall that then resumes (playhead advances) must not accumulate.
+        #expect(AetherEngine.endOfMediaParkFrozenTicks(previous: 2, tickQualifies: true, playheadFrozen: false) == 0)
+        // Conditions no longer hold (e.g. recovered to playing).
+        #expect(AetherEngine.endOfMediaParkFrozenTicks(previous: 2, tickQualifies: false, playheadFrozen: true) == 0)
+    }
+
+    @Test("End-of-media is synthesized only after the grace threshold of frozen ticks")
+    func synthesizesAfterGrace() {
+        #expect(!AetherEngine.shouldSynthesizeEndOfMediaFromPark(frozenTicks: 0))
+        #expect(!AetherEngine.shouldSynthesizeEndOfMediaFromPark(frozenTicks: AetherEngine.endOfMediaParkGraceTicks - 1))
+        #expect(AetherEngine.shouldSynthesizeEndOfMediaFromPark(frozenTicks: AetherEngine.endOfMediaParkGraceTicks))
+        #expect(AetherEngine.shouldSynthesizeEndOfMediaFromPark(frozenTicks: AetherEngine.endOfMediaParkGraceTicks + 1))
+    }
+}

--- a/Tests/AetherEngineTests/StartupReadinessGateTests.swift
+++ b/Tests/AetherEngineTests/StartupReadinessGateTests.swift
@@ -57,4 +57,43 @@ struct StartupReadinessGateTests {
                 masterAlreadyFellBack: false, hasMediaFallbackURL: true) == .fallBackToMedia)
         }
     }
+
+    // #169 Symptom 2: resuming into the tail anchors the master on the final segment, which is still
+    // being produced over a slow link, so awaitStartupReadiness times out with NO media loaded. That is
+    // not the cold DV/HDCP decode failure the gate was written for; reloading and falling back needlessly
+    // drops DV. The gate must wait for the first segment's data before judging the master dead.
+
+    @Test("An unstarted first segment (no data loaded yet) keeps awaiting instead of dropping DV")
+    func awaitsFirstSegmentBeforeFailingMaster() {
+        #expect(StartupReadinessGate.nextAction(
+            outcome: .awaitingData, attempt: 1, masterAttempts: 2,
+            masterAlreadyFellBack: false, hasMediaFallbackURL: true,
+            dataWaitRounds: 0) == .keepAwaitingData)
+        // Even at the last master attempt, it must not drop DV while data has never arrived.
+        #expect(StartupReadinessGate.nextAction(
+            outcome: .awaitingData, attempt: 2, masterAttempts: 2,
+            masterAlreadyFellBack: false, hasMediaFallbackURL: true,
+            dataWaitRounds: StartupReadinessGate.maxDataWaitRounds - 1) == .keepAwaitingData)
+    }
+
+    @Test("A first segment that never arrives falls through so a stuck producer still terminates")
+    func awaitingDataIsBounded() {
+        // Data-wait budget exhausted: fall through to the normal cold-failure logic (reload, then fallback).
+        #expect(StartupReadinessGate.nextAction(
+            outcome: .awaitingData, attempt: 1, masterAttempts: 2,
+            masterAlreadyFellBack: false, hasMediaFallbackURL: true,
+            dataWaitRounds: StartupReadinessGate.maxDataWaitRounds) == .reloadMaster)
+        #expect(StartupReadinessGate.nextAction(
+            outcome: .awaitingData, attempt: 2, masterAttempts: 2,
+            masterAlreadyFellBack: false, hasMediaFallbackURL: true,
+            dataWaitRounds: StartupReadinessGate.maxDataWaitRounds) == .fallBackToMedia)
+    }
+
+    @Test("The timeout outcome distinguishes an unserved first segment from a served-but-dead master")
+    func timeoutOutcomeSplitsOnLoadedMedia() {
+        // No media loaded when the window elapses: the first segment has not been served (slow production).
+        #expect(StartupReadinessGate.timeoutOutcome(hasLoadedMedia: false) == .awaitingData)
+        // Media loaded but still 0 tracks: the cold DV/HDCP decode failure the gate was written for.
+        #expect(StartupReadinessGate.timeoutOutcome(hasLoadedMedia: true) == .timedOut)
+    }
 }


### PR DESCRIPTION
Fixes both symptoms rrgomes reported in #169 (long 4K DV P8.1 loopback-HLS VOD, slow tvOS WAN link).

---

## Symptom 1: final segment never finishes at EOM → -12889

AVPlayer parks ~0.1s from the end in `WaitingToMinimizeStalls`, never fires `didPlayToEndTime`, and after ~43s dies with `-12889`. Reporter's shape: `duration=2881.3`, park at `2881.202`, `loaded=[2844.8-2881.3]`.

**Root cause (code-traced).** The final segment is produced and served fine (playback reaches 2881.202), so it is not missing. The final segment's advertised EXTINF is derived from the container duration (`sourceDurationSeconds`, `HLSVideoEngine+SegmentPlanning.swift:139`); the muxer writes the final video sample at EOF with only its one-frame duration (`resolveVideoSampleDuration`, `nextDts: nil`). When the container duration overshoots the last real video sample (audio a few frames longer, or a rounded-up MKV `Duration`), the **video track underfills the advertised segment by ~0.1s**. The video renderer parks waiting for frames that never existed while `loaded=[..2881.3]` (audio + segment map) reports full buffering.

**Fix.** The engine detects this tail park from its existing 1 Hz native tick (`LiveTelemetrySampler`) and synthesizes organic end-of-media, so the session finishes cleanly (`.ended` → mark-watched / autoplay-next / dismiss) after a ~3s grace instead of hanging then erroring at ~43s. Tight, all pure/tested discriminator: VOD only, playhead within `endOfMediaEpsilonSeconds` of duration, final segment loaded to the end (**raw** `loadedTimeRanges` end), `WaitingToMinimizeStalls`, frozen playhead held for a 3-tick grace.

Padding the final video sample to fill the EXTINF was rejected: the EOF-flushed packet is the last in **decode** order, not presentation order, so it would corrupt a B-frame tail. Completing at the honest video-exhaustion point is robust regardless of whether the video genuinely ends short or the tail dropped frames.

## Symptom 2: resume into the tail can't start a master (DV dropped)

Resuming at ~2878.5s, the #35 readiness gate reports "master never produced tracks", reloads, times out again, and degrades master → reduced master → media playlist, **dropping Dolby Vision**, then stalls anyway (`loaded=[2862.7-2877.5]`).

**Root cause.** A tail resume anchors the master on the final segment, still being produced over the slow link, so `awaitStartupReadiness` times out with 0 tracks and **no media loaded**. The gate (written for the cold DV/HDCP decode failure) misread unstarted production as a decode failure and burned the master→fallback chain, dropping DV needlessly. The gate was diagnosing "master failed" before it even had segment data to decode.

**Fix.** The gate splits a settle-window timeout by whether any media loaded: no media = first segment not served yet (`awaitingData`) → keep the DV master and re-await, bounded by `maxDataWaitRounds` (~24s, comfortably longer than a slow-link final-segment production); media loaded but 0 tracks = the real cold-decode park (`timedOut`) → reload/fallback chain unchanged. A genuinely wedged producer still falls through once the data-wait budget is spent, so it can never hang forever.

---

## Verification

- `NearEndOfMediaParkTests` (9) + `StartupReadinessGateTests` (+3), all TDD red→green.
- Full suite: **872 tests pass** (was 860). Existing `LiveTelemetrySamplerTests` / `StartupReadinessGateTests` still green.
- `swift build` clean; `xcodebuild` tvOS + iOS Simulator **BUILD SUCCEEDED** (Swift 6 mode = complete concurrency).

## Diagnostics for the reporter

Symptom 1 logs `[AetherEngine] #169 tail park: playhead=... duration=... loadedEnd=...` on completion (confirms video ends short of the container duration). Symptom 2 logs `[AetherEngine] #35/#169 readiness gate: master's first segment not served yet ... keeping the DV master and waiting (data-wait N/8)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NAPCg4tCDdSqkK6tPkNptw
