### PR TITLE
fix(subtitles): finalize PGS landing before clear-only successor

### DIFF
--- a/Sources/AetherEngine/AetherEngine+Subtitles.swift
+++ b/Sources/AetherEngine/AetherEngine+Subtitles.swift
@@ -302,20 +302,13 @@ extension AetherEngine {
             subtitleDrainCursors[channel] = SubtitleDrainCursor(
                 lastDecodedPts: lastDecoded ?? window.from,
                 lastPlayhead: playhead)
-            // #143 follow-up (cmcpherson274 5.9.7 retest): admitDuringReconstruction flushes the
-            // seeded active-line candidate only when a composition at/after the playhead decodes. A
-            // landing set that is the newest composition in the file, or whose next line is beyond the
-            // forward lead window (sparse dialogue, forced cues), has no such trigger, so the candidate
-            // hangs held and the overlay stays dark. Once the backscan has seeded a candidate and no
-            // successor is stored ahead in the lead window, finalize the pass so the landing line paints.
-            let hasSuccessorAhead = !store.entries(
-                streamIndex: streamIndex,
-                from: playhead.nextUp,
-                through: playhead + Self.subtitleDrainLeadSeconds).isEmpty
+            // #143/#204: a renderable composition at/after the playhead ends reconstruction while
+            // decoding above. If the pass remains active with a candidate after the whole window,
+            // finalize it. Raw packet presence cannot answer this: the landing line's own zero-object
+            // CLEAR is stored ahead and trims the candidate, but carries no cues that can end the pass.
             if SubtitleOverlayDrainer.shouldFinalizeReconstruction(
                 reconstructing: pgsStaleArrivalGates[channel]?.reconstructing ?? false,
-                hasCandidate: pgsStaleArrivalGates[channel]?.hasReconstructionCandidate ?? false,
-                hasSuccessorAhead: hasSuccessorAhead) {
+                hasCandidate: pgsStaleArrivalGates[channel]?.hasReconstructionCandidate ?? false) {
                 for cue in pgsStaleArrivalGates[channel, default: PGSStaleArrivalGate()]
                     .finalizeReconstruction(playhead: playhead) {
                     insertFinalizedReconstructionCue(cue, channel: channel)

--- a/Sources/AetherEngine/Subtitles/SubtitleOverlayDrainer.swift
+++ b/Sources/AetherEngine/Subtitles/SubtitleOverlayDrainer.swift
@@ -44,17 +44,12 @@ enum SubtitleOverlayDrainer {
         return .decode(from: cursor.lastDecodedPts.nextUp, through: through)
     }
 
-    /// #143 follow-up: whether a reconstruction pass should be finalized this tick because no
-    /// successor composition can end it. `admitDuringReconstruction` flushes the seeded active-line
-    /// candidate only when a composition at/after the playhead decodes; a landing set that is the
-    /// newest composition in the file (or whose next line is beyond the forward lead window) has no
-    /// such trigger, so the candidate hangs and the overlay stays dark. Finalize only inside a
-    /// reconstruction pass, only with a seeded candidate (a true gap with nothing decoded behind the
-    /// playhead is left alone), and only when nothing is stored ahead in the lead window (a stored
-    /// successor ends the pass the normal way).
+    /// Whether a reconstruction pass should be finalized after its drain window has decoded.
+    /// A renderable composition at/after the playhead ends the pass inside
+    /// `admitDuringReconstruction`. If the pass is still active with a seeded candidate, only
+    /// non-rendering packets such as a PGS clear were decoded ahead, or no successor was present.
     static func shouldFinalizeReconstruction(reconstructing: Bool,
-                                             hasCandidate: Bool,
-                                             hasSuccessorAhead: Bool) -> Bool {
-        reconstructing && hasCandidate && !hasSuccessorAhead
+                                             hasCandidate: Bool) -> Bool {
+        reconstructing && hasCandidate
     }
 }

--- a/Tests/AetherEngineTests/Issue143PGSLandingLineTests.swift
+++ b/Tests/AetherEngineTests/Issue143PGSLandingLineTests.swift
@@ -143,8 +143,8 @@ struct Issue143PGSLandingLineTests {
     // (the candidate seeds) yet never publishes. admitDuringReconstruction only flushes on an
     // at/after-playhead composition (the pass-end trigger); an isolated landing has none, so the
     // candidate hangs held and the overlay stays dark (tens of seconds on sparse dialogue, forever
-    // at EOF, forced cues included). The drain now finalizes the pass once it confirms no successor
-    // is stored ahead.
+    // at EOF, forced cues included). The drain now finalizes the pass when the decoded window
+    // leaves reconstruction active with a seeded candidate.
 
     @Test("isolated landing line (file's last composition) is emitted when the drain finalizes the pass")
     func isolatedLandingFinalizes() {

--- a/Tests/AetherEngineTests/Issue204PGSClearLandingTests.swift
+++ b/Tests/AetherEngineTests/Issue204PGSClearLandingTests.swift
@@ -1,0 +1,46 @@
+import CoreGraphics
+import Testing
+@testable import AetherEngine
+
+struct Issue204PGSClearLandingTests {
+    private func imageCue(id: Int, start: Double, end: Double = 4_296_178) -> SubtitleCue {
+        let context = CGContext(
+            data: nil,
+            width: 1,
+            height: 1,
+            bitsPerComponent: 8,
+            bytesPerRow: 4,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        )!
+        return SubtitleCue(
+            id: id,
+            startTime: start,
+            endTime: end,
+            body: .image(SubtitleImage(cgImage: context.makeImage()!, position: .zero))
+        )
+    }
+
+    @Test("a landing line followed only by its clear finalizes with the authored end")
+    func clearAheadDoesNotBlockFinalization() {
+        let playhead = 30.3
+        var gate = PGSStaleArrivalGate()
+        gate.reconstructing = true
+
+        #expect(gate.admit(
+            cues: [imageCue(id: 1, start: 30)],
+            isPGS: true,
+            isSelfContained: false,
+            playhead: playhead
+        ).isEmpty)
+        #expect(gate.resolveHeld(trimAt: 33, playhead: playhead).isEmpty)
+
+        #expect(SubtitleOverlayDrainer.shouldFinalizeReconstruction(
+            reconstructing: gate.reconstructing,
+            hasCandidate: gate.hasReconstructionCandidate
+        ))
+        let output = gate.finalizeReconstruction(playhead: playhead)
+        #expect(output.map(\.id) == [1])
+        #expect(output.first?.endTime == 33)
+    }
+}

