### PR TITLE
fix(vod): fold unproducible final plan segment

### DIFF
--- a/Sources/AetherEngine/Video/HLSVideoEngine+SegmentPlanning.swift
+++ b/Sources/AetherEngine/Video/HLSVideoEngine+SegmentPlanning.swift
@@ -171,8 +171,15 @@ extension HLSVideoEngine {
     /// endless item reload; Sodalite near-EOF resume hang, device-confirmed). Merging widens the window so
     /// a resident keyframe is guaranteed and the two agree. Interior/final short segments fold into the
     /// PRECEDING kept segment; a too-short first segment (no predecessor) folds forward into its successor.
-    /// Every kept boundary is still an original plan boundary (a real keyframe), and total duration is
-    /// conserved. Pure for offline testing.
+    /// Every kept boundary is still an original plan boundary, and total duration is conserved.
+    ///
+    /// AE#169: also fold a final slot shorter than the normal cut target into its predecessor. The final
+    /// boundary has no later IRAP that can rescue a Cues/runtime keyframe disagreement. Advertising that
+    /// terminal slot left seg719 structurally unproducible while the producer correctly carried its tail
+    /// in seg718. Folding only sub-target tails adds less than one ordinary segment span to the existing
+    /// final segment while removing the unrecoverable boundary.
+    ///
+    /// Pure for offline testing.
     static func collapseShortSegments(_ plan: [Segment], minDurationSeconds: Double) -> [Segment] {
         guard plan.count > 1, minDurationSeconds > 0 else { return plan }
         var out: [Segment] = []
@@ -199,6 +206,17 @@ extension HLSVideoEngine {
                 durationSeconds: a.durationSeconds + b.durationSeconds,
                 discontinuous: a.discontinuous)
             out.removeFirst()
+        }
+        if out.count > 1, let tail = out.last,
+           tail.durationSeconds < Self.targetSegmentDuration {
+            let previous = out[out.count - 2]
+            out[out.count - 2] = Segment(
+                startPts: previous.startPts,
+                endPts: tail.endPts,
+                startSeconds: previous.startSeconds,
+                durationSeconds: previous.durationSeconds + tail.durationSeconds,
+                discontinuous: previous.discontinuous)
+            out.removeLast()
         }
         return out
     }

--- a/Sources/AetherEngine/Video/HLSVideoEngine.swift
+++ b/Sources/AetherEngine/Video/HLSVideoEngine.swift
@@ -725,7 +725,7 @@ public final class HLSVideoEngine: @unchecked Sendable {
             sourceVideoTbSeconds = Double(videoTimeBase.num) / Double(videoTimeBase.den)
         }
         let durationSeconds = dem.duration
