### PR TITLE
fix(demux): suspend the persistent transfer for backpressure instead of blocking the delegate (#174)

### DIFF
--- a/Sources/AetherEngine/Demuxer/AVIOReader.swift
+++ b/Sources/AetherEngine/Demuxer/AVIOReader.swift
@@ -175,8 +175,13 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
 
     // MARK: - Persistent Mode (single forward-streaming connection, playback path)
 
-    // Backpressure: pause delivery above highWater; peak resident window ~22 MB.
+    // Backpressure: suspend the persistent task above highWater, resume below lowWater
+    // (#174). Suspend/resume is the only contractual flow control; blocking the delegate
+    // callback leaves the socket read running on TLS/H2 transports, and the undelivered
+    // body then accumulates in unbounded URLSession-internal allocations until jetsam.
+    // Peak resident window ~= highWater + transport in-flight (a few MB).
     private static let winHighWater = 16 * 1024 * 1024
+    private static let winLowWater = 8 * 1024 * 1024
     // Keep this many bytes behind the cursor for small matroska backward re-reads.
     private static let winLookback = 2 * 1024 * 1024
     // Trim in batches to avoid O(n^2) memmove storm on every 256 KB read.
@@ -245,6 +250,18 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
     private var connGeneration = 0
     private var activeSession: URLSession?
     private var activeTask: URLSessionDataTask?
+    // #174: true while the persistent task is suspended for window backpressure.
+    // winCond-guarded; every suspend/resume transition goes through this flag so the
+    // task's suspend count stays balanced.
+    private var persistentTaskSuspended = false
+
+    /// #174: winCond-guarded snapshot of the suspend state, internal so the task-level
+    /// backpressure is unit-tested against a loopback origin without private state access.
+    var persistentTaskIsSuspendedForTesting: Bool {
+        winCond.lock()
+        defer { winCond.unlock() }
+        return persistentTaskSuspended
+    }
     // #93 restart latency diagnostics (winCond-guarded): bytes dropped by the stale-generation
     // guard, plus per-generation time-to-first-data tracking.
     private var staleGenDroppedBytes: Int64 = 0
@@ -393,7 +410,8 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
                 // a size; if not, abandon it (generation bump ignores a size landing in the
                 // race window). fileSize is read under the lock because the delegate thread now
                 // writes it (issue #70 review #4/#5).
-                let (haveSize, abandoned) = resolveOptimisticOpen()
+                let (haveSize, abandoned, abandonedTask, wasSuspended) = resolveOptimisticOpen()
+                if wasSuspended { abandonedTask?.resume() }
                 abandoned?.invalidateAndCancel()
                 if !haveSize {
                     // The data connection resolved no size (no-length origin, a transient 429,
@@ -492,18 +510,21 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
     /// the read means a size that lands in the race window is ignored rather than racing a
     /// half-done teardown (issue #70 review #4/#5). Returns the session to cancel outside
     /// the lock. Demux thread, open-time only; leaves the AVIO context intact (unlike close()).
-    private func resolveOptimisticOpen() -> (haveSize: Bool, abandoned: URLSession?) {
+    private func resolveOptimisticOpen() -> (haveSize: Bool, abandoned: URLSession?, abandonedTask: URLSessionDataTask?, wasSuspended: Bool) {
         winCond.lock()
         defer { winCond.unlock() }
-        if fileSize > 0 { return (true, nil) }
+        if fileSize > 0 { return (true, nil, nil, false) }
         connGeneration &+= 1
         let session = activeSession
+        let task = activeTask
+        let suspended = persistentTaskSuspended
+        persistentTaskSuspended = false
         activeSession = nil
         activeTask = nil
         window = Data()
         connEnded = true
         winCond.broadcast()
-        return (false, session)
+        return (false, session, task, suspended)
     }
 
     // Close flags written on the teardown thread (markClosed / fullyClose) and read on the demux
@@ -593,11 +614,14 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
         // is released. Grab under winCond, invalidate outside it (mirrors close()).
         let session = activeSession
         let task = activeTask
+        let persistentWasSuspended = persistentTaskSuspended
+        persistentTaskSuspended = false
         activeSession = nil
         activeTask = nil
         connEnded = true
         winCond.broadcast()
         winCond.unlock()
+        if persistentWasSuspended { task?.resume() }
         task?.cancel()
         session?.invalidateAndCancel()
     }
@@ -647,17 +671,23 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
         connGeneration &+= 1
         connEnded = true
         let session = activeSession
+        let task = activeTask
+        let persistentWasSuspended = persistentTaskSuspended
+        persistentTaskSuspended = false
         activeSession = nil
         activeTask = nil
         window = Data()
         winCond.broadcast()
         winCond.unlock()
+        if persistentWasSuspended { task?.resume() }
         session?.invalidateAndCancel()
     }
 
     // MARK: - Read (called by FFmpeg on demux thread)
 
-    fileprivate func read(into buf: UnsafeMutablePointer<UInt8>, size: Int32) -> Int32 {
+    // Internal (not fileprivate) so the #174 backpressure tests can drive the consumer
+    // side directly; production entry stays the C read callback below.
+    func read(into buf: UnsafeMutablePointer<UInt8>, size: Int32) -> Int32 {
         guard !isClosed else { return -1 }
         if readDeadlinePassedOrAborted { readDeadlineFired = true; return -1 }
         // Check usePersistentReader before isStreaming: live feeds without
@@ -883,8 +913,8 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
             if readDeadlinePassedOrAborted { readDeadlineFired = true; return totalRead > 0 ? Int32(totalRead) : -1 }
 
             // #93/#96 residual: time the loop-head lock acquisition. A delegate thread holding winCond
-            // across its copy + backpressure window blocks the read HERE with nothing to show for it, so
-            // this turns that invisible wait into `lockWait=`.
+            // across its window copy blocks the read HERE with nothing to show for it, so this turns
+            // that invisible wait into `lockWait=`.
             let lockWaitStart = DispatchTime.now()
             winCond.lock()
             diag.recordLockWait(ms: msSince(lockWaitStart))
@@ -972,8 +1002,16 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
                 unproductiveReconnects = 0      // real progress
                 rateLimitStreak = 0             // real progress clears the 429 give-up streak (#71)
                 emitNetworkPhase(.flowing)      // recovered: source delivering again (#85)
-                winCond.broadcast()              // window may have shrunk: wake backpressure
+                // #174: resume the suspended transfer once the drain crosses lowWater.
+                var toResume: URLSessionDataTask?
+                if persistentTaskSuspended,
+                   window.count - max(0, Int(position - winStart)) <= Self.winLowWater {
+                    persistentTaskSuspended = false
+                    toResume = activeTask
+                }
+                winCond.broadcast()
                 winCond.unlock()
+                toResume?.resume()
                 continue
             }
 
@@ -1016,6 +1054,16 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
             }
 
             if !ended {
+                // #174: a suspended task never delivers; resume before waiting (mirrors
+                // readStreaming). Reached when a within-window forward seek lands at the
+                // frontier while the transfer is parked above lowWater.
+                if persistentTaskSuspended {
+                    persistentTaskSuspended = false
+                    let toResume = activeTask
+                    winCond.unlock()
+                    toResume?.resume()
+                    continue
+                }
                 // Wait for the live connection to fill forward. A false return
                 // means connStallTimeout elapsed with no data (socket stall).
                 let waitStart = DispatchTime.now()
@@ -1270,12 +1318,16 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
         connStartedAt = DispatchTime.now()   // #93: time-to-first-data per generation
         connFirstDataSeen = false
         let oldSession = activeSession
+        let oldTask = activeTask
+        let oldSuspended = persistentTaskSuspended
+        persistentTaskSuspended = false
         activeSession = nil
         activeTask = nil
-        // Wake a backpressure-blocked old-gen delegate so it sees it is stale.
         winCond.broadcast()
         winCond.unlock()
 
+        // #174: balance a pending suspend before cancel (mirrors the streaming teardown).
+        if oldSuspended { oldTask?.resume() }
         oldSession?.invalidateAndCancel()
 
         if isClosed { return }
@@ -1322,8 +1374,11 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
     }
 
     /// Force-copies `data` into the sliding window and applies backpressure by
-    /// blocking until the consumer drains below winHighWater. Force-copy releases
-    /// source dispatch_data per delivery (same leak control as the chunk path).
+    /// suspending the task once the window exceeds winHighWater (#174); readPersistent
+    /// resumes it when the consumer drains below winLowWater. Never blocks: parking this
+    /// delegate callback has no flow-control contract (TLS/H2 transports keep reading at
+    /// line rate into unbounded internal buffers, the #174 EXC_RESOURCE). Force-copy
+    /// releases source dispatch_data per delivery (same leak control as the chunk path).
     fileprivate func appendPersistentData(_ data: Data, generation: Int) {
         winCond.lock()
         guard generation == connGeneration, !isFullyClosed else {
@@ -1350,13 +1405,17 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
         }
         addBytesFetched(count)
         winCond.broadcast()
-        // Backpressure: 0.2s timeout is belt-and-suspenders; correctness from broadcasts.
-        while generation == connGeneration && !isClosed {
-            let ahead = window.count - max(0, Int(position - winStart))
-            if ahead <= Self.winHighWater { break }
-            _ = winCond.wait(until: Date(timeIntervalSinceNow: 0.2))
+        // Deliveries already dispatched before the suspend takes effect still land here
+        // (flag already set, no double-suspend), so the window can overshoot highWater by
+        // the transport's in-flight amount; the suspend count stays balanced via the flag.
+        var toSuspend: URLSessionDataTask?
+        let ahead = window.count - max(0, Int(position - winStart))
+        if ahead > Self.winHighWater, !persistentTaskSuspended, !isClosed {
+            persistentTaskSuspended = true
+            toSuspend = activeTask
         }
         winCond.unlock()
+        toSuspend?.suspend()
         if let firstDataMs {
             // #93/#96 residual: a slow first-data gap is release-visible so a device trace can pair it
             // with the response-header timing above. Small header gap + large first-data gap = the body

--- a/Tests/AetherEngineTests/Issue174PersistentReadBackpressureTests.swift
+++ b/Tests/AetherEngineTests/Issue174PersistentReadBackpressureTests.swift
@@ -1,0 +1,261 @@
+import Testing
+import Foundation
+@testable import AetherEngine
+
+/// #174: the persistent reader applied backpressure by BLOCKING the URLSession delegate
+/// callback until the consumer drained below winHighWater. Blocking the delegate has no
+/// flow-control contract: whether the connection stops reading from the socket is a
+/// transport implementation detail. Plain HTTP/1.1 happens to park after a few MB of
+/// internal buffering, but the field crash (HTTPS origin, boringssl in the crashing
+/// stack, iPadOS) shows the TLS/H2 path keeps pulling at line rate and buffers the
+/// undelivered body in unbounded internal allocations (cold pages compress, then
+/// EXC_RESOURCE at the jetsam limit). Real, contractual flow control is task
+/// suspend/resume ("a task, while suspended, produces no network traffic"), the same
+/// mechanism the streaming path already uses (streamHighWater / streamLowWater).
+///
+/// These tests run a loopback HTTP/1.1 origin that counts every body byte it manages to
+/// write. The load-bearing assertion is the suspend state itself (the transport-agnostic
+/// mechanism); the origin byte bound is the regression guard that catches a backpressure
+/// removal without a replacement.
+@Suite("AVIOReader persistent backpressure (#174)")
+struct Issue174PersistentReadBackpressureTests {
+
+    // MARK: - Loopback throttled origin
+
+    /// Minimal blocking HTTP origin on 127.0.0.1: serves `Range: bytes=X-` with a 206 and
+    /// an endless zero body, throttled to ~50 MB/s, counting bytes actually written. When
+    /// the client stops reading, write() parks on the full socket buffer, so `bytesWritten`
+    /// plateauing IS the observable for working flow control.
+    private final class ThrottledOriginServer: @unchecked Sendable {
+        let port: UInt16
+        private let listenFD: Int32
+        private let totalSize: Int64
+        private let chunkBytes: Int
+        private let throttleUs: useconds_t
+        private let lock = NSLock()
+        private var _bytesWritten: Int64 = 0
+        private var _connFDs: [Int32] = []
+        private var _stopped = false
+
+        var bytesWritten: Int64 {
+            lock.lock(); defer { lock.unlock() }
+            return _bytesWritten
+        }
+
+        private var stopped: Bool {
+            lock.lock(); defer { lock.unlock() }
+            return _stopped
+        }
+
+        init?(totalSize: Int64, chunkBytes: Int = 256 * 1024, throttleUs: useconds_t = 5000) {
+            self.totalSize = totalSize
+            self.chunkBytes = chunkBytes
+            self.throttleUs = throttleUs
+
+            let fd = socket(AF_INET, SOCK_STREAM, 0)
+            guard fd >= 0 else { return nil }
+            var one: Int32 = 1
+            setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &one, socklen_t(MemoryLayout<Int32>.size))
+
+            var addr = sockaddr_in()
+            addr.sin_family = sa_family_t(AF_INET)
+            addr.sin_port = 0
+            addr.sin_addr.s_addr = inet_addr("127.0.0.1")
+            let bindResult = withUnsafePointer(to: &addr) {
+                $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                    bind(fd, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+                }
+            }
+            guard bindResult == 0, listen(fd, 4) == 0 else {
+                close(fd)
+                return nil
+            }
+            var bound = sockaddr_in()
+            var len = socklen_t(MemoryLayout<sockaddr_in>.size)
+            let nameResult = withUnsafeMutablePointer(to: &bound) {
+                $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                    getsockname(fd, $0, &len)
+                }
+            }
+            guard nameResult == 0 else {
+                close(fd)
+                return nil
+            }
+            self.listenFD = fd
+            self.port = UInt16(bigEndian: bound.sin_port)
+
+            Thread.detachNewThread { [self] in acceptLoop() }
+        }
+
+        func stop() {
+            lock.lock()
+            let fds = _connFDs
+            _connFDs = []
+            let alreadyStopped = _stopped
+            _stopped = true
+            lock.unlock()
+            guard !alreadyStopped else { return }
+            // shutdown unblocks a write parked on a full socket buffer; close alone may not.
+            for fd in fds {
+                shutdown(fd, SHUT_RDWR)
+                close(fd)
+            }
+            shutdown(listenFD, SHUT_RDWR)
+            close(listenFD)
+        }
+
+        private func acceptLoop() {
+            while true {
+                let fd = accept(listenFD, nil, nil)
+                if fd < 0 { return }
+                var one: Int32 = 1
+                setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, &one, socklen_t(MemoryLayout<Int32>.size))
+                lock.lock()
+                if _stopped {
+                    lock.unlock()
+                    shutdown(fd, SHUT_RDWR)
+                    close(fd)
+                    return
+                }
+                _connFDs.append(fd)
+                lock.unlock()
+                Thread.detachNewThread { [self] in serve(fd) }
+            }
+        }
+
+        private func serve(_ fd: Int32) {
+            guard let request = readRequestHeader(fd) else { return }
+            var offset: Int64 = 0
+            if let rangeLine = request.components(separatedBy: "\r\n")
+                .first(where: { $0.lowercased().hasPrefix("range:") }),
+               let eq = rangeLine.range(of: "bytes="),
+               let dash = rangeLine.range(of: "-", range: eq.upperBound..<rangeLine.endIndex),
+               let start = Int64(rangeLine[eq.upperBound..<dash.lowerBound]) {
+                offset = start
+            }
+            let remaining = totalSize - offset
+            let header = "HTTP/1.1 206 Partial Content\r\n"
+                + "Content-Range: bytes \(offset)-\(totalSize - 1)/\(totalSize)\r\n"
+                + "Content-Length: \(remaining)\r\n"
+                + "Accept-Ranges: bytes\r\n"
+                + "Connection: close\r\n\r\n"
+            guard writeFully(fd, Array(header.utf8)) else { return }
+
+            let chunk = [UInt8](repeating: 0x55, count: chunkBytes)
+            var served: Int64 = 0
+            while served < remaining && !stopped {
+                let n = Int(min(Int64(chunkBytes), remaining - served))
+                guard writeBody(fd, Array(chunk[0..<n])) else { return }
+                served += Int64(n)
+                if throttleUs > 0 { usleep(throttleUs) }
+            }
+        }
+
+        private func readRequestHeader(_ fd: Int32) -> String? {
+            var buf = [UInt8](repeating: 0, count: 64 * 1024)
+            var collected = Data()
+            let terminator = Data("\r\n\r\n".utf8)
+            while collected.range(of: terminator) == nil {
+                let n = recv(fd, &buf, buf.count, 0)
+                guard n > 0 else { return nil }
+                collected.append(contentsOf: buf[0..<n])
+                if collected.count > 128 * 1024 { return nil }
+            }
+            return String(data: collected, encoding: .utf8)
+        }
+
+        private func writeFully(_ fd: Int32, _ bytes: [UInt8]) -> Bool {
+            var sent = 0
+            while sent < bytes.count {
+                let n = bytes[sent...].withUnsafeBytes { raw -> Int in
+                    write(fd, raw.baseAddress, raw.count)
+                }
+                guard n > 0 else { return false }
+                sent += n
+            }
+            return true
+        }
+
+        /// Like writeFully but counts every byte the kernel actually accepted, including a
+        /// final partial write, so a park mid-chunk is still measured accurately.
+        private func writeBody(_ fd: Int32, _ bytes: [UInt8]) -> Bool {
+            var sent = 0
+            while sent < bytes.count {
+                let n = bytes[sent...].withUnsafeBytes { raw -> Int in
+                    write(fd, raw.baseAddress, raw.count)
+                }
+                guard n > 0 else { return false }
+                lock.lock()
+                _bytesWritten += Int64(n)
+                lock.unlock()
+                sent += n
+            }
+            return true
+        }
+    }
+
+    // MARK: - Tests
+
+    @Test("stalled consumer parks the origin connection instead of buffering at line rate")
+    func stalledConsumerParksOrigin() async throws {
+        let server = try #require(ThrottledOriginServer(totalSize: 512 * 1024 * 1024))
+        defer { server.stop() }
+        let reader = AVIOReader(url: URL(string: "http://127.0.0.1:\(server.port)/movie.bin")!)
+        defer { reader.markClosed(); reader.close() }
+        try reader.open()
+
+        // Nobody consumes: the demux side is deliberately parked, the exact #174 shape
+        // (muxer backpressured on SegmentCache high water, no read ever advances position).
+        try await Task.sleep(for: .seconds(3))
+
+        // Origin line rate here is ~50 MB/s. Without real flow control the origin keeps
+        // serving (~150 MB in 3 s) into URLSession's internal buffering. With task-suspend
+        // backpressure it parks at winHighWater plus socket/transport buffer slack.
+        #expect(server.bytesWritten < 64 * 1024 * 1024,
+                "origin served \(server.bytesWritten / (1024 * 1024)) MB into a stalled consumer")
+        #expect(reader.persistentTaskIsSuspendedForTesting,
+                "the persistent task must be suspended once the window exceeds winHighWater")
+    }
+
+    @Test("resuming consumption after a stall delivers fresh bytes (resume liveness)")
+    func drainAfterStallResumesDelivery() async throws {
+        let server = try #require(ThrottledOriginServer(totalSize: 256 * 1024 * 1024))
+        defer { server.stop() }
+        let reader = AVIOReader(url: URL(string: "http://127.0.0.1:\(server.port)/movie.bin")!)
+        defer { reader.markClosed(); reader.close() }
+        try reader.open()
+
+        // Stall long enough for the suspend to engage, then consume far more than the
+        // window: delivery must keep flowing, which proves the task was resumed.
+        try await Task.sleep(for: .seconds(2))
+
+        let sliceCap = 256 * 1024
+        let target = 48 * 1024 * 1024
+        let buf = UnsafeMutablePointer<UInt8>.allocate(capacity: sliceCap)
+        defer { buf.deallocate() }
+        var got = 0
+        let deadline = Date().addingTimeInterval(30)
+        while got < target && Date() < deadline {
+            let n = reader.read(into: buf, size: Int32(sliceCap))
+            if n <= 0 { break }
+            got += Int(n)
+        }
+        #expect(got >= target, "only \(got / (1024 * 1024)) MB delivered after the stall")
+    }
+
+    @Test("teardown while suspended releases the task and does not hang")
+    func teardownWhileSuspended() async throws {
+        let server = try #require(ThrottledOriginServer(totalSize: 512 * 1024 * 1024))
+        defer { server.stop() }
+        let reader = AVIOReader(url: URL(string: "http://127.0.0.1:\(server.port)/movie.bin")!)
+        try reader.open()
+
+        try await Task.sleep(for: .seconds(2))
+
+        // Completing without a hang is the assertion; the suspended flag must be cleared
+        // so the balanced resume-before-cancel actually happened.
+        reader.markClosed()
+        reader.close()
+        #expect(!reader.persistentTaskIsSuspendedForTesting)
+    }
+}


