### PR TITLE
fix(routing): exempt DV Profile 5 from the VT capability probe gate (#176)

### DIFF
--- a/Sources/AetherEngine/AetherEngine.swift
+++ b/Sources/AetherEngine/AetherEngine.swift
@@ -2199,18 +2199,29 @@ public final class AetherEngine: ObservableObject {
         // there is no analogous fallback on the native route, so route it to the SoftwarePlaybackHost
         // (libavcodec), which decodes these profiles. VOD only: forced-native live keeps its verified path, and
         // broadcast H.264 / HEVC is HW-decodable. Apple Silicon HW-decodes these, so the probe keeps them native.
+        // #176: DV Profile 5 is exempt inside the policy; the raw-hvcC probe misjudges the dvh1 route and the
+        // software path decodes IPT-PQ-c2 with a green/purple cast, so P5 must stay native unconditionally.
         if !useSoftwarePath, !options.isLive, probeOpened,
            let vStream = probe.stream(at: probe.videoStreamIndex),
-           let codecpar = vStream.pointee.codecpar,
-           VideoRoutingPolicy.forcesSoftwareForUndecodableFormat(
-               codecID: detectedCodecID,
-               canHardwareDecode: VTCapabilityProbe.canHardwareDecode(codecpar: codecpar)) {
-            useSoftwarePath = true
-            EngineLog.emit(
-                "[AetherEngine] codec=\(detectedCodecID.rawValue) not hardware-decodable by "
-                + "VideoToolbox; routing to the software path so it plays instead of a black screen (#2)",
-                category: .engine
-            )
+           let codecpar = vStream.pointee.codecpar {
+            let dvProfile = Self.dvProfile(stream: vStream)
+            if VideoRoutingPolicy.forcesSoftwareForUndecodableFormat(
+                   codecID: detectedCodecID,
+                   dvProfile: dvProfile,
+                   canHardwareDecode: { VTCapabilityProbe.canHardwareDecode(codecpar: codecpar) }) {
+                useSoftwarePath = true
+                EngineLog.emit(
+                    "[AetherEngine] codec=\(detectedCodecID.rawValue) not hardware-decodable by "
+                    + "VideoToolbox; routing to the software path so it plays instead of a black screen (#2)",
+                    category: .engine
+                )
+            } else if detectedCodecID == AV_CODEC_ID_HEVC, dvProfile == 5 {
+                EngineLog.emit(
+                    "[AetherEngine] DV Profile 5: VT probe skipped, native dvh1 path is the only "
+                    + "correct decode (#176)",
+                    category: .engine
+                )
+            }
         }
         // Forward-only sources can't serve the native path's seeks (cue prewarm, segment seeks).
         // Covers custom readers AND URL sources whose AVIOReader resolved no size and degraded to

--- a/Sources/AetherEngine/Decoder/VideoRoutingPolicy.swift
+++ b/Sources/AetherEngine/Decoder/VideoRoutingPolicy.swift
@@ -48,16 +48,27 @@ enum VideoRoutingPolicy {
     /// Second-stage gate (#2): a codec that passed `requiresSoftwarePath` as native (H.264 / HEVC) but whose
     /// specific format VideoToolbox cannot HARDWARE-decode must still fall back to software, or the native
     /// AVPlayer path reaches readyToPlay and then renders nothing (H.264 High 4:2:2/4:4:4/High-10, HEVC Rext
-    /// on Intel Macs / older Apple TV). Pure so it is unit-testable; the impure VT probe result
-    /// (`VTCapabilityProbe.canHardwareDecode`) is injected as `canHardwareDecode`. Only H.264 / HEVC consult
-    /// this gate; AV1 / VP9 / etc. already have their own routing above and must not be reclassified here.
+    /// on Intel Macs / older Apple TV). Pure so it is unit-testable; the impure VT probe
+    /// (`VTCapabilityProbe.canHardwareDecode`) is injected as the `canHardwareDecode` closure and only runs
+    /// when the gate actually consults it. Only H.264 / HEVC consult this gate; AV1 / VP9 / etc. already
+    /// have their own routing above and must not be reclassified here.
+    ///
+    /// #176: HEVC DV Profile 5 bypasses the gate entirely. The probe builds a plain-HEVC format description
+    /// from the raw hvcC, which is not what the native path plays (dvh1 + dvcC, decoded by Apple's DV
+    /// decoder), so a probe rejection there is not evidence the dvh1 route fails. And P5 has no compatible
+    /// base layer: libavcodec decodes its IPT-PQ-c2 signal as YCbCr (green/purple cast), so the software
+    /// path is never a correct fallback for it. P7 / P8.x keep the gate; their base layer is standard
+    /// Main10 that the software path decodes with correct color.
     static func forcesSoftwareForUndecodableFormat(
         codecID: AVCodecID,
-        canHardwareDecode: Bool
+        dvProfile: Int?,
+        canHardwareDecode: () -> Bool
     ) -> Bool {
         switch codecID {
+        case AV_CODEC_ID_HEVC where dvProfile == 5:
+            return false
         case AV_CODEC_ID_H264, AV_CODEC_ID_HEVC:
-            return !canHardwareDecode
+            return !canHardwareDecode()
         default:
             return false
         }

--- a/Tests/AetherEngineTests/VideoRoutingPolicyTests.swift
+++ b/Tests/AetherEngineTests/VideoRoutingPolicyTests.swift
@@ -110,17 +110,17 @@ struct VideoRoutingPolicyTests {
     @Test("H.264 / HEVC that VideoToolbox can't HW-decode falls back to software")
     func undecodableHEVCH264Software() {
         #expect(VideoRoutingPolicy.forcesSoftwareForUndecodableFormat(
-            codecID: AV_CODEC_ID_H264, canHardwareDecode: false))
+            codecID: AV_CODEC_ID_H264, dvProfile: nil, canHardwareDecode: { false }))
         #expect(VideoRoutingPolicy.forcesSoftwareForUndecodableFormat(
-            codecID: AV_CODEC_ID_HEVC, canHardwareDecode: false))
+            codecID: AV_CODEC_ID_HEVC, dvProfile: nil, canHardwareDecode: { false }))
     }
 
     @Test("HW-decodable H.264 / HEVC stays native (no Apple Silicon regression)")
     func decodableHEVCH264Native() {
         #expect(!VideoRoutingPolicy.forcesSoftwareForUndecodableFormat(
-            codecID: AV_CODEC_ID_H264, canHardwareDecode: true))
+            codecID: AV_CODEC_ID_H264, dvProfile: nil, canHardwareDecode: { true }))
         #expect(!VideoRoutingPolicy.forcesSoftwareForUndecodableFormat(