--- a/Tests/AetherEngineTests/SubtitleOverlayDrainerTests.swift
+++ b/Tests/AetherEngineTests/SubtitleOverlayDrainerTests.swift
@@ -56,32 +56,24 @@ struct SubtitleOverlayDrainerTests {
         #expect(plan == .idle)
     }
 
-    // #143 follow-up: a reconstruction pass whose landing line is the newest composition in the
-    // drain window has no successor to trigger admitDuringReconstruction's flush. The drain
-    // finalizes it once it confirms a candidate is seeded and no composition is stored ahead in the
-    // lead window.
+    // #143/#204: after the drain window decodes, a still-active reconstruction pass with a seeded
+    // candidate has no renderable successor to end it. Raw packets ahead may be zero-object clears.
 
-    @Test("reconstruction with a seeded candidate and no successor ahead should finalize")
-    func finalizeWhenNoSuccessorAhead() {
+    @Test("reconstruction with a seeded candidate should finalize after the window decodes")
+    func finalizeWithCandidate() {
         #expect(SubtitleOverlayDrainer.shouldFinalizeReconstruction(
-            reconstructing: true, hasCandidate: true, hasSuccessorAhead: false))
-    }
-
-    @Test("a stored successor in the lead window ends the pass the normal way, not by finalize")
-    func noFinalizeWhenSuccessorAhead() {
-        #expect(!SubtitleOverlayDrainer.shouldFinalizeReconstruction(
-            reconstructing: true, hasCandidate: true, hasSuccessorAhead: true))
+            reconstructing: true, hasCandidate: true))
     }
 
     @Test("finalize needs a seeded candidate: a true gap with nothing behind ends nothing")
     func noFinalizeWithoutCandidate() {
         #expect(!SubtitleOverlayDrainer.shouldFinalizeReconstruction(
-            reconstructing: true, hasCandidate: false, hasSuccessorAhead: false))
+            reconstructing: true, hasCandidate: false))
     }
 
     @Test("finalize only applies inside a reconstruction pass")
     func noFinalizeOutsideReconstruction() {
         #expect(!SubtitleOverlayDrainer.shouldFinalizeReconstruction(
-            reconstructing: false, hasCandidate: true, hasSuccessorAhead: false))
+            reconstructing: false, hasCandidate: true))
     }
 }


### PR DESCRIPTION
## Summary

- finalize PGS reconstruction from decoded gate state instead of raw packet presence
- let a zero-object CLEAR trim the held landing cue without blocking publication
- add an Issue #204 regression covering the common SHOW then CLEAR authored shape

## Root cause

The 5.15.2 finalize gate treated every stored packet after the playhead as a successor. A zero-object PGS CLEAR is stored and correctly trims the held candidate, but it carries no cues and therefore cannot end `admitDuringReconstruction`. The candidate fell between both exit conditions and remained withheld.

After the drain window is decoded, `reconstructing` is now the authoritative result. A renderable successor already ends the pass while decoding. If reconstruction is still active with a candidate, the candidate can be finalized with its authored CLEAR end intact.

References #204.

## Verification

- `swift test`: 983 tests in 163 suites passed
- `swift build -Xswiftc -strict-concurrency=complete`
- `xcodebuild -scheme AetherEngine -destination "generic/platform=tvOS Simulator" build`
- regression test verified red before the production change and green after it