-        let plan: [Segment]
+        var plan: [Segment]
         if isLiveSession {
             sourceBitrate = dem.bitRate
             self.firstKeyframePts = 0
@@ -946,7 +946,8 @@ public final class HLSVideoEngine: @unchecked Sendable {
         // Fold degenerate sub-frame segments (keyframe clusters make buildKeyframeSegmentPlan emit
         // ~40 ms segments the producer cannot cut, wedging the near-EOF resume; the plan and producer
         // share these boundaries, so the merge fixes both at once).
-        self.segmentPlan = Self.collapseShortSegments(plan, minDurationSeconds: Self.minSegmentDurationSeconds)
+        plan = Self.collapseShortSegments(plan, minDurationSeconds: Self.minSegmentDurationSeconds)
+        self.segmentPlan = plan
 
         // #93 residual: anchor the FIRST producer at the session's start position instead of seg0.
         // A resume start otherwise produces seg0 (torn down and discarded seconds later when

--- a/Tests/AetherEngineTests/PlanCollapseShortSegmentsTests.swift
+++ b/Tests/AetherEngineTests/PlanCollapseShortSegmentsTests.swift
@@ -22,16 +22,16 @@ struct PlanCollapseShortSegmentsTests {
 
     @Test("A plan with no sub-minimum segment is returned unchanged")
     func noShortSegmentsUnchanged() {
-        let plan = [seg(0, 4), seg(4, 4), seg(8, 3.5)]
+        let plan = [seg(0, 4), seg(4, 4), seg(8, 4)]
         let out = HLSVideoEngine.collapseShortSegments(plan, minDurationSeconds: 1.0)
         #expect(out.count == 3)
-        #expect(out.map(\.durationSeconds) == [4, 4, 3.5])
+        #expect(out.map(\.durationSeconds) == [4, 4, 4])
     }
 
     @Test("An interior keyframe cluster folds into the preceding segment, boundaries preserved")
     func interiorClusterFoldsBackward() {
-        // 4 s normal, then four ~40 ms cluster segments, then a normal 3.9 s segment (the device shape).
-        let plan = [seg(0, 4), seg(4.00, 0.04), seg(4.04, 0.04), seg(4.08, 0.04), seg(4.12, 3.9)]
+        // 4 s normal, then four ~40 ms cluster segments, then one normal target-sized segment.
+        let plan = [seg(0, 4), seg(4.00, 0.04), seg(4.04, 0.04), seg(4.08, 0.04), seg(4.12, 4.0)]
         let out = HLSVideoEngine.collapseShortSegments(plan, minDurationSeconds: 1.0)
         #expect(out.count == 2)
         // The preceding segment swallowed the whole cluster: [0, 4.12).
@@ -41,7 +41,7 @@ struct PlanCollapseShortSegmentsTests {
         #expect(out[0].endPts == 4120)
         // The following normal segment is untouched, so its start is a real plan keyframe.
         #expect(abs(out[1].startSeconds - 4.12) < 1e-9)
-        #expect(abs(out[1].durationSeconds - 3.9) < 1e-9)
+        #expect(abs(out[1].durationSeconds - 4.0) < 1e-9)
         // No sub-minimum segment survives.
         #expect(out.allSatisfy { $0.durationSeconds >= 1.0 })
     }
@@ -63,6 +63,31 @@ struct PlanCollapseShortSegmentsTests {
         #expect(out.count == 1)
         #expect(abs(out[0].durationSeconds - 4.5) < 1e-9)
         #expect(out[0].endPts == 4500)
+    }
+
+    @Test("AE#169: a sub-target final slot folds into the last decodable segment")
+    func fragileFinalSlotFoldsBackward() {
+        // Device trace: seg718 contains the natural EOF tail, but the 2.799 s seg719 boundary
+        // is not a runtime keyframe. Advertising seg719 parks AVPlayer at the 718/719 seam.
+        let plan = [seg(0, 4), seg(4, 4), seg(8, 2.799)]
+        let out = HLSVideoEngine.collapseShortSegments(plan, minDurationSeconds: 1.0)
+
+        #expect(out.count == 2)
+        #expect(abs(out[0].durationSeconds - 4) < 1e-9)
+        #expect(abs(out[1].durationSeconds - 6.799) < 1e-9)
+        #expect(out[1].startSeconds == 4)
+        #expect(out[1].endPts == 10_799)
+    }
+
+    @Test("AE#169: the tail contribution stays bounded when its predecessor is a long GOP")
+    func fragileFinalSlotFoldsIntoLongPredecessor() {
+        let plan = [seg(0, 20), seg(20, 3)]
+        let out = HLSVideoEngine.collapseShortSegments(plan, minDurationSeconds: 1.0)
+
+        #expect(out.count == 1)
+        #expect(out[0].startSeconds == 0)
+        #expect(out[0].durationSeconds == 23)
+        #expect(out[0].endPts == 23_000)
     }
 
     @Test("Total advertised duration is conserved by the collapse")


### PR DESCRIPTION
## Root cause

The 5.20.1 PTS gate correction fixed tail starts, but the natural forward producer still cannot create the final advertised slot when the planned Cues boundary has no runtime keyframe. It reaches EOF after carrying the remaining media in the preceding segment, while the VOD playlist still advertises an extra terminal segment. AVPlayer then waits at that impossible seam and eventually reports -12889.

## Fix

- Fold a final plan slot shorter than the normal 4 second target into its predecessor.
- Preserve the total duration and terminal end PTS while removing the unrecoverable boundary.
- Use the collapsed plan consistently for engine state, provider construction, initial seek mapping, and producer startup.
- Add AE#169 regressions for the observed 2.799 second tail and for a long-GOP predecessor.

## Verification

- `swift test`: 983 tests in 162 suites passed
- `swift build -Xswiftc -strict-concurrency=complete`: passed
- tvOS Simulator build: passed
- Independent code review: no remaining findings

Refs #169