### PR TITLE
fix(routing): fail fast when IPT-only DV reaches the software path (#176)

### DIFF
--- a/Sources/AetherEngine/AetherEngine+Probe.swift
+++ b/Sources/AetherEngine/AetherEngine+Probe.swift
@@ -472,6 +472,12 @@ extension AetherEngine {
 
     /// Dolby Vision profile number (5, 7, 8, 10) from the dvcC/dvvC configuration record; nil when the stream carries no DV side-data. Same record `CodecRoutePolicy` reads for routing.
     nonisolated static func dvProfile(stream: UnsafeMutablePointer<AVStream>) -> Int? {
+        dvConfig(stream: stream)?.profile
+    }
+
+    /// Profile + base-layer signal compatibility ID from the dvcC/dvvC record (compat 0 = IPT-only, no
+    /// compatible base layer). nil when the stream carries no DV side-data.
+    nonisolated static func dvConfig(stream: UnsafeMutablePointer<AVStream>) -> (profile: Int, blCompatID: Int)? {
         let nb = Int(stream.pointee.codecpar.pointee.nb_coded_side_data)
         guard nb > 0, let sideData = stream.pointee.codecpar.pointee.coded_side_data else {
             return nil
@@ -480,7 +486,7 @@ extension AetherEngine {
             let item = sideData[i]
             guard item.type == AV_PKT_DATA_DOVI_CONF, let raw = item.data, item.size >= 8 else { continue }
             let record = raw.withMemoryRebound(to: AVDOVIDecoderConfigurationRecord.self, capacity: 1) { $0.pointee }
-            return Int(record.dv_profile)
+            return (Int(record.dv_profile), Int(record.dv_bl_signal_compatibility_id))
         }
         return nil
     }

--- a/Sources/AetherEngine/AetherEngine.swift
+++ b/Sources/AetherEngine/AetherEngine.swift
@@ -2239,6 +2239,29 @@ public final class AetherEngine: ObservableObject {
         }
         EngineLog.emit("[AetherEngine] dispatch: codec=\(detectedCodecID.rawValue) → \(useSoftwarePath ? "software" : "native")", category: .engine)
 
+        // #176 follow-up: IPT-only DV (HEVC P5, AV1 P10.0) must never start on the software path; the
+        // decoded IPT-PQ-c2 signal renders as YCbCr (green/purple cast). AV1 P10.0 without HW AV1 decode
+        // has no native fallback (AVPlayer HLS requires HW AV1), and HEVC P5 reaches here only off
+        // forward-only sources the native path cannot serve. Fail fast instead of playing wrong color.
+        if useSoftwarePath, probeOpened,
+           let vStream = probe.stream(at: probe.videoStreamIndex),
+           let dvConfig = Self.dvConfig(stream: vStream),
+           VideoRoutingPolicy.softwarePathCannotRepresent(
+               codecID: detectedCodecID,
+               dvProfile: dvConfig.profile,
+               dvBlCompatID: dvConfig.blCompatID) {
+            probe.markClosed()
+            Task.detached { [probe] in probe.close() }
+            let profileLabel = detectedCodecID == AV_CODEC_ID_AV1 ? "10.0" : "5"
+            EngineLog.emit(
+                "[AetherEngine] DV Profile \(profileLabel) routed to the software path; IPT-PQ-c2 has "
+                + "no compatible base layer and would render green/purple, failing fast (#176)",
+                category: .engine
+            )
+            state = .error("Dolby Vision Profile \(profileLabel) requires a hardware playback path on this device")
+            throw AetherEngineError.dolbyVisionUnplayableOnSoftwarePath(profile: profileLabel)
+        }
+
         // Demuxed-audio live ingest is native-path-only (side-demuxer merge lives in HLSSegmentProducer).
         // A demuxed-audio source routed SW would play silent; fail fast so the host falls back to server-muxed.
         if useSoftwarePath, options.isLive,
@@ -3523,6 +3546,10 @@ public enum AetherEngineError: Error, LocalizedError {
     /// AE#140: an HLS playlist URL (m3u8) was handed to `load(isLive:)` on the generic raw-byte path.
     /// Route m3u8 sources through `LoadOptions.nativeRemoteHLS` or `HLSLiveIngestReader` instead.
     case hlsPlaylistOnRawLivePath
+    /// #176 follow-up: HEVC P5 / AV1 P10.0 carry only an IPT-PQ-c2 signal (no compatible base layer);
+    /// the software path would decode it as YCbCr (green/purple cast), so the load fails instead.
+    /// AV1 P10.0 requires hardware AV1 decode; HEVC P5 requires a seekable source for the native path.
+    case dolbyVisionUnplayableOnSoftwarePath(profile: String)
 
     public var errorDescription: String? {
         switch self {
@@ -3530,6 +3557,8 @@ public enum AetherEngineError: Error, LocalizedError {
         case .noAudioStream: return "No audio stream in source"
         case .hlsPlaylistOnRawLivePath:
             return "HLS playlist supplied to the raw live path. Use LoadOptions.nativeRemoteHLS or HLSLiveIngestReader for m3u8 sources."
+        case .dolbyVisionUnplayableOnSoftwarePath(let profile):
+            return "Dolby Vision Profile \(profile) has no compatible base layer and cannot be color-correctly decoded on the software playback path"
         }
     }
 }

--- a/Sources/AetherEngine/Decoder/VideoRoutingPolicy.swift
+++ b/Sources/AetherEngine/Decoder/VideoRoutingPolicy.swift
@@ -73,4 +73,26 @@ enum VideoRoutingPolicy {
             return false
         }
     }
+
+    /// #176 follow-up: DV variants whose only signal is IPT-PQ-c2 (no compatible base layer) cannot be
+    /// color-correctly decoded by the software path: libavcodec / dav1d hand the IPT signal on as YCbCr,
+    /// which renders with a green/purple cast. That is HEVC P5 and AV1 P10.0 (compat 0). P7 / P8.x /
+    /// P10.1 / P10.2 / P10.4 base layers are self-contained HDR10 / SDR / HLG and stay software-eligible.
+    /// Consulted after the final routing decision; a true here fails the load instead of playing wrong color
+    /// (AV1 P10.0 without HW AV1 has no native fallback, HEVC P5 reaches software only off forward-only
+    /// sources the native path cannot serve).
+    static func softwarePathCannotRepresent(
+        codecID: AVCodecID,
+        dvProfile: Int?,
+        dvBlCompatID: Int?
+    ) -> Bool {
+        switch codecID {
+        case AV_CODEC_ID_HEVC:
+            return dvProfile == 5
+        case AV_CODEC_ID_AV1:
+            return dvProfile == 10 && dvBlCompatID == 0
+        default:
+            return false
+        }
+    }
 }

--- a/Tests/AetherEngineTests/VideoRoutingPolicyTests.swift
+++ b/Tests/AetherEngineTests/VideoRoutingPolicyTests.swift
@@ -164,4 +164,46 @@ struct VideoRoutingPolicyTests {
         #expect(VideoRoutingPolicy.forcesSoftwareForUndecodableFormat(
             codecID: AV_CODEC_ID_H264, dvProfile: 5, canHardwareDecode: { false }))
     }
