### PR TITLE
fix(hls): reroute live remote-HLS onto the ingest path when video carriage is rejected (#168)

### DIFF
--- a/Sources/AetherEngine/AetherEngine+Loading.swift
+++ b/Sources/AetherEngine/AetherEngine+Loading.swift
@@ -132,6 +132,8 @@ extension AetherEngine {
     /// the historical no-initial-seek behavior every live caller relies on.
     func loadRemoteHLS(url: URL, options: LoadOptions, startPosition: Double? = nil) async throws {
         playbackBackend = .native
+        // #168 follow-up: detect a superseding load()/stop() between the carriage verdict and the reroute.
+        let bypassGeneration = loadGeneration
 
         let host: NativeAVPlayerHost
         if let existing = nativeHost {
@@ -192,6 +194,19 @@ extension AetherEngine {
                 self.applyRemoteHLSDisplayCriteria(format: fmt, options: options)
             }
             .store(in: &nativeCancellables)
+        // #168 follow-up: an advertised video rendition that never builds an item track means HEVC carried
+        // in MPEG-TS segments, which AVFoundation's HLS demuxer does not support (audio-only, black). The
+        // loopback ingest remuxes TS to fMP4 and plays the same stream, so reroute there transparently.
+        host.$remoteHLSVideoCarriageRejected
+            .filter { $0 }
+            .prefix(1)
+            .sink { [weak self] _ in
+                guard let self else { return }
+                Task { @MainActor in
+                    await self.rerouteRemoteHLSOntoLiveIngest(url: url, expectedGeneration: bypassGeneration)
+                }
+            }
+            .store(in: &nativeCancellables)
         startLiveWindowTimer(host: host)
         // settlePausedAtReadiness off when autostarting: the terminal host.play() runs, so readyToPlay is only a waypoint. Flipping to .paused here would drop the spinner during Jellyfin's ~10 s transcode spin-up. timeControlStatus sink holds .loading until AVPlayer renders.
         // #124: a paused mount (autoplay=false) skips that play(), so the readiness sink settles .loading -> .paused.
@@ -241,7 +256,11 @@ extension AetherEngine {
                   // This lean path has no live-reopen / readiness watchdog; let AVPlayer's "gave up"
                   // signal surface a dead upstream (segment 404 / token expiry) so the host can retune.
                   surfaceEndFailures: true,
-                  httpHeaders: options.httpHeaders)
+                  httpHeaders: options.httpHeaders,
+                  // #168 follow-up: live-only (VOD remote HLS is the AE#154 reroute target; ingesting it
+                  // back would ping-pong), and hosts can opt out via LoadOptions.
+                  armVideoCarriageWatchdog: RemoteHLSIngestFallback.shouldArm(
+                      isLive: options.isLive, fallbackEnabled: options.nativeRemoteHLSIngestFallback))
 
         // AE#154: surface the item's legible AVMediaSelectionGroup as `subtitleTracks` so hosts with
         // their own picker see the external WebVTT renditions AVPlayer renders on this bypass.
@@ -274,6 +293,35 @@ extension AetherEngine {
             codecTag: nil,
             omitColorExtensions: options.omitCriteriaColorExtensions
         )
+    }
+
+    /// AetherEngine#168 follow-up: reload the current live remote-HLS source through the loopback ingest
+    /// path (`HLSLiveIngestReader` remuxes TS to fMP4), because AVPlayer reached readyToPlay without ever
+    /// building a video track for a master that advertises one (HEVC-in-MPEG-TS carriage). The rerouted
+    /// session runs the full loopback pipeline, including the probe-time display-criteria handshake the
+    /// bypass lacks. `LoadOptions.httpHeaders` ride onto the ingest fetches so header-enforcing origins
+    /// keep working (#119). The generation guard drops a verdict that a newer load()/stop() has outrun.
+    @MainActor
+    private func rerouteRemoteHLSOntoLiveIngest(url: URL, expectedGeneration: UInt64) async {
+        guard loadGeneration == expectedGeneration else {
+            EngineLog.emit("[AetherEngine] #168: ingest reroute dropped (session superseded)", category: .engine)
+            return
+        }
+        EngineLog.emit(
+            "[AetherEngine] #168: nativeRemoteHLS built no video track for a master that advertises video; "
+            + "rerouting onto the live-ingest loopback path (TS -> fMP4 remux)",
+            category: .engine
+        )
+        var options = loadedOptions
+        options.nativeRemoteHLS = false
+        let reader = HLSLiveIngestReader(playlistURL: url, httpHeaders: options.httpHeaders)
+        do {
+            _ = try await load(source: .custom(reader, formatHint: "mpegts"), options: options)
+        } catch is CancellationError {
+        } catch {
+            // load() has already surfaced .error state on its failure paths; nothing to add here.
+            EngineLog.emit("[AetherEngine] #168: ingest reroute load failed: \(error)", category: .engine)
+        }
     }
 
     func loadNative(

--- a/Sources/AetherEngine/IO/HLSIngest/HLSLiveIngestReader.swift
+++ b/Sources/AetherEngine/IO/HLSIngest/HLSLiveIngestReader.swift
@@ -17,6 +17,7 @@ public final class HLSLiveIngestReader: IOReader, LiveIngestSourceInfo, @uncheck
     }
 
     private let playlistURL: URL
+    private let httpHeaders: [String: String]
     private let role: Role
     private let fifo = ByteFIFO(capacity: 16 * 1024 * 1024)
     private let session: URLSession
@@ -96,11 +97,19 @@ public final class HLSLiveIngestReader: IOReader, LiveIngestSourceInfo, @uncheck
     }
 
     public convenience init(playlistURL: URL) {
-        self.init(playlistURL: playlistURL, role: .mainVideo)
+        self.init(playlistURL: playlistURL, httpHeaders: [:], role: .mainVideo)
     }
 
-    init(playlistURL: URL, role: Role) {
+    /// `httpHeaders` ride on every fetch (playlist, segment, AES key) and inherit to the companion audio
+    /// reader, so header-enforcing IPTV origins (Referer / User-Agent / Authorization, #119) accept the
+    /// ingest the same way they accept the AVPlayer bypass (AetherEngine#168).
+    public convenience init(playlistURL: URL, httpHeaders: [String: String]) {
+        self.init(playlistURL: playlistURL, httpHeaders: httpHeaders, role: .mainVideo)
+    }
+
+    init(playlistURL: URL, httpHeaders: [String: String] = [:], role: Role) {
         self.playlistURL = playlistURL
+        self.httpHeaders = httpHeaders
         self.role = role
         let config = URLSessionConfiguration.ephemeral
         config.timeoutIntervalForRequest = 10
@@ -356,7 +365,7 @@ public final class HLSLiveIngestReader: IOReader, LiveIngestSourceInfo, @uncheck
                     + "starting companion reader on \(audioURL.lastPathComponent)",
                     category: .engine
                 )
-                installCompanion(HLSLiveIngestReader(playlistURL: audioURL, role: .companionAudio))
+                installCompanion(HLSLiveIngestReader(playlistURL: audioURL, httpHeaders: httpHeaders, role: .companionAudio))
             }
             EngineLog.emit("[HLSIngest] master playlist: picked variant bandwidth=\(best.bandwidth)", category: .engine)
             return (url, nil)
@@ -400,9 +409,18 @@ public final class HLSLiveIngestReader: IOReader, LiveIngestSourceInfo, @uncheck
         try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
     }
 
