### PR TITLE
feat(native): own an MPNowPlayingSession for the native video path

### DIFF
--- a/Sources/AetherEngine/AetherEngine+Loading.swift
+++ b/Sources/AetherEngine/AetherEngine+Loading.swift
@@ -145,6 +145,9 @@ extension AetherEngine {
         if !pendingExternalMetadata.isEmpty {
             host.setExternalMetadata(pendingExternalMetadata)
         }
+        if !pendingVideoNowPlayingInfo.isEmpty {
+            host.setNowPlayingInfo(pendingVideoNowPlayingInfo)
+        }
         self.nativeHost = host
         // A surface bound BEFORE load ran presentCurrentLayer() while nativeHost was still nil
         // (no-op); without this re-present nothing ever attaches host.playerLayer and AVPlayer
@@ -727,6 +730,9 @@ extension AetherEngine {
         // Forward pre-load externalMetadata so the AVPlayerItem picks it up before AVPlayer assigns it.
         if !pendingExternalMetadata.isEmpty {
             host.setExternalMetadata(pendingExternalMetadata)
+        }
+        if !pendingVideoNowPlayingInfo.isEmpty {
+            host.setNowPlayingInfo(pendingVideoNowPlayingInfo)
         }
         self.nativeHost = host
         applyDesiredVolume(to: host)

--- a/Sources/AetherEngine/AetherEngine.swift
+++ b/Sources/AetherEngine/AetherEngine.swift
@@ -2914,6 +2914,30 @@ public final class AetherEngine: ObservableObject {
         audioAVPlayerHost?.setExternalMetadata(items)
     }
 
+    #if os(tvOS) || os(iOS)
+    /// MPNowPlayingSession for the native VIDEO path, or nil (software path / no host). Same contract
+    /// as `audioNowPlayingSession`: the host app registers transport commands on
+    /// `remoteCommandCenter` and stages identity metadata via `setVideoNowPlayingInfo`; the session
+    /// auto-publishes elapsed/rate/duration from the AVPlayer and survives native->native reloads
+    /// with the host (issue #15), so system Now-Playing ownership holds across a background pause.
+    public var videoNowPlayingSession: MPNowPlayingSession? {
+        nativeHost?.nowPlayingSession
+    }
+    #endif
+
+    /// Staged per-item Now-Playing dictionary for the native video path. Replayed at host creation
+    /// and onto every fresh AVPlayerItem (gate reloads, media fallback, in-place swaps). Caller-managed
+    /// like the audio variant: pass an empty dict to clear.
+    var pendingVideoNowPlayingInfo: [String: Any] = [:]
+
+    /// Stage the system Now-Playing identity dictionary for the native video path (MPMediaItemProperty
+    /// keys + a force-decoded, @Sendable-wrapped MPMediaItemArtwork). Elapsed/rate/duration keys are
+    /// unnecessary — the session merges the player truth. Safe before load(); replayed at host creation.
+    public func setVideoNowPlayingInfo(_ info: [String: Any]) {
+        pendingVideoNowPlayingInfo = info
+        nativeHost?.setNowPlayingInfo(info)
+    }
+
     #if os(iOS) || os(tvOS)
     /// Staged per-item Now-Playing dictionary for the audio AVPlayer path. Replayed at host creation.
     var pendingAudioNowPlayingInfo: [String: Any] = [:]

--- a/Sources/AetherEngine/Native/NativeAVPlayerHost.swift
+++ b/Sources/AetherEngine/Native/NativeAVPlayerHost.swift
@@ -2,6 +2,9 @@ import Foundation
 import AVFoundation
 import AVKit
 import Combine
+#if os(tvOS) || os(iOS)
+import MediaPlayer
+#endif
 
 /// NativeAVPlayerHost: AVPlayer + AVPlayerLayer wrapper for the HLS-fMP4 loopback path.
 /// tvOS exposes the HDMI DV/HDR handshake only through AVPlayer-rooted playback, not AVSampleBufferDisplayLayer.
@@ -128,12 +131,48 @@ final class NativeAVPlayerHost {
 
     // MARK: - Init
 
+    #if os(tvOS) || os(iOS)
+    /// Now-Playing session bound to THIS player (same rationale as
+    /// AudioAVPlayerHost): the shared MPRemoteCommandCenter /
+    /// MPNowPlayingInfoCenter aren't reliably bound to a bare AVPlayer — a
+    /// background pause (rate 0) drops the app as active Now-Playing and the
+    /// shared center stops receiving commands. Owning the session keeps
+    /// ownership across pause; it also persists with the host across
+    /// native->native reloads (issue #15), so MediaRemote registration
+    /// survives the seam. Hosts register transport commands on
+    /// `nowPlayingSession.remoteCommandCenter` and stage per-item metadata
+    /// via `setNowPlayingInfo`; auto-publish merges the player-derived
+    /// elapsed/rate/duration, so nobody writes the shared info center.
+    let nowPlayingSession: MPNowPlayingSession
+    #endif
+
+    /// Per-item Now-Playing dictionary (identity keys + a force-decoded,
+    /// @Sendable-wrapped MPMediaItemArtwork) replayed onto every new item so
+    /// readiness-gate master reloads, media fallbacks, and in-place swaps
+    /// keep the system card.
+    private var pendingNowPlayingInfo: [String: Any] = [:]
+
     init() {
         let player = AVPlayer()
         // Keep automaticallyWaitsToMinimizeStalling at default true: false caused permanent startup stall on 4K HEVC (rate dropped to 0 after asset.load and never resumed).
         self.avPlayer = player
         self.playerLayer = AVPlayerLayer(player: player)
         self.playerLayer.videoGravity = .resizeAspect
+        #if os(tvOS) || os(iOS)
+        nowPlayingSession = MPNowPlayingSession(players: [player])
+        nowPlayingSession.automaticallyPublishesNowPlayingInfo = true
+        nowPlayingSession.becomeActiveIfPossible(completion: { _ in })
+        #endif
+    }
+
+    /// Stage (and immediately apply) the per-item system Now-Playing
+    /// dictionary. Identity keys only — the auto-publishing session owns
+    /// elapsed/rate/duration. Empty clears.
+    func setNowPlayingInfo(_ info: [String: Any]) {
+        pendingNowPlayingInfo = info
+        #if os(tvOS) || os(iOS)
+        playerItem?.nowPlayingInfo = info.isEmpty ? nil : info
+        #endif
     }
 
     // No deinit cleanup: under Swift 6 strict concurrency the deinit
@@ -197,6 +236,11 @@ final class NativeAVPlayerHost {
         if !pendingExternalMetadata.isEmpty {
             item.externalMetadata = pendingExternalMetadata
         }
+        #endif
+        #if os(tvOS) || os(iOS)
+        // Replay staged Now-Playing identity onto the fresh item (gate
+        // reloads / media fallback / in-place swaps keep the system card).
+        item.nowPlayingInfo = pendingNowPlayingInfo.isEmpty ? nil : pendingNowPlayingInfo
         #endif
         playerItem = item
         accessLogCount = 0


### PR DESCRIPTION
The audio AVPlayer path already owns an auto-publishing MPNowPlayingSession
(AudioAVPlayerHost) because the shared MPRemoteCommandCenter /
MPNowPlayingInfoCenter aren't reliably bound to a bare AVPlayer: a
background pause drops the app as active Now-Playing and the shared center
stops receiving commands. The native VIDEO path had the same exposure with
no equivalent - custom-UI hosts (no AVPlayerViewController) got the
half-working bare-AVPlayer registration.

NativeAVPlayerHost now owns the same sanctioned session pattern:

- MPNowPlayingSession bound to the host's AVPlayer, auto-publish ON, so
  elapsed/rate/duration come from player truth and nobody writes the
  shared info center.
- The session persists with the host across native->native reloads
  (issue #15), so MediaRemote registration survives the reload seam that
  previously blanked the system card.
- Per-item identity metadata staged via setNowPlayingInfo and replayed
  onto every fresh AVPlayerItem, so readiness-gate master reloads, media
  fallbacks, and in-place swaps keep the card.

Engine surface mirrors the audio contract exactly:
videoNowPlayingSession (hosts register transport commands on its
remoteCommandCenter) and setVideoNowPlayingInfo (caller-managed, empty
clears, safe before load(), replayed at host creation).

Shipped in a production tvOS consumer with a custom player UI; commands
and card verified against pause/resume, seek, and gate-reload seams.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---
Validated: builds for generic tvOS Simulator (arm64) against this repo's own manifest; running in a production tvOS consumer whose host registers transport commands on `videoNowPlayingSession.remoteCommandCenter` and stamps identity via `setVideoNowPlayingInfo`.