### PR TITLE
fix(video): recover from a VOD producer that dies mid-session at the tail (#169)

### DIFF
--- a/Sources/AetherEngine/Video/HLSVideoEngine+LiveReopen.swift
+++ b/Sources/AetherEngine/Video/HLSVideoEngine+LiveReopen.swift
@@ -15,6 +15,18 @@ extension HLSVideoEngine {
         return packetsWritten == 0 && cachedSegments == 0
     }
 
+    /// AE#169 round 2 pure decision: a VOD pump read-error exit that produced media before dying
+    /// is revivable (the source worked; a reconnect-churned read failed). The complement is the
+    /// #126 dead-source fatal surface; live keeps its reopen machinery.
+    static func shouldReviveVODAfterReadError(
+        isLive: Bool,
+        packetsWritten: Int,
+        cachedSegments: Int
+    ) -> Bool {
+        guard !isLive else { return false }
+        return packetsWritten > 0 || cachedSegments > 0
+    }
+
     /// #167 follow-up pure decision: live pump exits that delegate to host retune leave a provider no
     /// producer will ever cut into again. Its blocking-reload advert must drop and its held ?_HLS_msn=
     /// waiters release, or the zombie session (and any item reload against it while the host retunes)
@@ -54,14 +66,19 @@ extension HLSVideoEngine {
         // written, empty segment cache) is a dead source: the playlist exists but no segment
         // will ever land, no restart arm covers readError, and AVPlayer parks in waitingToPlay
         // until the host's first-frame timeout. Surface it as fatal instead of dying silently.
-        // Mid-session read errors (packets/segments already produced) keep the existing
-        // behavior: AVIO absorbs transients, the scrub/wedge arms cover recovery.
+        // AE#169 round 2: a MID-SESSION read error (packets/segments already produced) gets a
+        // bounded revive. The old assumption that the scrub/wedge arms cover it was false for a
+        // request within the forward-wait window of the dead producer's front: the wedge detector
+        // died with the pump and the provider's restart escalation judged by index distance alone,
+        // so the tail request parked 30 s at a time into -12889 (rrgomes' seg719 trace).
         if case .readError(let code) = reason, !isLiveSession {
-            if Self.isFatalVODPumpExit(
-                reason: reason, isLive: isLiveSession,
+            if Self.shouldReviveVODAfterReadError(
+                isLive: isLiveSession,
                 packetsWritten: prod.packetsWrittenCount,
                 cachedSegments: cache?.count ?? 0
             ) {
+                handleVODReadErrorExit(code)
+            } else {
                 EngineLog.emit(
                     "[HLSVideoEngine] VOD pump died before producing anything "
                     + "(readError \(code)); surfacing fatal source failure",
@@ -133,6 +150,41 @@ extension HLSVideoEngine {
         Task.detached(priority: .userInitiated) { [weak self] in
             await self?.performLiveReopen(failedProducer: prod)
         }
+    }
+
+    /// AE#169 round 2: revive a VOD session whose pump died on a mid-session read error. Mirrors
+    /// the #99 muxerFailed arm: bounded by its own gate, aimed at the pending seek target or
+    /// AVPlayer's real position, authoritative so it wins the coalescer's pending slot. The
+    /// demuxer whose read just threw is marked suspect so performRestart replaces it via the #79
+    /// fresh-demuxer path instead of seeking the failed connection.
+    func handleVODReadErrorExit(_ code: Int32) {
+        restartLock.lock()
+        let admitted = readErrorReviveGate.admit()
+        let attempts = readErrorReviveGate.attempts
+        let cap = readErrorReviveGate.maxAttempts
+        if admitted { mainDemuxerSuspectDead = true }
+        restartLock.unlock()
+        guard admitted else {
+            EngineLog.emit(
+                "[HLSVideoEngine] #169 VOD readError revive cap reached "
+                + "(\(attempts) failures, cap \(cap)); giving up (source not readable in this session)",
+                category: .session
+            )
+            return
+        }
+        let frozen = currentPlaybackPositionProvider?() ?? 0
+        let anchor = AetherEngine.recoveryAnchorPosition(
+            frozenPosition: frozen, pendingSeekTarget: recoverySeekTargetProvider?(),
+            currentRendered: frozen)
+        let idx = segmentIndexForPlaylistTime(anchor)
+        EngineLog.emit(
+            "[HLSVideoEngine] #169 VOD pump died mid-session (readError \(code)); "
+            + "rebuilding producer on a fresh demuxer at "
+            + "\(String(format: "%.2f", anchor))s -> seg\(idx) "
+            + "(attempt \(attempts)/\(cap))",
+            category: .session
+        )
+        requestRestart(at: idx, authoritative: true)
     }
 
     /// #99: revive a VOD session whose pump died with muxerFailed. The restart path rebuilds the

--- a/Sources/AetherEngine/Video/HLSVideoEngine.swift
+++ b/Sources/AetherEngine/Video/HLSVideoEngine.swift
@@ -442,6 +442,18 @@ public final class HLSVideoEngine: @unchecked Sendable {
     /// a persistent cause exhausts the cap instead of restart-storming.
     var muxerFailureReviveGate = MuxerFailureReviveGate(maxAttempts: 2)
 
+    /// AE#169 round 2: bounded revive for a VOD pump that died on a MID-SESSION read error (under
+    /// `restartLock`). #126 only surfaced the nothing-ever-produced case as fatal and assumed the
+    /// scrub/wedge arms covered the rest; a tail request within the forward-wait window of the dead
+    /// producer's front reached neither (rrgomes: seg719 miss x11 into -12889), so the exit gets
+    /// its own event-driven arm. Same gate shape as #99.
+    var readErrorReviveGate = MuxerFailureReviveGate(maxAttempts: 2)
+
+    /// AE#169 round 2 (under `restartLock`): the demuxer's last read threw, so the next
+    /// performRestart replaces it via the #79 fresh-demuxer path instead of seeking a connection
+    /// that just failed (a sticky pb error would burn the revive gate without one fresh attempt).
+    var mainDemuxerSuspectDead = false
+
     /// #93 residual: a stalled AVPlayer sometimes never resumes REQUESTING after a wedge re-anchor
     /// (device: plain playback, one -15628 errorLog, then zero segment GETs while parked in
     /// waitingToMinimizeStalls forever, item never fails). The served playlist alone cannot reach
@@ -1224,6 +1236,11 @@ public final class HLSVideoEngine: @unchecked Sendable {
             activeProducerBase: isLiveSession ? nil : { [weak self] in
                 self?.currentProducerBaseIndex
             },
+            // AE#169 round 2: a finished pump can never march; the forward-window wait must
+            // escalate to restart instead of parking on its frozen front.
+            producerFinished: isLiveSession ? nil : { [weak self] in
+                self?.currentProducerFinished ?? false
+            },
             // #93 residual: the first producer may be anchored at the resume segment; without this
             // the cold-start heuristic (abs(index - lastRestartIndex) > 2) restarts it immediately.
             initialRestartIndex: initialProducerBaseIndex,
@@ -1773,6 +1790,14 @@ public final class HLSVideoEngine: @unchecked Sendable {
         return producer?.anchoredBaseIndex
     }
 
+    /// AE#169 round 2: whether the installed producer's pump has exited. nil producer (mid-restart)
+    /// reads as false; the coalescer's restartActivity covers that window.
+    var currentProducerFinished: Bool {
+        restartLock.lock()
+        defer { restartLock.unlock() }
+        return producer?.didFinish ?? false
+    }
+
     /// Total media-segment requests seen this session (#93 residual): the stall-triggered
     /// re-engage watchdog compares snapshots to detect a consumer that stopped requesting.
     var mediaFetchCountSnapshot: UInt64 {
@@ -1885,6 +1910,11 @@ public final class HLSVideoEngine: @unchecked Sendable {
         let ab = audioBridge
         let targetStartPts = segmentPlan[idx].startPts
         let videoTb = savedVideoConfig?.timeBase ?? AVRational(num: 1, den: 1000)
+        // AE#169 round 2: consume the suspect-dead mark (the demuxer's last read threw); this
+        // restart replaces it via the #79 fresh-demuxer path instead of seeking the failed
+        // connection.
+        let demuxerSuspectDead = mainDemuxerSuspectDead
+        mainDemuxerSuspectDead = false
         restartLock.unlock()
 
         let restartStart = DispatchTime.now()
@@ -1895,56 +1925,65 @@ public final class HLSVideoEngine: @unchecked Sendable {
         var reopenMs: Double? = nil
         var seekMs: Double = 0
 
-        // The new producer reuses this demuxer unless we have to replace a wedged one (#79, below).
+        // The new producer reuses this demuxer unless we have to replace a wedged (#79) or
+        // suspect-dead (#169) one, below.
         var activeDem = dem
         var freshDemuxer: Demuxer?
+        var oldPumpExited = true
         if let old {
             old.stop()
-            let ok = old.waitForFinish(timeout: 5.0)
+            oldPumpExited = old.waitForFinish(timeout: 5.0)
             stopWaitMs = msSince(restartStart)
-            if !ok {
-                // #79: the old pump is wedged in a blocking network read on the SHARED demuxer; stop() can't
-                // unblock a socket read, so waitForFinish timed out. Reusing this demuxer makes the new
-                // producer's first post-seek read queue behind that stuck read for the full ~20s
-                // connStallTimeout (the reporter's ~25s restart), after which the abandoned reader also steals
-                // the first packet. markClosed() aborts the stuck read immediately (the existing thread-safe
-                // unblock) but dooms the demuxer, so open a FRESH one and hand it to the new producer. Open
-                // FIRST, abort only on success, so a reopen failure falls back to the prior abandon behaviour
-                // (no regression) rather than poisoning the only demuxer. Scoped to the VOD single-demuxer
-                // scrub case; the side-source / live-reopen paths keep their existing behaviour.
-                if !isLiveSession, sideAudioDemuxer == nil {
-                    let reopenStart = DispatchTime.now()
-                    let fresh = Demuxer()
-                    do {
-                        // .restartReopen: bounded find_stream_info budget; the FULL playback budget was
-                        // the bulk of a 44 s wedge-reopen over WAN (#93 residual). The pass itself must
-                        // run so video_delay resolves, else B-frame dts arrive broken (#93 judder).
-                        try fresh.open(url: sourceURL, extraHeaders: sourceHTTPHeaders, profile: .restartReopen, isLive: false)
-                        dem.markClosed() // abort the wedged read now that the replacement is ready
-                        freshDemuxer = fresh
-                        activeDem = fresh
-                        EngineLog.emit(
-                            "[HLSVideoEngine] restart at idx=\(idx): old producer wedged in a read past 5s; "
-                            + "aborted it and reopened a fresh demuxer (avoids the ~20s shared-read stall)",
-                            category: .session
-                        )
-                    } catch {
-                        fresh.close()
-                        EngineLog.emit(
-                            "[HLSVideoEngine] restart at idx=\(idx): old producer wedged; reopen failed (\(error)), "
-                            + "abandoning it and reusing the demuxer",
-                            category: .session
-                        )
-                    }
-                    reopenMs = msSince(reopenStart)
-                } else {
+        }
+        if !oldPumpExited || demuxerSuspectDead {
+            // #79: the old pump is wedged in a blocking network read on the SHARED demuxer; stop() can't
+            // unblock a socket read, so waitForFinish timed out. Reusing this demuxer makes the new
+            // producer's first post-seek read queue behind that stuck read for the full ~20s
+            // connStallTimeout (the reporter's ~25s restart), after which the abandoned reader also steals
+            // the first packet. markClosed() aborts the stuck read immediately (the existing thread-safe
+            // unblock) but dooms the demuxer, so open a FRESH one and hand it to the new producer. Open
+            // FIRST, abort only on success, so a reopen failure falls back to the prior abandon behaviour
+            // (no regression) rather than poisoning the only demuxer. Scoped to the VOD single-demuxer
+            // scrub case; the side-source / live-reopen paths keep their existing behaviour.
+            // AE#169 round 2 takes the same path when the pump exited BECAUSE the demuxer's read
+            // threw: the connection is known-bad, so the revive gets one fresh connection instead
+            // of seeking the demuxer that just failed.
+            if !isLiveSession, sideAudioDemuxer == nil {
+                let reopenStart = DispatchTime.now()
+                let fresh = Demuxer()
+                do {
+                    // .restartReopen: bounded find_stream_info budget; the FULL playback budget was
+                    // the bulk of a 44 s wedge-reopen over WAN (#93 residual). The pass itself must
+                    // run so video_delay resolves, else B-frame dts arrive broken (#93 judder).
+                    try fresh.open(url: sourceURL, extraHeaders: sourceHTTPHeaders, profile: .restartReopen, isLive: false)
+                    dem.markClosed() // abort any wedged read now that the replacement is ready
+                    freshDemuxer = fresh
+                    activeDem = fresh
                     EngineLog.emit(
-                        "[HLSVideoEngine] restart at idx=\(idx): old producer didn't exit within 5s, abandoning it "
-                        + "(its in-flight read shares the demuxer and may consume the first post-seek packet; "
-                        + "if the new session starts a GOP late, this is why)",
+                        "[HLSVideoEngine] restart at idx=\(idx): "
+                        + (oldPumpExited
+                            ? "#169 demuxer suspect-dead after read error; "
+                            : "old producer wedged in a read past 5s; aborted it and ")
+                        + "reopened a fresh demuxer",
+                        category: .session
+                    )
+                } catch {
+                    fresh.close()
+                    EngineLog.emit(
+                        "[HLSVideoEngine] restart at idx=\(idx): "
+                        + (oldPumpExited ? "#169 suspect-dead demuxer" : "old producer wedged")
+                        + "; reopen failed (\(error)), reusing the demuxer",
                         category: .session
                     )
                 }
+                reopenMs = msSince(reopenStart)
+            } else if !oldPumpExited {
+                EngineLog.emit(
+                    "[HLSVideoEngine] restart at idx=\(idx): old producer didn't exit within 5s, abandoning it "
+                    + "(its in-flight read shares the demuxer and may consume the first post-seek packet; "
+                    + "if the new session starts a GOP late, this is why)",
+                    category: .session
+                )
             }
         }
 

--- a/Sources/AetherEngine/Video/VideoSegmentProvider.swift
+++ b/Sources/AetherEngine/Video/VideoSegmentProvider.swift
@@ -145,6 +145,18 @@ final class VideoSegmentProvider: HLSSegmentProvider, @unchecked Sendable {
     /// Base index of the active producer (#93 residual): a fetch for an index within the
     /// producer's forward march window waits for the march instead of tearing it down.
     private let activeProducerBase: (() -> Int?)?
+    /// AE#169 round 2: whether the installed producer's pump has EXITED (any reason). A finished
+    /// pump can never march, so a forward-window fetch must restart instead of backpressure-waiting
+    /// on a front that is provably frozen. nil/false during a coalesced restart (no producer
+    /// installed) keeps the normal wait+ride paths.
+    private let producerFinished: (() -> Bool)?
+
+    /// AE#169 round 2: single-slot record of the last forward-window fetch that burned its FULL
+    /// backpressure wait. Same index + unmoved march front on the next fetch is proof the march is
+    /// not coming (the wait would re-arm forever against a dead producer); a moved front overwrites
+    /// the record and keeps the patience. Guarded by stateLock.
+    private var _forwardMissIndex: Int = .min
+    private var _forwardMissFront: Int = .min
 
     /// Base index of the engine's current producer. Guards against stale-producer waits:
     /// abs(index - lastRestartIndex) <= 2 = cold start, wait; larger = restart needed.
@@ -215,6 +227,7 @@ final class VideoSegmentProvider: HLSSegmentProvider, @unchecked Sendable {
         restartHandler: ((Int) -> Void)? = nil,
         restartActivity: (() -> Bool)? = nil,
         activeProducerBase: (() -> Int?)? = nil,
+        producerFinished: (() -> Bool)? = nil,
         initialRestartIndex: Int = 0,
         repositionWaitSlice: TimeInterval = 8.0,
         sparseHoleWaitSlice: TimeInterval = 2.0,
@@ -245,6 +258,7 @@ final class VideoSegmentProvider: HLSSegmentProvider, @unchecked Sendable {
         self.restartHandler = restartHandler
         self.restartActivity = restartActivity
         self.activeProducerBase = activeProducerBase
+        self.producerFinished = producerFinished
         self._lastRestartIndex = initialRestartIndex
         self.repositionWaitSlice = repositionWaitSlice
         self.sparseHoleWaitSlice = sparseHoleWaitSlice
@@ -487,6 +501,14 @@ final class VideoSegmentProvider: HLSSegmentProvider, @unchecked Sendable {
             producerPassedAndPruned = highWater > index
         }
         let needsRestart: Bool
+        // AE#169 round 2: set when the forward-wait branch has PROOF the active march is never
+        // arriving (pump finished, or a full backpressure wait elapsed with zero front progress
+        // for this same index). Bypasses the restart loop's producerCovers veto below, which
+        // otherwise reads the dead producer's still-installed base and suppresses the fire.
+        var marchProvenDead = false
+        // AE#169 round 2: true when the fetch takes the VOD forward-window backpressure wait, so a
+        // full-timeout miss records (index, front) for the frozen-march escalation above.
+        var tookForwardWait = false
         if staleBelowProducer || producerPassedAndPruned {
             needsRestart = true
         } else if let r = range {
@@ -511,7 +533,36 @@ final class VideoSegmentProvider: HLSSegmentProvider, @unchecked Sendable {
                 // at 75; the request for seg159 parked 3x30 s into -1017 item death while the
                 // march was ~2 minutes away). highWater is reset per provider-fired restart, so
                 // max(highWater, lastRestartIndex) tracks the active producer's front.
-                needsRestart = index > activeMarchFront + Self.forwardWaitWindow
+                //
+                // AE#169 round 2: index distance alone is still not proof the march will ARRIVE.
+                // A producer that died mid-session (source read error at the tail) freezes the
+                // front just below the request, and the 30 s wait re-armed forever (seg719 miss
+                // x11 into -12889). A finished pump, or a full wait already burned with zero
+                // front progress for this same index, escalates to restart instead. VOD only:
+                // live has its own pump watchdogs and reopen machinery.
+                let front = activeMarchFront
+                tookForwardWait = !isLive
+                if !isLive {
+                    stateLock.lock()
+                    let missIndex = _forwardMissIndex
+                    let missFront = _forwardMissFront
+                    stateLock.unlock()
+                    marchProvenDead = Self.forwardWaitMarchDead(
+                        index: index, marchFront: front,
+                        producerFinished: producerFinished?() ?? false,
+                        lastMissIndex: missIndex, lastMissFront: missFront)
+                    if marchProvenDead {
+                        EngineLog.emit(
+                            "[HLSVideoEngine] seg\(index): #169 forward-wait march dead "
+                            + "(front=\(front) "
+                            + (producerFinished?() ?? false
+                                ? "producer finished" : "frozen across a full wait")
+                            + "); escalating to restart",
+                            category: .session
+                        )
+                    }
+                }
+                needsRestart = index > front + Self.forwardWaitWindow || marchProvenDead
             }
         } else {
             // Empty cache: cold start (producer at lastRestartIndex, hasn't written yet) vs. big scrub
@@ -545,7 +596,10 @@ final class VideoSegmentProvider: HLSSegmentProvider, @unchecked Sendable {
                     // covers (base <= index <= base + forward window) never fires OR backstops:
                     // the march will deliver it, and the backstop killed a 75%-complete capture
                     // on device while a forward-march neighbor got its healthy producer restarted.
-                    let producerCovers = activeProducerCovers(index)
+                    // AE#169 round 2: a march proven dead (finished pump / frozen front across a
+                    // full wait) must not veto the fire; the still-installed dead producer's base
+                    // covering the index is exactly the wedge being escaped.
+                    let producerCovers = !marchProvenDead && activeProducerCovers(index)
                     // A request superseded by a NEWER declared target is an orphan of a skip
                     // storm: AVPlayer's newest request is what it actually wants (the same
                     // newest-wins semantics the coalescer applies to immediate restarts).
@@ -564,6 +618,7 @@ final class VideoSegmentProvider: HLSSegmentProvider, @unchecked Sendable {
                             category: .session
                         )
                         lastRestartIndex = index
+                        clearForwardWaitMiss()
                         restart(index)
                         // Reset highWater AFTER restart() returns (synchronous: old producer has exited).
                         // Pre-restart reset would be clobbered by the old producer's final write re-bumping
@@ -581,7 +636,41 @@ final class VideoSegmentProvider: HLSSegmentProvider, @unchecked Sendable {
         }
 
         let bytes = cache.fetch(index: index, timeout: forwardBackpressureWaitSeconds)
+        if tookForwardWait, !needsRestart {
+            if bytes == nil {
+                // Record the front as of the END of the burned wait: progress DURING the wait
+                // resets the comparison base, so only a truly frozen march escalates next time.
+                recordForwardWaitMiss(index: index, front: activeMarchFront)
+            } else {
+                clearForwardWaitMiss()
+            }
+        }
         return logServed(index: index, bytes: bytes, totalStart: totalStart, restarted: needsRestart)
+    }
+
+    /// AE#169 round 2 pure decision: whether the forward-window backpressure wait may still trust
+    /// the active march to deliver `index`. A FINISHED pump can never march. A recorded full-wait
+    /// miss for the same index with an unmoved front means the wait already failed empirically and
+    /// re-arming it would park forever (rrgomes: seg719 miss x11 into -12889). Everything else
+    /// keeps the wait: slow sources legitimately take most of the patience window for one segment.
+    static func forwardWaitMarchDead(index: Int, marchFront: Int, producerFinished: Bool,
+                                     lastMissIndex: Int, lastMissFront: Int) -> Bool {
+        if producerFinished { return true }
+        return lastMissIndex == index && lastMissFront == marchFront
+    }
+
+    private func recordForwardWaitMiss(index: Int, front: Int) {
+        stateLock.lock()
+        _forwardMissIndex = index
+        _forwardMissFront = front
+        stateLock.unlock()
+    }
+
+    private func clearForwardWaitMiss() {
+        stateLock.lock()
+        _forwardMissIndex = .min
+        _forwardMissFront = .min
+        stateLock.unlock()
     }
 
     private func logServed(index: Int, bytes: Data?, totalStart: DispatchTime, restarted: Bool) -> Data? {

--- a/Tests/AetherEngineTests/Issue169DeadProducerEscalationTests.swift
+++ b/Tests/AetherEngineTests/Issue169DeadProducerEscalationTests.swift
@@ -1,0 +1,203 @@
+import Testing
+import Foundation
+@testable import AetherEngine
+
+/// AE#169 round 2 (rrgomes): the final segment's producer died mid-session (source read error after
+/// LAN reconnect churn) and the request for seg719 parked in the forward-wait branch forever:
+/// `needsRestart = index > activeMarchFront + forwardWaitWindow` judges "will this arrive?" by index
+/// distance alone, so a dead producer's frozen front re-arms the 30 s wait indefinitely
+/// (`cache miss after 30005ms (cache=46 restarted=false)` x11 into -12889). Two provider-side
+/// escapes: a FINISHED pump is proof the march is never coming (skip the wait entirely), and a full
+/// backpressure wait that elapsed with zero front progress for the same index escalates on the next
+/// request. Both must also bypass the restart loop's producerCovers veto, which reads the dead
+/// producer's still-installed base.
+struct Issue169DeadProducerEscalationTests {
+
+    private final class Recorder: @unchecked Sendable {
+        private let lock = NSLock()
+        private var fired: [Int] = []
+        func record(_ idx: Int) { lock.lock(); fired.append(idx); lock.unlock() }
+        var all: [Int] { lock.lock(); defer { lock.unlock() }; return fired }
+    }
+
+    private func segments(_ n: Int) -> [HLSVideoEngine.Segment] {
+        (0..<n).map { i in
+            HLSVideoEngine.Segment(startPts: Int64(i) * 4000, endPts: Int64(i + 1) * 4000,
+                                   startSeconds: Double(i) * 4.0, durationSeconds: 4.0)
+        }
+    }
+
+    private func makeProvider(cache: SegmentCache, recorder: Recorder,
+                              producerBase: Int?, initialRestartIndex: Int,
+                              producerFinished: @escaping () -> Bool,
+                              storeOnRestart: Bool = true,
+                              backpressureWait: TimeInterval = 0.3) -> VideoSegmentProvider {
+        VideoSegmentProvider(
+            cache: cache, segments: segments(200), codecsString: "hvc1", supplementalCodecs: nil,
+            resolution: (3840, 2160), videoRange: .sdr, frameRate: 24.0, hdcpLevel: nil,
+            sourceBitrate: 60_000_000,
+            restartHandler: { [weak cache] idx in
+                recorder.record(idx)
+                if storeOnRestart {
+                    cache?.store(index: idx, data: Data(repeating: 0x41, count: 8))
+                }
+            },
+            restartActivity: { false },
+            activeProducerBase: { producerBase },
+            producerFinished: producerFinished,
+            initialRestartIndex: initialRestartIndex,
+            repositionWaitSlice: 0.05,
+            repositionRideCapSeconds: 5.0,
+            forwardBackpressureWaitSeconds: backpressureWait
+        )
+    }
+
+    /// Seeds the device geometry at test scale: producer anchored at 40 wrote 40..46 then died.
+    private func seedDeadProducerBand(_ cache: SegmentCache) {
+        cache.resetHighWaterForRestart()
+        for i in 40...46 { cache.store(index: i, data: Data(repeating: 0xA9, count: 8)) }
+    }
+
+    /// The trace shape: pump exited (readError) with seg719 never written; AVPlayer requests the
+    /// next index above the frozen front. A finished pump can never march, so the fetch must
+    /// restart immediately instead of burning the 30 s backpressure wait even once. The dead
+    /// producer's base still covers the index, so this also proves the producerCovers bypass.
+    @Test("a forward-window fetch with a finished producer restarts immediately")
+    func finishedProducerForwardFetchRestartsImmediately() {
+        let cache = SegmentCache(forwardWindow: 60, backwardWindow: 60)
+        defer { cache.close() }
+        let recorder = Recorder()
+        seedDeadProducerBand(cache)
+        let provider = makeProvider(cache: cache, recorder: recorder,
+                                    producerBase: 40, initialRestartIndex: 40,
+                                    producerFinished: { true },
+                                    backpressureWait: 5.0)
+
+        let start = DispatchTime.now()
+        let served = provider.mediaSegment(at: 47)
+        let elapsed = Double(DispatchTime.now().uptimeNanoseconds - start.uptimeNanoseconds) / 1e9
+
+        #expect(served != nil)
+        #expect(recorder.all == [47])
+        #expect(elapsed < 2.0)
+    }
+
+    /// The blocked-in-read variant: the pump never finishes (no exit event), the front just stops.
+    /// The first fetch keeps the full backpressure patience (slow WAN reads legitimately take
+    /// 20-30 s); the SECOND fetch for the same index with an unmoved front is proof the march is
+    /// not coming and must escalate to restart.
+    @Test("a repeated forward-window miss with a frozen march front escalates to restart")
+    func frozenMarchEscalatesOnSecondMiss() {
+        let cache = SegmentCache(forwardWindow: 60, backwardWindow: 60)
+        defer { cache.close() }
+        let recorder = Recorder()
+        seedDeadProducerBand(cache)
+        let provider = makeProvider(cache: cache, recorder: recorder,
+                                    producerBase: 40, initialRestartIndex: 40,
+                                    producerFinished: { false })
+
+        let firstStart = DispatchTime.now()
+        let first = provider.mediaSegment(at: 47)
+        let firstElapsed = Double(DispatchTime.now().uptimeNanoseconds - firstStart.uptimeNanoseconds) / 1e9
+        #expect(first == nil)
+        #expect(recorder.all.isEmpty)
+        #expect(firstElapsed >= 0.25)
+
+        let second = provider.mediaSegment(at: 47)
+        #expect(second != nil)
+        #expect(recorder.all == [47])
+    }
+
+    /// A slow-but-alive producer keeps its patience: the front advanced between the two misses, so
+    /// the second fetch must keep waiting (no restart teardown of a healthy march, the #141/#93
+    /// protections). Once the front freezes across a full wait, the third fetch escalates.
+    @Test("an advancing march front resets the escalation and keeps the backpressure wait")
+    func advancingMarchDoesNotEscalate() {
+        let cache = SegmentCache(forwardWindow: 60, backwardWindow: 60)
+        defer { cache.close() }
+        let recorder = Recorder()
+        seedDeadProducerBand(cache)
+        let provider = makeProvider(cache: cache, recorder: recorder,
+                                    producerBase: 40, initialRestartIndex: 40,
+                                    producerFinished: { false })
+
+        #expect(provider.mediaSegment(at: 50) == nil)   // miss 1: front 46 recorded
+        cache.store(index: 47, data: Data(repeating: 0xA9, count: 8))   // march advances
+        #expect(provider.mediaSegment(at: 50) == nil)   // miss 2: front moved, keep waiting
+        #expect(recorder.all.isEmpty)
+
+        let third = provider.mediaSegment(at: 50)        // miss 3: front frozen at 47, escalate
+        #expect(third != nil)
+        #expect(recorder.all == [50])
+    }
+
+    /// Escalation is VOD-only: live sessions have their own pump watchdogs and reopen machinery,
+    /// and a live forward-window miss (producer briefly behind the playlist edge) must keep its
+    /// plain backpressure wait.
+    @Test("live sessions never escalate a forward-window miss")
+    func liveNeverEscalates() {
+        let cache = SegmentCache(forwardWindow: 60, backwardWindow: 60)
+        defer { cache.close() }
+        let recorder = Recorder()
+        seedDeadProducerBand(cache)
+        let provider = VideoSegmentProvider(
+            cache: cache, segments: segments(200), codecsString: "hvc1", supplementalCodecs: nil,
+            resolution: (3840, 2160), videoRange: .sdr, frameRate: 24.0, hdcpLevel: nil,
+            sourceBitrate: 60_000_000, isLive: true,
+            restartHandler: { recorder.record($0) },
+            restartActivity: { false },
+            activeProducerBase: { 40 },
+            producerFinished: { true },
+            initialRestartIndex: 40,
+            repositionWaitSlice: 0.05,
+            repositionRideCapSeconds: 5.0,
+            forwardBackpressureWaitSeconds: 0.2
+        )
+
+        #expect(provider.mediaSegment(at: 47) == nil)
+        #expect(provider.mediaSegment(at: 47) == nil)
+        #expect(recorder.all.isEmpty)
+    }
+
+    // MARK: - Pure decisions
+
+    @Test("forwardWaitMarchDead: finished pump is dead regardless of miss history")
+    func marchDeadOnFinishedPump() {
+        #expect(VideoSegmentProvider.forwardWaitMarchDead(
+            index: 719, marchFront: 718, producerFinished: true,
+            lastMissIndex: Int.min, lastMissFront: Int.min))
+    }
+
+    @Test("forwardWaitMarchDead: same index with unmoved front is dead; moved front or new index is not")
+    func marchDeadOnFrozenFrontOnly() {
+        #expect(VideoSegmentProvider.forwardWaitMarchDead(
+            index: 719, marchFront: 718, producerFinished: false,
+            lastMissIndex: 719, lastMissFront: 718))
+        #expect(!VideoSegmentProvider.forwardWaitMarchDead(
+            index: 719, marchFront: 719, producerFinished: false,
+            lastMissIndex: 719, lastMissFront: 718))
+        #expect(!VideoSegmentProvider.forwardWaitMarchDead(
+            index: 720, marchFront: 718, producerFinished: false,
+            lastMissIndex: 719, lastMissFront: 718))
+        #expect(!VideoSegmentProvider.forwardWaitMarchDead(
+            index: 719, marchFront: 718, producerFinished: false,
+            lastMissIndex: Int.min, lastMissFront: Int.min))
+    }
+
+    /// AE#169 round 2 engine arm: a VOD pump that dies on a read error MID-SESSION (it produced
+    /// media before dying) gets a bounded revive; the nothing-ever-produced case stays the #126
+    /// fatal surface, and live keeps its reopen machinery.
+    @Test("shouldReviveVODAfterReadError: mid-session yes, dead-source no, live no")
+    func readErrorReviveDecision() {
+        #expect(HLSVideoEngine.shouldReviveVODAfterReadError(
+            isLive: false, packetsWritten: 1265, cachedSegments: 46))
+        #expect(HLSVideoEngine.shouldReviveVODAfterReadError(
+            isLive: false, packetsWritten: 1265, cachedSegments: 0))
+        #expect(HLSVideoEngine.shouldReviveVODAfterReadError(
+            isLive: false, packetsWritten: 0, cachedSegments: 46))
+        #expect(!HLSVideoEngine.shouldReviveVODAfterReadError(
+            isLive: false, packetsWritten: 0, cachedSegments: 0))
+        #expect(!HLSVideoEngine.shouldReviveVODAfterReadError(
+            isLive: true, packetsWritten: 1265, cachedSegments: 46))
+    }
+}


