### PR TITLE
fix(live): advertise HOLD-BACK and size startup cushion to the live-edge holdback (AE#189)

### DIFF
--- a/Sources/AetherEngine/Network/HLSLocalServer.swift
+++ b/Sources/AetherEngine/Network/HLSLocalServer.swift
@@ -1189,32 +1189,37 @@ final class HLSLocalServer: @unchecked Sendable {
         // Sliding live: no PLAYLIST-TYPE tag and no ENDLIST (EVENT forbids removal; VOD implies finished asset).
         let typeIsLive = (provider.playlistType == .live && !snapshot.endlistAdded)
 
-        // TARGETDURATION must be >= every EXTINF (HLS spec).
+        // TARGETDURATION must be >= every EXTINF (HLS spec). For live it is also floored by ceil(1.5 x cut
+        // target) (widens AVPlayer's unchanged-playlist patience, anti -12888: (1) empty first manifest,
+        // (2) transcode warm-up stall) and by the observed upstream arrival cadence (bursty ingest). The
+        // SAME derivation feeds the startup cushion (LiveEdgePolicy.startupCushionSatisfied), so the depth
+        // the cushion builds to matches the holdback AVPlayer computes from this value.
         var maxDuration: Double = 0
         for i in firstVisible..<count {
             maxDuration = max(maxDuration, provider.segmentDuration(at: i))
         }
-        var targetDuration = Int(ceil(max(1.0, maxDuration)))
-
-        // Live TARGETDURATION floor = ceil(1.5 * cutTarget). Fixes two problems: (1) empty first manifest (maxDuration=0 -> TD=1, AVPlayer gets only 1.5s patience, -12888 on high-bitrate sources); (2) transcode warm-up ~8s stall at startup (-12888 once before recovery). Advertising a generous TD widens AVPlayer's unchanged-playlist patience at no startup-latency cost; EXTINF stays at cutTarget, reload cadence unchanged.
-        if typeIsLive, let liveTarget = provider.liveTargetSegmentDuration {
-            let liveFloor = Int(ceil(liveTarget * 1.5))
-            targetDuration = max(targetDuration, liveFloor)
-        }
-
-        // Bursty ingest: raise TD to the real upstream arrival cadence so AVPlayer's unchanged-playlist patience (1.5x TD) covers the inter-batch gap. Pairs with liveBlockingReloadEnabled=false.
-        if typeIsLive, let cadenceFloor = provider.liveTargetDurationFloorSeconds {
-            targetDuration = max(targetDuration, Int(ceil(cadenceFloor)))
-        }
+        let targetDuration = LiveEdgePolicy.targetDurationSeconds(
+            maxSegmentDuration: maxDuration,
+            cutTargetSeconds: typeIsLive ? provider.liveTargetSegmentDuration : nil,
+            cadenceFloorSeconds: typeIsLive ? provider.liveTargetDurationFloorSeconds : nil)
 
         var lines: [String] = []
         lines.append("#EXTM3U")
         lines.append("#EXT-X-VERSION:7")
         if typeIsLive {
+            var serverControl: [String] = []
             // CAN-BLOCK-RELOAD: AVPlayer sends ?_HLS_msn=N and the server holds the response until that segment is cut (see waitForLiveSegment), so AVPlayer gets each segment the instant it exists instead of a poll-interval late. Segment-level only (no EXT-X-PART). Gated on liveBlockingReloadEnabled: bursty sources can't honor the contract (-15410 and periodic stalls on device repro 2026-06-11); they fall back to plain reloads with a raised TARGETDURATION.
             if provider.liveBlockingReloadEnabled {
-                lines.append("#EXT-X-SERVER-CONTROL:CAN-BLOCK-RELOAD=YES")
+                serverControl.append("CAN-BLOCK-RELOAD=YES")
             }
+            // HOLD-BACK: pin the live-edge holdback to 3 x TARGETDURATION (the RFC 8216bis floor, and
+            // AVPlayer's implicit default made explicit). Without it AVPlayer restarts inside its own
+            // stall-danger zone (-16832) whenever the served window carries less than 3 x TD behind the
+            // edge (AE#189: 5.76s long-GOP segments -> TD=6 -> 18s holdback vs a 9.6s startup window). The
+            // startup cushion is built to exactly this depth, so the advertised value is always satisfiable.
+            let holdBack = LiveEdgePolicy.holdBackSeconds(targetDuration: targetDuration)
+            serverControl.append("HOLD-BACK=\(String(format: "%.3f", holdBack))")
+            lines.append("#EXT-X-SERVER-CONTROL:\(serverControl.joined(separator: ","))")
         }
         lines.append("#EXT-X-TARGETDURATION:\(targetDuration)")
         lines.append("#EXT-X-MEDIA-SEQUENCE:\(firstVisible)")

--- a/Sources/AetherEngine/Video/VideoSegmentProvider.swift
+++ b/Sources/AetherEngine/Video/VideoSegmentProvider.swift
@@ -37,6 +37,60 @@ struct LiveWindowSizing {
     }
 }
 
+// MARK: - Live-edge holdback policy
+
+/// Couples the served `#EXT-X-TARGETDURATION` / `HOLD-BACK` to the startup cushion so they can never
+/// drift. AVPlayer's default live-edge holdback (absent an explicit `HOLD-BACK`) is `3 x TARGETDURATION`:
+/// it wants to play that far behind the live edge. When the served window holds LESS than that behind the
+/// edge, AVPlayer restarts inside its own stall-danger zone and spams
+/// `-16832 restarting Ns from end of live playlist; target duration Ts - stall danger`, rebuffering until
+/// the window naturally deepens (AE#189: long-GOP HEVC-in-TS, 5.76s segments -> TD=6 -> 18s holdback, but
+/// the fixed 2-segment cushion only built ~9.6s). Both the served playlist
+/// (`HLSLocalServer.buildMediaPlaylistText`) and the startup gate (`waitForFirstLiveSegment`) derive
+/// TARGETDURATION here, so the depth the cushion builds to is exactly the depth AVPlayer enforces.
+enum LiveEdgePolicy {
+    /// Never serve an empty or single-segment live playlist (a 1-segment window is an instant -12888).
+    static let minStartupSegments = 2
+
+    /// Served `#EXT-X-TARGETDURATION`, in whole seconds: `>= ceil(max EXTINF)` (HLS requirement), floored
+    /// by `ceil(1.5 x cut target)` (widens AVPlayer's unchanged-playlist patience, anti -12888) and the
+    /// observed-cadence floor. `cutTargetSeconds` / `cadenceFloorSeconds` are nil for VOD/EVENT.
+    static func targetDurationSeconds(maxSegmentDuration: Double,
+                                      cutTargetSeconds: Double?,
+                                      cadenceFloorSeconds: Double?) -> Int {
+        var td = Int(ceil(max(1.0, maxSegmentDuration)))
+        if let cut = cutTargetSeconds { td = max(td, Int(ceil(cut * 1.5))) }
+        if let floor = cadenceFloorSeconds { td = max(td, Int(ceil(floor))) }
+        return td
+    }
+
+    /// AVPlayer's default (and our explicitly advertised) live-edge holdback: `3 x TARGETDURATION`, the
+    /// RFC 8216bis floor for `EXT-X-SERVER-CONTROL:HOLD-BACK`.
+    static func holdBackSeconds(targetDuration: Int) -> Double { Double(3 * targetDuration) }
+
+    /// First-serve gate: hold the first live manifest until the window carries at least the live-edge
+    /// holdback (`3 x TD`) of content behind the edge, so AVPlayer's initial seek-to-edge-minus-holdback
+    /// lands inside the window instead of the stall-danger zone. Bounded above by `windowSegmentCount`: a
+    /// tiny-segment source can never be made to wait for more than the sliding window will ever hold (the
+    /// wall-clock deadline in `waitForFirstLiveSegment` is the outer bound). A source that arrives with a
+    /// backlog (Jellyfin transcode, or an upstream live window pulled at I/O speed) satisfies this almost
+    /// immediately; only a strict-realtime origin pays the deepen-the-buffer latency, which is inherent to
+    /// joining long-GOP live safely.
+    static func startupCushionSatisfied(segmentCount: Int,
+                                        summedDurationSeconds: Double,
+                                        maxSegmentDuration: Double,
+                                        cutTargetSeconds: Double?,
+                                        cadenceFloorSeconds: Double?,
+                                        windowSegmentCount: Int) -> Bool {
+        guard segmentCount >= minStartupSegments else { return false }
+        if segmentCount >= windowSegmentCount { return true }
+        let td = targetDurationSeconds(maxSegmentDuration: maxSegmentDuration,
+                                       cutTargetSeconds: cutTargetSeconds,
+                                       cadenceFloorSeconds: cadenceFloorSeconds)
+        return summedDurationSeconds >= holdBackSeconds(targetDuration: td)
+    }
+}
+
 // MARK: - Cache-backed provider
 
 /// Thin HLSSegmentProvider over SegmentCache. Cache misses block the HTTP server's connection
@@ -665,45 +719,69 @@ final class VideoSegmentProvider: HLSSegmentProvider, @unchecked Sendable {
         if let policy { return policy.blockingReloadEnabled }
         return true
     }
-    /// 2 = one segment (~4 s) of startup cushion absorbing transcode jitter that caused -16832
-    /// "restarting from end of live playlist". 1 disables. Distinct from the reverted hold-back
-    /// which trailed the ADVERTISED edge without building an actual buffer.
-    private static let liveStartupSegments = 2
+    /// Under stateLock: (count, summed EXTINF, max EXTINF) over the resident segments. At startup the
+    /// window has not slid yet, so this is the full first-served window (LiveEdgePolicy sizes the cushion).
+    private func liveCushionSnapshot() -> (count: Int, summed: Double, maxDuration: Double) {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        var summed = 0.0
+        var maxDuration = 0.0
+        for seg in segments {
+            summed += seg.durationSeconds
+            maxDuration = max(maxDuration, seg.durationSeconds)
+        }
+        return (segments.count, summed, maxDuration)
+    }
 
-    /// Block until liveStartupSegments segments exist. Avoids -12888 on an empty playlist
-    /// and gives AVPlayer its startup cushion. Subsequent polls return instantly.
+    /// Block until the first live window holds the live-edge holdback (3 x TARGETDURATION) of content, so
+    /// AVPlayer's initial seek to edge-minus-holdback lands inside the window instead of its stall-danger
+    /// zone (-16832; AE#189). Also avoids -12888 on an empty playlist. Subsequent polls return instantly.
+    /// The gate is `LiveEdgePolicy.startupCushionSatisfied`, computed from the SAME TARGETDURATION the
+    /// served playlist advertises, so the depth built here is exactly the depth AVPlayer enforces.
     func waitForFirstLiveSegment(timeout: TimeInterval) -> Bool {
         guard isLive else { return true }
         let deadline = Date().addingTimeInterval(timeout)
+        let window = liveWindowSizing.windowSegmentCount
+        let cadenceFloor = liveCadencePolicy?.targetDurationFloorSeconds
+        let cutTarget = liveWindowSizing.targetSegmentDurationSeconds
         firstSegmentCondition.lock()
         defer { firstSegmentCondition.unlock() }
         while true {
             if waitersCancelled { return false }
-            stateLock.lock()
-            let count = segments.count
-            stateLock.unlock()
-            if count >= Self.liveStartupSegments { return true }
+            let snap = liveCushionSnapshot()
+            if LiveEdgePolicy.startupCushionSatisfied(segmentCount: snap.count,
+                                                       summedDurationSeconds: snap.summed,
+                                                       maxSegmentDuration: snap.maxDuration,
+                                                       cutTargetSeconds: cutTarget,
+                                                       cadenceFloorSeconds: cadenceFloor,
+                                                       windowSegmentCount: window) {
+                return true
+            }
             if !firstSegmentCondition.wait(until: deadline) {
-                // Re-read after the timed-out wait: an append racing the
-                // deadline would otherwise be judged on the stale count
-                // (waitForLiveSegment below already does this).
-                stateLock.lock()
-                let count = segments.count
-                stateLock.unlock()
-                // Degraded start: serving the first playlist with fewer
-                // than liveStartupSegments segments loses the startup
-                // cushion that absorbs transcode jitter, so a -16832
-                // "restarting from end of live playlist" stall right
-                // after startup becomes likely. Make it observable.
-                if count > 0 && count < Self.liveStartupSegments {
+                // Re-read after the timed-out wait: an append racing the deadline would otherwise be judged
+                // on the stale snapshot (waitForLiveSegment below already does this).
+                let after = liveCushionSnapshot()
+                // Degraded start: serving before the holdback cushion is built (transcode too slow, or a
+                // strict-realtime origin that has not produced 3 x TD of content within the deadline) makes
+                // a -16832 "restarting from end of live playlist" stall right after startup likely. Observe it.
+                if after.count > 0 && !LiveEdgePolicy.startupCushionSatisfied(segmentCount: after.count,
+                                                                             summedDurationSeconds: after.summed,
+                                                                             maxSegmentDuration: after.maxDuration,
+                                                                             cutTargetSeconds: cutTarget,
+                                                                             cadenceFloorSeconds: cadenceFloor,
+                                                                             windowSegmentCount: window) {
+                    let td = LiveEdgePolicy.targetDurationSeconds(maxSegmentDuration: after.maxDuration,
+                                                                  cutTargetSeconds: cutTarget,
+                                                                  cadenceFloorSeconds: cadenceFloor)
                     EngineLog.emit(
-                        "[HLSVideoEngine] WARNING: live startup degraded, serving first "
-                        + "playlist with \(count)/\(Self.liveStartupSegments) segments after "
-                        + "\(Int(timeout))s timeout (no startup cushion)",
+                        "[HLSVideoEngine] WARNING: live startup degraded, serving first playlist with "
+                        + "\(after.count) segments / \(String(format: "%.1f", after.summed))s < "
+                        + "\(String(format: "%.1f", LiveEdgePolicy.holdBackSeconds(targetDuration: td)))s holdback "
+                        + "after \(Int(timeout))s timeout (undersized startup cushion)",
                         category: .session
                     )
                 }
-                return count > 0
+                return after.count > 0
             }
         }
     }

--- a/Tests/AetherEngineTests/Issue189LiveEdgeHoldbackTests.swift
+++ b/Tests/AetherEngineTests/Issue189LiveEdgeHoldbackTests.swift
@@ -1,0 +1,102 @@
+// Tests/AetherEngineTests/Issue189LiveEdgeHoldbackTests.swift
+// AE#189 root cause (reporter-confirmed on 5.18.3): the served TARGETDURATION is correct (TD=6 for the
+// reporter's 4.8-5.76s long-GOP HEVC-in-TS segments), but the loopback advertised no explicit HOLD-BACK,
+// so AVPlayer fell back to its implicit 3 x TD (18s) holdback while the fixed 2-segment startup cushion
+// only built ~9.6s. AVPlayer then restarted inside its own stall-danger zone (-16832) until the realtime
+// window naturally deepened. Fix: (1) advertise EXT-X-SERVER-CONTROL:HOLD-BACK=3xTD, (2) size the startup
+// cushion to that same holdback depth. These tests pin both, and that the two derive TD identically.
+import XCTest
+@testable import AetherEngine
+
+/// Reporter's builder-visible outputs on 5.18.3: finalized live segments of 4.8s (keyframe-aligned at the
+/// upstream GOP), cut target 4.0s, cadence floor absent (worst case for the TD floor). Blocking-reload left
+/// at the default so the combined SERVER-CONTROL line carries both attributes.
+private final class Reporter189HoldbackProvider: HLSSegmentProvider, @unchecked Sendable {
+    let n: Int
+    let segSeconds: Double
+    init(n: Int, segSeconds: Double = 4.800) { self.n = n; self.segSeconds = segSeconds }
+
+    func initSegment() -> Data? { Data([0x00]) }
+    func mediaSegment(at index: Int) -> Data? { Data([0x00]) }
+    var segmentCount: Int { n }
+    func segmentDuration(at index: Int) -> Double { segSeconds }
+    var playlistType: HLSPlaylistType { .live }
+    var liveTargetSegmentDuration: Double? { 4.0 }
+    var liveTargetDurationFloorSeconds: Double? { nil }
+
+    func notePlaylistBuild() -> (visibleCount: Int, firstVisible: Int, refreshCounter: Int, endlistAdded: Bool, discontinuitySequence: Int) {
+        (n, 0, 1, false, 0)
+    }
+}
+
+final class Issue189LiveEdgeHoldbackTests: XCTestCase {
+
+    // MARK: - Shared TARGETDURATION / holdback policy
+
+    func testTargetDurationFlooredByCutTargetForLongGOP() {
+        // 4.8s segments: ceil(4.8)=5, floored up to ceil(1.5*4.0)=6.
+        XCTAssertEqual(LiveEdgePolicy.targetDurationSeconds(maxSegmentDuration: 4.8, cutTargetSeconds: 4.0, cadenceFloorSeconds: nil), 6)
+        // 5.76s segments: ceil(5.76)=6 already dominates the cut-target floor.
+        XCTAssertEqual(LiveEdgePolicy.targetDurationSeconds(maxSegmentDuration: 5.76, cutTargetSeconds: 4.0, cadenceFloorSeconds: nil), 6)
+        // Observed cadence dominates when the upstream is bursty.
+        XCTAssertEqual(LiveEdgePolicy.targetDurationSeconds(maxSegmentDuration: 4.8, cutTargetSeconds: 4.0, cadenceFloorSeconds: 9.2), 10)
+    }
+
+    func testHoldBackIsThreeTargetDurations() {
+        XCTAssertEqual(LiveEdgePolicy.holdBackSeconds(targetDuration: 6), 18.0, accuracy: 0.0001)
+    }
+
+    // MARK: - Startup cushion sizing
+
+    func testStartupCushionRejectsSubHoldbackWindow() {
+        // Two 4.8s segments = 9.6s < 18s holdback -> the reporter's exact failing startup window.
+        XCTAssertFalse(LiveEdgePolicy.startupCushionSatisfied(
+            segmentCount: 2, summedDurationSeconds: 9.6, maxSegmentDuration: 4.8,
+            cutTargetSeconds: 4.0, cadenceFloorSeconds: nil, windowSegmentCount: 15))
+    }
+
+    func testStartupCushionAcceptsHoldbackDepth() {
+        // Four 4.8s segments = 19.2s >= 18s holdback.
+        XCTAssertTrue(LiveEdgePolicy.startupCushionSatisfied(
+            segmentCount: 4, summedDurationSeconds: 19.2, maxSegmentDuration: 4.8,
+            cutTargetSeconds: 4.0, cadenceFloorSeconds: nil, windowSegmentCount: 15))
+    }
+
+    func testStartupCushionNeverServesSingleSegment() {
+        // Even a single huge segment that already covers the holdback must not be served alone (-12888).
+        XCTAssertFalse(LiveEdgePolicy.startupCushionSatisfied(
+            segmentCount: 1, summedDurationSeconds: 30.0, maxSegmentDuration: 30.0,
+            cutTargetSeconds: 4.0, cadenceFloorSeconds: nil, windowSegmentCount: 15))
+    }
+
+    func testStartupCushionBoundedByWindowForTinySegments() {
+        // Tiny 2s segments: 3xTD (TD floored to 6) = 18s would need 9 segments, but the window only ever
+        // holds windowSegmentCount; reaching that count releases the gate so a full window never blocks.
+        XCTAssertTrue(LiveEdgePolicy.startupCushionSatisfied(
+            segmentCount: 8, summedDurationSeconds: 16.0, maxSegmentDuration: 2.0,
+            cutTargetSeconds: 4.0, cadenceFloorSeconds: nil, windowSegmentCount: 8))
+    }
+
+    // MARK: - Served playlist
+
+    func testServedPlaylistAdvertisesHoldBack() {
+        let provider = Reporter189HoldbackProvider(n: 4)
+        let playlist = HLSLocalServer.buildMediaPlaylistText(provider: provider)
+        print("=== AE#189 served loopback media.m3u8 (holdback) ===\n\(playlist)\n=== end ===")
+
+        let td = playlist.split(separator: "\n")
+            .first { $0.hasPrefix("#EXT-X-TARGETDURATION:") }
+            .flatMap { Int($0.dropFirst("#EXT-X-TARGETDURATION:".count)) }
+        XCTAssertEqual(td, 6, "TD must cover the long-GOP segment")
+
+        let serverControl = playlist.split(separator: "\n").first { $0.hasPrefix("#EXT-X-SERVER-CONTROL:") }
+        XCTAssertNotNil(serverControl, "live playlist must advertise EXT-X-SERVER-CONTROL")
+        XCTAssertTrue(serverControl?.contains("HOLD-BACK=18.000") ?? false,
+                      "holdback must be pinned to 3 x TD so AVPlayer stops falling back to the implicit default: \(serverControl ?? "")")
+        // Single SERVER-CONTROL line carrying both attributes (spec: one tag, comma-separated attributes).
+        XCTAssertTrue(serverControl?.contains("CAN-BLOCK-RELOAD=YES") ?? false,
+                      "blocking-reload attribute must ride the same line: \(serverControl ?? "")")
+        XCTAssertEqual(playlist.components(separatedBy: "#EXT-X-SERVER-CONTROL:").count - 1, 1,
+                       "exactly one EXT-X-SERVER-CONTROL line")
+    }
+}

--- a/Tests/AetherEngineTests/Issue189ServedTargetDurationTests.swift
+++ b/Tests/AetherEngineTests/Issue189ServedTargetDurationTests.swift
@@ -1,0 +1,43 @@
+// Tests/AetherEngineTests/Issue189ServedTargetDurationTests.swift
+// AE#189 ground-truth: reproduce the EXACT served loopback media playlist for the reporter's
+// scenario (4K50 HEVC-in-TS, cut target 4.0s, actual keyframe-aligned segments 5.76s) and pin
+// what #EXT-X-TARGETDURATION the real builder emits. The reporter inferred TD=3 from AVFoundation's
+// -16832 message; this pins what the loopback ACTUALLY serves.
+import XCTest
+@testable import AetherEngine
+
+/// Mirrors the real VideoSegmentProvider's builder-visible outputs for the reporter's stream:
+/// finalized live segments of 5.76s (GOP at 50fps), cut target 4.0s, cadence floor still nil
+/// (LiveCadencePolicy not yet converged / absent), which is the WORST case for the TD floor.
+private final class Reporter189Provider: HLSSegmentProvider, @unchecked Sendable {
+    let n: Int
+    init(n: Int) { self.n = n }
+
+    func initSegment() -> Data? { Data([0x00]) }
+    func mediaSegment(at index: Int) -> Data? { Data([0x00]) }
+    var segmentCount: Int { n }
+    func segmentDuration(at index: Int) -> Double { 5.760 }   // real finalized duration from the reporter's logs
+    var playlistType: HLSPlaylistType { .live }
+    var liveTargetSegmentDuration: Double? { 4.0 }            // liveWindowSizing.targetSegmentDurationSeconds
+    var liveTargetDurationFloorSeconds: Double? { nil }       // cadence floor absent / unconverged: worst case
+
+    func notePlaylistBuild() -> (visibleCount: Int, firstVisible: Int, refreshCounter: Int, endlistAdded: Bool, discontinuitySequence: Int) {
+        (n, 0, 1, false, 0)
+    }
+}
+
+final class Issue189ServedTargetDurationTests: XCTestCase {
+    func testServedTargetDurationNeverBelowSegmentDuration() {
+        let provider = Reporter189Provider(n: 6)
+        let playlist = HLSLocalServer.buildMediaPlaylistText(provider: provider)
+        print("=== AE#189 served loopback media.m3u8 ===\n\(playlist)\n=== end ===")
+
+        let td = playlist
+            .split(separator: "\n")
+            .first { $0.hasPrefix("#EXT-X-TARGETDURATION:") }
+            .flatMap { Int($0.dropFirst("#EXT-X-TARGETDURATION:".count)) }
+        XCTAssertNotNil(td)
+        // HLS spec: TARGETDURATION >= ceil(max EXTINF). Reporter claims served TD=3 while EXTINF=5.76.
+        XCTAssertGreaterThanOrEqual(td ?? 0, 6, "served TD must cover the 5.76s segment; builder can never emit 3")
+    }
+}

--- a/Tests/AetherEngineTests/LiveCadencePolicyTests.swift
+++ b/Tests/AetherEngineTests/LiveCadencePolicyTests.swift
@@ -145,7 +145,7 @@ final class LiveCadencePolicyTests: XCTestCase {
     func testBurstyProviderOmitsBlockingReloadAndRaisesTargetDuration() {
         let provider = ScriptedManifestProvider(count: 5, blockingReload: false, floor: 20)
         let ls = lines(HLSLocalServer.buildMediaPlaylistText(provider: provider))
-        XCTAssertFalse(ls.contains("#EXT-X-SERVER-CONTROL:CAN-BLOCK-RELOAD=YES"),
+        XCTAssertFalse(serverControlHasAttribute(ls, "CAN-BLOCK-RELOAD"),
                        "bursty ingest must not advertise blocking-reload (-15410)")
         XCTAssertTrue(ls.contains("#EXT-X-TARGETDURATION:20"),
                       "TARGETDURATION floor must cover the observed inter-batch gap (anti -12888)")
@@ -154,7 +154,15 @@ final class LiveCadencePolicyTests: XCTestCase {
     func testDisciplinedProviderAdvertisesBlockingReload() {
         let provider = ScriptedManifestProvider(count: 5, blockingReload: true, floor: nil)
         let ls = lines(HLSLocalServer.buildMediaPlaylistText(provider: provider))
-        XCTAssertTrue(ls.contains("#EXT-X-SERVER-CONTROL:CAN-BLOCK-RELOAD=YES"))
+        // Combined SERVER-CONTROL line: CAN-BLOCK-RELOAD rides alongside HOLD-BACK (AE#189).
+        XCTAssertTrue(serverControlHasAttribute(ls, "CAN-BLOCK-RELOAD=YES"))
+        XCTAssertTrue(serverControlHasAttribute(ls, "HOLD-BACK="),
+                      "live playlists always pin the live-edge holdback")
+    }
+
+    /// True if any EXT-X-SERVER-CONTROL line carries the given attribute (order/co-attributes agnostic).
+    private func serverControlHasAttribute(_ ls: [String], _ attribute: String) -> Bool {
+        ls.contains { $0.hasPrefix("#EXT-X-SERVER-CONTROL:") && $0.contains(attribute) }
     }
 }
 

--- a/Tests/AetherEngineTests/LivePlaylistRefreshTests.swift
+++ b/Tests/AetherEngineTests/LivePlaylistRefreshTests.swift
@@ -40,7 +40,10 @@ final class LivePlaylistRefreshTests: XCTestCase {
         let ls = lines(playlist)
 
         XCTAssertTrue(ls.contains("#EXT-X-MEDIA-SEQUENCE:0"))
-        XCTAssertTrue(ls.contains("#EXT-X-SERVER-CONTROL:CAN-BLOCK-RELOAD=YES"))
+        // Combined SERVER-CONTROL line carries CAN-BLOCK-RELOAD alongside the live-edge HOLD-BACK (AE#189).
+        let serverControl = ls.first { $0.hasPrefix("#EXT-X-SERVER-CONTROL:") }
+        XCTAssertTrue(serverControl?.contains("CAN-BLOCK-RELOAD=YES") ?? false)
+        XCTAssertTrue(serverControl?.contains("HOLD-BACK=") ?? false)
         XCTAssertFalse(ls.contains("#EXT-X-ENDLIST"),
                        "a live playlist must stay open so AVPlayer keeps polling")
         XCTAssertFalse(ls.contains(where: { $0.hasPrefix("#EXT-X-PLAYLIST-TYPE") }),


### PR DESCRIPTION
## Root cause (reporter-confirmed on 5.18.3, AE#189)

Long-GOP live (4K50 HEVC-in-TS, keyframe-aligned segments of 4.8-5.76s -> `TARGETDURATION` 6) routed through the loopback advertised **no explicit** `EXT-X-SERVER-CONTROL:HOLD-BACK`, so AVPlayer fell back to its implicit `3 x TARGETDURATION` (18s) live-edge holdback. The fixed 2-segment startup cushion only built ~9.6s of content behind the edge, so AVPlayer's initial seek to edge-minus-holdback landed inside its own stall-danger zone. It then spammed:

```
-16832 restarting 9.600000s from end of live playlist; target duration 6s - stall danger
```

rebuffering until the realtime window naturally deepened past 18s. The reporter confirmed the served `TARGETDURATION` is correct (TD=6) and the driver is the **holdback**, not `TARGETDURATION`.

## Fix

- New `LiveEdgePolicy` owns the shared `TARGETDURATION` derivation and the holdback (`3 x TD`). Both the served playlist and the startup gate compute it identically, so the depth the cushion builds to is exactly the depth AVPlayer enforces (no drift).
- `buildMediaPlaylistText` emits `EXT-X-SERVER-CONTROL:HOLD-BACK=3xTD` (the RFC 8216bis floor, AVPlayer's implicit default made explicit), merged onto **one** `SERVER-CONTROL` line alongside `CAN-BLOCK-RELOAD`.
- `waitForFirstLiveSegment` holds the first manifest until the window carries at least the holdback depth, bounded above by `windowSegmentCount` and the existing wall-clock deadline. Backlog sources (Jellyfin transcode, or an upstream live window pulled at I/O speed) satisfy it near-instantly; only a strict-realtime origin pays the deepen-the-buffer latency inherent to joining long-GOP live safely.

Spec note: `HOLD-BACK` must be >= `3 x TARGETDURATION` (RFC 8216bis 4.4.3.8), so advertising a smaller value to match a thin cushion is not an option. The cushion is deepened to the holdback instead.

## Tests

- `Issue189LiveEdgeHoldbackTests`: `LiveEdgePolicy` TARGETDURATION / holdback / cushion decisions, plus served-playlist `HOLD-BACK` emission and single combined `SERVER-CONTROL` line.
- `Issue189ServedTargetDurationTests`: ground-truth that the builder can never serve TD below the segment duration (documents the reporter's original TD misdiagnosis).
- Existing `SERVER-CONTROL` assertions moved from full-line equality to attribute checks (the line now carries `HOLD-BACK` too).

Full suite green (359 XCTest + 942 swift-testing), tvOS-simulator build clean.

Refs AE#189. Left open for reporter device retest before the issue is closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)