### PR TITLE
fix(view): rebind AetherPlayerSurface to its engine on update (#188)

### DIFF
--- a/Sources/AetherEngine/View/AetherPlayerView.swift
+++ b/Sources/AetherEngine/View/AetherPlayerView.swift
@@ -154,6 +154,12 @@ public struct AetherPlayerSurface: UIViewRepresentable {
     }
 
     public func updateUIView(_ uiView: AetherPlayerView, context: Context) {
+        // #188: when a host swaps its AetherEngine instance at the same structural
+        // position, SwiftUI reuses this platform view and only calls updateUIView,
+        // so the new engine's bind(view:) never runs from makeUIView. Rebinding here
+        // points the new engine at the reused view and re-attaches its layer; bind is
+        // idempotent for the steady-state existing === view case, so this is cheap.
+        engine.bind(view: uiView)
     }
 
     public static func dismantleUIView(_ uiView: AetherPlayerView, coordinator: ()) {
@@ -178,7 +184,11 @@ public struct AetherPlayerSurface: NSViewRepresentable {
         return view
     }
 
-    public func updateNSView(_ nsView: AetherPlayerView, context: Context) {}
+    public func updateNSView(_ nsView: AetherPlayerView, context: Context) {
+        // #188: rebind on update so an engine swap at the same structural position
+        // takes over the reused view. Idempotent for the steady-state case.
+        engine.bind(view: nsView)
+    }
 
     public static func dismantleNSView(_ nsView: AetherPlayerView, coordinator: ()) {
         Task { @MainActor in

--- a/Tests/AetherEngineTests/Issue188SurfaceRebindTests.swift
+++ b/Tests/AetherEngineTests/Issue188SurfaceRebindTests.swift
@@ -1,0 +1,67 @@
+import Testing
+import Foundation
+@testable import AetherEngine
+
+/// #188: `AetherPlayerSurface.updateUIView` was empty, so it only called `bind(view:)` from
+/// `makeUIView`. When a host replaces its `AetherEngine` instance at the same structural position
+/// (a retry/reload flow), SwiftUI reuses the platform view and calls only `updateUIView`, so the
+/// new engine's `bind(view:)` never ran: its `boundView` stayed nil, `presentCurrentLayer()`
+/// no-oped, and the reused view kept displaying the previous engine's detached layer, black video
+/// over working audio. The fix rebinds on every update; these tests lock the engine-level contract
+/// that rebind relies on: a reused view taken over by a new engine shows the new engine's layer and
+/// the old engine no longer owns it, and steady-state rebind of the same engine is a no-op swap.
+@Suite("AetherPlayerSurface rebind on engine swap (#188)")
+struct Issue188SurfaceRebindTests {
+
+    @MainActor
+    @Test("A view bound to a second engine takes over its layer; the first engine's layer is dropped")
+    func rebindSwapsLayerOwnership() async throws {
+        let engineA = try AetherEngine()
+        try await engineA.loadRemoteHLS(
+            url: URL(string: "http://127.0.0.1:9/a.m3u8")!,
+            options: LoadOptions(isLive: true, nativeRemoteHLS: true))
+        let hostA = try #require(engineA.nativeHost)
+
+        // Host embeds the surface: makeUIView binds engineA to the view.
+        let view = AetherPlayerView(frame: .init(x: 0, y: 0, width: 640, height: 360))
+        engineA.bind(view: view)
+        #expect(hostA.playerLayer.superlayer === view.layer)
+
+        // Host swaps to a fresh engine at the same structural position. SwiftUI reuses `view` and
+        // calls updateUIView, which now rebinds. Simulate exactly that: a second engine binds the
+        // same view.
+        let engineB = try AetherEngine()
+        try await engineB.loadRemoteHLS(
+            url: URL(string: "http://127.0.0.1:9/b.m3u8")!,
+            options: LoadOptions(isLive: true, nativeRemoteHLS: true))
+        let hostB = try #require(engineB.nativeHost)
+
+        engineB.bind(view: view)
+
+        #expect(hostB.playerLayer.superlayer === view.layer,
+                "the reused view must display the new engine's layer after rebind")
+        #expect(hostA.playerLayer.superlayer !== view.layer,
+                "the previous engine's layer must be detached from the reused view")
+    }
+
+    @MainActor
+    @Test("Rebinding the same engine to the same view is an idempotent no-op swap")
+    func steadyStateRebindIsIdempotent() async throws {
+        let engine = try AetherEngine()
+        try await engine.loadRemoteHLS(
+            url: URL(string: "http://127.0.0.1:9/live.m3u8")!,
+            options: LoadOptions(isLive: true, nativeRemoteHLS: true))
+        let host = try #require(engine.nativeHost)
+
+        let view = AetherPlayerView(frame: .init(x: 0, y: 0, width: 640, height: 360))
+        engine.bind(view: view)
+        #expect(host.playerLayer.superlayer === view.layer)
+
+        // updateUIView fires repeatedly during steady-state layout; each call rebinds. The hosted
+        // layer identity must not churn (attach short-circuits on the same layer).
+        engine.bind(view: view)
+        engine.bind(view: view)
+
+        #expect(host.playerLayer.superlayer === view.layer)
+    }
+}


### PR DESCRIPTION
## Problem

`AetherPlayerSurface` binds the engine to its platform view only in `makeUIView`/`makeNSView`; the update path was empty. When a host replaces its `AetherEngine` instance at the same structural position (a retry/reload flow that tears down and recreates the engine), SwiftUI reuses the platform view and calls only `updateUIView`, so the new engine's `bind(view:)` never runs. Its `boundView` stays nil, the post-load `presentCurrentLayer()` no-ops on the guard, and the reused view keeps displaying the previous engine's detached layer, black video over working audio. `isReadyForDisplay` reads true throughout, since the host's layer reports ready without being attached to any on-screen view.

Root-caused and reported by @rrgomes in #188, who is shipping the `.id(ObjectIdentifier(engine))` workaround host-side.

## Fix

`updateUIView`/`updateNSView` now call `engine.bind(view:)` on every update:

- Steady state (`existing === view`): `bind` re-runs `presentCurrentLayer()`, and `AetherPlayerView.attach` short-circuits on an identical hosted layer, so repeated update passes are a cheap no-op swap.
- Engine swap: the new engine's `bind` points `boundView` at the reused view and re-attaches its layer; the previous engine's layer is detached.

## Tests

`Issue188SurfaceRebindTests` locks the engine-level contract the rebind relies on:
- a reused view bound to a second engine takes over its layer and the first engine's layer is dropped;
- rebinding the same engine to the same view is an idempotent no-op swap.

Full suite green (942 tests), tvOS-simulator build clean under Swift 6 strict concurrency.

Part of #188 (device retest pending from the reporter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NAPCg4tCDdSqkK6tPkNptw