-            codecID: AV_CODEC_ID_HEVC, canHardwareDecode: true))
+            codecID: AV_CODEC_ID_HEVC, dvProfile: nil, canHardwareDecode: { true }))
     }
 
     @Test("non-H.264/HEVC codecs ignore the undecodable gate (own policy governs them)")
@@ -129,7 +129,39 @@ struct VideoRoutingPolicyTests {
         // it, and must never reclassify VP9 / MPEG-2 / etc. off a codec they don't apply to.
         for codec in [AV_CODEC_ID_AV1, AV_CODEC_ID_VP9, AV_CODEC_ID_MPEG2VIDEO, AV_CODEC_ID_VC1] {
             #expect(!VideoRoutingPolicy.forcesSoftwareForUndecodableFormat(
-                codecID: codec, canHardwareDecode: false))
+                codecID: codec, dvProfile: nil, canHardwareDecode: { false }))
         }
+    }
+
+    // MARK: - #176 DV Profile 5 bypasses the VT probe gate
+
+    @Test("HEVC DV P5 stays native even when the raw-hvcC probe says undecodable")
+    func dvProfile5StaysNative() {
+        #expect(!VideoRoutingPolicy.forcesSoftwareForUndecodableFormat(
+            codecID: AV_CODEC_ID_HEVC, dvProfile: 5, canHardwareDecode: { false }))
+    }
+
+    @Test("HEVC DV P5 never runs the VT probe")
+    func dvProfile5SkipsProbe() {
+        var probed = false
+        _ = VideoRoutingPolicy.forcesSoftwareForUndecodableFormat(
+            codecID: AV_CODEC_ID_HEVC, dvProfile: 5, canHardwareDecode: { probed = true; return false })
+        #expect(!probed)
+    }
+
+    @Test("HEVC DV P7 / P8 keep the gate (base layer is standard Main10)")
+    func dvProfile78KeepGate() {
+        for profile in [7, 8] {
+            #expect(VideoRoutingPolicy.forcesSoftwareForUndecodableFormat(
+                codecID: AV_CODEC_ID_HEVC, dvProfile: profile, canHardwareDecode: { false }))
+            #expect(!VideoRoutingPolicy.forcesSoftwareForUndecodableFormat(
+                codecID: AV_CODEC_ID_HEVC, dvProfile: profile, canHardwareDecode: { true }))
+        }
+    }
+
+    @Test("H.264 with DV side-data keeps the gate (P5 is HEVC-only)")
+    func h264DVKeepsGate() {
+        #expect(VideoRoutingPolicy.forcesSoftwareForUndecodableFormat(
+            codecID: AV_CODEC_ID_H264, dvProfile: 5, canHardwareDecode: { false }))
     }
 }


### PR DESCRIPTION
Fixes #176.

## Problem

A DV Profile 5 HEVC MKV on an M4 Mac mini played through the software path with a green/purple color shift. The reporter's log shows the #2 second-stage gate misfiring:

```
[VTProbe] canHardwareDecode codec=173 3840x2160 -> false (status=-4)
[AetherEngine] codec=173 not hardware-decodable by VideoToolbox; routing to the software path so it plays instead of a black screen (#2)
[SWDecoder] Opened: 3840x2160, codec=hevc, threads=10, 8-bit
```

## Root cause

`VTCapabilityProbe.canHardwareDecode` builds a plain-HEVC format description from the raw hvcC and asks VT for a hardware session. For DV Profile 5 that is not representative of what the native route actually plays: the muxer emits dvh1 + dvcC and Apple's DV decoder handles it (device-verified in #98, including tonemapping on non-DV panels). VT rejects the bare P5 hvcC with -12906/-4 even on Apple Silicon, so the probe returns a false negative and the #2 fallback routes P5 to the SoftwarePlaybackHost.

The software path then decodes the IPT-PQ-c2 base layer as YCbCr, which is exactly the green/purple cast from the screenshot (same symptom class as the pre-dvh1 era of #4). P5 has no HDR10/HLG/SDR-compatible base layer, so software is never a correct fallback for it, regardless of what VT says.

## Fix

`VideoRoutingPolicy.forcesSoftwareForUndecodableFormat` now takes the DOVI profile and a probe closure. HEVC + DV profile 5 bypasses the gate and stays native unconditionally; the closure form means the VT probe is not even invoked for P5. P7 / P8.x keep the gate since their base layer is standard Main10 that the software path decodes with correct color (and where the Intel / older Apple TV fallback of #2 remains valid).

## Verification

- New policy tests: P5 stays native with a refusing probe, P5 never invokes the probe, P7/P8 keep the gate, H.264 ignores the P5 exemption. 899/899 tests pass.
- `swift build -Xswiftc -strict-concurrency=complete` clean.
- tvOS Simulator `xcodebuild` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NAPCg4tCDdSqkK6tPkNptw