+
+    // MARK: - #176 follow-up: IPT-only DV is unrepresentable on the software path
+
+    @Test("AV1 DV P10.0 (no base layer) is unrepresentable in software")
+    func av1Profile100Unrepresentable() {
+        #expect(VideoRoutingPolicy.softwarePathCannotRepresent(
+            codecID: AV_CODEC_ID_AV1, dvProfile: 10, dvBlCompatID: 0))
+    }
+
+    @Test("AV1 DV P10.1 / P10.2 / P10.4 stay software-eligible (compatible base layer)")
+    func av1Profile10CompatBaseEligible() {
+        for compat in [1, 2, 4] {
+            #expect(!VideoRoutingPolicy.softwarePathCannotRepresent(
+                codecID: AV_CODEC_ID_AV1, dvProfile: 10, dvBlCompatID: compat))
+        }
+    }
+
+    @Test("HEVC DV P5 is unrepresentable in software (forward-only escape hatch)")
+    func hevcProfile5Unrepresentable() {
+        #expect(VideoRoutingPolicy.softwarePathCannotRepresent(
+            codecID: AV_CODEC_ID_HEVC, dvProfile: 5, dvBlCompatID: 0))
+    }
+
+    @Test("HEVC DV P7 / P8 and non-DV streams stay software-eligible")
+    func hevcOtherProfilesEligible() {
+        for profile in [7, 8] {
+            #expect(!VideoRoutingPolicy.softwarePathCannotRepresent(
+                codecID: AV_CODEC_ID_HEVC, dvProfile: profile, dvBlCompatID: 1))
+        }
+        #expect(!VideoRoutingPolicy.softwarePathCannotRepresent(
+            codecID: AV_CODEC_ID_HEVC, dvProfile: nil, dvBlCompatID: nil))
+        #expect(!VideoRoutingPolicy.softwarePathCannotRepresent(
+            codecID: AV_CODEC_ID_AV1, dvProfile: nil, dvBlCompatID: nil))
+    }
+
+    @Test("non-DV-capable codecs never trip the unrepresentable check")
+    func otherCodecsNeverUnrepresentable() {
+        for codec in [AV_CODEC_ID_H264, AV_CODEC_ID_VP9, AV_CODEC_ID_MPEG2VIDEO] {
+            #expect(!VideoRoutingPolicy.softwarePathCannotRepresent(
+                codecID: codec, dvProfile: 10, dvBlCompatID: 0))
+        }
+    }
 }


