### PR TITLE
feat(demux): surface container (Matroska/MP4) chapters as mediaChapters

### DIFF
--- a/Sources/AetherEngine/AetherEngine+Loading.swift
+++ b/Sources/AetherEngine/AetherEngine+Loading.swift
@@ -1310,6 +1310,10 @@ extension AetherEngine {
         let wasOnSoftwarePath = (playbackBackend == .software)
         // Preserve codec so the decoder label can be reconstructed without re-probing.
         let preservedVideoCodec = lastDetectedVideoCodec
+        // Container chapters belong to the (unchanged) source URL, so an audio-switch / background
+        // reload republishes the load-time snapshot rather than re-probing. Disc chapters are NOT
+        // snapshot here: a title switch changes them, so they recapture from the reopened demuxer below.
+        let preservedMediaChapters = mediaChapters
         let reloadStart = DispatchTime.now()
         EngineLog.emit("[AetherEngine] reload: stopInternal start", category: .engine)
         // resetDisplayCriteria: false: video format is unchanged; resetting triggers a full waitForSwitch Stage 2 timeout (5 s at the 2026-05-26 device test, ~2 s cap since #117; Bose SLIII A2DP + 4K HDR10 PQ: each switch added ~12 s black-screen). On the same route a panel SDR drop during the reset window failed the PQ variant with AVFoundationErrorDomain -11868 / CoreMediaErrorDomain -17223.
@@ -1510,6 +1514,8 @@ extension AetherEngine {
             }
         } else {
             activeDiscTitleID = nil
+            // Non-disc reload: restore the container chapters stopInternal wiped (same source, same chapters).
+            mediaChapters = preservedMediaChapters
         }
 
         // Re-arm subtitle: sidecar branch wins because loadedSidecarURL is set only for sidecar sources.

