### PR TITLE
fix(live): halt blocking-reload when the segment producer exits for host retune (#167)

### DIFF
--- a/Sources/AetherEngine/Network/HLSLocalServer.swift
+++ b/Sources/AetherEngine/Network/HLSLocalServer.swift
@@ -615,7 +615,14 @@ final class HLSLocalServer: @unchecked Sendable {
                 if let msn = Self.parseHLSMsn(query) {
                     // LL-HLS blocking reload: hold until segment msn is cut so AVPlayer receives it the instant it exists, not a reload-interval late. Gated on liveBlockingReloadEnabled: bursty ingest sources can't honor the contract and withheld it.
                     if p.liveBlockingReloadEnabled {
-                        _ = p.waitForLiveSegment(index: msn, timeout: 18.0)
+                        // Unsatisfiable hold (producer halted/stalled, or timeout): 503, never the
+                        // unchanged playlist. A 200 without the requested MSN after a hold is "Invalid
+                        // server blocking reload behavior" (-15410) to AVPlayer (#167 follow-up;
+                        // RFC 8216bis requires the 503 here).
+                        if !p.waitForLiveSegment(index: msn, timeout: 18.0) {
+                            return send503(fd: fd, path: normalizedPath,
+                                           reason: "blocking reload msn=\(msn) unsatisfiable")
+                        }
                     }
                 } else {
                     _ = p.waitForFirstLiveSegment(timeout: 30.0)

--- a/Sources/AetherEngine/Video/HLSVideoEngine+LiveReopen.swift
+++ b/Sources/AetherEngine/Video/HLSVideoEngine+LiveReopen.swift
@@ -15,6 +15,25 @@ extension HLSVideoEngine {
         return packetsWritten == 0 && cachedSegments == 0
     }
 
+    /// #167 follow-up pure decision: live pump exits that delegate to host retune leave a provider no
+    /// producer will ever cut into again. Its blocking-reload advert must drop and its held ?_HLS_msn=
+    /// waiters release, or the zombie session (and any item reload against it while the host retunes)
+    /// trips -15410 on a hold that cannot be satisfied. Reopenable URL exits resume cutting into the
+    /// same provider and must NOT latch; stop/muxer/backpressure exits have their own arms.
+    static func shouldHaltLiveProduction(
+        reason: HLSSegmentProducer.PumpExitReason,
+        sourceReopenableByURL: Bool
+    ) -> Bool {
+        switch reason {
+        case .segmentStall, .sourceReplay:
+            return true
+        case .eof, .readError, .keyframeStarvation:
+            return !sourceReopenableByURL
+        case .stopRequested, .muxerFailed, .backpressureWedge:
+            return false
+        }
+    }
+
     func handlePumpFinished(_ prod: HLSSegmentProducer,
                                     reason: HLSSegmentProducer.PumpExitReason) {
         // #65 (VOD only): a broken backpressure wedge means AVPlayer is stuck behind a parked producer.
@@ -53,6 +72,9 @@ extension HLSVideoEngine {
             return
         }
         guard isLiveSession else { return }
+        if Self.shouldHaltLiveProduction(reason: reason, sourceReopenableByURL: sourceReopenableByURL) {
+            provider?.markLiveProductionHalted()
+        }
         switch reason {
         case .stopRequested, .muxerFailed, .backpressureWedge:
             return

--- a/Sources/AetherEngine/Video/VideoSegmentProvider.swift
+++ b/Sources/AetherEngine/Video/VideoSegmentProvider.swift
@@ -133,6 +133,11 @@ final class VideoSegmentProvider: HLSSegmentProvider, @unchecked Sendable {
     /// Set by cancelWaiters() on stop(). Without it, parked LL-HLS blocking-reload threads sleep
     /// their full timeout (18-30 s) and can write stale playlists into a recycled fd of the next session.
     private var waitersCancelled = false
+    /// Terminal latch (#167 follow-up): the live pump exited for host retune (SSAI cutter wedge,
+    /// source replay, custom-reader death), so no further segment will ever be cut into this provider.
+    /// The cadence policy cannot see this (it observes ingest arrivals, which keep flowing while the
+    /// cutter is wedged), so it is a separate, producer-level condition.
+    private var _liveProductionHalted = false
     private var refreshCounter: Int = 0
     /// EXT-X-MEDIA-SEQUENCE first index; monotonically advancing, stays 0 for VOD.
     private var _liveFirstVisible: Int = 0
@@ -622,7 +627,26 @@ final class VideoSegmentProvider: HLSSegmentProvider, @unchecked Sendable {
         isLive ? liveWindowSizing.targetSegmentDurationSeconds : nil
     }
     var liveBlockingReloadEnabled: Bool {
-        Self.resolveLiveBlockingReload(override: blockingReloadOverride, policy: liveCadencePolicy)
+        Self.resolveLiveBlockingReload(halted: liveProductionHalted,
+                                       override: blockingReloadOverride,
+                                       policy: liveCadencePolicy)
+    }
+
+    var liveProductionHalted: Bool {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return _liveProductionHalted
+    }
+
+    /// Live pump exited for host retune: no further segment will ever be cut into this provider.
+    /// Latch blocking-reload off for every subsequent manifest render (including an item reload
+    /// against this server) and release parked ?_HLS_msn= waiters so they 503 now instead of
+    /// sleeping out their full hold against a dead producer (-15410, #167 follow-up).
+    func markLiveProductionHalted() {
+        stateLock.lock()
+        _liveProductionHalted = true
+        stateLock.unlock()
+        cancelWaiters()
     }
     var liveTargetDurationFloorSeconds: Double? {
         // The floor tracks observed cadence regardless of the gate override: patience must cover the real
@@ -630,10 +654,13 @@ final class VideoSegmentProvider: HLSSegmentProvider, @unchecked Sendable {
         isLive ? liveCadencePolicy?.targetDurationFloorSeconds : nil
     }
 
-    /// Resolve blocking-reload eligibility: a host override wins everywhere; otherwise the observed-cadence
-    /// policy decides for ingest sources; signal-less live (plain-url Jellyfin transcode) keeps the
-    /// low-latency default. Pure so the precedence is unit-testable without a full provider (#167).
-    static func resolveLiveBlockingReload(override: Bool?, policy: LiveCadencePolicy?) -> Bool {
+    /// Resolve blocking-reload eligibility: a halted producer disables it unconditionally (no override
+    /// can conjure segments from a dead pump, #167 follow-up); otherwise a host override wins; otherwise
+    /// the observed-cadence policy decides for ingest sources; signal-less live (plain-url Jellyfin
+    /// transcode) keeps the low-latency default. Pure so the precedence is unit-testable without a full
+    /// provider (#167).
+    static func resolveLiveBlockingReload(halted: Bool = false, override: Bool?, policy: LiveCadencePolicy?) -> Bool {
+        if halted { return false }
         if let override { return override }
         if let policy { return policy.blockingReloadEnabled }
         return true

--- a/Tests/AetherEngineTests/LiveProductionHaltTests.swift
+++ b/Tests/AetherEngineTests/LiveProductionHaltTests.swift
@@ -1,0 +1,187 @@
+// Tests/AetherEngineTests/LiveProductionHaltTests.swift
+// AetherEngine#167 follow-up: a live session whose LOCAL segment producer stalls (SSAI cutter wedge,
+// field log G00380316 2026-07) while blocking-reload is latched ON must (a) answer the held ?_HLS_msn=
+// reload with a retriable 503 instead of a spec-invalid unchanged 200 (RFC 8216bis blocking reload;
+// AVPlayer -15410 otherwise), and (b) stop advertising CAN-BLOCK-RELOAD for the rest of the session,
+// including a client-initiated item reload against the same zombie server. The cadence policy cannot
+// see this failure mode: it observes ingest arrivals, which keep flowing while the cutter is wedged.
+import XCTest
+@testable import AetherEngine
+
+final class LiveProductionHaltTests: XCTestCase {
+
+    // MARK: - Resolver precedence
+
+    func testHaltBeatsOverrideAndPolicy() {
+        XCTAssertFalse(
+            VideoSegmentProvider.resolveLiveBlockingReload(halted: true, override: true, policy: nil),
+            "a dead producer cannot honor blocking-reload no matter what the host forces")
+        XCTAssertFalse(
+            VideoSegmentProvider.resolveLiveBlockingReload(halted: true, override: nil, policy: nil))
+        XCTAssertTrue(
+            VideoSegmentProvider.resolveLiveBlockingReload(halted: false, override: nil, policy: nil),
+            "non-halted signal-less live keeps the low-latency default")
+    }
+
+    // MARK: - Pump-exit classification
+
+    func testHostRetuneExitsHaltLiveProduction() {
+        XCTAssertTrue(HLSVideoEngine.shouldHaltLiveProduction(
+            reason: .segmentStall, sourceReopenableByURL: true),
+            "cutter wedge exits to host retune; the provider will never cut again")
+        XCTAssertTrue(HLSVideoEngine.shouldHaltLiveProduction(
+            reason: .sourceReplay, sourceReopenableByURL: true))
+        XCTAssertTrue(HLSVideoEngine.shouldHaltLiveProduction(
+            reason: .eof, sourceReopenableByURL: false),
+            "custom-reader pump death delegates to host retune")
+        XCTAssertTrue(HLSVideoEngine.shouldHaltLiveProduction(
+            reason: .readError(code: -5), sourceReopenableByURL: false))
+    }
+
+    func testRecoverableExitsDoNotHaltLiveProduction() {
+        XCTAssertFalse(HLSVideoEngine.shouldHaltLiveProduction(
+            reason: .eof, sourceReopenableByURL: true),
+            "reopenable URL exits resume cutting into the same provider")
+        XCTAssertFalse(HLSVideoEngine.shouldHaltLiveProduction(
+            reason: .readError(code: -5), sourceReopenableByURL: true))
+        XCTAssertFalse(HLSVideoEngine.shouldHaltLiveProduction(
+            reason: .keyframeStarvation, sourceReopenableByURL: true))
+        XCTAssertFalse(HLSVideoEngine.shouldHaltLiveProduction(
+            reason: .stopRequested, sourceReopenableByURL: false))
+        XCTAssertFalse(HLSVideoEngine.shouldHaltLiveProduction(
+            reason: .muxerFailed, sourceReopenableByURL: false))
+        XCTAssertFalse(HLSVideoEngine.shouldHaltLiveProduction(
+            reason: .backpressureWedge, sourceReopenableByURL: false))
+    }
+
+    // MARK: - Provider halt latch
+
+    private func segments(_ n: Int) -> [HLSVideoEngine.Segment] {
+        (0..<n).map { i in
+            HLSVideoEngine.Segment(startPts: Int64(i) * 4000, endPts: Int64(i + 1) * 4000,
+                                   startSeconds: Double(i) * 4.0, durationSeconds: 4.0)
+        }
+    }
+
+    func testMarkHaltDropsAdvertAndReleasesHeldWaiter() {
+        let cache = SegmentCache(forwardWindow: 10, backwardWindow: 10)
+        defer { cache.close() }
+        let provider = VideoSegmentProvider(
+            cache: cache, segments: segments(12), codecsString: "hvc1", supplementalCodecs: nil,
+            resolution: (1920, 1080), videoRange: .sdr, frameRate: 25.0, hdcpLevel: nil,
+            sourceBitrate: 8_000_000, isLive: true,
+            blockingReloadOverride: true)
+        XCTAssertTrue(provider.liveBlockingReloadEnabled, "override ON before the halt")
+
+        final class ResultBox: @unchecked Sendable { var value = true }
+        let box = ResultBox()
+        let released = expectation(description: "held blocking-reload waiter released")
+        DispatchQueue.global().async {
+            // The reporter's shape: playlist ends at segment 11, AVPlayer holds ?_HLS_msn=12.
+            box.value = provider.waitForLiveSegment(index: 12, timeout: 10)
+            released.fulfill()
+        }
+        Thread.sleep(forTimeInterval: 0.2)  // let the waiter park
+        provider.markLiveProductionHalted()
+        wait(for: [released], timeout: 2.0)
+        XCTAssertFalse(box.value, "released waiter must report the segment as unavailable, well before its 10s timeout")
+        XCTAssertFalse(provider.liveBlockingReloadEnabled,
+                       "halted session must stop advertising CAN-BLOCK-RELOAD, beating the host override")
+    }
+
+    // MARK: - Server 503 on unsatisfiable held reload (socket level)
+
+    private func fetch(_ url: URL) throws -> (status: Int, body: String) {
+        let semaphore = DispatchSemaphore(value: 0)
+        final class Box: @unchecked Sendable {
+            var status = -1
+            var body = ""
+            var error: Error?
+        }
+        let box = Box()
+        let task = URLSession.shared.dataTask(with: url) { data, response, error in
+            box.error = error
+            box.status = (response as? HTTPURLResponse)?.statusCode ?? -1
+            box.body = data.flatMap { String(data: $0, encoding: .utf8) } ?? ""
+            semaphore.signal()
+        }
+        task.resume()
+        XCTAssertEqual(semaphore.wait(timeout: .now() + 5), .success, "request to \(url) timed out")
+        if let error = box.error { throw error }
+        return (box.status, box.body)
+    }
+
+    func testUnsatisfiedHeldBlockingReloadReturns503() throws {
+        let provider = ScriptedLiveHoldProvider(count: 3, blockingReload: true, holdSatisfied: false)
+        let server = HLSLocalServer(provider: provider)
+        try server.start()
+        defer { server.stop() }
+        let result = try fetch(URL(string: "http://127.0.0.1:\(server.port)/media.m3u8?_HLS_msn=99")!)
+        XCTAssertEqual(result.status, 503,
+                       "a held blocking reload that cannot be satisfied must 503 (retriable), never serve the unchanged playlist (-15410)")
+    }
+
+    func testSatisfiedHeldBlockingReloadServesPlaylist() throws {
+        let provider = ScriptedLiveHoldProvider(count: 3, blockingReload: true, holdSatisfied: true)
+        let server = HLSLocalServer(provider: provider)
+        try server.start()
+        defer { server.stop() }
+        let result = try fetch(URL(string: "http://127.0.0.1:\(server.port)/media.m3u8?_HLS_msn=2")!)
+        XCTAssertEqual(result.status, 200)
+        XCTAssertTrue(result.body.contains("#EXTM3U"), "satisfied hold serves the playlist as before")
+    }
+
+    func testGateOffMsnRequestServesImmediatelyWithoutHolding() throws {
+        // Field-proven 5.16.0 path: gate OFF ignores the directive and serves plainly; it must not
+        // start holding (or 503ing) now that unsatisfied holds are refused.
+        let provider = ScriptedLiveHoldProvider(count: 3, blockingReload: false, holdSatisfied: false)
+        let server = HLSLocalServer(provider: provider)
+        try server.start()
+        defer { server.stop() }
+        let result = try fetch(URL(string: "http://127.0.0.1:\(server.port)/media.m3u8?_HLS_msn=99")!)
+        XCTAssertEqual(result.status, 200)
+        XCTAssertTrue(result.body.contains("#EXTM3U"))
+        XCTAssertEqual(provider.holdCalls, 0, "gate OFF must never park the request in waitForLiveSegment")
+    }
+}
+
+/// Minimal live provider with a scripted waitForLiveSegment outcome, so the server's held-reload
+/// response shape can be pinned over a real socket without a producer.
+private final class ScriptedLiveHoldProvider: HLSSegmentProvider, @unchecked Sendable {
+    let count: Int
+    let blockingReload: Bool
+    let holdSatisfied: Bool
+    private let lock = NSLock()
+    private var _holdCalls = 0
+    var holdCalls: Int {
+        lock.lock(); defer { lock.unlock() }
+        return _holdCalls
+    }
+
+    init(count: Int, blockingReload: Bool, holdSatisfied: Bool) {
+        self.count = count
+        self.blockingReload = blockingReload
+        self.holdSatisfied = holdSatisfied
+    }
+
+    func initSegment() -> Data? { Data([0x00]) }
+    func mediaSegment(at index: Int) -> Data? { Data([0x00]) }
+    var segmentCount: Int { count }
+    func segmentDuration(at index: Int) -> Double { 4.0 }
+    var playlistType: HLSPlaylistType { .live }
+    var liveTargetSegmentDuration: Double? { 4.0 }
+    var liveBlockingReloadEnabled: Bool { blockingReload }
+    var liveTargetDurationFloorSeconds: Double? { nil }
+
+    func waitForLiveSegment(index: Int, timeout: TimeInterval) -> Bool {
+        lock.lock()
+        _holdCalls += 1
+        lock.unlock()
+        return holdSatisfied
+    }
+    func waitForFirstLiveSegment(timeout: TimeInterval) -> Bool { true }
+
+    func notePlaylistBuild() -> (visibleCount: Int, firstVisible: Int, refreshCounter: Int, endlistAdded: Bool, discontinuitySequence: Int) {
+        (count, 0, 1, false, 0)
+    }
+}


### PR DESCRIPTION
Follow-up to the 5.16.0 observed-cadence fix, from G00380316's retest on #167: the original bursty-origin case holds, but a LOCAL segment-producer stall (SSAI cutter wedge) with blocking-reload latched ON reproduces -15410 through a different mechanism.

The cadence policy observes ingest arrivals, which keep flowing while the cutter is wedged, so it cannot see this failure mode. The held ?_HLS_msn= reload waited on a segment that will never be cut, timed out after 18s, and was answered with the unchanged playlist (no requested MSN): spec-invalid, AVPlayer errors -15410. The stall watchdog's item reload against the same zombie server then immediately re-armed a second one.

Three coordinated changes:

- `HLSLocalServer` answers an unsatisfiable held blocking reload with a retriable 503 (RFC 8216bis) instead of a spec-invalid unchanged 200. Satisfied holds and the field-proven gate-off immediate serve are unchanged.
- `VideoSegmentProvider` gains a terminal production-halted latch that beats the host override and the cadence policy, and releases parked waiters immediately (they 503 now instead of sleeping out the hold).
- `handlePumpFinished` latches it on every live exit that delegates to host retune (`segmentStall`, `sourceReplay`, non-URL-reopenable pump deaths). Reopenable URL exits keep cutting into the same provider and do not latch.

Covered by `LiveProductionHaltTests` (resolver precedence, exit-reason classification, waiter release, and socket-level 503/200 response shapes). Full suite green, strict-concurrency build clean, tvOS Simulator build clean.

Closes nothing on its own; #167 stays open for the reporter retest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NAPCg4tCDdSqkK6tPkNptw