### PR TITLE
fix(demux): follow RFC 9559 for Matroska TrackTimestampScale (#145 rework)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ the public-API contract.
 
 ## [Unreleased]
 
+## [5.17.2] - 2026-07-21
+
+([release notes](https://github.com/superuser404notfound/AetherEngine/releases/tag/5.17.2))
+
+### Fixed
+
+- **Matroska `TrackTimestampScale != 1` follows RFC 9559 again (FFmpegBuild 2.2.0): the 5.9.4 clamp is dropped, the warning stays.** Upstream review of our proposed FFmpeg patch ([FFmpeg PR 23852](https://code.ffmpeg.org/FFmpeg/FFmpeg/pulls/23852)) corrected the #145 premise: RFC 9559 (11.1.3, 11.2, 5.1.3.5.3) puts Block/SimpleBlock relative timestamps and BlockDuration in Track Ticks, absolute time is `(cluster + rel x TTS) x TimestampScale`, and upstream `matroskadec` implements exactly that. The "hybrid axis" described in the 5.9.4 entry does not exist; the file that motivated it was authored on the segment axis and is invalid per RFC, and the clamp would have mistimed a conformant `TTS != 1` file. Timestamp behavior is now exactly upstream's RFC behavior; the demuxer still warns whenever a track carries `TTS != 1` (the element is deprecated and widely ignored, so such files may be authored against readers that ignore it), which keeps the actual defect reported in #145, the silence, fixed. `Issue145MatroskaTrackTimestampScaleTests` now locks the RFC semantics: a conformant Track Ticks file demuxes at its authored times (the clamp broke exactly this case), and a segment-axis-authored file documents the RFC-scaled rendering as invalid-file behavior.
+
 ## [5.17.1] - 2026-07-21
 
 ([release notes](https://github.com/superuser404notfound/AetherEngine/releases/tag/5.17.1))

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "c4c0edd109d648f25715de570364b0d8baa80810bfc0f6ad588ecb7e2b326c1d",
+  "originHash" : "15e2a2ab60b2c56e8de5ab631c52a26c4886a5492c8dda0e5d300e6453f08e00",
   "pins" : [
     {
       "identity" : "ffmpegbuild",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/superuser404notfound/FFmpegBuild",
       "state" : {
-        "revision" : "06409cd0b0d833eeb3810c59d42395b9b3c59352",
-        "version" : "2.1.3"
+        "revision" : "e832f22c89909297b7abe3a94c05b2816414b054",
+        "version" : "2.2.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
         // No network stack, we use custom AVIO + URLSession for HTTP streams.
         // Resolved over Git rather than a local path so consumers (and
         // Xcode Cloud) can build without a sibling FFmpegBuild checkout.
-        .package(url: "https://github.com/superuser404notfound/FFmpegBuild", from: "2.1.3"),  // 2.1.3: sup demuxer (raw PGS sidecars); 2.1.2: matroska TrackTimestampScale clamp (#145); 2.1.1: pgssubdec Epoch-Continue retain (#142); 2.1.0: yadif_videotoolbox + hwupload (Metal GPU deinterlace); 2.0.0: dynamic frameworks (LGPL), zvbi GPL excision
+        .package(url: "https://github.com/superuser404notfound/FFmpegBuild", from: "2.2.0"),  // 2.2.0: matroska TTS warn-only per RFC 9559 (#145 rework); 2.1.3: sup demuxer (raw PGS sidecars); 2.1.2: matroska TrackTimestampScale clamp (#145, dropped in 2.2.0); 2.1.1: pgssubdec Epoch-Continue retain (#142); 2.1.0: yadif_videotoolbox + hwupload (Metal GPU deinterlace); 2.0.0: dynamic frameworks (LGPL), zvbi GPL excision
         // Pure-Swift SMB2 client (MIT) that speaks the protocol over
         // NWConnection. Replaces AMSMB2/libsmb2, which EPERMs on tvOS/iOS.
         // Pinned to the 0.3.x minor: SMBClient is pre-1.0 with an actively

--- a/Tests/AetherEngineTests/Issue145MatroskaTrackTimestampScaleTests.swift
+++ b/Tests/AetherEngineTests/Issue145MatroskaTrackTimestampScaleTests.swift
@@ -3,40 +3,43 @@ import Testing
 import Libavcodec
 @testable import AetherEngine
 
-/// #145 (cmcpherson274): an MKV whose subtitle track carries TrackTimestampScale != 1 came out on a
-/// HYBRID timestamp axis: cue pts = cluster timestamp + (in-cluster relative timestamp x TTS),
-/// which is neither the unscaled (cluster + rel) nor the fully scaled ((cluster + rel) x TTS) axis.
-/// Consequences on a TTS=2.0 fixture: cue starts shifted by relTs x (TTS - 1) per cluster (12->14 s,
-/// 24.5->29 s), packets arrived non-monotonic in storage order (a late-rel cue in cluster N landing
-/// past an early-rel clear in cluster N+1), and a stale fade outlived its authored clear. All of it
-/// silent: right pixels, wrong times, no warning.
+/// #145 (cmcpherson274), premise corrected after upstream review (FFmpeg PR 23852, jamrial):
+/// RFC 9559 (11.1.3, 11.2, 5.1.3.5.3) puts Block/SimpleBlock relative timestamps AND BlockDuration
+/// in Track Ticks, so a block's absolute time is (cluster + rel x TTS) x TimestampScale. FFmpeg's
+/// matroska demuxer implements exactly that (stream time_base = TimestampScale x TTS, cluster
+/// component divided by TTS once); the "hybrid axis" this suite originally locked in does not
+/// exist. The reporter's fixture (control mux with TrackTimestampScale set to 2.0 and nothing
+/// rescaled) was an invalid file: its blocks were authored in Segment Ticks.
 ///
-/// Root cause is inherited from FFmpeg's matroska demuxer (n8.1.2 and master): read_header bakes the
-/// track's TrackTimestampScale into the stream time_base (segment scale x TTS) but the block parser
-/// divides only the CLUSTER component by TTS (`cluster_time / track->time_scale + block_time`), so
-/// the relative component ends up scaled and the cluster component does not.
+/// The earlier FFmpegBuild clamp (any TTS != 1 forced to 1.0) made that invalid fixture land on
+/// its authored times but would mistime a conformant TTS != 1 file. It is replaced by a warn-only
+/// patch: RFC behavior is preserved verbatim and a warning surfaces TTS != 1, since many readers
+/// ignore the element and files carrying it may have been authored against such readers. The
+/// reporter's core defect (the silence) stays fixed; the axis follows the spec.
 ///
-/// The fix (FFmpegBuild patch_ffmpeg_matroska_tts) clamps any TrackTimestampScale != 1.0 to 1.0 at
-/// read_header with a warning, extending FFmpeg's own existing `< 0.01` clamp. That lands every
-/// track on the coherent, unscaled segment axis (cluster + rel): the axis the file's clusters are
-/// stored on, monotonic in storage order, and in sync with the file's other tracks. Full spec
-/// scaling was rejected deliberately: RFC 9559 deprecates the element (maxver 3), matroska.org
-/// documents that most readers ignore it, and a real-world TTS != 1 is almost always muxer damage
-/// where full scaling would desync the track from its siblings instead of playing it correctly.
+/// This suite locks the RFC semantics: a conformant Track Ticks file demuxes at its authored
+/// times (the clamp would have broken exactly this case), and a segment-axis-authored file
+/// (invalid per RFC) demuxes on the RFC-scaled axis, documenting inherited upstream behavior.
 struct Issue145MatroskaTrackTimestampScaleTests {
 
-    /// One authored subtitle event: absolute time = cluster + rel (both ms on the segment axis).
+    private static let tts = 2.0
+
+    /// One authored subtitle event: intended absolute time = cluster + rel (both ms).
     fileprivate struct Event {
         let clusterMs: Int
         let relMs: Int
         let durationMs: Int
         var authoredSeconds: Double { Double(clusterMs + relMs) / 1000.0 }
         var authoredDurationSeconds: Double { Double(durationMs) / 1000.0 }
+        /// RFC rendering of a file whose block fields carry these ms values verbatim (Segment
+        /// Ticks authoring, invalid for TTS != 1): rel and duration are read as Track Ticks.
+        func rfcSeconds(tts: Double) -> Double { (Double(clusterMs) + Double(relMs) * tts) / 1000.0 }
+        func rfcDurationSeconds(tts: Double) -> Double { Double(durationMs) * tts / 1000.0 }
     }
 
     /// Mirrors the reporter's fixture shape: 5 s clusters, a late-rel cue in the 20 s cluster
-    /// (authored 24.5 s) followed by an early-rel event in the 25 s cluster. On the hybrid axis with
-    /// TTS=2 those emit as 29 s then 25 s: shifted AND non-monotonic.
+    /// (authored 24.5 s) followed by an early-rel event in the 25 s cluster. All rel/duration
+    /// values divide evenly by TTS=2 so the conformant variant needs no rounding.
     private static let events: [Event] = [
         Event(clusterMs: 0, relMs: 2000, durationMs: 1000),
         Event(clusterMs: 5000, relMs: 2000, durationMs: 1000),
@@ -65,10 +68,11 @@ struct Issue145MatroskaTrackTimestampScaleTests {
         return out
     }
 
-    @Test("TTS=2.0 track demuxes on the authored segment axis, not the hybrid axis")
-    func scaledTrackKeepsAuthoredTimes() throws {
-        let packets = try demuxSubtitleTimes(MatroskaTTSFixture.make(trackTimestampScale: 2.0,
-                                                                     events: Self.events))
+    @Test("conformant TTS=2.0 file (Track Ticks authoring) demuxes at its authored times")
+    func conformantScaledTrackKeepsAuthoredTimes() throws {
+        let packets = try demuxSubtitleTimes(MatroskaTTSFixture.make(trackTimestampScale: Self.tts,
+                                                                     events: Self.events,
+                                                                     authoring: .trackTicks))
         #expect(packets.count == Self.events.count)
         for (packet, event) in zip(packets, Self.events) {
             #expect(abs(packet.pts - event.authoredSeconds) < 0.0005,
@@ -78,25 +82,42 @@ struct Issue145MatroskaTrackTimestampScaleTests {
         }
     }
 
-    @Test("TTS=2.0 track emits monotonic pts in storage order")
-    func scaledTrackStaysMonotonic() throws {
-        let packets = try demuxSubtitleTimes(MatroskaTTSFixture.make(trackTimestampScale: 2.0,
-                                                                     events: Self.events))
-        let times = packets.map(\.pts)
-        #expect(times == times.sorted(),
-                "storage order must stay monotonic on a coherent axis, got \(times)")
-    }
-
-    @Test("TTS=2.0 file demuxes identically to the TTS-less control")
-    func scaledTrackMatchesControl() throws {
+    @Test("conformant TTS=2.0 file demuxes identically to the TTS-less control")
+    func conformantScaledTrackMatchesControl() throws {
         let control = try demuxSubtitleTimes(MatroskaTTSFixture.make(trackTimestampScale: nil,
-                                                                     events: Self.events))
-        let scaled = try demuxSubtitleTimes(MatroskaTTSFixture.make(trackTimestampScale: 2.0,
-                                                                    events: Self.events))
+                                                                     events: Self.events,
+                                                                     authoring: .segmentTicks))
+        let scaled = try demuxSubtitleTimes(MatroskaTTSFixture.make(trackTimestampScale: Self.tts,
+                                                                    events: Self.events,
+                                                                    authoring: .trackTicks))
         #expect(control.count == scaled.count)
         for (c, s) in zip(control, scaled) {
             #expect(abs(c.pts - s.pts) < 0.0005, "control \(c.pts)s vs scaled \(s.pts)s")
             #expect(abs(c.duration - s.duration) < 0.0005)
+        }
+    }
+
+    @Test("conformant TTS=2.0 file emits monotonic pts in storage order")
+    func conformantScaledTrackStaysMonotonic() throws {
+        let packets = try demuxSubtitleTimes(MatroskaTTSFixture.make(trackTimestampScale: Self.tts,
+                                                                     events: Self.events,
+                                                                     authoring: .trackTicks))
+        let times = packets.map(\.pts)
+        #expect(times == times.sorted(),
+                "conformant authoring must stay monotonic in storage order, got \(times)")
+    }
+
+    @Test("segment-axis-authored TTS file (invalid per RFC 9559) demuxes on the RFC-scaled axis")
+    func segmentAxisAuthoredFileFollowsRFCScaledAxis() throws {
+        let packets = try demuxSubtitleTimes(MatroskaTTSFixture.make(trackTimestampScale: Self.tts,
+                                                                     events: Self.events,
+                                                                     authoring: .segmentTicks))
+        #expect(packets.count == Self.events.count)
+        for (packet, event) in zip(packets, Self.events) {
+            #expect(abs(packet.pts - event.rfcSeconds(tts: Self.tts)) < 0.0005,
+                    "invalid file: RFC renders \(event.rfcSeconds(tts: Self.tts))s, got \(packet.pts)s")
+            #expect(abs(packet.duration - event.rfcDurationSeconds(tts: Self.tts)) < 0.0005,
+                    "invalid file: RFC duration \(event.rfcDurationSeconds(tts: Self.tts))s, got \(packet.duration)s")
         }
     }
 }
@@ -104,7 +125,17 @@ struct Issue145MatroskaTrackTimestampScaleTests {
 /// Minimal in-memory Matroska writer: one S_TEXT/UTF8 subtitle track, one BlockGroup (Block +
 /// BlockDuration) per event, one Cluster per distinct cluster timestamp. Sizes are always encoded
 /// as 8-byte EBML vints so nesting needs no length backpatching.
+///
+/// `authoring` selects the axis the block fields are written on. `.trackTicks` divides rel and
+/// duration by TrackTimestampScale (conformant per RFC 9559; requires even division).
+/// `.segmentTicks` writes the ms values verbatim (the reporter's fixture shape; invalid for
+/// TTS != 1, since readers scale these fields by TTS).
 private enum MatroskaTTSFixture {
+
+    enum Authoring {
+        case trackTicks
+        case segmentTicks
+    }
 
     private static func vintSize(_ n: Int) -> [UInt8] {
         var bytes: [UInt8] = [0x01]
@@ -135,7 +166,7 @@ private enum MatroskaTTSFixture {
 
     private static func string(_ s: String) -> [UInt8] { Array(s.utf8) }
 
-    static func make(trackTimestampScale: Double?, events: [Event]) -> Data {
+    static func make(trackTimestampScale: Double?, events: [Event], authoring: Authoring) -> Data {
         let header = element([0x1A, 0x45, 0xDF, 0xA3],
                              element([0x42, 0x86], uint(1)) +          // EBMLVersion
                              element([0x42, 0xF7], uint(1)) +          // EBMLReadVersion
@@ -162,19 +193,35 @@ private enum MatroskaTTSFixture {
         }
         let tracks = element([0x16, 0x54, 0xAE, 0x6B], element([0xAE], trackFields))
 
+        // Track Ticks authoring divides the ms fields by TTS (conformant); Segment Ticks writes
+        // them verbatim (reporter-shaped, invalid for TTS != 1).
+        let divisor: Int
+        switch authoring {
+        case .trackTicks:
+            let tts = trackTimestampScale ?? 1.0
+            precondition(tts == tts.rounded() && tts >= 1.0, "integer TTS required for tick math")
+            divisor = Int(tts)
+        case .segmentTicks:
+            divisor = 1
+        }
+
         var clusters: [UInt8] = []
         let grouped = Dictionary(grouping: events, by: \.clusterMs).sorted { $0.key < $1.key }
         for (clusterMs, clusterEvents) in grouped {
             var body = element([0xE7], uint(clusterMs))  // Cluster Timestamp
             for event in clusterEvents.sorted(by: { $0.relMs < $1.relMs }) {
+                precondition(event.relMs % divisor == 0 && event.durationMs % divisor == 0,
+                             "event values must divide evenly by TTS")
+                let rel = event.relMs / divisor
+                let duration = event.durationMs / divisor
                 let block: [UInt8] = [0x81,                             // track number vint
-                                      UInt8((event.relMs >> 8) & 0xFF),
-                                      UInt8(event.relMs & 0xFF),        // int16 relative timestamp
+                                      UInt8((rel >> 8) & 0xFF),
+                                      UInt8(rel & 0xFF),                // int16 relative timestamp
                                       0x00]                             // flags
                                      + string("line @\(clusterMs + event.relMs)ms")
                 body += element([0xA0],                                 // BlockGroup
                                 element([0xA1], block) +                // Block
-                                element([0x9B], uint(event.durationMs)))  // BlockDuration
+                                element([0x9B], uint(duration)))        // BlockDuration
             }
             clusters += element([0x1F, 0x43, 0xB6, 0x75], body)
         }


### PR DESCRIPTION
FFmpegBuild 2.2.0 replaces the 2.1.2 TrackTimestampScale clamp with a warn-only patch after upstream review of the proposed FFmpeg fix ([FFmpeg PR 23852](https://code.ffmpeg.org/FFmpeg/FFmpeg/pulls/23852)).

The review corrected the #145 premise: RFC 9559 (11.1.3, 11.2, 5.1.3.5.3) puts Block/SimpleBlock relative timestamps and BlockDuration in Track Ticks, absolute time is `(cluster + rel x TTS) x TimestampScale`, and upstream matroskadec implements exactly that. There is no hybrid axis; the file that motivated #145 was authored on the segment axis (invalid per RFC), and the clamp would have mistimed a conformant `TTS != 1` file.

With this PR timestamp behavior is upstream's RFC behavior again, and the demuxer still warns whenever a track carries `TTS != 1`, keeping the actual #145 defect (the silence) fixed.

`Issue145MatroskaTrackTimestampScaleTests` is flipped to lock the RFC semantics:
- a conformant Track Ticks file demuxes at its authored times (red under the clamp, which broke exactly this case)
- a segment-axis-authored file (the reporter's fixture shape) documents the RFC-scaled rendering as invalid-file behavior
- full suite: 892 tests green, tvOS Simulator build green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NAPCg4tCDdSqkK6tPkNptw