### PR TITLE
feat(buffer): bound the opt-in prefetch in bytes, raise the window ceiling to 2700 (#207)

### DIFF
--- a/Sources/AetherEngine/PlayerState.swift
+++ b/Sources/AetherEngine/PlayerState.swift
@@ -253,9 +253,15 @@ public struct LoadOptions: Sendable, Equatable {
     /// resident (the two are coupled by construction, see `SegmentCache`). Larger values buffer more of
     /// the source up front (network-dropout robustness) at the cost of disk (segments are disk-backed,
     /// mmap reads) and ahead-of-time demux work: 4K HEVC runs ~ 10 MB per segment, so 150 segments can
-    /// occupy ~ 1.5 GB on disk. The engine clamps to 4...150 (below 4 AVPlayer's own ~ 5-7-segment
-    /// prefetch would starve, see `LiveWindowSizing.minSafeSegments`). nil keeps the historical default
-    /// of 10 (~ 40 s). Ignored for `nativeRemoteHLS`, where AVPlayer talks to the remote server directly.
+    /// occupy ~ 1.5 GB on disk. The engine clamps to 4...2700 (below 4 AVPlayer's own ~ 5-7-segment
+    /// prefetch would starve, see `LiveWindowSizing.minSafeSegments`; 2700 ~ 3 h is a sanity bound that
+    /// covers a whole feature film, so a host's "buffer without limit" option can pass `Int.max`).
+    /// Beyond the historical 150 the real bound is bytes, not segments: the prefetch runs until it
+    /// fills the session retention budget (a quarter of the tmp volume's free space, see
+    /// `HLSVideoEngine.vodRetentionBudgetBytes`) and then tracks the playhead, so a large window
+    /// buffers as much of the source as safely fits rather than a fixed count (#207). nil keeps the
+    /// historical default of 10 (~ 40 s). Ignored for `nativeRemoteHLS`, where AVPlayer talks to the
+    /// remote server directly.
     public var forwardBufferSegments: Int?
 
     /// Autostart at load completion. Default `true`: every load path ends in `host.play()` and a

--- a/Sources/AetherEngine/Video/HLSSegmentProducer.swift
+++ b/Sources/AetherEngine/Video/HLSSegmentProducer.swift
@@ -408,6 +408,11 @@ final class HLSSegmentProducer: @unchecked Sendable {
     /// never writes past the cache's forward edge (a drift is exactly what stalls AVPlayer).
     private let bufferAheadSegments: Int
 
+    /// #207: byte bound for an opt-in whole-source window. The segment ceiling is only a sanity bound,
+    /// so the race-ahead parks once it has filled the session retention budget (`PrefetchDiskBudget`).
+    /// 0 disables the park (live, and any host that never opted in stays far below its budget anyway).
+    private let prefetchDiskBudgetBytes: Int
+
     /// #65 stall diag: only log a park once it exceeds ~2 segment durations of zero playback progress, so normal
     /// backpressure (releases within one segment) stays silent and a real wedge surfaces its frozen tuple.
     private static let backpressureWedgeLogThresholdSeconds = 12
@@ -416,6 +421,10 @@ final class HLSSegmentProducer: @unchecked Sendable {
     /// Set above the log threshold so the diag tuple surfaces first. The host then re-anchors the producer on
     /// AVPlayer's real position; a slow-but-advancing consumer never trips the detector (see BackpressureWedgeDetector).
     private static let backpressureWedgeBreakThresholdSeconds = 24
+
+    /// #207: a disk park is normal steady state for an opt-in prefetch, so it stays quiet until it has
+    /// held long enough to be worth a line, then repeats every 30 s.
+    private static let prefetchDiskParkLogThresholdSeconds = 10
 
     /// #93 retest fast path: break the park once the consumer fetch target AND the rendered clock have
     /// both been frozen this long while the consumer wants to play (rrgomes: the clock is provably flat
@@ -670,9 +679,11 @@ final class HLSSegmentProducer: @unchecked Sendable {
         isLive: Bool = false,
         packedSideAudioStartPts: Int64? = nil,
         packedSideAudioFallbackDurationPts: Int64 = 0,
-        bufferAheadSegments: Int = 10
+        bufferAheadSegments: Int = 10,
+        prefetchDiskBudgetBytes: Int = 0
     ) throws {
         self.bufferAheadSegments = bufferAheadSegments
+        self.prefetchDiskBudgetBytes = prefetchDiskBudgetBytes
         self.demuxer = demuxer
         self.sideAudioDemuxer = sideAudioDemuxer
         // Packed side audio: synthesize timestamps from ID3 PRIV anchor; TS-side sessions use real timestamps.
@@ -995,6 +1006,47 @@ final class HLSSegmentProducer: @unchecked Sendable {
         return false
     }
 
+    /// #207 disk park. The segment window is a sanity bound; the real bound on an opt-in whole-source
+    /// prefetch is the session retention budget, which `pruneOutsideWindow` cannot enforce because it
+    /// never evicts the hard window. Parks the pump while the race-ahead has filled that budget AND the
+    /// consumer still has a safe lead, so the footprint tracks the budget instead of the source length.
+    /// Deliberately has no wedge breaker: the park only ever holds with `PrefetchDiskBudget
+    /// .minAheadSegments` of produced content ahead of the consumer, and the extras eviction that
+    /// follows the advancing playhead releases it. Returns true on release, false when stop was
+    /// requested.
+    private func awaitPrefetchDiskBudgetRelease(head: Int, context: String) -> Bool {
+        guard prefetchDiskBudgetBytes > 0 else { return true }
+        var parked = 0
+        var nextLogAt = Self.prefetchDiskParkLogThresholdSeconds
+        while !checkShouldStop() {
+            if cache.awaitPrefetchDiskHeadroom(head: head,
+                                               budgetBytes: prefetchDiskBudgetBytes,
+                                               timeout: 1.0) {
+                if parked >= Self.prefetchDiskParkLogThresholdSeconds {
+                    EngineLog.emit(
+                        "[HLSSegmentProducer] #207 prefetch disk park released (\(context)) head=\(head) "
+                        + "after=\(parked)s cacheTarget=\(cache.targetIndex) "
+                        + "forward=\(cache.forwardBytes / (1 << 20)) MiB",
+                        category: .session
+                    )
+                }
+                return true
+            }
+            parked += 1
+            if parked >= nextLogAt {
+                nextLogAt += 30
+                EngineLog.emit(
+                    "[HLSSegmentProducer] #207 prefetch disk PARK (\(context)) head=\(head) "
+                    + "cacheTarget=\(cache.targetIndex) forward=\(cache.forwardBytes / (1 << 20)) MiB "
+                    + "budget=\(prefetchDiskBudgetBytes / (1 << 20)) MiB parked=\(parked)s "
+                    + "(opt-in prefetch full; resumes as playback advances)",
+                    category: .session
+                )
+            }
+        }
+        return false
+    }
+
     private func markBackpressureWedgeBroken() {
         stateLock.lock()
         _backpressureWedgeBroken = true
@@ -1177,6 +1229,7 @@ final class HLSSegmentProducer: @unchecked Sendable {
         currentMuxerSegmentIndex = newIdx
         let backpressureTarget = newIdx - bufferAheadSegments
         if !awaitBackpressureRelease(target: backpressureTarget, head: newIdx, context: "advance") { return nil }
+        if !awaitPrefetchDiskBudgetRelease(head: newIdx, context: "advance") { return nil }
         if checkShouldStop() { return nil }
 
         return muxer

--- a/Sources/AetherEngine/Video/HLSVideoEngine.swift
+++ b/Sources/AetherEngine/Video/HLSVideoEngine.swift
@@ -517,10 +517,24 @@ public final class HLSVideoEngine: @unchecked Sendable {
     /// clamped to a quarter of the tmp volume's available capacity, so a nearly-full device never
     /// trades playback headroom for seek history. Live passes 0 (window-only pruning; the sliding
     /// playlist already dropped everything behind the window, so retention would serve nothing).
-    static func vodRetentionBudgetBytes(volumeAvailableBytes: Int64?) -> Int {
+    /// `capRelaxed` (#207) drops the 2 GiB default for a host that explicitly asked to pre-buffer more
+    /// than the historical window could hold; the quarter-of-free-space clamp, which is what actually
+    /// protects the volume, always applies. Unknown capacity keeps the conservative cap either way.
+    static func vodRetentionBudgetBytes(volumeAvailableBytes: Int64?, capRelaxed: Bool = false) -> Int {
         let cap = 2 << 30
         guard let available = volumeAvailableBytes else { return cap }
-        return min(cap, max(0, Int(available / 4)))
+        let quarterOfFree = max(0, Int(available / 4))
+        return capRelaxed ? quarterOfFree : min(cap, quarterOfFree)
+    }
+
+    /// Largest forward window the default 2 GiB retention budget covers by construction
+    /// (150 segments x ~10 MB for 4K HEVC ~ 1.5 GB), i.e. the old `clampedForwardWindow` ceiling.
+    static let defaultRetentionCapWindowCeiling = 150
+
+    /// #207: a window past `defaultRetentionCapWindowCeiling` is an explicit host opt-in into a
+    /// whole-source prefetch, so the budget follows it up (see `vodRetentionBudgetBytes`).
+    static func retentionCapRelaxed(forwardWindowSegments: Int) -> Bool {
+        forwardWindowSegments > defaultRetentionCapWindowCeiling
     }
 
     // MARK: - Measurement spike: sliding-window prototype (superseded)
@@ -605,12 +619,18 @@ public final class HLSVideoEngine: @unchecked Sendable {
     /// AVPlayer, see `SegmentCache`). From `LoadOptions.forwardBufferSegments`; nil -> historical 10.
     let forwardWindowSegments: Int
 
+    /// Session retention budget resolved in `start()`; also bounds the producer's race-ahead on disk
+    /// (#207, see `PrefetchDiskBudget`). 0 for live (window-only pruning).
+    private var retentionBudgetBytes: Int = 0
+
     /// Clamp for `forwardWindowSegments`: below 4 the window would undercut AVPlayer's own ~5-7-segment
-    /// prefetch and starve it (see `LiveWindowSizing.minSafeSegments`); above 150 (~10 min at 4 s
-    /// segments, ~1.5 GB disk for 4K HEVC) the disk and ahead-of-time demux cost stops being worth it.
-    /// nil keeps the historical default of 10.
+    /// prefetch and starve it (see `LiveWindowSizing.minSafeSegments`). The 2700 ceiling (~3 h at 4 s
+    /// segments) is a sanity bound against accidental values, not a cost bound: it covers a whole
+    /// feature film, so a host's "buffer without limit" option can pass `Int.max` (#207). The disk cost
+    /// is bounded in bytes rather than segments, by the session retention budget the producer parks on
+    /// (`PrefetchDiskBudget`, `vodRetentionBudgetBytes`). nil keeps the historical default of 10.
     static func clampedForwardWindow(_ requested: Int?) -> Int {
-        min(max(requested ?? 10, 4), 150)
+        min(max(requested ?? 10, 4), 2700)
     }
 
     /// When true, `start()` skips the VOD duration guard / cue prewarm / precomputed plan and
@@ -900,15 +920,19 @@ public final class HLSVideoEngine: @unchecked Sendable {
             .resourceValues(forKeys: [.volumeAvailableCapacityForImportantUsageKey]))?
             .volumeAvailableCapacityForImportantUsage
         #endif
+        let capRelaxed = Self.retentionCapRelaxed(forwardWindowSegments: forwardWindowSegments)
         let retentionBudget = isLiveSession
             ? 0
-            : Self.vodRetentionBudgetBytes(volumeAvailableBytes: availableBytes)
+            : Self.vodRetentionBudgetBytes(volumeAvailableBytes: availableBytes, capRelaxed: capRelaxed)
+        self.retentionBudgetBytes = retentionBudget
         let segmentCache = SegmentCache(forwardWindow: forwardWindowSegments,
                                         retentionBudgetBytes: retentionBudget)
         self.cache = segmentCache
         EngineLog.emit(
             "[HLSVideoEngine] segment retention budget: \(retentionBudget / (1 << 20)) MiB "
-            + "(volumeAvailable=\(availableBytes.map { "\($0 / (1 << 20)) MiB" } ?? "unknown"))",
+            + "(volumeAvailable=\(availableBytes.map { "\($0 / (1 << 20)) MiB" } ?? "unknown"), "
+            + "forwardWindow=\(forwardWindowSegments) seg"
+            + (capRelaxed ? ", opt-in prefetch: default cap relaxed" : "") + ")",
             category: .session
         )
 
@@ -1719,7 +1743,8 @@ public final class HLSVideoEngine: @unchecked Sendable {
             isLive: isLiveSession,
             packedSideAudioStartPts: packedSideAudioStartPts,
             packedSideAudioFallbackDurationPts: packedSideAudioFallbackDurationPts,
-            bufferAheadSegments: forwardWindowSegments
+            bufferAheadSegments: forwardWindowSegments,
+            prefetchDiskBudgetBytes: retentionBudgetBytes
         )
         prod.onFirstHDR10PlusDetected = { [weak self] in
             self?.notifyHDR10PlusOnce()

--- a/Sources/AetherEngine/Video/PrefetchDiskBudget.swift
+++ b/Sources/AetherEngine/Video/PrefetchDiskBudget.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// Disk bound for an opt-in whole-source prefetch (#207).
+///
+/// `SegmentCache.pruneOutsideWindow` never evicts the hard window, so the retention budget bounds only
+/// what lives outside it. That is correct for the historical windows (10 segments ~ 100 MB, the 150
+/// ceiling ~ 1.5 GB), which fit under the budget by construction. A host that opts into buffering a
+/// whole film (`LoadOptions.forwardBufferSegments`) makes the window itself the dominant footprint, and
+/// nothing would stop it from filling the volume: a failed segment write degrades to a cache miss and
+/// stalls playback, which is the exact failure the option exists to prevent.
+///
+/// So the producer parks once the window's own bytes reach the budget. Eviction of the extras behind
+/// the playhead frees room as playback advances, which releases the park, so the prefetch tracks the
+/// budget instead of the source length. Sessions that never opt in never reach the condition.
+enum PrefetchDiskBudget {
+
+    /// Segments the producer may always run ahead of the consumer, budget or not. Bounding disk closer
+    /// than the historical forward window would starve AVPlayer's own ~5-7-segment prefetch, i.e. trade
+    /// a full volume for a stall. A pathologically small budget therefore loses to playback, by design.
+    static let minAheadSegments = 10
+
+    /// - Parameters:
+    ///   - forwardBytes: on-disk bytes at or above the consumer's target (`SegmentCache.forwardBytes`),
+    ///     i.e. what the producer's race-ahead owns. History behind the playhead is excluded: the
+    ///     extras eviction already bounds it, and counting it would throttle a standard session.
+    ///   - budgetBytes: the session retention budget; 0 (live) never parks.
+    ///   - head: segment index the producer is about to write.
+    ///   - consumerTarget: the consumer's last declared fetch index (`SegmentCache.targetIndex`).
+    static func shouldPark(forwardBytes: Int,
+                           budgetBytes: Int,
+                           head: Int,
+                           consumerTarget: Int,
+                           minAheadSegments: Int = minAheadSegments) -> Bool {
+        guard budgetBytes > 0, forwardBytes >= budgetBytes else { return false }
+        return head - consumerTarget >= minAheadSegments
+    }
+}

--- a/Sources/AetherEngine/Video/SegmentCache.swift
+++ b/Sources/AetherEngine/Video/SegmentCache.swift
@@ -372,6 +372,41 @@ final class SegmentCache: @unchecked Sendable {
         return _totalBytes
     }
 
+    /// On-disk bytes at or above the consumer's current target: what the producer's race-ahead owns
+    /// (#207). Everything behind the playhead is either the small backward window or budget-evictable
+    /// extras, so this is the only footprint an opt-in whole-source window grows without bound.
+    var forwardBytes: Int {
+        condition.lock()
+        defer { condition.unlock() }
+        return currentForwardBytes()
+    }
+
+    /// #207 producer park step: true once the producer may write `head`. Withheld while its race-ahead
+    /// has reached `budgetBytes` and the consumer still has a safe lead behind it; the extras eviction
+    /// that follows the advancing playhead is what frees the room again.
+    func awaitPrefetchDiskHeadroom(head: Int, budgetBytes: Int, timeout: TimeInterval = 1.0) -> Bool {
+        condition.lock()
+        defer { condition.unlock() }
+        if !shouldParkLocked(head: head, budgetBytes: budgetBytes) { return true }
+        _ = condition.wait(until: Date().addingTimeInterval(timeout))
+        return !shouldParkLocked(head: head, budgetBytes: budgetBytes)
+    }
+
+    /// Must be called with condition held.
+    private func shouldParkLocked(head: Int, budgetBytes: Int) -> Bool {
+        PrefetchDiskBudget.shouldPark(forwardBytes: currentForwardBytes(),
+                                      budgetBytes: budgetBytes,
+                                      head: head,
+                                      consumerTarget: currentTargetIndex)
+    }
+
+    /// Must be called with condition held.
+    private func currentForwardBytes() -> Int {
+        var bytes = 0
+        for (k, b) in entryBytes where k >= currentTargetIndex { bytes += b }
+        return bytes
+    }
+
     // MARK: - Internal
 
     /// Prune to [currentTarget - backwardWindow, max(currentTarget + forwardWindow, highestStoredIndex)].

--- a/Tests/AetherEngineTests/ForwardBufferWindowTests.swift
+++ b/Tests/AetherEngineTests/ForwardBufferWindowTests.swift
@@ -16,6 +16,8 @@ struct ForwardBufferWindowTests {
         #expect(HLSVideoEngine.clampedForwardWindow(4) == 4)
         #expect(HLSVideoEngine.clampedForwardWindow(50) == 50)
         #expect(HLSVideoEngine.clampedForwardWindow(150) == 150)
+        #expect(HLSVideoEngine.clampedForwardWindow(900) == 900)
+        #expect(HLSVideoEngine.clampedForwardWindow(2700) == 2700)
     }
 
     @Test("values below the floor clamp up to 4 (AVPlayer prefetch would starve)")
@@ -25,10 +27,10 @@ struct ForwardBufferWindowTests {
         #expect(HLSVideoEngine.clampedForwardWindow(-5) == 4)
     }
 
-    @Test("values above the ceiling clamp down to 150 (disk/demux cost)")
+    @Test("values above the sanity ceiling clamp down to 2700 (~3 h, whole-film bound)")
     func aboveCeilingClampsDown() {
-        #expect(HLSVideoEngine.clampedForwardWindow(151) == 150)
-        #expect(HLSVideoEngine.clampedForwardWindow(1000) == 150)
+        #expect(HLSVideoEngine.clampedForwardWindow(2701) == 2700)
+        #expect(HLSVideoEngine.clampedForwardWindow(Int.max) == 2700)
     }
 
     @Test("LoadOptions defaults forwardBufferSegments to nil")

--- a/Tests/AetherEngineTests/PrefetchDiskBudgetTests.swift
+++ b/Tests/AetherEngineTests/PrefetchDiskBudgetTests.swift
@@ -1,0 +1,160 @@
+// Tests/AetherEngineTests/PrefetchDiskBudgetTests.swift
+// Opt-in whole-source prefetch (#207): a host that offers "buffer without limit" passes a large
+// LoadOptions.forwardBufferSegments. The hard prune window is never evicted (see SegmentRetentionTests),
+// so a window that spans the whole film makes the retention budget, the only guard against filling a
+// nearly full volume, unreachable. Two pieces keep that honest: the budget drops its 2 GiB default cap
+// for opt-in windows (the quarter-of-free-space clamp stays), and the producer parks once its race-ahead
+// reaches the budget instead of writing past it.
+import Foundation
+import Testing
+@testable import AetherEngine
+
+@Suite("Opt-in prefetch budget sizing")
+struct PrefetchBudgetSizingTests {
+
+    @Test("Opt-in windows drop the 2 GiB cap and keep a quarter of free space")
+    func optInDropsTheDefaultCap() {
+        #expect(HLSVideoEngine.vodRetentionBudgetBytes(volumeAvailableBytes: 100 << 30,
+                                                       capRelaxed: true) == 25 << 30)
+    }
+
+    @Test("Opt-in budget still clamps to a quarter of a tight volume")
+    func optInStillClampsToQuarterOfFreeDisk() {
+        #expect(HLSVideoEngine.vodRetentionBudgetBytes(volumeAvailableBytes: 4 << 30,
+                                                       capRelaxed: true) == 1 << 30)
+    }
+
+    @Test("Opt-in budget keeps the conservative cap when capacity is unknown")
+    func optInUnknownCapacityFallsBackToTheCap() {
+        #expect(HLSVideoEngine.vodRetentionBudgetBytes(volumeAvailableBytes: nil,
+                                                       capRelaxed: true) == 2 << 30)
+    }
+
+    @Test("The cap relaxes only above the historical window ceiling")
+    func capRelaxesOnlyForOptInWindows() {
+        #expect(HLSVideoEngine.retentionCapRelaxed(forwardWindowSegments: 10) == false)
+        #expect(HLSVideoEngine.retentionCapRelaxed(forwardWindowSegments: 150) == false)
+        #expect(HLSVideoEngine.retentionCapRelaxed(forwardWindowSegments: 151) == true)
+        #expect(HLSVideoEngine.retentionCapRelaxed(forwardWindowSegments: 2700) == true)
+    }
+}
+
+@Suite("Prefetch disk-budget backpressure decision")
+struct PrefetchDiskBudgetDecisionTests {
+
+    @Test("A session without a retention budget never parks (live keeps window-only pruning)")
+    func noBudgetNeverParks() {
+        #expect(PrefetchDiskBudget.shouldPark(forwardBytes: 5_000, budgetBytes: 0,
+                                              head: 100, consumerTarget: 0) == false)
+    }
+
+    @Test("A race-ahead that fits the budget never parks (every pre-207 session)")
+    func raceAheadUnderBudgetNeverParks() {
+        #expect(PrefetchDiskBudget.shouldPark(forwardBytes: 999, budgetBytes: 1_000,
+                                              head: 100, consumerTarget: 0) == false)
+    }
+
+    @Test("A race-ahead at the budget parks while the consumer has a safe lead")
+    func raceAheadAtBudgetParks() {
+        #expect(PrefetchDiskBudget.shouldPark(forwardBytes: 1_000, budgetBytes: 1_000,
+                                              head: 100, consumerTarget: 80) == true)
+    }
+
+    @Test("The park never starves the consumer: a short lead keeps producing")
+    func shortLeadKeepsProducing() {
+        // AVPlayer is within the historical 10-segment window of the write head: bounding disk here
+        // would stall playback, which is the failure the whole opt-in exists to avoid.
+        #expect(PrefetchDiskBudget.shouldPark(forwardBytes: 5_000, budgetBytes: 1_000,
+                                              head: 100, consumerTarget: 91) == false)
+        #expect(PrefetchDiskBudget.shouldPark(forwardBytes: 5_000, budgetBytes: 1_000,
+                                              head: 100, consumerTarget: 90) == true)
+    }
+}
+
+@Suite("SegmentCache prefetch footprint")
+struct SegmentCachePrefetchFootprintTests {
+
+    private func makeData(_ n: Int) -> Data { Data(repeating: 0xAA, count: n) }
+
+    /// Bytes behind the playhead are either the small backward window or budget-evictable extras, so
+    /// only what sits at or above the consumer's target can grow the footprint without bound.
+    @Test("Forward bytes count only what sits at or above the consumer target")
+    func forwardBytesExcludeHistory() {
+        let c = SegmentCache(forwardWindow: 2, backwardWindow: 2, retentionBudgetBytes: 1_000_000)
+        defer { c.close() }
+        for i in 0...10 { c.declareTarget(i); c.store(index: i, data: makeData(10)) }
+        #expect(c.forwardBytes == 10)
+        #expect(c.totalBytes == 110)
+    }
+
+    /// The #207 shape: the producer races a whole-source window ahead of a consumer that has barely
+    /// moved, so every segment it writes lands inside the exempt span and the budget evicts nothing.
+    @Test("A whole-source prefetch keeps every raced segment resident past the budget")
+    func wholeSourcePrefetchOutgrowsTheBudget() {
+        let c = SegmentCache(forwardWindow: 1_000, backwardWindow: 2, retentionBudgetBytes: 50)
+        defer { c.close() }
+        c.declareTarget(0)
+        for i in 0...10 { c.store(index: i, data: makeData(10)) }
+        #expect(c.forwardBytes == 110)
+        #expect(c.totalBytes == 110)   // 2.2x the budget: the window is exempt from it
+    }
+
+    @Test("Headroom is immediate while the race-ahead fits the budget")
+    func headroomImmediateUnderBudget() {
+        let c = SegmentCache(forwardWindow: 1_000, backwardWindow: 2, retentionBudgetBytes: 1_000)
+        defer { c.close() }
+        c.declareTarget(0)
+        for i in 0...10 { c.store(index: i, data: makeData(10)) }
+        #expect(c.awaitPrefetchDiskHeadroom(head: 11, budgetBytes: 1_000, timeout: 0.05) == true)
+    }
+
+    @Test("Headroom is withheld once the race-ahead fills the budget")
+    func headroomWithheldOverBudget() {
+        let c = SegmentCache(forwardWindow: 1_000, backwardWindow: 2, retentionBudgetBytes: 50)
+        defer { c.close() }
+        c.declareTarget(0)
+        for i in 0...10 { c.store(index: i, data: makeData(10)) }
+        #expect(c.awaitPrefetchDiskHeadroom(head: 11, budgetBytes: 50, timeout: 0.05) == false)
+    }
+
+    @Test("Headroom is granted regardless of the budget while the consumer is close behind")
+    func headroomGrantedForACloseConsumer() {
+        let c = SegmentCache(forwardWindow: 1_000, backwardWindow: 2, retentionBudgetBytes: 50)
+        defer { c.close() }
+        c.declareTarget(0)
+        for i in 0...10 { c.store(index: i, data: makeData(10)) }
+        #expect(c.awaitPrefetchDiskHeadroom(head: 5, budgetBytes: 50, timeout: 0.05) == true)
+    }
+
+    @Test("A session without a budget never withholds headroom")
+    func headroomGrantedWithoutBudget() {
+        let c = SegmentCache(forwardWindow: 1_000, backwardWindow: 2, retentionBudgetBytes: 0)
+        defer { c.close() }
+        c.declareTarget(0)
+        for i in 0...10 { c.store(index: i, data: makeData(10)) }
+        #expect(c.awaitPrefetchDiskHeadroom(head: 11, budgetBytes: 0, timeout: 0.05) == true)
+    }
+
+    @Test("Headroom returns once the playhead advances into the buffered span")
+    func headroomReturnsAsPlaybackAdvances() {
+        let c = SegmentCache(forwardWindow: 1_000, backwardWindow: 2, retentionBudgetBytes: 50)
+        defer { c.close() }
+        c.declareTarget(0)
+        for i in 0...10 { c.store(index: i, data: makeData(10)) }
+        #expect(c.awaitPrefetchDiskHeadroom(head: 11, budgetBytes: 50, timeout: 0.05) == false)
+        c.declareTarget(9)   // playback marched on: only segments 9 and 10 are still ahead of it
+        #expect(c.awaitPrefetchDiskHeadroom(head: 11, budgetBytes: 50, timeout: 0.05) == true)
+    }
+
+    /// Regression guard for the standard path: a long session fills the retention budget with retained
+    /// history, which the extras eviction already bounds. Counting it as prefetch would throttle a
+    /// producer whose actual race-ahead is a handful of segments.
+    @Test("Retained history behind the playhead never withholds headroom")
+    func retainedHistoryDoesNotWithholdHeadroom() {
+        let c = SegmentCache(forwardWindow: 10, backwardWindow: 2, retentionBudgetBytes: 50)
+        defer { c.close() }
+        for i in 0...10 { c.declareTarget(i); c.store(index: i, data: makeData(10)) }
+        #expect(c.totalBytes == 50)   // budget full of retained history
+        #expect(c.awaitPrefetchDiskHeadroom(head: 30, budgetBytes: 50, timeout: 0.05) == true)
+    }
+}


