### PR TITLE
fix(hls): strip non-parameter-set NAL arrays from the HEVC hvcC on the VOD remux path (#187)

### DIFF
--- a/Sources/AetherEngine/Video/HLSVideoEngine+SegmentPlanning.swift
+++ b/Sources/AetherEngine/Video/HLSVideoEngine+SegmentPlanning.swift
@@ -282,6 +282,55 @@ extension HLSVideoEngine {
         return hvcC
     }
 
+    /// Rewrite an hvcC config record to keep only the VPS(32)/SPS(33)/PPS(34) parameter-set arrays, dropping
+    /// SEI_PREFIX(39)/SEI_SUFFIX(40) and any other NAL arrays. libx265 (and other encoders) embed a large
+    /// user-data SEI_PREFIX array in the hvcC; the VOD muxer forwards the source config record verbatim, so
+    /// that array reaches the fMP4 init sample description. Apple TV hardware builds the HEVC format
+    /// description straight from the hvcC parameter-set arrays and rejects a record carrying non-parameter-set
+    /// arrays: `asset.tracks count=0`, `AVFoundationErrorDomain -11829`, `CoreMediaErrorDomain -12848` (AE#187).
+    /// macOS and the tvOS Simulator tolerate it, so it only surfaces on device. The live MPEG-TS and direct
+    /// fMP4-HLS paths never hit this because their hvcC is rebuilt from parameter sets alone; canonicalizing
+    /// here aligns the VOD path with them. HDR10 static metadata is unaffected: it rides in-band per-IRAP in
+    /// the media packets (untouched) and in the muxer's `mdcv`/`clli` boxes, not the hvcC SEI array. DV is
+    /// unaffected too: the dvcC/dvvC boxes and RPU live outside the hvcC extradata. Returns nil when the record
+    /// already holds only parameter-set arrays (no rewrite needed) or cannot be parsed as an hvcC.
+    static func canonicalizeHEVCConfigRecord(_ extradata: [UInt8]) -> [UInt8]? {
+        guard extradata.count >= 23 else { return nil }
+        guard extradata[0] == 1 else { return nil }  // configurationVersion; guards against Annex-B / non-hvcC
+        let numOfArrays = Int(extradata[22])
+        guard numOfArrays > 0 else { return nil }  // numOfArrays=0 is the in-band-rebuild path, not this one
+
+        // Collect each array's [start, end) byte range and its NAL type, bounds-checked. Any inconsistency
+        // (truncated record) returns nil so a malformed source is forwarded unchanged rather than corrupted.
+        var arrays: [(type: Int, range: Range<Int>)] = []
+        var offset = 23
+        for _ in 0..<numOfArrays {
+            let arrayStart = offset
+            guard offset + 3 <= extradata.count else { return nil }
+            let nalType = Int(extradata[offset]) & 0x3F
+            let numNalus = (Int(extradata[offset + 1]) << 8) | Int(extradata[offset + 2])
+            offset += 3
+            for _ in 0..<numNalus {
+                guard offset + 2 <= extradata.count else { return nil }
+                let nalLen = (Int(extradata[offset]) << 8) | Int(extradata[offset + 1])
+                offset += 2 + nalLen
+                guard offset <= extradata.count else { return nil }
+            }
+            arrays.append((type: nalType, range: arrayStart..<offset))
+        }
+
+        let parameterSetTypes: Set<Int> = [32, 33, 34]  // VPS, SPS, PPS
+        let kept = arrays.filter { parameterSetTypes.contains($0.type) }
+        guard kept.count < arrays.count else { return nil }  // nothing to drop: already canonical
+
+        var out: [UInt8] = []
+        out.reserveCapacity(23 + kept.reduce(0) { $0 + $1.range.count })
+        out.append(contentsOf: extradata[0..<22])  // header verbatim (profile/tier/level/lengthSize)
+        out.append(UInt8(kept.count))               // rewritten numOfArrays
+        for array in kept { out.append(contentsOf: extradata[array.range]) }
+        return out
+    }
+
     /// ADTS AAC from MPEG-TS arrives without an AudioSpecificConfig in `extradata`; the fMP4 `mp4a`/`esds` sample entry can't be written. Synthesizes a 2-byte ASC, installs it, and clears the TS codec_tag the mov muxer rejects. Returns true when applied; caller strips per-frame ADTS headers.
     static func prepareAACForFMP4(
         _ codecpar: UnsafeMutablePointer<AVCodecParameters>

--- a/Sources/AetherEngine/Video/HLSVideoEngine.swift
+++ b/Sources/AetherEngine/Video/HLSVideoEngine.swift
@@ -791,20 +791,36 @@ public final class HLSVideoEngine: @unchecked Sendable {
         // negotiation state didn't match (Vincent test 2026-05-26, HDR10 panel).
         let hdcpLevel: String? = nil
 
-        // 5. Rebuild hvcC from in-band parameter sets when numOfArrays=0 (DV P5 MP4 encoders
-        //    that ship VPS/SPS/PPS per-IRAP instead of in the config record, #19 Wandering Earth 2).
-        //    Without VPS/SPS/PPS in hvcC, AVPlayer fails the dvh1 sample entry with CME -4.
-        let hevcExtradataOverride = rebuildHEVCExtradataWithInBandParameterSets(
+        // 5. Normalize the HEVC config record shipped in init.mp4:
+        //    a) numOfArrays=0 (DV P5 MP4 encoders shipping VPS/SPS/PPS per-IRAP, #19 Wandering Earth 2):
+        //       rebuild the hvcC from in-band parameter sets, else the dvh1 sample entry fails CME -4.
+        //    b) numOfArrays>0 but carrying non-parameter-set arrays (libx265's user-data SEI_PREFIX, AE#187):
+        //       strip everything but VPS/SPS/PPS. Apple TV hardware rejects an hvcC with an SEI array
+        //       (tracks count=0 / -12848); macOS + the tvOS Simulator tolerate it, so it is device-only.
+        let hevcExtradataOverride: [UInt8]?
+        if let rebuilt = rebuildHEVCExtradataWithInBandParameterSets(
             demuxer: dem,
             videoStreamIndex: videoIndex,
             codecpar: codecpar
-        )
-        if let rebuilt = hevcExtradataOverride {
+        ) {
+            hevcExtradataOverride = rebuilt
             EngineLog.emit(
                 "[HLSVideoEngine] rebuilt hvcC with in-band parameter sets: "
                 + "\(codecpar.pointee.extradata_size) B → \(rebuilt.count) B",
                 category: .session
             )
+        } else if codecpar.pointee.codec_id == AV_CODEC_ID_HEVC,
+                  let ed = codecpar.pointee.extradata,
+                  case let source = Array(UnsafeBufferPointer(start: ed, count: Int(codecpar.pointee.extradata_size))),
+                  let canonical = Self.canonicalizeHEVCConfigRecord(source) {
+            hevcExtradataOverride = canonical
+            EngineLog.emit(
+                "[HLSVideoEngine] canonicalized hvcC (stripped non-parameter-set NAL arrays): "
+                + "\(source.count) B → \(canonical.count) B (AE#187)",
+                category: .session
+            )
+        } else {
+            hevcExtradataOverride = nil
         }
 
         // 6. Reset demuxer cursor to 0 (cue prewarm moved it mid-file). Skipped for live

--- a/Tests/AetherEngineTests/HEVCConfigRecordTests.swift
+++ b/Tests/AetherEngineTests/HEVCConfigRecordTests.swift
@@ -1,0 +1,118 @@
+import Testing
+@testable import AetherEngine
+
+/// AE#187: the VOD muxer forwarded the source hvcC verbatim, including libx265's large SEI_PREFIX array,
+/// which Apple TV hardware rejects (asset tracks count=0 / CoreMediaErrorDomain -12848). These cover the
+/// pure canonicalizer that strips every non-parameter-set NAL array so the init sample description matches
+/// the canonical VPS/SPS/PPS-only form the live-TS and direct-fMP4 paths already emit.
+@Suite("HEVCConfigRecord canonicalization")
+struct HEVCConfigRecordTests {
+
+    /// 22-byte hvcC fixed header (configurationVersion=1, lengthSizeMinusOne=3). Only [0], [21], [22] are read
+    /// by the canonicalizer; the rest are plausible filler.
+    static func header22() -> [UInt8] {
+        var h = [UInt8](repeating: 0, count: 22)
+        h[0] = 1        // configurationVersion
+        h[21] = 0xFF    // reserved(6 bits, 1)=0xFC | lengthSizeMinusOne=3
+        return h
+    }
+
+    /// Encode one hvcC NAL array: (completeness<<7 | type), numNalus(2B), then each NAL as len(2B)+bytes.
+    static func encodeArray(type: UInt8, completeness: Bool, nals: [[UInt8]]) -> [UInt8] {
+        var a: [UInt8] = [(completeness ? 0x80 : 0) | (type & 0x3F)]
+        a.append(UInt8(nals.count >> 8)); a.append(UInt8(nals.count & 0xFF))
+        for nal in nals {
+            a.append(UInt8(nal.count >> 8)); a.append(UInt8(nal.count & 0xFF))
+            a.append(contentsOf: nal)
+        }
+        return a
+    }
+
+    static func buildHvcC(_ arrays: [[UInt8]]) -> [UInt8] {
+        var r = header22()
+        r.append(UInt8(arrays.count))
+        for a in arrays { r.append(contentsOf: a) }
+        return r
+    }
+
+    @Test("Drops the SEI_PREFIX array, keeps VPS/SPS/PPS in order")
+    func stripsSeiPrefix() {
+        let vps: [UInt8] = Array(repeating: 0xA1, count: 24)
+        let sps: [UInt8] = Array(repeating: 0xB2, count: 43)
+        let pps: [UInt8] = Array(repeating: 0xC3, count: 7)
+        let sei: [UInt8] = Array(repeating: 0xD4, count: 2316)  // x265 options SEI, the AE#187 payload
+        let source = Self.buildHvcC([
+            Self.encodeArray(type: 32, completeness: true, nals: [vps]),
+            Self.encodeArray(type: 33, completeness: true, nals: [sps]),
+            Self.encodeArray(type: 34, completeness: true, nals: [pps]),
+            Self.encodeArray(type: 39, completeness: false, nals: [sei]),
+        ])
+
+        let canonical = HLSVideoEngine.canonicalizeHEVCConfigRecord(source)
+        let expected = Self.buildHvcC([
+            Self.encodeArray(type: 32, completeness: true, nals: [vps]),
+            Self.encodeArray(type: 33, completeness: true, nals: [sps]),
+            Self.encodeArray(type: 34, completeness: true, nals: [pps]),
+        ])
+        #expect(canonical == expected)
+        // 23-byte header + VPS(5+24) + SPS(5+43) + PPS(5+7) = 112 B, matching a clean packager's hvcC payload.
+        #expect(canonical?.count == 112)
+        #expect(canonical?[22] == 3)                     // numOfArrays rewritten to 3
+        #expect(Array(canonical![0..<22]) == Array(source[0..<22]))  // header preserved
+    }
+
+    @Test("Already-canonical record returns nil (no rewrite)")
+    func canonicalReturnsNil() {
+        let source = Self.buildHvcC([
+            Self.encodeArray(type: 32, completeness: true, nals: [[0xA1, 0xA2]]),
+            Self.encodeArray(type: 33, completeness: true, nals: [[0xB1, 0xB2]]),
+            Self.encodeArray(type: 34, completeness: true, nals: [[0xC1]]),
+        ])
+        #expect(HLSVideoEngine.canonicalizeHEVCConfigRecord(source) == nil)
+    }
+
+    @Test("Also strips SEI_SUFFIX(40) and unknown arrays")
+    func stripsSuffixAndUnknown() {
+        let source = Self.buildHvcC([
+            Self.encodeArray(type: 33, completeness: true, nals: [[0xB1]]),
+            Self.encodeArray(type: 40, completeness: false, nals: [[0xE1, 0xE2, 0xE3]]),  // SEI_SUFFIX
+            Self.encodeArray(type: 34, completeness: true, nals: [[0xC1]]),
+            Self.encodeArray(type: 62, completeness: false, nals: [[0xF1]]),               // unspecified
+        ])
+        let canonical = HLSVideoEngine.canonicalizeHEVCConfigRecord(source)
+        let expected = Self.buildHvcC([
+            Self.encodeArray(type: 33, completeness: true, nals: [[0xB1]]),
+            Self.encodeArray(type: 34, completeness: true, nals: [[0xC1]]),
+        ])
+        #expect(canonical == expected)
+        #expect(canonical?[22] == 2)
+    }
+
+    @Test("numOfArrays=0 returns nil (handled by the in-band rebuild path)")
+    func emptyArraysReturnsNil() {
+        var r = Self.header22()
+        r.append(0)  // numOfArrays = 0
+        #expect(HLSVideoEngine.canonicalizeHEVCConfigRecord(r) == nil)
+    }
+
+    @Test("Non-hvcC / Annex-B extradata returns nil (configurationVersion != 1)")
+    func nonHvcCReturnsNil() {
+        let annexB: [UInt8] = [0x00, 0x00, 0x00, 0x01] + Array(repeating: 0x42, count: 40)
+        #expect(HLSVideoEngine.canonicalizeHEVCConfigRecord(annexB) == nil)
+    }
+
+    @Test("Truncated record returns nil rather than corrupting")
+    func truncatedReturnsNil() {
+        var source = Self.buildHvcC([
+            Self.encodeArray(type: 33, completeness: true, nals: [Array(repeating: 0xB2, count: 40)]),
+            Self.encodeArray(type: 39, completeness: false, nals: [Array(repeating: 0xD4, count: 100)]),
+        ])
+        source.removeLast(50)  // chop the SEI array mid-NAL
+        #expect(HLSVideoEngine.canonicalizeHEVCConfigRecord(source) == nil)
+    }
+
+    @Test("Too-short buffer returns nil")
+    func tooShortReturnsNil() {
+        #expect(HLSVideoEngine.canonicalizeHEVCConfigRecord([1, 2, 3]) == nil)
+    }
+}


### PR DESCRIPTION
## Problem (#187)

A plain **HEVC-in-MP4 progressive file** dispatched to the native/loopback path builds a fMP4 init that **Apple TV hardware rejects**:

```
asset.load(tracks) ok  count=0
item.status=failed  err=AVFoundationErrorDomain/-11829 'Cannot Open'
item.error.underlying=CoreMediaErrorDomain/-12848
```

before any media fetch. H.264 through the same muxer, HEVC-in-TS through the live ingest remux (#168), and HEVC fMP4-HLS played directly all work. Both 8-bit Main and 10-bit Main10/HDR10 fail identically.

## Root cause

libx265 (and other encoders) embed a large user-data **`SEI_PREFIX` (NAL type 39) array in the hvcC** config record (2316 B in the reporter's file). The VOD muxer copies the source codecpar verbatim (`avcodec_parameters_copy`), so that array reaches the `init.mp4` sample description. Apple TV builds the HEVC format description straight from the hvcC parameter-set arrays and rejects a record carrying a non-parameter-set array.

macOS and the **tvOS Simulator both tolerate it** (verified: `item.status=READY`, `tracks=2`), so it only surfaces on real hardware. The live MPEG-TS and direct fMP4-HLS paths never hit this because their hvcC is rebuilt from parameter sets alone (VPS/SPS/PPS).

This is **not a recent code regression**: the remux path (the current libavformat muxer and the pre-May self-built `FMP4VideoMuxer`) has always copied the source hvcC verbatim; `extradataOverride` only ever handled the `numOfArrays=0` in-band rebuild. The defect is longstanding and became visible on device.

## Fix

Canonicalize the HEVC config record before `write_header`, keeping only **VPS(32)/SPS(33)/PPS(34)** arrays and dropping `SEI_PREFIX(39)`/`SEI_SUFFIX(40)` and any other NAL arrays, so the VOD init matches the canonical form the working paths emit. Wired into the existing extradata-override selection alongside the `numOfArrays=0` rebuild.

- **HDR10 unaffected**: static metadata rides in-band per-IRAP in the media packets (untouched) and in the muxer's `colr`/`mdcv`/`clli` boxes, not the hvcC SEI array.
- **DV unaffected**: `dvcC`/`dvvC` and the RPU live outside the hvcC extradata.

## Verification

`aetherctl segverify` end-to-end:

| file | source hvcC | init hvcC after fix | notes |
|------|-------------|---------------------|-------|
| libx265 8-bit Main | 2433 B (4 arrays) | **112 B** (VPS/SPS/PPS) | still independently decodable |
| libx265 10-bit HDR10 | 2554 B | **115 B** | `colr` PQ/BT2020 box preserved |

New pure-function unit suite (7 tests): strip, no-op-when-canonical, SEI_SUFFIX/unknown arrays, `numOfArrays=0`, non-hvcC, truncated, short inputs. Full suite **940/940**, tvOS Simulator build green.

> [!NOTE]
> Local reproduction of the *rejection* is not possible (macOS and the tvOS Simulator both accept the SEI-laden init; only Apple TV hardware rejects it). Device verification of the fixed init is still pending on an Apple TV 4K.

Closes #187.

🤖 Generated with [Claude Code](https://claude.com/claude-code)