### PR TITLE
fix(live): recover rerouted ingest sessions in-engine and remember the #168 carriage verdict

### DIFF
--- a/Sources/AetherEngine/AetherEngine+Loading.swift
+++ b/Sources/AetherEngine/AetherEngine+Loading.swift
@@ -314,6 +314,9 @@ extension AetherEngine {
             + "rerouting onto the live-ingest loopback path (TS -> fMP4 remux)",
             category: .engine
         )
+        // #199: remember the verdict so the next load of this master (host retune after an ingest
+        // death, zap-back) skips the doomed native mount and its watchdog grace entirely.
+        rerouteVerdictMemory.record(url, now: Date())
         var options = loadedOptions
         options.nativeRemoteHLS = false
         let reader = HLSLiveIngestReader(playlistURL: url, httpHeaders: options.httpHeaders)
@@ -356,6 +359,19 @@ extension AetherEngine {
             liveCadenceObservation = nil
         }
         let initialTargetDurationFloor = liveIngest?.upstreamTargetDuration
+        // #199: in-engine reopen transport for live ingest sessions. Only HLSLiveIngestReader main
+        // readers are reconstructible blind (immutable URL + headers, hint always "mpegts"); the
+        // demuxed-audio shape is excluded because a reopen would also have to rebuild the side audio
+        // demuxer over the fresh companion. Other custom readers (disc, SMB) have no transport and
+        // keep the host-retune contract.
+        let ingestReopenFactory: HLSVideoEngine.CustomSourceReopenFactory?
+        if isLive, let ingestReader = customReader as? HLSLiveIngestReader, companionAudioReader == nil {
+            ingestReopenFactory = {
+                ingestReader.makeFreshMainReader().map { (reader: $0 as IOReader, formatHint: "mpegts") }
+            }
+        } else {
+            ingestReopenFactory = nil
+        }
         let session = HLSVideoEngine(
             url: url,
             sourceHTTPHeaders: sourceHTTPHeaders,
@@ -376,6 +392,7 @@ extension AetherEngine {
             initialTargetDurationFloor: initialTargetDurationFloor,
             preopenedDemuxer: preopenedDemuxer,
             sourceReopenableByURL: !isCustomSource,
+            customSourceReopenFactory: ingestReopenFactory,
             companionAudioReader: companionAudioReader,
             // Caller-bounded probe budget (#68) for the fallback open / live reopen; the happy path reuses preopenedDemuxer.
             probesize: loadedOptions.probesize,

--- a/Sources/AetherEngine/AetherEngine.swift
+++ b/Sources/AetherEngine/AetherEngine.swift
@@ -919,6 +919,11 @@ public final class AetherEngine: ObservableObject {
     /// bounded reload budget. Cancelled on load reset; superseded by newer deaths.
     var itemDeathConfirmTask: Task<Void, Never>? = nil
     var itemDeathReviveGate = ItemDeathReviveGate(maxAttempts: 3)
+
+    /// #199: masters whose #168 carriage verdict fired; consulted at the top of `load(source:)` to
+    /// route known cases straight onto the live-ingest loopback. Engine-lifetime by design: it must
+    /// survive stop()/load() seams (zap away and back) or the discovery tax returns per retune.
+    var rerouteVerdictMemory = RerouteVerdictMemory()
     nonisolated static let itemDeathConfirmSeconds: TimeInterval = 3.0
 
     /// Single-shot latch for the reactive master->media fallback (#98): fall back at most once per
@@ -1734,6 +1739,29 @@ public final class AetherEngine: ObservableObject {
         audioSourceStreamIndex: Int32? = nil,
         discTitleID: Int? = nil
     ) async throws -> SourceProbe? {
+        var source = source
+        var options = options
+        // #199: a live master whose #168 carriage verdict already fired routes straight onto the
+        // live-ingest loopback. Remounting the native bypass would burn readyToPlay plus the watchdog
+        // grace on a deterministic no-video-track outcome; after an ingest death that discovery tax
+        // used to run once per host retune (the reporter's ~13s reroute cycle).
+        if case .url(let candidate) = source,
+           options.nativeRemoteHLS,
+           RemoteHLSIngestFallback.shouldRouteDirectlyToIngest(
+               isLive: options.isLive,
+               fallbackEnabled: options.nativeRemoteHLSIngestFallback,
+               verdictRemembered: rerouteVerdictMemory.remembers(candidate, now: Date())) {
+            EngineLog.emit(
+                "[AetherEngine] #199: master is a remembered no-video-track carriage case; "
+                + "routing directly onto the live-ingest loopback path",
+                category: .engine
+            )
+            options.nativeRemoteHLS = false
+            source = .custom(
+                HLSLiveIngestReader(playlistURL: candidate, httpHeaders: options.httpHeaders),
+                formatHint: "mpegts"
+            )
+        }
         // Preserve the NativeAVPlayerHost across native->native reloads so AVKit's system Now-Playing
         // registration survives the seam (issue #15). Captured before stopInternal resets playbackBackend;
         // the SW dispatch branch releases it if this source routes software.

--- a/Sources/AetherEngine/IO/HLSIngest/HLSLiveIngestReader.swift
+++ b/Sources/AetherEngine/IO/HLSIngest/HLSLiveIngestReader.swift
@@ -115,6 +115,15 @@ public final class HLSLiveIngestReader: IOReader, LiveIngestSourceInfo, @uncheck
         self.init(playlistURL: playlistURL, httpHeaders: httpHeaders, role: .mainVideo)
     }
 
+    /// #199: fresh reader over the same playlist URL and headers, for the in-engine live reopen of an
+    /// engine-created ingest session (the dead reader's construction inputs are immutable, so the fresh
+    /// one rejoins the same channel at its current live edge). Main-video role only: the companion
+    /// audio reader's lifetime is owned by its parent and never reopens independently.
+    func makeFreshMainReader() -> HLSLiveIngestReader? {
+        guard role == .mainVideo else { return nil }
+        return HLSLiveIngestReader(playlistURL: playlistURL, httpHeaders: httpHeaders, role: .mainVideo)
+    }
+
     init(playlistURL: URL, httpHeaders: [String: String] = [:], role: Role) {
         self.playlistURL = playlistURL
         self.httpHeaders = httpHeaders

--- a/Sources/AetherEngine/IO/HLSIngest/HLSPlaylistTracker.swift
+++ b/Sources/AetherEngine/IO/HLSIngest/HLSPlaylistTracker.swift
@@ -8,6 +8,17 @@ struct HLSPlaylistTracker {
     private let minJoinCoverageSeconds: Double // floor for the duration-coverage target
     private(set) var nextSequence: Int?  // next media-sequence not yet returned; nil until primed
     private(set) var stallCount = 0
+    /// #199: consecutive refreshes whose whole window sits BEHIND the cursor (MEDIA-SEQUENCE went
+    /// backward: encoder restart, looped test pool). One or two can be a stale CDN edge; at the
+    /// threshold the axis is treated as reset and the tracker rejoins at the new edge. Regressions
+    /// never feed `stallCount`: they are reset evidence, not upstream silence, and must not push
+    /// the reader toward its ingestStalled terminal trip.
+    private var sequenceRegressionCount = 0
+
+    /// Third consecutive regression = reset. A stale-edge flap alternates with fresh windows and
+    /// resets the counter; a real MSN reset regresses on every refresh and crosses this in ~3
+    /// refresh intervals, well inside the reader's stall budget.
+    static let sequenceResetRejoinThreshold = 3
 
     init(edgeOffset: Int = 3, minJoinCoverageSeconds: Double = 8) {
         self.edgeOffset = edgeOffset
@@ -54,8 +65,22 @@ struct HLSPlaylistTracker {
             // Window slid past cursor: rejoin and mark the seam.
             nextSequence = windowEnd
             stallCount = 0
+            sequenceRegressionCount = 0
             return segments(from: joinStart(), markFirstDiscontinuity: true)
         }
+
+        if cursor > windowEnd {
+            // #199: the whole window is behind the cursor, MEDIA-SEQUENCE went backward. The old
+            // behavior returned empty batches forever, starving the reader into ingestStalled and
+            // tearing down the session for a condition the stream itself survives.
+            sequenceRegressionCount += 1
+            guard sequenceRegressionCount >= Self.sequenceResetRejoinThreshold else { return [] }
+            nextSequence = windowEnd
+            stallCount = 0
+            sequenceRegressionCount = 0
+            return segments(from: joinStart(), markFirstDiscontinuity: true)
+        }
+        sequenceRegressionCount = 0
 
         let fresh = segments(from: cursor, markFirstDiscontinuity: false)
         if fresh.isEmpty {

--- a/Sources/AetherEngine/Native/RemoteHLSIngestFallback.swift
+++ b/Sources/AetherEngine/Native/RemoteHLSIngestFallback.swift
@@ -58,4 +58,14 @@ enum RemoteHLSIngestFallback {
     static func shouldArm(isLive: Bool, fallbackEnabled: Bool) -> Bool {
         isLive && fallbackEnabled
     }
+
+    /// #199: a load whose master already fired the carriage verdict (`RerouteVerdictMemory`) routes
+    /// straight onto the live-ingest loopback, skipping the deterministically doomed native mount and
+    /// its watchdog grace. Gated exactly like the watchdog itself: the memory may only short-circuit
+    /// a reroute the watchdog would have performed anyway.
+    static func shouldRouteDirectlyToIngest(
+        isLive: Bool, fallbackEnabled: Bool, verdictRemembered: Bool
+    ) -> Bool {
+        shouldArm(isLive: isLive, fallbackEnabled: fallbackEnabled) && verdictRemembered
+    }
 }

--- a/Sources/AetherEngine/Native/RerouteVerdictMemory.swift
+++ b/Sources/AetherEngine/Native/RerouteVerdictMemory.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// #199: bounded, expiring memory of master URLs whose remote-HLS video-carriage watchdog fired
+/// (#168: master advertises video, AVPlayer builds no video track for MPEG-TS carriage). The verdict
+/// costs a full native mount plus the watchdog grace to discover; remembering it lets `load()` route
+/// a known case straight onto the live-ingest loopback, so a host retune after an ingest death relands
+/// on the working path instead of re-running the doomed native mount every lap (the #199 cycle).
+///
+/// Keyed on the exact absolute URL: IPTV origins distinguish channels by path or query, so any
+/// normalization risks cross-channel false positives. A rotated per-session token misses the cache
+/// and merely re-pays the one-time discovery, same as today. Entries expire so an origin that fixes
+/// its packaging is not permanently exiled from the native bypass. Pure state, injectable clock.
+struct RerouteVerdictMemory {
+    private let capacity: Int
+    private let ttl: TimeInterval
+    private var recordedAt: [String: Date] = [:]
+
+    init(capacity: Int = 32, ttl: TimeInterval = 6 * 60 * 60) {
+        self.capacity = capacity
+        self.ttl = ttl
+    }
+
+    /// Records a fired carriage verdict; re-recording refreshes the entry's age. Over capacity the
+    /// oldest entry is evicted.
+    mutating func record(_ url: URL, now: Date) {
+        recordedAt[url.absoluteString] = now
+        while recordedAt.count > capacity {
+            guard let oldest = recordedAt.min(by: { $0.value < $1.value }) else { break }
+            recordedAt.removeValue(forKey: oldest.key)
+        }
+    }
+
+    /// True while a non-expired verdict exists for this exact URL. Prunes lazily.
+    mutating func remembers(_ url: URL, now: Date) -> Bool {
+        guard let stamp = recordedAt[url.absoluteString] else { return false }
+        guard now.timeIntervalSince(stamp) <= ttl else {
+            recordedAt.removeValue(forKey: url.absoluteString)
+            return false
+        }
+        return true
+    }
+}

--- a/Sources/AetherEngine/Video/HLSVideoEngine+LiveReopen.swift
+++ b/Sources/AetherEngine/Video/HLSVideoEngine+LiveReopen.swift
@@ -30,20 +30,39 @@ extension HLSVideoEngine {
     /// #167 follow-up pure decision: live pump exits that delegate to host retune leave a provider no
     /// producer will ever cut into again. Its blocking-reload advert must drop and its held ?_HLS_msn=
     /// waiters release, or the zombie session (and any item reload against it while the host retunes)
-    /// trips -15410 on a hold that cannot be satisfied. Reopenable URL exits resume cutting into the
-    /// same provider and must NOT latch; stop/muxer/backpressure exits have their own arms.
+    /// trips -15410 on a hold that cannot be satisfied. Reopenable exits (URL source, or a #199
+    /// engine-created ingest reader with a fresh-reader factory) resume cutting into the same provider
+    /// and must NOT latch; stop/muxer/backpressure exits have their own arms.
     static func shouldHaltLiveProduction(
         reason: HLSSegmentProducer.PumpExitReason,
-        sourceReopenableByURL: Bool
+        sourceReopenable: Bool
     ) -> Bool {
         switch reason {
         case .segmentStall, .sourceReplay:
             return true
         case .eof, .readError, .keyframeStarvation:
-            return !sourceReopenableByURL
+            return !sourceReopenable
         case .stopRequested, .muxerFailed, .backpressureWedge:
             return false
         }
+    }
+
+    /// #199 pure decision: which transport a live pump-exit reopen uses for the fresh source
+    /// connection. URL sources reopen by URL (unchanged); an engine-created ingest reader reopens
+    /// through its fresh-reader factory; a host-provided custom reader has neither and cannot reopen
+    /// in-engine (its exit delegates to host retune as before).
+    enum LiveReopenTransport: Equatable {
+        case url
+        case customFactory
+        case none
+    }
+
+    static func liveReopenTransport(
+        sourceReopenableByURL: Bool, hasCustomSourceReopenFactory: Bool
+    ) -> LiveReopenTransport {
+        if sourceReopenableByURL { return .url }
+        if hasCustomSourceReopenFactory { return .customFactory }
+        return .none
     }
 
     func handlePumpFinished(_ prod: HLSSegmentProducer,
@@ -89,7 +108,10 @@ extension HLSVideoEngine {
             return
         }
         guard isLiveSession else { return }
-        if Self.shouldHaltLiveProduction(reason: reason, sourceReopenableByURL: sourceReopenableByURL) {
+        let reopenTransport = Self.liveReopenTransport(
+            sourceReopenableByURL: sourceReopenableByURL,
+            hasCustomSourceReopenFactory: customSourceReopenFactory != nil)
+        if Self.shouldHaltLiveProduction(reason: reason, sourceReopenable: reopenTransport != .none) {
             provider?.markLiveProductionHalted()
         }
         switch reason {
@@ -114,11 +136,14 @@ extension HLSVideoEngine {
             onLiveSourceReset?()
             return
         case .eof, .readError, .keyframeStarvation:
-            // Custom-reader sources (e.g. live HLS ingest) own their own reconnection; URL reopen burns the backoff budget on guaranteed failures.
-            if !sourceReopenableByURL {
+            // Host-provided custom readers own their own reconnection and no in-engine transport can
+            // rebuild them, so their loss surfaces to the host immediately. #199: engine-created
+            // ingest readers DO have a transport (the fresh-reader factory) and fall through into the
+            // bounded reopen flow below instead of tearing the whole player session down.
+            if reopenTransport == .none {
                 EngineLog.emit(
                     "[HLSVideoEngine] live custom-source pump exited (reason=\(reason)); "
-                    + "URL reopen not possible, requesting host retune",
+                    + "no in-engine reopen transport, requesting host retune",
                     category: .session
                 )
                 onLiveSourceReset?()
@@ -141,6 +166,13 @@ extension HLSVideoEngine {
                 + "\(barrenNow) reopen cycles; giving up (source considered dead)",
                 category: .session
             )
+            if reopenTransport == .customFactory {
+                // #199: same last-resort surface as reopen exhaustion; without it the recoverable
+                // exit reason skipped the halt above and the zombie session would hold blocking
+                // reloads it can never satisfy.
+                provider?.markLiveProductionHalted()
+                onLiveSourceReset?()
+            }
             return
         }
         EngineLog.emit(
@@ -301,6 +333,9 @@ extension HLSVideoEngine {
     }
 
     private func performLiveReopen(failedProducer: HLSSegmentProducer) async {
+        let transport = Self.liveReopenTransport(
+            sourceReopenableByURL: sourceReopenableByURL,
+            hasCustomSourceReopenFactory: customSourceReopenFactory != nil)
         for attempt in 1...Self.liveReopenMaxAttempts {
             guard currentProducerIs(failedProducer) else { return }
 
@@ -310,14 +345,34 @@ extension HLSVideoEngine {
             let dem = Demuxer()
             registerReopenDemuxer(dem)  // register before blocking open so stop() can abort via markClosed
             defer { unregisterReopenDemuxer(dem) }
+            var freshReader: IOReader?
             do {
-                try dem.open(url: sourceURL, extraHeaders: sourceHTTPHeaders, profile: openProfile, isLive: true)
+                switch transport {
+                case .url:
+                    try dem.open(url: sourceURL, extraHeaders: sourceHTTPHeaders, profile: openProfile, isLive: true)
+                case .customFactory:
+                    // #199: fresh engine-created ingest reader over the same channel; the dead
+                    // reader's construction inputs are immutable, so this rejoins at the live edge.
+                    guard let vend = customSourceReopenFactory?() else {
+                        EngineLog.emit(
+                            "[HLSVideoEngine] #199 live reopen attempt \(attempt)/\(Self.liveReopenMaxAttempts): "
+                            + "factory vended no reader",
+                            category: .session
+                        )
+                        continue
+                    }
+                    freshReader = vend.reader
+                    try dem.open(reader: vend.reader, formatHint: vend.formatHint, profile: openProfile, isLive: true)
+                case .none:
+                    return  // handlePumpFinished already delegated this exit to host retune
+                }
             } catch {
                 EngineLog.emit(
                     "[HLSVideoEngine] live reopen attempt \(attempt)/\(Self.liveReopenMaxAttempts) failed: \(error)",
                     category: .session
                 )
                 dem.close()
+                freshReader?.close()
                 continue
             }
             // Reopened producer reuses savedVideoConfig/savedAudioConfig (stream indices + time bases from original probe); layout mismatch means server changed transcode shape.
@@ -328,10 +383,12 @@ extension HLSVideoEngine {
                     category: .session
                 )
                 dem.close()
+                freshReader?.close()
                 continue
             }
 
-            switch finishLiveReopen(failedProducer: failedProducer, dem: dem, attempt: attempt) {
+            switch finishLiveReopen(failedProducer: failedProducer, dem: dem,
+                                    freshReader: freshReader, attempt: attempt) {
             case .done, .aborted:
                 return
             case .retry:
@@ -343,6 +400,13 @@ extension HLSVideoEngine {
             + "source considered permanently lost",
             category: .session
         )
+        if transport == .customFactory {
+            // #199: the in-engine transport is exhausted; surface the loss the way a factory-less
+            // custom source would have immediately, so the host can retune instead of holding a
+            // zombie session whose blocking-reload advert can never be satisfied.
+            provider?.markLiveProductionHalted()
+            onLiveSourceReset?()
+        }
     }
 
     /// NSLock unavailable from async contexts; this synchronous helper wraps the check.
@@ -368,11 +432,13 @@ extension HLSVideoEngine {
 
     private func finishLiveReopen(failedProducer: HLSSegmentProducer,
                                   dem: Demuxer,
+                                  freshReader: IOReader?,
                                   attempt: Int) -> LiveReopenOutcome {
         restartLock.lock()
         guard producer === failedProducer, let prov = provider else {
             restartLock.unlock()
             dem.close()
+            freshReader?.close()
             return .aborted
         }
         let oldDem = demuxer
@@ -389,8 +455,13 @@ extension HLSVideoEngine {
                 self?.handleLiveTimelineRebase(shiftPts, seamOutputSeconds: outputEnd)
             }
             producer = newProd
+            // #199: the new demuxer reads from the factory-vended reader; take ownership so stop()
+            // and the next reopen close it. The initial load's reader stays engine-owned.
+            let oldReader = reopenCustomReader
+            if freshReader != nil { reopenCustomReader = freshReader }
             restartLock.unlock()
             oldDem?.close()
+            if freshReader != nil { oldReader?.close() }
             newProd.start()
             EngineLog.emit(
                 "[HLSVideoEngine] live reopen succeeded on attempt \(attempt): "
@@ -402,6 +473,7 @@ extension HLSVideoEngine {
             demuxer = oldDem
             restartLock.unlock()
             dem.close()
+            freshReader?.close()
             EngineLog.emit(
                 "[HLSVideoEngine] live reopen attempt \(attempt): producer build failed (\(error))",
                 category: .session

--- a/Sources/AetherEngine/Video/HLSVideoEngine.swift
+++ b/Sources/AetherEngine/Video/HLSVideoEngine.swift
@@ -548,6 +548,7 @@ public final class HLSVideoEngine: @unchecked Sendable {
         initialTargetDurationFloor: Double? = nil,
         preopenedDemuxer: Demuxer? = nil,
         sourceReopenableByURL: Bool = true,
+        customSourceReopenFactory: CustomSourceReopenFactory? = nil,
         companionAudioReader: IOReader? = nil,
         probesize: Int64? = nil,
         maxAnalyzeDuration: Int64? = nil,
@@ -585,6 +586,7 @@ public final class HLSVideoEngine: @unchecked Sendable {
         }
         self.preopenedDemuxer = preopenedDemuxer
         self.sourceReopenableByURL = sourceReopenableByURL
+        self.customSourceReopenFactory = customSourceReopenFactory
         self.companionAudioReader = companionAudioReader
         self.forwardWindowSegments = Self.clampedForwardWindow(forwardBufferSegments)
     }
@@ -615,6 +617,18 @@ public final class HLSVideoEngine: @unchecked Sendable {
     /// False for IOReader-backed sources (`aether-custom://source` placeholder); `handlePumpFinished`
     /// surfaces loss via `onLiveSourceReset` immediately instead of burning 6 reopen attempts.
     let sourceReopenableByURL: Bool
+
+    /// #199: vends a fresh reader (plus FFmpeg format hint) for an engine-created ingest source, so a
+    /// live pump exit reopens in-session instead of delegating to host retune. Called once per reopen
+    /// attempt; each vended reader is owned by this session (closed on replacement and on stop). nil for
+    /// URL sources and host-provided custom readers.
+    public typealias CustomSourceReopenFactory = @Sendable () -> (reader: IOReader, formatHint: String?)?
+    let customSourceReopenFactory: CustomSourceReopenFactory?
+
+    /// #199: the reader vended by `customSourceReopenFactory` that the CURRENT demuxer reads from.
+    /// Guarded by `restartLock`. The original load's reader stays engine-owned (AetherEngine closes it
+    /// in stopInternal); only factory-vended replacements are owned here.
+    var reopenCustomReader: IOReader?
 
     /// Demuxed audio rendition reader for live HLS ingest. When the main demuxer finds no audio and
     /// this is non-nil, `start()` opens `sideAudioDemuxer` over it. Engine owns the side demuxer, not
@@ -1579,9 +1593,15 @@ public final class HLSVideoEngine: @unchecked Sendable {
         ownedCodecParams = []
         let reopening = reopenDemuxer
         reopenDemuxer = nil
+        // #199: factory-vended ingest reader feeding the current demuxer; session-owned, closed here.
+        let reopenReader = reopenCustomReader
+        reopenCustomReader = nil
         segmentPlan = []
         restartLock.unlock()
         reopening?.markClosed()
+        // Close before waitForFinish: cancels the reader's FIFO so a pump parked in a blocking
+        // custom-IO read unblocks (mirrors markClosed for URL demuxers).
+        reopenReader?.close()
 
         p?.stop()
 

--- a/Tests/AetherEngineTests/HLSPlaylistTrackerTests.swift
+++ b/Tests/AetherEngineTests/HLSPlaylistTrackerTests.swift
@@ -76,4 +76,46 @@ final class HLSPlaylistTrackerTests: XCTestCase {
         XCTAssertEqual(new.map(\.uri), ["v", "u"])
         XCTAssertTrue(new[0].discontinuityBefore, "rejoin must be marked as a discontinuity")
     }
+
+    // MARK: - #199: MEDIA-SEQUENCE regression (encoder restart / looped test pool)
+
+    func testSequenceResetRejoinsAtEdgeWithDiscontinuityAfterThreshold() {
+        var tracker = HLSPlaylistTracker(edgeOffset: 3, minJoinCoverageSeconds: 8)
+        _ = tracker.newSegments(in: playlist(sequence: 100, uris: ["a", "b", "c"])) // cursor -> 103
+        // MSN regressed below the cursor: the old code starved here forever (empty batches
+        // until the reader's stall counter went terminal with ingestStalled).
+        XCTAssertTrue(tracker.newSegments(in: playlist(sequence: 0, uris: ["x", "y", "z"])).isEmpty)
+        XCTAssertTrue(tracker.newSegments(in: playlist(sequence: 0, uris: ["x", "y", "z"])).isEmpty)
+        let rejoined = tracker.newSegments(in: playlist(sequence: 0, uris: ["x", "y", "z"]))
+        XCTAssertEqual(rejoined.map(\.uri), ["y", "z"], "third consecutive regression rejoins at the new edge")
+        XCTAssertTrue(rejoined[0].discontinuityBefore, "reset rejoin must be marked as a discontinuity")
+        // Cursor continues normally on the new sequence axis.
+        let next = tracker.newSegments(in: playlist(sequence: 1, uris: ["y", "z", "w"]))
+        XCTAssertEqual(next.map(\.uri), ["w"])
+    }
+
+    func testSingleStaleRegressionDoesNotRejoin() {
+        var tracker = HLSPlaylistTracker(edgeOffset: 3, minJoinCoverageSeconds: 8)
+        _ = tracker.newSegments(in: playlist(sequence: 100, uris: ["a", "b", "c"])) // cursor -> 103
+        // One stale CDN edge serving an older window is not a reset.
+        XCTAssertTrue(tracker.newSegments(in: playlist(sequence: 98, uris: ["p", "q", "r"])).isEmpty)
+        // Fresh edge resumes: only the genuinely new segment comes back, no discontinuity.
+        let new = tracker.newSegments(in: playlist(sequence: 101, uris: ["b", "c", "d"]))
+        XCTAssertEqual(new.map(\.uri), ["d"])
+        XCTAssertFalse(new[0].discontinuityBefore)
+        // A later isolated regression starts counting from zero again.
+        XCTAssertTrue(tracker.newSegments(in: playlist(sequence: 99, uris: ["p", "q", "r"])).isEmpty)
+        let resumed = tracker.newSegments(in: playlist(sequence: 102, uris: ["c", "d", "e"]))
+        XCTAssertEqual(resumed.map(\.uri), ["e"])
+    }
+
+    func testSequenceRegressionDoesNotInflateStallCount() {
+        var tracker = HLSPlaylistTracker(edgeOffset: 3, minJoinCoverageSeconds: 8)
+        _ = tracker.newSegments(in: playlist(sequence: 100, uris: ["a", "b", "c"]))
+        _ = tracker.newSegments(in: playlist(sequence: 0, uris: ["x", "y", "z"]))
+        _ = tracker.newSegments(in: playlist(sequence: 0, uris: ["x", "y", "z"]))
+        // Regressions are reset evidence, not upstream silence; they must not push the
+        // reader's stall counter toward its ingestStalled terminal trip.
+        XCTAssertEqual(tracker.stallCount, 0)
+    }
 }

--- a/Tests/AetherEngineTests/Issue199RerouteRecoveryTests.swift
+++ b/Tests/AetherEngineTests/Issue199RerouteRecoveryTests.swift
@@ -1,0 +1,110 @@
+// Tests/AetherEngineTests/Issue199RerouteRecoveryTests.swift
+// AetherEngine#199: a #168-rerouted live-ingest session that died (looped-pool MSN reset, CDN gap,
+// encoder restart) used to reland on the known-bad native bypass every time the host retuned, because
+// (a) the no-video-track carriage verdict was discovered per mount and thrown away, and (b) the
+// engine-created ingest reader had no in-engine reopen path (every pump exit delegated to host retune).
+// These tests pin the verdict memory, the direct-to-ingest load routing, the reopen transport decision,
+// and the fresh-reader factory.
+import XCTest
+@testable import AetherEngine
+
+final class Issue199RerouteRecoveryTests: XCTestCase {
+
+    // MARK: - Reroute verdict memory
+
+    private let base = Date(timeIntervalSince1970: 1_000_000)
+    private func url(_ s: String) -> URL { URL(string: s)! }
+
+    func testRecordedMasterIsRemembered() {
+        var memory = RerouteVerdictMemory()
+        memory.record(url("http://origin/live/master.m3u8"), now: base)
+        XCTAssertTrue(memory.remembers(url("http://origin/live/master.m3u8"), now: base))
+        XCTAssertFalse(memory.remembers(url("http://origin/live/other.m3u8"), now: base),
+                       "verdicts are per exact URL; a different channel must not inherit them")
+    }
+
+    func testEntryExpiresAfterTTL() {
+        var memory = RerouteVerdictMemory(capacity: 32, ttl: 60)
+        memory.record(url("http://origin/live/master.m3u8"), now: base)
+        XCTAssertTrue(memory.remembers(url("http://origin/live/master.m3u8"), now: base.addingTimeInterval(59)))
+        XCTAssertFalse(memory.remembers(url("http://origin/live/master.m3u8"), now: base.addingTimeInterval(61)),
+                       "an origin that fixes its packaging must not stay exiled from the native bypass")
+    }
+
+    func testCapacityEvictsOldestEntry() {
+        var memory = RerouteVerdictMemory(capacity: 2, ttl: 3600)
+        memory.record(url("http://a/1.m3u8"), now: base)
+        memory.record(url("http://a/2.m3u8"), now: base.addingTimeInterval(1))
+        memory.record(url("http://a/3.m3u8"), now: base.addingTimeInterval(2))
+        XCTAssertFalse(memory.remembers(url("http://a/1.m3u8"), now: base.addingTimeInterval(3)),
+                       "capacity overflow evicts the oldest verdict")
+        XCTAssertTrue(memory.remembers(url("http://a/2.m3u8"), now: base.addingTimeInterval(3)))
+        XCTAssertTrue(memory.remembers(url("http://a/3.m3u8"), now: base.addingTimeInterval(3)))
+    }
+
+    func testRerecordRefreshesEntryAge() {
+        var memory = RerouteVerdictMemory(capacity: 2, ttl: 3600)
+        memory.record(url("http://a/1.m3u8"), now: base)
+        memory.record(url("http://a/2.m3u8"), now: base.addingTimeInterval(1))
+        memory.record(url("http://a/1.m3u8"), now: base.addingTimeInterval(2)) // re-fire refreshes 1
+        memory.record(url("http://a/3.m3u8"), now: base.addingTimeInterval(3))
+        XCTAssertTrue(memory.remembers(url("http://a/1.m3u8"), now: base.addingTimeInterval(4)))
+        XCTAssertFalse(memory.remembers(url("http://a/2.m3u8"), now: base.addingTimeInterval(4)),
+                       "with 1 refreshed, 2 is now the oldest and gets evicted")
+    }
+
+    // MARK: - Direct-to-ingest load routing
+
+    func testKnownVerdictRoutesDirectlyToIngest() {
+        XCTAssertTrue(RemoteHLSIngestFallback.shouldRouteDirectlyToIngest(
+            isLive: true, fallbackEnabled: true, verdictRemembered: true))
+    }
+
+    func testDirectRouteRespectsWatchdogGates() {
+        XCTAssertFalse(RemoteHLSIngestFallback.shouldRouteDirectlyToIngest(
+            isLive: false, fallbackEnabled: true, verdictRemembered: true),
+            "VOD remote HLS is the AE#154 reroute target; ingesting it back would ping-pong")
+        XCTAssertFalse(RemoteHLSIngestFallback.shouldRouteDirectlyToIngest(
+            isLive: true, fallbackEnabled: false, verdictRemembered: true),
+            "hosts that opted out of the fallback must never be silently rerouted")
+        XCTAssertFalse(RemoteHLSIngestFallback.shouldRouteDirectlyToIngest(
+            isLive: true, fallbackEnabled: true, verdictRemembered: false))
+    }
+
+    // MARK: - Reopen transport decision
+
+    func testURLSourcesReopenByURL() {
+        XCTAssertEqual(HLSVideoEngine.liveReopenTransport(
+            sourceReopenableByURL: true, hasCustomSourceReopenFactory: false), .url)
+    }
+
+    func testEngineCreatedIngestSourcesReopenViaFactory() {
+        XCTAssertEqual(HLSVideoEngine.liveReopenTransport(
+            sourceReopenableByURL: false, hasCustomSourceReopenFactory: true), .customFactory)
+    }
+
+    func testHostProvidedCustomSourcesCannotReopen() {
+        XCTAssertEqual(HLSVideoEngine.liveReopenTransport(
+            sourceReopenableByURL: false, hasCustomSourceReopenFactory: false), .none)
+    }
+
+    // MARK: - Fresh-reader factory
+
+    func testMainVideoReaderVendsFreshIndependentReader() {
+        let reader = HLSLiveIngestReader(playlistURL: url("http://origin/live/master.m3u8"),
+                                         httpHeaders: ["Referer": "http://origin/"])
+        defer { reader.close() }
+        let fresh = reader.makeFreshMainReader()
+        XCTAssertNotNil(fresh)
+        XCTAssertTrue(fresh !== reader, "factory must vend a fresh reader, not the dead one")
+        fresh?.close()
+    }
+
+    func testCompanionAudioReaderDoesNotVendFreshReader() {
+        let companion = HLSLiveIngestReader(playlistURL: url("http://origin/live/audio.m3u8"),
+                                            httpHeaders: [:], role: .companionAudio)
+        defer { companion.close() }
+        XCTAssertNil(companion.makeFreshMainReader(),
+                     "only the main video reader owns the session's reopen identity")
+    }
+}

--- a/Tests/AetherEngineTests/LiveProductionHaltTests.swift
+++ b/Tests/AetherEngineTests/LiveProductionHaltTests.swift
@@ -27,31 +27,31 @@ final class LiveProductionHaltTests: XCTestCase {
 
     func testHostRetuneExitsHaltLiveProduction() {
         XCTAssertTrue(HLSVideoEngine.shouldHaltLiveProduction(
-            reason: .segmentStall, sourceReopenableByURL: true),
+            reason: .segmentStall, sourceReopenable: true),
             "cutter wedge exits to host retune; the provider will never cut again")
         XCTAssertTrue(HLSVideoEngine.shouldHaltLiveProduction(
-            reason: .sourceReplay, sourceReopenableByURL: true))
+            reason: .sourceReplay, sourceReopenable: true))
         XCTAssertTrue(HLSVideoEngine.shouldHaltLiveProduction(
-            reason: .eof, sourceReopenableByURL: false),
-            "custom-reader pump death delegates to host retune")
+            reason: .eof, sourceReopenable: false),
+            "host-provided custom-reader pump death delegates to host retune")
         XCTAssertTrue(HLSVideoEngine.shouldHaltLiveProduction(
-            reason: .readError(code: -5), sourceReopenableByURL: false))
+            reason: .readError(code: -5), sourceReopenable: false))
     }
 
     func testRecoverableExitsDoNotHaltLiveProduction() {
         XCTAssertFalse(HLSVideoEngine.shouldHaltLiveProduction(
-            reason: .eof, sourceReopenableByURL: true),
-            "reopenable URL exits resume cutting into the same provider")
+            reason: .eof, sourceReopenable: true),
+            "reopenable exits (URL source, or #199 engine-created ingest reader with a fresh-reader factory) resume cutting into the same provider")
         XCTAssertFalse(HLSVideoEngine.shouldHaltLiveProduction(
-            reason: .readError(code: -5), sourceReopenableByURL: true))
+            reason: .readError(code: -5), sourceReopenable: true))
         XCTAssertFalse(HLSVideoEngine.shouldHaltLiveProduction(
-            reason: .keyframeStarvation, sourceReopenableByURL: true))
+            reason: .keyframeStarvation, sourceReopenable: true))
         XCTAssertFalse(HLSVideoEngine.shouldHaltLiveProduction(
-            reason: .stopRequested, sourceReopenableByURL: false))
+            reason: .stopRequested, sourceReopenable: false))
         XCTAssertFalse(HLSVideoEngine.shouldHaltLiveProduction(
-            reason: .muxerFailed, sourceReopenableByURL: false))
+            reason: .muxerFailed, sourceReopenable: false))
         XCTAssertFalse(HLSVideoEngine.shouldHaltLiveProduction(
-            reason: .backpressureWedge, sourceReopenableByURL: false))
+            reason: .backpressureWedge, sourceReopenable: false))
     }
 
     // MARK: - Provider halt latch


### PR DESCRIPTION
Fixes the #199 reroute-recovery cycle: a #168-rerouted live session that lost its ingest tore down into a host retune that relanded on the deterministically doomed native bypass, re-paying the full mount plus watchdog grace every ~13s lap (kskchaitanya1993's deep-window trace).

## Three layers

1. **`HLSPlaylistTracker` MEDIA-SEQUENCE reset rejoin.** Three consecutive refreshes whose whole window sits behind the cursor (encoder restart, looped test pool) rejoin at the new edge with a discontinuity seam instead of starving the reader into its `ingestStalled` terminal. Isolated stale-CDN-edge regressions do not trip it, and regressions never feed the stall counter.
2. **`RerouteVerdictMemory`.** Bounded (32), expiring (6h) memory of master URLs whose video-carriage watchdog fired. `load()` consults it under the exact watchdog gates (live + fallback enabled) and routes remembered cases straight onto the live-ingest loopback. A host retune after an ingest death now relands on the working path immediately.
3. **In-engine reopen transport for engine-created ingest readers.** `HLSLiveIngestReader.makeFreshMainReader()` vends a fresh reader (immutable URL + headers); live pump exits (`eof`/`readError`/`keyframeStarvation`) run through the existing bounded reopen machinery (`Demuxer.open(reader:)`, continuation indices, `EXT-X-DISCONTINUITY` seam) instead of delegating to host retune. Exhaustion (attempt cap or barren cycles) halts production and surfaces `liveSourceReset` as the last resort. Host-provided custom readers and demuxed-audio companion sessions keep the immediate host-retune contract.

## Verification

- New tests: MSN-reset rejoin threshold/stale-edge/stall-isolation (`HLSPlaylistTrackerTests`), verdict memory record/TTL/LRU/refresh, direct-route gating, reopen-transport decision, fresh-reader factory roles (`Issue199RerouteRecoveryTests`); `shouldHaltLiveProduction` reopenable semantics extended (`LiveProductionHaltTests`). All watched fail first.
- Full suite green (965 tests, 159 suites), `swift build -Xswiftc -strict-concurrency=complete` clean, tvOS Simulator build succeeded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NAPCg4tCDdSqkK6tPkNptw