--- a/Sources/AetherEngine/AetherEngine.swift
+++ b/Sources/AetherEngine/AetherEngine.swift
@@ -192,6 +192,11 @@ public final class AetherEngine: ObservableObject {
     /// Chapters of the selected title. Empty until Blu-ray chapter parsing ships (Phase 2); declared
     /// now so hosts can bind the picker against a stable API.
     @Published public internal(set) var discChapters: [ChapterInfo] = []
+    /// Container (Matroska/MP4) chapters of the loaded source, from the probe demuxer at load. Empty
+    /// when the container declares none and for disc sources (whose chapters publish on `discChapters`
+    /// with title-relative seek semantics). `startSeconds` values are content timestamps a host passes
+    /// straight to `seek(to:)`.
+    @Published public internal(set) var mediaChapters: [ChapterInfo] = []
     /// The id of the title the disc demuxer should (re)open with. Mirrors `selectedDiscTitle?.id` but
     /// kept as plain state so it survives the stopInternal inside a reload and threads into audio-switch /
     /// background-resume reopens (a URL-disc reopen with no id would silently revert to the main title).
@@ -1790,6 +1795,7 @@ public final class AetherEngine: ObservableObject {
         discTitles = []
         selectedDiscTitle = nil
         discChapters = []
+        mediaChapters = []
         subtitleCueDiagnosticCount = 0
         // Reset format/dimension state so paths that skip the probe (nativeRemoteHLS) or find no video
         // don't keep publishing the predecessor's values (e.g. Live TV after an HDR10 film kept reporting .hdr10).
@@ -1973,6 +1979,7 @@ public final class AetherEngine: ObservableObject {
         // clamped to an in-range id); non-disc sources report empty/nil (#67).
         discTitles = probeOpened ? probe.discTitleInfos() : []
         discChapters = probeOpened ? probe.discChapterInfos() : []
+        mediaChapters = (probeOpened && discTitles.isEmpty) ? probe.mediaChapterInfos() : []
         activeDiscTitleID = probeOpened ? probe.selectedDiscTitleID : nil
         selectedDiscTitle = activeDiscTitleID.flatMap { id in discTitles.first { $0.id == id } }
         // Content start PTS for the software-path chapter-seek base (see sourceStartSeconds). start_time is
@@ -3243,6 +3250,7 @@ public final class AetherEngine: ObservableObject {
         discTitles = []
         selectedDiscTitle = nil
         discChapters = []
+        mediaChapters = []
         activeDiscTitleID = nil
         sourceStartSeconds = 0
         isLive = false

--- a/Sources/AetherEngine/Demuxer/Demuxer.swift
+++ b/Sources/AetherEngine/Demuxer/Demuxer.swift
@@ -648,6 +648,47 @@ public final class Demuxer: @unchecked Sendable {
         )
     }
 
+    /// Container (Matroska/MP4) chapters mapped to the public model, sorted by start and re-ided
+    /// sequentially so ids stay stable list indices for hosts. Empty when the container declares none.
+    /// Disc sources keep their playlist/IFO chapters via `discChapterInfos`; both can coexist and the
+    /// engine picks. Untitled entries fall back to "Chapter N" (matching the disc naming). A chapter's
+    /// declared end is trusted only for the duration of the LAST entry; earlier durations run to the
+    /// next chapter's start, because real-world MKV muxes routinely write end == start.
+    func mediaChapterInfos() -> [ChapterInfo] {
+        accessLock.lock()
+        defer { accessLock.unlock() }
+        guard let ctx = formatContext,
+              ctx.pointee.nb_chapters > 0,
+              let chapterList = ctx.pointee.chapters else { return [] }
+
+        struct RawChapter { let start: Double; let end: Double; let title: String? }
+        var raw: [RawChapter] = []
+        raw.reserveCapacity(Int(ctx.pointee.nb_chapters))
+        for i in 0..<Int(ctx.pointee.nb_chapters) {
+            guard let chapter = chapterList[i]?.pointee else { continue }
+            let tb = chapter.time_base
+            guard tb.den > 0, tb.num >= 0, chapter.start != Int64.min else { continue }
+            let scale = Double(tb.num) / Double(tb.den)
+            let start = Swift.max(0, Double(chapter.start) * scale)
+            let end = chapter.end != Int64.min ? Double(chapter.end) * scale : start
+            raw.append(RawChapter(
+                start: start,
+                end: end,
+                title: metadataValue(chapter.metadata, key: "title")
+            ))
+        }
+        raw.sort { $0.start < $1.start }
+
+        return raw.enumerated().map { i, ch in
+            let end = i + 1 < raw.count ? raw[i + 1].start : Swift.max(ch.end, ch.start)
+            let trimmed = ch.title?.trimmingCharacters(in: .whitespacesAndNewlines)
+            let name = (trimmed?.isEmpty == false) ? trimmed! : "Chapter \(i + 1)"
+            return ChapterInfo(id: i, name: name,
+                               startSeconds: ch.start,
+                               durationSeconds: Swift.max(0, end - ch.start))
+        }
+    }
+
     private func attachedPictureData() -> Data? {
         guard let ctx = formatContext else { return nil }
         for i in 0..<Int(ctx.pointee.nb_streams) {


### PR DESCRIPTION
Reads AVFormatContext.chapters in the probe demuxer and publishes them as
engine.mediaChapters, giving hosts a chapter list for ordinary file/URL
sources to build chapter navigation UI on - previously only disc
(DVD/Blu-ray) sources exposed chapters via discChapters.

- Demuxer.mediaChapterInfos(): sorted by start, re-ided sequentially,
  "Chapter N" fallback naming (matching the disc naming). Declared end
  times are trusted only for the last entry - real-world MKV muxes
  routinely write end == start - earlier durations run to the next start.
- Suppressed for disc sources: those keep their playlist/IFO chapters on
  discChapters with title-relative seek semantics; both lists never
  populate at once, so hosts can bind one picker.
- Wiped in both engine reset paths; preserved across the audio-switch /
  background reload seam via a pre-stopInternal snapshot (the source URL
  is unchanged, so re-probing would be waste), while disc chapters keep
  their existing reopened-demuxer recapture (a title switch legitimately
  changes them).

startSeconds values are content timestamps a host passes straight to
seek(to:). Shipped in a production tvOS consumer driving a chapter rail
on both this engine and a libmpv twin.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---
Validated: builds for generic tvOS Simulator (arm64) against this repo's own manifest; running in a production tvOS consumer (custom chapter-rail UI over this API alongside a libmpv twin reading `chapter-list`, so the surface was designed engine-agnostic).