### PR DESCRIPTION
Fixes #174.

## Root cause

The persistent reader (loopback VOD/live playback path) applied window backpressure by blocking the URLSession delegate callback in `appendPersistentData` until the consumer drained below `winHighWater` (16 MB). Blocking the delegate has no flow-control contract. Whether the connection stops reading from the socket is a transport implementation detail:

- Plain HTTP/1.1 (verified against a loopback origin) happens to park the transfer after a few MB of internal buffering.
- The field crash is an HTTPS origin (boringssl in the crashing stack, iPadOS): that path keeps pulling from the origin at line rate while the delegate is parked, and the undelivered body accumulates in unbounded URLSession-internal allocations (~1.8 KB malloc blocks at ~5k blocks/s in the reporter's memprobe, matching TLS-record-sized fragments).

With a realtime consumer, that buffering grows at line rate minus playback rate, goes cold, gets compressed (vmCmp climbing ~500 MB per 30 s with rss flat), and trips `EXC_RESOURCE` at the jetsam limit. The reporter's thread stacks show exactly this: every engine thread correctly backpressured or idle, only the network thread active mid `SSL_read`.

The reporter's own numbers confirm the delivery/ingest split: `avioFetchedMB` (bytes delivered to the window) grew ~34 MB per 30 s (playback rate, consistent with `cacheMB`), while `mallocMB` grew ~409 MB per 30 s (the origin's line rate).

## Fix

Replace the blocking wait with task suspend/resume, the contractual flow control ("a task, while suspended, produces no network traffic") and the same mechanism the streaming path already uses (`streamHighWater`/`streamLowWater`):

- `appendPersistentData` never blocks; it suspends the task once the window exceeds `winHighWater`.
- `readPersistent` resumes the task when the drain crosses the new `winLowWater` (8 MB), and before parking in the frontier wait (a suspended task never delivers; mirrors `readStreaming`).
- All reconnect/teardown paths (`startPersistentConnection`, `markClosed`, `close`, `resolveOptimisticOpen`) balance a pending suspend before cancel so the suspend count stays level.

## Tests

`Issue174PersistentReadBackpressureTests` runs a loopback throttled origin that counts every body byte it manages to write:

- stalled consumer parks the transfer (suspend state asserted, plus an origin-served byte bound as regression guard),
- resume liveness: consumption after a long stall keeps delivering well past the window,
- teardown while suspended releases the task without hanging.

Full suite: 895 tests green, `-strict-concurrency=complete` clean, tvOS Simulator build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)