### PR TITLE
fix(seek): stop dropping seeks during load and against pending authoritative restarts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ the public-API contract.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Seeks issued while the initial load is still in progress are no longer silently dropped.** `seek(to:)` no-oped for the whole `state == .loading` window (probe, native load, readiness gate, several seconds on slow sources), so hosts rendering the target optimistically watched playback snap back to the pre-seek position. The latest loading-window seek is now stashed in the #127 pre-ready slot, published optimistically to the scrub clock, and replayed when the session settles into a playable state (including autostart paths, where readiness fires while `state` is still `.loading`); a load that dies discards it. Reported by YangHanqing (#178, mechanism 1). Covered by `Issue178LoadingSeekStashTests`.
+- **An ordinary seek issued while a recovery re-anchor was pending no longer lands on the recovery position instead of its own target.** Once a seek-deadline reconcile parked an authoritative restart in the coalescer's pending slot (#79), a subsequent user seek's segment-driven restart was dropped outright, and the producer stayed anchored ~10 s+ away from the requested target while the provider's re-fire bookkeeping believed the restart had run. A new user seek now releases the superseded authoritative claim before dispatching the host seek, so its restart takes the pending slot normally; the #79 lock still blocks stale burst-tail scrubs that arrive without a fresh user seek. Reported by YangHanqing (#178, mechanism 2). Covered by `RestartCoalescerTests`.
+
 ## [5.18.1] - 2026-07-21
 
 ([release notes](https://github.com/superuser404notfound/AetherEngine/releases/tag/5.18.1))

--- a/Sources/AetherEngine/AetherEngine+Loading.swift
+++ b/Sources/AetherEngine/AetherEngine+Loading.swift
@@ -110,7 +110,9 @@ extension AetherEngine {
                     self.state = .paused
                 }
                 // #127: replay the latest host seek that arrived while the item was pre-ready.
-                if ready, let pending = self.pendingPreReadySeekSeconds {
+                // #178: not while still .loading (autostart paths hold .loading past readiness);
+                // replaying now would just re-stash. The state didSet resolves that case.
+                if ready, self.state != .loading, let pending = self.pendingPreReadySeekSeconds {
                     self.pendingPreReadySeekSeconds = nil
                     EngineLog.emit("[AetherEngine] replaying deferred pre-ready seek to \(String(format: "%.2f", pending))s (#127)", category: .engine)
                     Task { @MainActor in await self.seek(to: pending) }

--- a/Sources/AetherEngine/AetherEngine.swift
+++ b/Sources/AetherEngine/AetherEngine.swift
@@ -55,7 +55,10 @@ public final class AetherEngine: ObservableObject {
     // MARK: - Public State
 
     @Published public internal(set) var state: PlaybackState = .idle {
-        didSet { recomputePlaybackPhase() }
+        didSet {
+            recomputePlaybackPhase()
+            resolveLoadingStashedSeek(from: oldValue)
+        }
     }
 
     /// Mid-playback rebuffer flag. `state` stays `.playing` across a rebuffer to avoid icon flicker;
@@ -356,6 +359,40 @@ public final class AetherEngine: ObservableObject {
         nativeHostReady: Bool
     ) -> Bool {
         nativeSessionActive && !isLive && !nativeHostReady
+    }
+
+    /// #178: what to do with a seek stashed while `state == .loading` when `state` changes.
+    /// Only transitions OUT of `.loading` resolve the stash; every other transition holds it
+    /// (non-loading stashes belong to the #127 readiness sink). `.seeking` cannot follow
+    /// `.loading` (the `.loading` guard stashes instead of seeking) but holds defensively.
+    enum LoadingStashResolution { case replay, discard, hold }
+
+    nonisolated static func loadingStashResolution(
+        oldState: PlaybackState, newState: PlaybackState
+    ) -> LoadingStashResolution {
+        guard oldState == .loading else { return .hold }
+        switch newState {
+        case .playing, .paused: return .replay
+        case .idle, .ended, .error: return .discard
+        case .loading, .seeking: return .hold
+        }
+    }
+
+    /// #178: `state` didSet hook. Replays the loading-window seek once the session settles into a
+    /// playable state (covers autostart paths where readiness fires while `state` is still
+    /// `.loading` and the #127 sink must not replay yet), discards it when the load dies.
+    private func resolveLoadingStashedSeek(from oldState: PlaybackState) {
+        guard let pending = pendingPreReadySeekSeconds else { return }
+        switch Self.loadingStashResolution(oldState: oldState, newState: state) {
+        case .hold:
+            return
+        case .discard:
+            pendingPreReadySeekSeconds = nil
+        case .replay:
+            pendingPreReadySeekSeconds = nil
+            EngineLog.emit("[AetherEngine] replaying seek stashed during load to \(String(format: "%.2f", pending))s (#178)", category: .engine)
+            Task { @MainActor in await self.seek(to: pending) }
+        }
     }
 
     /// 1 Hz diagnostics sampler. Separate ObservableObject for the same reason as `clock`: per-sample
@@ -2524,8 +2561,14 @@ public final class AetherEngine: ObservableObject {
             EngineLog.emit("[AetherEngine] seek(to:\(seconds)) ignored: no active session (state=\(state))", category: .engine)
             return
         case .loading:
-            // No hosts yet; body would no-op but still flip state to .playing, dropping the host's spinner early.
-            EngineLog.emit("[AetherEngine] seek(to:\(seconds)) ignored: load in progress", category: .engine)
+            // #178: don't drop a seek raced against load(). No hosts exist yet (forwarding would
+            // no-op and flip state early, dropping the host's spinner), so stash the latest target
+            // in the #127 slot and resolve it on the transition out of .loading (state didSet):
+            // replay into a playable state, discard into a terminal one. Clamp/live guards re-run
+            // at replay when the session is actually known; duration may still be unprobed here.
+            pendingPreReadySeekSeconds = seconds
+            clock.currentTime = duration > 0 ? max(0, min(seconds, duration)) : max(0, seconds)
+            EngineLog.emit("[AetherEngine] seek(to:\(String(format: "%.2f", seconds))) stashed during load; will replay when the session settles (#178)", category: .engine)
             return
         default:
             break
@@ -2599,6 +2642,11 @@ public final class AetherEngine: ObservableObject {
             setProgrammaticSeek(inFlight: false, target: nil)
             return
         }
+        // #178: this seek supersedes any recovery re-anchor still holding the restart coalescer's
+        // authoritative slot (it was computed for the seek being superseded). Released before the
+        // host seek below so the new target's segment-driven restart cannot be dropped against a
+        // locked slot. Live never reaches here (returned above); LiveReopen's anchors are safe.
+        nativeVideoSession?.releaseSupersededAuthoritativeRestart()
         // Convert the (display-axis) target to AVPlayer's HLS clock. The origin re-adds a disc title's clip-0
         // STC base so `target` (0-based, matching duration) lands on the source-PTS shift the producer subtracts,
         // i.e. clockTarget == the 0-based playlist time (AE#105). Origin 0 off disc, so this stays

--- a/Sources/AetherEngine/Video/HLSVideoEngine.swift
+++ b/Sources/AetherEngine/Video/HLSVideoEngine.swift
@@ -1726,6 +1726,17 @@ public final class HLSVideoEngine: @unchecked Sendable {
         return provider?.mediaFetchCount ?? 0
     }
 
+    /// #178: called by the engine when a NEW user seek is dispatched. A recovery re-anchor still
+    /// holding the coalescer's authoritative slot belongs to the superseded seek; left in place it
+    /// would drop the new seek's segment-driven restart and land the producer on the stale
+    /// recovery position. Runs before the host seek so AVPlayer's new segment GETs never race a
+    /// locked slot.
+    func releaseSupersededAuthoritativeRestart() {
+        restartLock.lock()
+        restartCoalescer.clearSupersededAuthoritativePending()
+        restartLock.unlock()
+    }
+
     func requestRestart(at idx: Int, authoritative: Bool = false) {
         restartLock.lock()
         let shouldRun = restartCoalescer.begin(idx, authoritative: authoritative)

--- a/Sources/AetherEngine/Video/RestartCoalescer.swift
+++ b/Sources/AetherEngine/Video/RestartCoalescer.swift
@@ -25,8 +25,10 @@ struct RestartCoalescer {
             } else if !pendingAuthoritative {
                 pending = idx
             }
-            // else: an authoritative pending owns the slot; drop this scrub (AVPlayer re-requests on the next
-            // segment GET if the user really moved, so nothing is lost).
+            // else: an authoritative pending owns the slot; drop this scrub. Since #178 a NEW user
+            // seek releases the slot (clearSupersededAuthoritativePending) before its segment GETs
+            // can fire a restart, so what lands here is a stale burst-tail fetch from an abandoned
+            // position, exactly what the #79 lock exists to block.
             return false
         }
         inFlight = true
@@ -36,6 +38,17 @@ struct RestartCoalescer {
     /// True while a coalesced restart run is executing (#93 residual: segment fetches ride this
     /// instead of burning fixed retry budgets against a progressing restart).
     var isInFlight: Bool { inFlight }
+
+    /// #178: a NEW user seek makes a pending authoritative recovery re-anchor obsolete; it was
+    /// computed for the seek being superseded. Dropping it releases the slot lock so the new seek's
+    /// segment-driven restart is not discarded (the #79 lock exists to block STALE burst-tail
+    /// scrubs, not fresher user intent), and removes a target that would otherwise re-anchor the
+    /// producer away from where AVPlayer plays next. Ordinary pendings keep their newest-wins flow.
+    mutating func clearSupersededAuthoritativePending() {
+        guard pendingAuthoritative else { return }
+        pending = nil
+        pendingAuthoritative = false
+    }
 
     /// Returns next pending target, or `nil` when the burst has settled (clears in-flight flag).
     mutating func next(justRan idx: Int) -> Int? {

--- a/Tests/AetherEngineTests/Issue178LoadingSeekStashTests.swift
+++ b/Tests/AetherEngineTests/Issue178LoadingSeekStashTests.swift
@@ -1,0 +1,71 @@
+import Foundation
+import Testing
+@testable import AetherEngine
+
+/// #178 mechanism 1 (YangHanqing): `seek(to:)` unconditionally no-oped while `state == .loading`,
+/// silently discarding any seek issued in the multi-second initial-load window. Hosts that render
+/// the target optimistically then watch playback snap back to the pre-seek position. The fix
+/// stashes the latest loading-window seek in `pendingPreReadySeekSeconds` (the #127 slot) and
+/// resolves it on the transition out of `.loading`: replay into a playable state, discard into a
+/// terminal one. The `.loading` state itself is never left early (spinner hold, see #127 notes).
+struct Issue178LoadingSeekStashTests {
+
+    @MainActor
+    @Test("a seek issued while load is in progress is stashed, not dropped")
+    func loadingSeekStashes() async throws {
+        let engine = try AetherEngine()
+        engine.state = .loading
+        await engine.seek(to: 42)
+        #expect(engine.pendingPreReadySeekSeconds == 42)
+        #expect(engine.state == .loading)          // spinner hold intact
+        #expect(engine.clock.currentTime == 42)    // optimistic scrub clock follows the target
+    }
+
+    @MainActor
+    @Test("the latest of several loading-window seeks wins")
+    func loadingSeekLatestWins() async throws {
+        let engine = try AetherEngine()
+        engine.state = .loading
+        await engine.seek(to: 42)
+        await engine.seek(to: 97)
+        #expect(engine.pendingPreReadySeekSeconds == 97)
+    }
+
+    @MainActor
+    @Test("the stashed seek replays once loading settles into a playable state")
+    func stashReplaysOnSettle() async throws {
+        let engine = try AetherEngine()
+        engine.state = .loading
+        await engine.seek(to: 42)
+        engine.state = .playing   // autostart path: timeControlStatus sink flips .loading -> .playing
+        for _ in 0..<50 {
+            if engine.pendingPreReadySeekSeconds == nil { break }
+            await Task.yield()
+        }
+        #expect(engine.pendingPreReadySeekSeconds == nil)
+        #expect(engine.clock.currentTime == 42)
+    }
+
+    @MainActor
+    @Test("a load that dies discards the stash instead of leaking it into the next session")
+    func stashDiscardedOnTerminalTransition() async throws {
+        let engine = try AetherEngine()
+        engine.state = .loading
+        await engine.seek(to: 42)
+        engine.state = .error("load failed")
+        #expect(engine.pendingPreReadySeekSeconds == nil)
+    }
+
+    @Test("stash resolution: replay into playable, discard into terminal, hold otherwise")
+    func stashResolutionPolicy() {
+        #expect(AetherEngine.loadingStashResolution(oldState: .loading, newState: .playing) == .replay)
+        #expect(AetherEngine.loadingStashResolution(oldState: .loading, newState: .paused) == .replay)
+        #expect(AetherEngine.loadingStashResolution(oldState: .loading, newState: .idle) == .discard)
+        #expect(AetherEngine.loadingStashResolution(oldState: .loading, newState: .ended) == .discard)
+        #expect(AetherEngine.loadingStashResolution(oldState: .loading, newState: .error("x")) == .discard)
+        #expect(AetherEngine.loadingStashResolution(oldState: .loading, newState: .loading) == .hold)
+        // Non-loading transitions belong to the #127 readiness sink, not the loading resolver.
+        #expect(AetherEngine.loadingStashResolution(oldState: .playing, newState: .paused) == .hold)
+        #expect(AetherEngine.loadingStashResolution(oldState: .paused, newState: .idle) == .hold)
+    }
+}

--- a/Tests/AetherEngineTests/RestartCoalescerTests.swift
+++ b/Tests/AetherEngineTests/RestartCoalescerTests.swift
@@ -65,6 +65,52 @@ struct RestartCoalescerTests {
         #expect(c.next(justRan: 978) == nil)
     }
 
+    // MARK: - Superseded authoritative pending (#178)
+
+    @Test("A superseding user seek releases the authoritative slot so the next scrub is not dropped")
+    func supersedeReleasesAuthoritativeSlot() {
+        // #178 repro: seek #1's deadline reconcile parks an authoritative re-anchor in the pending
+        // slot; the user then issues seek #2. Without the release, seek #2's segment-driven restart
+        // is dropped and the producer lands on the stale recovery position (~13 s off in the report).
+        var c = RestartCoalescer()
+        #expect(c.begin(618) == true)                        // worker in-flight
+        #expect(c.begin(978, authoritative: true) == false)  // recovery re-anchor for seek #1
+        c.clearSupersededAuthoritativePending()              // user issued seek #2
+        #expect(c.begin(1120) == false)                      // seek #2's segment GET must take the slot
+        #expect(c.next(justRan: 618) == 1120)                // not dropped, not 978
+        #expect(c.next(justRan: 1120) == nil)
+    }
+
+    @Test("Superseding drops an obsolete recovery target that has no follow-up scrub")
+    func supersedeDropsObsoleteRecoveryTarget() {
+        // The recovery anchor served the SUPERSEDED seek; if the new seek's segments are already
+        // resident (no restart fires), running the stale re-anchor would move the producer away
+        // from where AVPlayer is now playing.
+        var c = RestartCoalescer()
+        #expect(c.begin(618) == true)
+        #expect(c.begin(978, authoritative: true) == false)
+        c.clearSupersededAuthoritativePending()
+        #expect(c.next(justRan: 618) == nil)
+        #expect(c.begin(700) == true)                        // coalescer idle again
+    }
+
+    @Test("Superseding leaves an ordinary pending untouched")
+    func supersedeLeavesOrdinaryPending() {
+        var c = RestartCoalescer()
+        #expect(c.begin(10) == true)
+        #expect(c.begin(20) == false)
+        c.clearSupersededAuthoritativePending()
+        #expect(c.next(justRan: 10) == 20)
+    }
+
+    @Test("Superseding when idle is a no-op")
+    func supersedeIdleNoOp() {
+        var c = RestartCoalescer()
+        c.clearSupersededAuthoritativePending()
+        #expect(c.begin(5) == true)
+        #expect(c.next(justRan: 5) == nil)
+    }
+
     @Test("After an authoritative target is consumed, ordinary scrubs coalesce normally again")
     func scrubResumesAfterAuthoritativeConsumed() {
         var c = RestartCoalescer()


### PR DESCRIPTION
Fixes #178.

Two related races silently discarded user-issued seeks on the VOD loopback-HLS path.

## Mechanism 1: seeks during `.loading`

`seek(to:)` no-oped for the whole `state == .loading` window (probe, native load, readiness gate) with no queuing or replay. Hosts rendering the target optimistically watched playback snap back to the pre-seek position once the pending target cleared.

The latest loading-window seek is now stashed in the #127 pre-ready slot, published optimistically to the scrub clock, and resolved on the transition out of `.loading` via the `state` didSet:

- into `.playing` / `.paused`: replayed through the normal `seek(to:)` path (clamp and live-DVR guards re-run against the now-known session). This chokepoint also covers autostart paths, where readiness fires while `state` is still `.loading` and the #127 readiness sink must not replay yet (it now explicitly skips that case).
- into `.idle` / `.ended` / `.error`: discarded, so a dead load cannot leak a stale seek into the next session.

The `.loading` spinner hold is unchanged; the state itself is never flipped early.

## Mechanism 2: ordinary seek vs. pending authoritative restart

Once a seek-deadline reconcile parked an authoritative recovery re-anchor in `RestartCoalescer`'s pending slot (#79), a subsequent ordinary scrub `begin()` was dropped outright. The comment claimed "AVPlayer re-requests on the next segment GET, so nothing is lost", but the provider had already recorded `lastRestartIndex = index` and `firedThisCall = true` for the dropped fire, so its own re-fire logic (same-index guard, orphan backstop) suppressed the recovery; the producer stayed anchored on the stale recovery position (~13 s off in the reporter's log) until the seek deadline reconciled the clock back to the rendered position.

A new user seek now releases the superseded authoritative claim (`clearSupersededAuthoritativePending`) before the host seek is dispatched, so the new target's segment-driven restart takes the pending slot normally. The obsolete recovery target is dropped with it: it was computed for the seek being superseded, and left in place it would re-anchor the producer away from where AVPlayer plays next.

The #79 protection is intact: without a fresh user seek, the authoritative pending still owns the slot and stale burst-tail scrubs are still blocked (existing tests unchanged). LiveReopen's authoritative anchors are unaffected; live seeks return before the release call.

## Tests

- `Issue178LoadingSeekStashTests`: stash, latest-wins, replay-on-settle, discard-on-death, and the full resolution policy matrix.
- `RestartCoalescerTests`: supersede releases the slot, drops the obsolete recovery target, leaves ordinary pendings untouched, idle no-op; all pre-existing #35/#79 expectations unchanged.
- Full suite: 933/933 pass; strict-concurrency build clean; tvOS Simulator build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)