### PR DESCRIPTION
Follow-up to #182 (the P5 VT-probe exemption). Part of the #176 cleanup.

## Problem

AV1 DV Profile 10.0 (compat 0) carries the same IPT-PQ-c2-only signal as HEVC P5: no HDR10/HLG/SDR-compatible base layer. On devices without hardware AV1 decode (all Apple TVs, M1/M2 Macs, pre-A17 iPhones), `requiresSoftwarePath` routes AV1 to the software host, where dav1d's output is treated as YCbCr and renders with the same green/purple cast reported in #176. Unlike HEVC P5 there is no native fallback to prefer: AVPlayer's HLS pipeline requires HW AV1 (`VTIsHardwareDecodeSupported` gate), so no route on such devices can render P10.0 with correct color.

HEVC P5 also retained two remaining doors into the software path after #182: forward-only sources (which the native path cannot serve) and the test override.

## Fix

A new pure policy check, `VideoRoutingPolicy.softwarePathCannotRepresent(codecID:dvProfile:dvBlCompatID:)`, is consulted in the dispatch after the final routing decision. When IPT-only DV (HEVC P5, AV1 P10.0) would start on the software path, the load fails fast with a new public error (`AetherEngineError.dolbyVisionUnplayableOnSoftwarePath`) and a clear player-state message instead of starting a session that can only render wrong color. P7 / P8.x and AV1 P10.1 / P10.2 / P10.4 stay software-eligible; their base layer is self-contained and decodes with correct color.

New public error case, so this releases as a minor bump (5.18.0).

## Verification

- New `VideoRoutingPolicyTests` cases: P10.0 unrepresentable, P10.1/2/4 eligible, P5 unrepresentable, P7/P8/non-DV eligible, non-DV-capable codecs never trip. 904/904 tests pass.
- `swift build -Xswiftc -strict-concurrency=complete` clean.
- tvOS Simulator `xcodebuild` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NAPCg4tCDdSqkK6tPkNptw