+    /// Applies the configured origin headers to every ingest fetch. Internal for the header-contract tests.
+    func makeRequest(_ url: URL) -> URLRequest {
+        var request = URLRequest(url: url)
+        for (field, value) in httpHeaders {
+            request.setValue(value, forHTTPHeaderField: field)
+        }
+        return request
+    }
+
     /// Fetch + parse a playlist. Returns parsed playlist and final URL after redirects (relative segment URIs resolve against it).
     private func fetchPlaylist(_ url: URL) async throws -> (HLSPlaylist, URL) {
-        let (data, response) = try await session.data(from: url)
+        let (data, response) = try await session.data(for: makeRequest(url))
         let status = (response as? HTTPURLResponse)?.statusCode ?? -1
         guard (200..<300).contains(status) else {
             throw HLSIngestError.playlistUnreachable(status: status)
@@ -418,7 +436,7 @@ public final class HLSLiveIngestReader: IOReader, LiveIngestSourceInfo, @uncheck
         for attempt in 0..<3 {
             if Task.isCancelled { throw CancellationError() }
             do {
-                let (data, response) = try await session.data(from: url)
+                let (data, response) = try await session.data(for: makeRequest(url))
                 lastStatus = (response as? HTTPURLResponse)?.statusCode ?? -1
                 if (200..<300).contains(lastStatus) { return data }
                 if lastStatus == 404 { return Data() } // slid out of provider window; tracker advances regardless
@@ -451,7 +469,7 @@ public final class HLSLiveIngestReader: IOReader, LiveIngestSourceInfo, @uncheck
         let cacheKey = url.absoluteString
         if let cached = keyCacheLock.withLock({ keyCache[cacheKey] }) { return cached }
 
-        let (data, response) = try await session.data(from: url)
+        let (data, response) = try await session.data(for: makeRequest(url))
         let status = (response as? HTTPURLResponse)?.statusCode ?? -1
         guard (200..<300).contains(status) else {
             throw HLSIngestError.segmentDecryptFailed(reason: "key fetch HTTP \(status)")

--- a/Sources/AetherEngine/Native/NativeAVPlayerHost.swift
+++ b/Sources/AetherEngine/Native/NativeAVPlayerHost.swift
@@ -56,6 +56,15 @@ final class NativeAVPlayerHost {
     /// Match Frame Rate (the reporter's 4K item is 50 fps). nil when no video track / rate resolves.
     @Published private(set) var detectedVideoFrameRate: Double?
 
+    /// AetherEngine#168 follow-up: fires once when the armed carriage watchdog concludes the master
+    /// advertises a video rendition but AVPlayer never built a video track past the grace window
+    /// (HEVC-in-MPEG-TS carriage, which AVFoundation's HLS demuxer does not support). The engine's
+    /// remote-HLS load subscribes and reroutes the session onto the loopback live-ingest path.
+    @Published private(set) var remoteHLSVideoCarriageRejected = false
+    /// Set per load; the watchdog itself starts at readyToPlay (a dead origin never reaches it).
+    private var carriageWatchdogArmed = false
+    private var carriageWatchdogTask: Task<Void, Never>?
+
     /// #35 (Sodalite) cold-DV-master startup-readiness gate. While the engine drives the bounded
     /// retry loop this is true, so a startup failure (`.failed` with any code, including a
     /// display-rejection) is NOT published: the gate polls `awaitStartupReadiness` and decides to
@@ -150,10 +159,11 @@ final class NativeAVPlayerHost {
     /// after an in-PiP recovery reload) and the pause bounces transport for nothing. The swap
     /// keeps transport intent, clocks and the old item alive until replaceCurrentItem hands
     /// AVPlayer the fresh one.
-    func load(url: URL, startPosition: Double?, perFrameHDR: Bool = true, skipInitialSeek: Bool = false, forwardBufferDuration: Double = 4.0, surfaceEndFailures: Bool = false, inPlaceSwap: Bool = false, httpHeaders: [String: String] = [:]) {
+    func load(url: URL, startPosition: Double?, perFrameHDR: Bool = true, skipInitialSeek: Bool = false, forwardBufferDuration: Double = 4.0, surfaceEndFailures: Bool = false, inPlaceSwap: Bool = false, httpHeaders: [String: String] = [:], armVideoCarriageWatchdog: Bool = false) {
         unloadCurrentItem(inPlaceSwap: inPlaceSwap)
 
         self.surfaceEndFailures = surfaceEndFailures
+        self.carriageWatchdogArmed = armVideoCarriageWatchdog
         Self.nextSessionID += 1
         sessionID = Self.nextSessionID
         let sid = sessionID
@@ -283,6 +293,11 @@ final class NativeAVPlayerHost {
                     }
                     // #168: publish the item's real dynamic range for the probe-free remote-HLS badge.
                     await self.publishDetectedVideoFormat(from: item)
+                    // #168 follow-up: watch for an advertised video rendition that never builds a track
+                    // (HEVC-in-MPEG-TS carriage); anchored at readyToPlay so dead origins never arm it.
+                    if self.carriageWatchdogArmed, self.carriageWatchdogTask == nil {
+                        self.startVideoCarriageWatchdog(item: item)
+                    }
                 case .failed:
                     let desc = item.error?.localizedDescription ?? "AVPlayerItem failed (no description)"
                     self.handleItemFailed(desc, item: item)
@@ -804,6 +819,11 @@ final class NativeAVPlayerHost {
         // #168: a reused host must not report the prior session's dynamic range before the new item resolves.
         detectedVideoFormat = nil
         detectedVideoFrameRate = nil
+        // #168 follow-up: the carriage verdict belongs to the outgoing item.
+        carriageWatchdogTask?.cancel()
+        carriageWatchdogTask = nil
+        carriageWatchdogArmed = false
+        remoteHLSVideoCarriageRejected = false
         // Re-arm #50 hasEverPlayed: reused host must not inherit prior session's established state.
         hasEverPlayed = false
         // #93 recovery reload: same content, same position, playback must continue. Skip the
@@ -891,6 +911,52 @@ final class NativeAVPlayerHost {
                 + "enabled=\(itemTrack.isEnabled)\(extra) (readyToPlay)",
                 category: .engine
             )
+        }
+    }
+
+    /// AetherEngine#168 follow-up: after readyToPlay, poll `item.tracks` at a 0.5 s cadence against the
+    /// pure `RemoteHLSIngestFallback.Watchdog`. Advertisement evidence comes from `AVURLAsset.variants`,
+    /// AVFoundation's own already-fetched master-playlist parse, so this adds no origin connect (IPTV
+    /// tokens / WAFs). Publishes `remoteHLSVideoCarriageRejected` once when an advertised video rendition
+    /// never builds an item track (HEVC-in-MPEG-TS carriage); every healthy or judgeless outcome disarms.
+    @MainActor
+    private func startVideoCarriageWatchdog(item: AVPlayerItem) {
+        let sid = sessionID
+        carriageWatchdogTask = Task { @MainActor [weak self] in
+            var watchdog = RemoteHLSIngestFallback.Watchdog()
+            let variants: [AVAssetVariant]
+            if let urlAsset = item.asset as? AVURLAsset {
+                variants = (try? await urlAsset.load(.variants)) ?? []
+            } else {
+                variants = []
+            }
+            let advertises = RemoteHLSIngestFallback.advertisesVideo(
+                variantHasVideoAttributes: variants.map { $0.videoAttributes != nil })
+            while !Task.isCancelled {
+                guard let self, self.playerItem === item else { return }
+                let videoTrackCount = item.tracks.filter { $0.assetTrack?.mediaType == .video }.count
+                switch watchdog.tick(videoTrackCount: videoTrackCount, variantsAdvertiseVideo: advertises) {
+                case .keepWaiting:
+                    break
+                case .disarm:
+                    EngineLog.emit(
+                        "[NativeAVPlayerHost] #\(sid) carriage watchdog disarmed "
+                        + "(videoTracks=\(videoTrackCount) advertised=\(advertises.map { "\($0)" } ?? "unknown"))",
+                        category: .engine
+                    )
+                    return
+                case .fire:
+                    EngineLog.emit(
+                        "[NativeAVPlayerHost] #\(sid) master advertises video "
+                        + "(\(variants.count) variant(s)) but AVPlayer built no video track after grace; "
+                        + "HEVC-in-MPEG-TS carriage suspected (#168)",
+                        category: .engine
+                    )
+                    self.remoteHLSVideoCarriageRejected = true
+                    return
+                }
+                try? await Task.sleep(nanoseconds: 500_000_000)
+            }
         }
     }
 

--- a/Sources/AetherEngine/Native/RemoteHLSIngestFallback.swift
+++ b/Sources/AetherEngine/Native/RemoteHLSIngestFallback.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+/// AetherEngine#168 follow-up: AVFoundation's HLS demuxer builds video tracks for HEVC only from fMP4
+/// carriage (HLS Authoring Spec); a master that advertises hvc1/hev1 but delivers MPEG-TS segments
+/// reaches readyToPlay with audio only and never creates a video track, so the picture stays black and
+/// there is no CMFormatDescription for the #168 range detection to read. The loopback ingest path
+/// (HLSLiveIngestReader -> HLSVideoEngine) remuxes TS to fMP4 and plays the same stream, so the engine
+/// reroutes a live `nativeRemoteHLS` session there when this signature is detected.
+///
+/// Pure decision logic; the timing loop and AVFoundation reads live in NativeAVPlayerHost.
+enum RemoteHLSIngestFallback {
+
+    enum Verdict: Equatable {
+        /// No verdict yet; poll again after the tick cadence.
+        case keepWaiting
+        /// Healthy or legitimately video-free session; stop watching.
+        case disarm
+        /// Advertised video never built a track; reroute onto the live-ingest path.
+        case fire
+    }
+
+    /// Per-tick state machine, armed once the item reaches readyToPlay (a dead origin never gets there,
+    /// so it can never misfire on a stream that served nothing at all). Fires only on positive evidence:
+    /// the master advertised a video rendition and AVPlayer still built no video track after the grace.
+    /// `variantsAdvertiseVideo` nil = no master-level evidence (media-playlist-direct URL or variants not
+    /// resolved yet); after the grace that disarms rather than fires, so audio-only sources whose masters
+    /// we cannot judge keep their working AVPlayer session.
+    struct Watchdog {
+        let graceTicks: Int
+        private(set) var ticksObserved = 0
+
+        /// 8 ticks at the host's 0.5 s cadence = 4 s past readyToPlay, comfortably beyond the late
+        /// video-track builds seen on slow origins while keeping the black interval short.
+        init(graceTicks: Int = 8) {
+            self.graceTicks = graceTicks
+        }
+
+        mutating func tick(videoTrackCount: Int, variantsAdvertiseVideo: Bool?) -> Verdict {
+            if videoTrackCount > 0 { return .disarm }
+            if variantsAdvertiseVideo == false { return .disarm }
+            ticksObserved += 1
+            guard ticksObserved >= graceTicks else { return .keepWaiting }
+            return variantsAdvertiseVideo == true ? .fire : .disarm
+        }
+    }
+
+    /// Maps `AVAssetVariant.videoAttributes` presence per variant to the watchdog's evidence input:
+    /// no variants at all = unknown (nil), any variant with video attributes = advertised, an all-audio
+    /// variant set = a radio-style master where zero video tracks is the correct steady state.
+    static func advertisesVideo(variantHasVideoAttributes: [Bool]) -> Bool? {
+        guard !variantHasVideoAttributes.isEmpty else { return nil }
+        return variantHasVideoAttributes.contains(true)
+    }
+
+    /// The watchdog runs only for live bypass sessions with the fallback enabled: VOD remote HLS is the
+    /// AE#154 reroute target (ingesting it back would ping-pong), and hosts can opt out via
+    /// `LoadOptions.nativeRemoteHLSIngestFallback`.
+    static func shouldArm(isLive: Bool, fallbackEnabled: Bool) -> Bool {
+        isLive && fallbackEnabled
+    }
+}

--- a/Sources/AetherEngine/PlayerState.swift
+++ b/Sources/AetherEngine/PlayerState.swift
@@ -166,6 +166,14 @@ public struct LoadOptions: Sendable, Equatable {
     /// AVPlayer item from the remote URL directly (Jellyfin live `master.m3u8`): no demuxer probe, no loopback. AVPlayer manages live edge / reconnect. Pair with `isLive: true`. Default `false`.
     public var nativeRemoteHLS: Bool
 
+    /// Reroute a live `nativeRemoteHLS` session onto the loopback live-ingest path when AVPlayer reaches
+    /// readyToPlay but never builds a video track for a master that advertises one. That signature means
+    /// the master delivers HEVC in MPEG-TS segments, which AVFoundation's HLS demuxer does not support
+    /// (the HLS Authoring Spec sanctions HEVC only in fMP4); the ingest path remuxes TS to fMP4 and plays
+    /// the same stream. Live-only (VOD remote HLS is the AE#154 reroute target). `httpHeaders` ride along
+    /// onto the ingest fetches. Default `true` (AetherEngine#168).
+    public var nativeRemoteHLSIngestFallback: Bool
+
     /// Emit raw ASS event lines (`ReadOrder,Layer,Style,...,Text` including override tags) instead of plain-text extraction. Opt-in for hosts that render ASS styling themselves; pair with `TrackInfo.assHeader`. Only affects ASS / SSA codecs. Default `false` (AetherEngine#30).
     public var preserveASSMarkup: Bool
 
@@ -261,6 +269,7 @@ public struct LoadOptions: Sendable, Equatable {
         dvrWindowSeconds: Double? = nil,
         liveBlockingReload: Bool? = nil,
         nativeRemoteHLS: Bool = false,
+        nativeRemoteHLSIngestFallback: Bool = true,
         preserveASSMarkup: Bool = false,
         prepareNativeSubtitles: Bool = false,
         eagerNativeSubtitleReaders: Bool = false,
@@ -288,6 +297,7 @@ public struct LoadOptions: Sendable, Equatable {
         self.dvrWindowSeconds = dvrWindowSeconds
         self.liveBlockingReload = liveBlockingReload
         self.nativeRemoteHLS = nativeRemoteHLS
+        self.nativeRemoteHLSIngestFallback = nativeRemoteHLSIngestFallback
         self.preserveASSMarkup = preserveASSMarkup
         self.prepareNativeSubtitles = prepareNativeSubtitles
         self.eagerNativeSubtitleReaders = eagerNativeSubtitleReaders

--- a/Tests/AetherEngineTests/HLSLiveIngestHeaderTests.swift
+++ b/Tests/AetherEngineTests/HLSLiveIngestHeaderTests.swift
@@ -1,0 +1,33 @@
+import XCTest
+@testable import AetherEngine
+
+/// AetherEngine#168 follow-up: the engine-side reroute from `nativeRemoteHLS` onto the live-ingest path
+/// must not drop `LoadOptions.httpHeaders`. Header-enforcing IPTV origins (Referer / User-Agent /
+/// Authorization, see #119) would otherwise 403 the ingest that the AVPlayer bypass reached fine.
+/// Pins the request builder every ingest fetch (playlist, segment, AES key) goes through.
+final class HLSLiveIngestHeaderTests: XCTestCase {
+
+    func testMakeRequestAppliesConfiguredHeaders() throws {
+        let reader = HLSLiveIngestReader(
+            playlistURL: URL(string: "https://origin.example/live/master.m3u8")!,
+            httpHeaders: [
+                "Referer": "https://portal.example/",
+                "User-Agent": "SodaliteTV/1.0",
+                "Authorization": "Bearer token123",
+            ]
+        )
+        defer { reader.close() }
+        let request = reader.makeRequest(URL(string: "https://origin.example/live/seg42.ts")!)
+        XCTAssertEqual(request.url?.absoluteString, "https://origin.example/live/seg42.ts")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Referer"), "https://portal.example/")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "User-Agent"), "SodaliteTV/1.0")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer token123")
+    }
+
+    func testMakeRequestWithoutHeadersAddsNoFields() throws {
+        let reader = HLSLiveIngestReader(playlistURL: URL(string: "https://origin.example/live/master.m3u8")!)
+        defer { reader.close() }
+        let request = reader.makeRequest(URL(string: "https://origin.example/live/media.m3u8")!)
+        XCTAssertTrue(request.allHTTPHeaderFields?.isEmpty ?? true)
+    }
+}

--- a/Tests/AetherEngineTests/RemoteHLSIngestFallbackTests.swift
+++ b/Tests/AetherEngineTests/RemoteHLSIngestFallbackTests.swift
@@ -1,0 +1,94 @@
+import XCTest
+@testable import AetherEngine
+
+/// AetherEngine#168 follow-up: AVFoundation's HLS demuxer builds no video track for HEVC carried in
+/// MPEG-TS segments (the HLS Authoring Spec sanctions HEVC only in fMP4), so a master that advertises
+/// hvc1 but serves .ts reaches readyToPlay with audio only and a black picture. The engine reroutes such
+/// live sessions onto the loopback ingest path (HLSLiveIngestReader remuxes TS to fMP4). These tests pin
+/// the pure decision logic: the per-tick watchdog, the variant-advertisement mapper, and the arm gate.
+final class RemoteHLSIngestFallbackTests: XCTestCase {
+
+    // MARK: - Watchdog verdicts
+
+    func testVideoTrackPresentDisarmsImmediately() {
+        var dog = RemoteHLSIngestFallback.Watchdog(graceTicks: 8)
+        XCTAssertEqual(dog.tick(videoTrackCount: 1, variantsAdvertiseVideo: true), .disarm)
+    }
+
+    func testAdvertisedVideoNeverBuiltFiresAtGraceExhaustion() {
+        var dog = RemoteHLSIngestFallback.Watchdog(graceTicks: 8)
+        for _ in 1...7 {
+            XCTAssertEqual(dog.tick(videoTrackCount: 0, variantsAdvertiseVideo: true), .keepWaiting)
+        }
+        XCTAssertEqual(dog.tick(videoTrackCount: 0, variantsAdvertiseVideo: true), .fire)
+    }
+
+    func testAudioOnlyMasterDisarmsImmediately() {
+        // A master whose variants advertise no video (radio channel): zero video tracks is the
+        // legitimate steady state, never a reroute signal.
+        var dog = RemoteHLSIngestFallback.Watchdog(graceTicks: 8)
+        XCTAssertEqual(dog.tick(videoTrackCount: 0, variantsAdvertiseVideo: false), .disarm)
+    }
+
+    func testUnknownAdvertisementNeverFires() {
+        // Media-playlist-direct URL: AVAsset has no variants, so there is no positive evidence that
+        // video was ever advertised. Conservative: wait out the grace, then disarm without firing.
+        var dog = RemoteHLSIngestFallback.Watchdog(graceTicks: 4)
+        for _ in 1...3 {
+            XCTAssertEqual(dog.tick(videoTrackCount: 0, variantsAdvertiseVideo: nil), .keepWaiting)
+        }
+        XCTAssertEqual(dog.tick(videoTrackCount: 0, variantsAdvertiseVideo: nil), .disarm)
+    }
+
+    func testLateAdvertisementResolutionStillFires() {
+        // asset.load(.variants) resolving a few ticks after readyToPlay must not lose the reroute.
+        var dog = RemoteHLSIngestFallback.Watchdog(graceTicks: 6)
+        for _ in 1...3 {
+            XCTAssertEqual(dog.tick(videoTrackCount: 0, variantsAdvertiseVideo: nil), .keepWaiting)
+        }
+        for _ in 4...5 {
+            XCTAssertEqual(dog.tick(videoTrackCount: 0, variantsAdvertiseVideo: true), .keepWaiting)
+        }
+        XCTAssertEqual(dog.tick(videoTrackCount: 0, variantsAdvertiseVideo: true), .fire)
+    }
+
+    func testLateVideoTrackDisarmsBeforeGraceExhaustion() {
+        // HLS video tracks can join item.tracks well after readyToPlay; a late build is a healthy session.
+        var dog = RemoteHLSIngestFallback.Watchdog(graceTicks: 8)
+        for _ in 1...5 {
+            XCTAssertEqual(dog.tick(videoTrackCount: 0, variantsAdvertiseVideo: true), .keepWaiting)
+        }
+        XCTAssertEqual(dog.tick(videoTrackCount: 1, variantsAdvertiseVideo: true), .disarm)
+    }
+
+    func testDefaultGraceCoversFourSecondsAtHalfSecondCadence() {
+        XCTAssertEqual(RemoteHLSIngestFallback.Watchdog().graceTicks, 8)
+    }
+
+    // MARK: - Variant advertisement mapper
+
+    func testAdvertisesVideoWithNoVariantsIsUnknown() {
+        XCTAssertNil(RemoteHLSIngestFallback.advertisesVideo(variantHasVideoAttributes: []))
+    }
+
+    func testAdvertisesVideoWhenAnyVariantCarriesVideoAttributes() {
+        XCTAssertEqual(RemoteHLSIngestFallback.advertisesVideo(variantHasVideoAttributes: [false, true]), true)
+    }
+
+    func testAdvertisesVideoAllAudioVariantsIsFalse() {
+        XCTAssertEqual(RemoteHLSIngestFallback.advertisesVideo(variantHasVideoAttributes: [false, false]), false)
+    }
+
+    // MARK: - Arm gate
+
+    func testLoadOptionsIngestFallbackDefaultsOn() {
+        XCTAssertTrue(LoadOptions().nativeRemoteHLSIngestFallback)
+    }
+
+    func testArmsOnlyLiveSessionsWithFallbackEnabled() {
+        XCTAssertTrue(RemoteHLSIngestFallback.shouldArm(isLive: true, fallbackEnabled: true))
+        XCTAssertFalse(RemoteHLSIngestFallback.shouldArm(isLive: false, fallbackEnabled: true))
+        XCTAssertFalse(RemoteHLSIngestFallback.shouldArm(isLive: true, fallbackEnabled: false))
+        XCTAssertFalse(RemoteHLSIngestFallback.shouldArm(isLive: false, fallbackEnabled: false))
+    }
+}


### PR DESCRIPTION
## Problem

Retest feedback on #168 (5.16.1) settled the open question: on the reproducing channel AVPlayer never builds a video track at all (`asset.load(tracks) -> count=0`, audio item track present, no video item track at readyToPlay or later). The master advertises `CODECS="hvc1.2.2.L153.B0,mp4a.40.2"` but delivers MPEG-TS segments; per the HLS Authoring Spec, AVFoundation supports HEVC only in fMP4 carriage, so no video track is ever created. With no video track there is no CMFormatDescription for the 5.16.1 range detection to read and nothing to program display criteria for. The same stream plays on the loopback path because it remuxes TS to fMP4.

## Fix

- After readyToPlay, a carriage watchdog on the `nativeRemoteHLS` bypass polls `item.tracks` at a 0.5 s cadence for 4 s. Advertisement evidence comes from `AVURLAsset.variants` (AVFoundation's already-fetched master parse, so no second origin connect past IPTV tokens or WAFs).
- When variants advertise a video rendition and no video item track ever builds, the engine reroutes the live session onto the loopback ingest path (`HLSLiveIngestReader` remuxes TS to fMP4), which also runs the full display-criteria handshake the bypass lacks.
- `HLSLiveIngestReader` now carries `LoadOptions.httpHeaders` on every playlist, segment, and AES-key fetch (companion audio reader inherits), so header-enforcing origins (#119) accept the rerouted ingest.
- `LoadOptions.nativeRemoteHLSIngestFallback` (default `true`) lets hosts opt out.

## Guards

- Live-only: VOD remote HLS is the AE#154 reroute target, so no reroute ping-pong is possible.
- Disarms immediately when a video track builds or when the master is audio-only (radio channels keep their working AVPlayer session); a judgeless master (media-playlist-direct URL, no variants) waits out the grace and disarms without firing.
- Armed only at readyToPlay, so dead origins never trigger it; a generation check drops verdicts outrun by a newer load()/stop().

## Tests

14 new unit tests (watchdog verdict matrix, variant advertisement mapper, arm gate, LoadOptions default, ingest request header contract). Full suite: 344 XCTest + 872 Swift Testing, 0 failures. strict-concurrency=complete build clean, tvOS Simulator build SUCCEEDED.

Closes the remaining black-screen path in #168.

🤖 Generated with [Claude Code](https://claude.com/claude-code)