### PR DESCRIPTION
## Context

Round-2 reopen of #169 by rrgomes with a decisive trace: the earlier "fixed on 5.16.2" verdict was their host-side near-end workaround firing, not the engine. With the workaround removed, the tail failure is unchanged on 5.18.4, and it is a different mechanism than the 5.16.2 symptoms: the producer provably stops mid-session before writing the final segment (seg719 never produced; avioFetchedMB/packetsWritten frozen across four 30 s memprobes), and the request for seg719 re-arms a 30 s backpressure wait forever (`cache miss after 30005ms (cache=46 restarted=false)` x11) until AVPlayer dies with -12889.

## Root cause (three defects lined up)

1. **No recovery arm for a mid-session VOD readError exit.** `handlePumpFinished` only surfaced the nothing-ever-produced case as fatal (#126) and assumed "the scrub/wedge arms cover recovery" for the rest. Both arms are unreachable here: the #65 wedge detector runs inside the pump and died with it, and the provider's restart escalation (2) never fires.
2. **Forward-wait liveness gap** (the mechanism rrgomes identified, confirmed verbatim): in the `r.1 < index <= r.1 + forwardWaitWindow` branch, `needsRestart = index > activeMarchFront + forwardWaitWindow` answers "will this arrive?" by index distance alone. A dead producer freezes the front just below the request, so the same 30 s wait re-arms indefinitely with no escalation. The final segment is maximally exposed: there is nothing beyond it for the march to advance into.
3. **producerCovers veto.** Even an escalated restart would not have fired: the restart loop's `producerCovers` guard reads the dead producer's still-installed base, which covers the requested index.

## Fix (defense in depth, VOD only)

- **Event-driven revive:** a mid-session VOD readError exit now gets a bounded revive (own gate, 2 attempts) mirroring the #99 muxerFailed arm, aimed at the pending seek target or AVPlayer's real position. The demuxer whose read just threw is marked suspect-dead so `performRestart` replaces it via the existing #79 fresh-demuxer path instead of seeking the connection that just failed. This recovers the trace's shape within seconds of the pump exit.
- **Provider-side liveness escalation:** a FINISHED pump skips the forward wait entirely and restarts immediately. A pump that never finishes (e.g. blocked in a read) escalates when a full backpressure wait elapsed with zero march-front progress for the same index; an advancing front resets the record and keeps the full #141/#93 patience (slow WAN reads legitimately take 20-30 s). Both proofs bypass the producerCovers veto. This covers any way the march stops that produces no exit event.

Live sessions are untouched: they keep their pump watchdogs (#167/#177) and reopen machinery, and the escalation is gated `!isLive`.

## Retest signatures (for the reporter)

- Pump exit case: `#169 VOD pump died mid-session (readError N); rebuilding producer on a fresh demuxer at ...` followed by seg719 producing and serving.
- Silent-stop case: `seg719: #169 forward-wait march dead (front=718 frozen across a full wait); escalating to restart`.

## Verification

- New `Issue169DeadProducerEscalationTests` (7 tests): immediate restart on finished pump (including the producerCovers bypass), second-miss escalation on a frozen front, patience preserved while the front advances, live never escalates, pure-decision matrices for `forwardWaitMarchDead` and `shouldReviveVODAfterReadError`.
- Full suite 965/965 green; `swift build -Xswiftc -strict-concurrency=complete` clean; tvOS Simulator build green.

Refs #169 (leaving the issue to the reporter's device retest; not auto-closing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NAPCg4tCDdSqkK6tPkNptw