### PR DESCRIPTION
Follow-up to #102, addressing #207.

## Why the ceiling alone was not enough

`SegmentCache.pruneOutsideWindow` never evicts the hard window, so the retention budget (`min(2 GiB, a quarter of the tmp volume's free space)`) bounds only the extras outside it. That is correct for the historical windows (10 segments ~ 100 MB, the 150 ceiling ~ 1.5 GB), which fit under the budget by construction. A window spanning a whole film makes the window itself the dominant footprint and the budget unreachable: ~18 GB of 4K HEVC lands on the volume unchecked, and `SegmentCache.store` degrades a failed write to a cache miss, i.e. a stall. That is the failure the option exists to prevent, with disk instead of network as the cause.

## What this does

- `clampedForwardWindow` ceiling 150 -> 2700 (~3 h at 4 s), a sanity bound that covers a whole feature film, so a host can pass `Int.max`. Floor (4) and the nil default (10) unchanged; 150 still passes through.
- Windows past the historical 150 count as an explicit opt-in, so `vodRetentionBudgetBytes` drops its 2 GiB default cap for them. The quarter-of-free-space clamp, which is what protects the volume, always applies, and an unknown capacity keeps the conservative cap.
- New `PrefetchDiskBudget`: the producer parks once its race-ahead (bytes at or above the consumer's target) has filled the budget, while the consumer still has `minAheadSegments` (10) of produced content ahead of it. The extras eviction that follows the advancing playhead releases the park, so the prefetch tracks the budget instead of the source length.

Counting only bytes at or above the consumer target, rather than the whole window, keeps retained backward history (already bounded by the extras eviction) from throttling a producer whose actual race-ahead is a handful of segments. The park has no wedge breaker by design: it only holds with a safe lead of produced content, and a short lead keeps producing regardless of the budget, so bounding disk can never win over playback.

## Behavior for hosts that do not opt in

Unchanged. `forwardBufferSegments` nil or <= 150 keeps the same budget, and the park's condition (race-ahead bytes >= budget) is unreachable at those window sizes.

## Tests

16 new tests (999 total, all green): budget sizing with and without the relaxed cap, the park decision (no budget / under budget / at budget / short consumer lead), `SegmentCache.forwardBytes` semantics, the headroom park primitive including release as the playhead advances, and a regression guard that retained history never withholds headroom. Ceiling test deltas taken from the reporter's patch.

Verified: `swift test` 999 passed, `swift build -Xswiftc -strict-concurrency=complete` clean, tvOS Simulator build succeeded. Not yet device-verified with a real opt-in prefetch session.

Reported with a ceiling-raise patch by @fxndxs.