### PR TITLE
fix(player): AudioPlaybackHost/SoftwarePlaybackHost memory leaks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ the public-API contract.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Long-running SoftwarePlaybackHost live sessions no longer leak memory into eventual Jetsam termination.** Each of the four dispatch-block loops (demux, reader, feeder, pumpAudio) now drains its autorelease pool on every iteration instead of only at session end, and inner wait/poll loops (paused condition-wait, back-pressure `isReadyForMoreMediaData` spin, live-edge wait) drain their own pools per spin so that temporaries from `Date` bridging and ObjC runtime calls do not accumulate during extended pauses or renderer back-pressure. The same drain is applied to `AudioPlaybackHost.runDemuxLoop` for parity. Reported and fixed by Nathan Piper (#205).
+
 ## [5.20.7] - 2026-07-24
 
 ([release notes](https://github.com/superuser404notfound/AetherEngine/releases/tag/5.20.7))

--- a/Sources/AetherEngine/Audio/AudioPlaybackHost.swift
+++ b/Sources/AetherEngine/Audio/AudioPlaybackHost.swift
@@ -308,14 +308,16 @@ final class AudioPlaybackHost {
         var lastEnqueuedEnd: Double = 0
         var seenSeekGeneration = seekGeneration()
 
-        while !stopRequested() {
+        func demuxIteration() -> Bool {
             if !isPlaying() {
                 condition.lock()
                 while !isPlaying() && !stopRequested() {
-                    _ = condition.wait(until: Date(timeIntervalSinceNow: 0.5))
+                    autoreleasepool {
+                        _ = condition.wait(until: Date(timeIntervalSinceNow: 0.5))
+                    }
                 }
                 condition.unlock()
-                continue
+                return true
             }
 
             // A seek invalidates the enqueue high-water mark: a stale pre-seek value after a backward seek
@@ -331,9 +333,11 @@ final class AudioPlaybackHost {
             if clockArmed(), let aOut = audioOutput {
                 while !stopRequested() && isPlaying()
                     && (lastEnqueuedEnd - aOut.currentTimeSeconds) > maxBufferAhead {
-                    Thread.sleep(forTimeInterval: 0.05)
+                    autoreleasepool {
+                        Thread.sleep(forTimeInterval: 0.05)
+                    }
                 }
-                if stopRequested() { break }
+                if stopRequested() { return false }
             }
 
             let packet: UnsafeMutablePointer<AVPacket>?
@@ -342,7 +346,7 @@ final class AudioPlaybackHost {
             } catch {
                 EngineLog.emit("[AudioHost] demux read failed: \(error)", category: .swPlayback)
                 onError("Playback error: \(error.localizedDescription)")
-                break
+                return false
             }
 
             guard let packet else {
@@ -365,18 +369,21 @@ final class AudioPlaybackHost {
                 var seekedAway = false
                 while !stopRequested()
                     && (audioOutput?.currentTimeSeconds ?? lastEnqueuedEnd) < lastEnqueuedEnd - 0.25 {
-                    // A seek during the drain re-positions the demuxer so EOF no longer holds. Without this check
-                    // the drain played silence up to the stale high-water mark then fired onEnd(), skipping the seek.
-                    if seekGeneration() != seenSeekGeneration {
-                        seekedAway = true
-                        break
+                    autoreleasepool {
+                        // A seek during the drain re-positions the demuxer so EOF no longer holds. Without this check
+                        // the drain played silence up to the stale high-water mark then fired onEnd(), skipping the seek.
+                        if seekGeneration() != seenSeekGeneration {
+                            seekedAway = true
+                        } else {
+                            Thread.sleep(forTimeInterval: 0.1)
+                        }
                     }
-                    Thread.sleep(forTimeInterval: 0.1)
+                    if seekedAway { break }
                 }
-                if seekedAway { continue }
-                if seekGeneration() != seenSeekGeneration { continue }
+                if seekedAway { return true }
+                if seekGeneration() != seenSeekGeneration { return true }
                 onEnd()
-                break
+                return false
             }
 
             // A seek landed while this packet was in flight: it predates the seek's renderer flush, so enqueueing
@@ -384,7 +391,7 @@ final class AudioPlaybackHost {
             if seekGeneration() != seenSeekGeneration {
                 av_packet_unref(packet)
                 av_packet_free_safe(packet)
-                continue
+                return true
             }
 
             if packet.pointee.stream_index == audioStreamIndex,
@@ -406,6 +413,14 @@ final class AudioPlaybackHost {
 
             av_packet_unref(packet)
             av_packet_free_safe(packet)
+            return true
+        }
+
+        while !stopRequested() {
+            let keepGoing: Bool = autoreleasepool {
+                demuxIteration()
+            }
+            if !keepGoing { break }
         }
     }
 

--- a/Sources/AetherEngine/Native/SoftwarePlaybackHost.swift
+++ b/Sources/AetherEngine/Native/SoftwarePlaybackHost.swift
@@ -973,7 +973,7 @@ final class SoftwarePlaybackHost {
             condition.unlock()
         }
 
-        while !stopRequested() {
+        func readerIteration() -> Bool {
             let packet: UnsafeMutablePointer<AVPacket>?
             do {
                 packet = try demuxer.readPacket()
@@ -981,12 +981,12 @@ final class SoftwarePlaybackHost {
                 EngineLog.emit("[SWHost] live reader read failed: \(error)", category: .swPlayback)
                 onError("Playback error: \(error.localizedDescription)")
                 onSourceEnded()
-                break
+                return false
             }
             guard let packet else {
                 EngineLog.emit("[SWHost] live reader EOF (source lost)", category: .swPlayback)
                 onSourceEnded()
-                break
+                return false
             }
 
             let streamIdx = packet.pointee.stream_index
@@ -1089,6 +1089,14 @@ final class SoftwarePlaybackHost {
 
             av_packet_unref(packet)
             av_packet_free_safe(packet)
+            return true
+        }
+
+        while !stopRequested() {
+            let keepGoing: Bool = autoreleasepool {
+                readerIteration()
+            }
+            if !keepGoing { break }
         }
     }
 
@@ -1130,25 +1138,25 @@ final class SoftwarePlaybackHost {
         func pumpAudio() {
             guard let aDec = audioDecoder, let aOut = audioOutput, audioStreamIndex >= 0 else { return }
             var seq = audioLookahead.align(to: readCursor())
-            while !stopRequested() && isPlaying() {
+            func pumpIteration() -> Bool {
                 let armed = clockArmed()
                 guard AudioLookaheadPolicy.decide(
                     clockArmed: armed,
                     preArmPacketsFed: preArmPacketsFed,
                     lastFedAudioPTS: audioLookahead.lastFedAudioPTS,
                     clockSeconds: aOut.currentTimeSeconds
-                ) == .feed else { break }
-                guard seq < ring.seqBounds.end else { break }  // live edge: nothing to pump yet
+                ) == .feed else { return false }
+                guard seq < ring.seqBounds.end else { return false }  // live edge: nothing to pump yet
                 guard let pkt = ring.packet(atSeq: seq) else {
                     // Evicted/unreadable under the pump: skip, same as the combined loop.
-                    guard audioLookahead.advance(from: seq, fedPTS: nil) else { break }
+                    guard audioLookahead.advance(from: seq, fedPTS: nil) else { return false }
                     seq += 1
-                    continue
+                    return true
                 }
                 if pkt.isVideo {
-                    guard audioLookahead.advance(from: seq, fedPTS: nil) else { break }
+                    guard audioLookahead.advance(from: seq, fedPTS: nil) else { return false }
                     seq += 1
-                    continue
+                    return true
                 }
                 let producedAudio = feedRingPacket(
                     pkt,
@@ -1171,8 +1179,16 @@ final class SoftwarePlaybackHost {
                         markClockArmed()
                     }
                 }
-                guard audioLookahead.advance(from: seq, fedPTS: pkt.pts) else { break }
+                guard audioLookahead.advance(from: seq, fedPTS: pkt.pts) else { return false }
                 seq += 1
+                return true
+            }
+
+            while !stopRequested() && isPlaying() {
+                let keepGoing: Bool = autoreleasepool {
+                    pumpIteration()
+                }
+                if !keepGoing { break }
             }
             // Live-edge underrun handling (#107): a source delivering below real time would
             // otherwise leave the free-running clock permanently ahead of the stream, and
@@ -1223,14 +1239,16 @@ final class SoftwarePlaybackHost {
             }
         }
 
-        while !stopRequested() {
+        func feederIteration() -> Bool {
             if !isPlaying() {
                 condition.lock()
                 while !isPlaying() && !stopRequested() {
-                    _ = condition.wait(until: Date(timeIntervalSinceNow: 0.5))
+                    autoreleasepool {
+                        _ = condition.wait(until: Date(timeIntervalSinceNow: 0.5))
+                    }
                 }
                 condition.unlock()
-                continue
+                return true
             }
 
             // Keep the audio renderer topped up before (possibly expensive) video work.
@@ -1247,7 +1265,7 @@ final class SoftwarePlaybackHost {
                     category: .swPlayback
                 )
                 clampCursor(cursor, bounds.first)
-                continue
+                return true
             }
             guard let pkt = ring.packet(atSeq: cursor) else {
                 // Resident entry whose file read failed (disk hiccup,
@@ -1259,7 +1277,7 @@ final class SoftwarePlaybackHost {
                         category: .swPlayback
                     )
                     advanceCursor(cursor)
-                    continue
+                    return true
                 }
                 // At the live edge (cursor == end): wait for the reader's
                 // next append, or finish when the source is gone and the
@@ -1269,12 +1287,14 @@ final class SoftwarePlaybackHost {
                     audioDecoder?.flush()
                     renderer.drainReorderBuffer()
                     onEnd()
-                    break
+                    return false
                 }
                 condition.lock()
-                _ = condition.wait(until: Date(timeIntervalSinceNow: 0.25))
+                autoreleasepool {
+                    _ = condition.wait(until: Date(timeIntervalSinceNow: 0.25))
+                }
                 condition.unlock()
-                continue
+                return true
             }
 
             if pkt.isVideo {
@@ -1282,16 +1302,18 @@ final class SoftwarePlaybackHost {
                 // The wait can outlast the audio lead, so keep pumping audio while parked.
                 var waitTicks = 0
                 while !renderer.isReadyForMoreMediaData && !stopRequested() && isPlaying() {
-                    Thread.sleep(forTimeInterval: 0.005)
-                    waitTicks += 1
-                    if waitTicks % 20 == 0 { pumpAudio() }
+                    autoreleasepool {
+                        Thread.sleep(forTimeInterval: 0.005)
+                        waitTicks += 1
+                        if waitTicks % 20 == 0 { pumpAudio() }
+                    }
                 }
-                if stopRequested() { break }
-                if !isPlaying() { continue }
+                if stopRequested() { return false }
+                if !isPlaying() { return true }
             } else if cursor < audioLookahead.current {
                 // Audio the pump already delivered: consume the slot without re-decoding.
                 advanceCursor(cursor)
-                continue
+                return true
             }
 
             let producedAudio = feedRingPacket(
@@ -1318,6 +1340,14 @@ final class SoftwarePlaybackHost {
             }
 
             advanceCursor(cursor)
+            return true
+        }
+
+        while !stopRequested() {
+            let keepGoing: Bool = autoreleasepool {
+                feederIteration()
+            }
+            if !keepGoing { break }
         }
     }
 
@@ -1393,14 +1423,16 @@ final class SoftwarePlaybackHost {
         var audioPacketsSeen = 0
         var audioBuffersProduced = false
 
-        while !stopRequested() {
+        func demuxIteration() -> Bool {
             if !isPlaying() {
                 condition.lock()
                 while !isPlaying() && !stopRequested() {
-                    _ = condition.wait(until: Date(timeIntervalSinceNow: 0.5))
+                    autoreleasepool {
+                        _ = condition.wait(until: Date(timeIntervalSinceNow: 0.5))
+                    }
                 }
                 condition.unlock()
-                continue
+                return true
             }
 
             let genBeforeRead = seekGeneration()
@@ -1410,7 +1442,7 @@ final class SoftwarePlaybackHost {
             } catch {
                 EngineLog.emit("[SWHost] demux read failed: \(error)", category: .swPlayback)
                 onError("Playback error: \(error.localizedDescription)")
-                break
+                return false
             }
 
             guard let packet else {
@@ -1418,14 +1450,14 @@ final class SoftwarePlaybackHost {
                 audioDecoder?.flush()
                 renderer.drainReorderBuffer()
                 onEnd()
-                break
+                return false
             }
 
             // Stale packet from before seek flush: decoding would clear the skip threshold (visible fast-forward burst). Discard.
             if seekGeneration() != genBeforeRead {
                 av_packet_unref(packet)
                 av_packet_free_safe(packet)
-                continue
+                return true
             }
 
             let streamIdx = packet.pointee.stream_index
@@ -1505,36 +1537,40 @@ final class SoftwarePlaybackHost {
                 if backgroundAudioOnly() {
                     av_packet_unref(packet)
                     av_packet_free_safe(packet)
-                    continue
+                    return true
                 }
                 // Back-pressure via SampleBufferRenderer.isReadyForMoreMediaData (not the deprecated layer property). Park on condition while paused to avoid 200 Hz CPU spin.
                 while !renderer.isReadyForMoreMediaData && !stopRequested() && !backgroundAudioOnly() {
-                    if !isPlaying() {
-                        condition.lock()
-                        while !isPlaying() && !stopRequested() {
-                            _ = condition.wait(until: Date(timeIntervalSinceNow: 0.5))
+                    autoreleasepool {
+                        if !isPlaying() {
+                            condition.lock()
+                            while !isPlaying() && !stopRequested() {
+                                autoreleasepool {
+                                    _ = condition.wait(until: Date(timeIntervalSinceNow: 0.5))
+                                }
+                            }
+                            condition.unlock()
+                        } else {
+                            Thread.sleep(forTimeInterval: 0.005)
                         }
-                        condition.unlock()
-                    } else {
-                        Thread.sleep(forTimeInterval: 0.005)
                     }
                 }
                 // Entered background while parked on back-pressure: drop this frame.
                 if backgroundAudioOnly() {
                     av_packet_unref(packet)
                     av_packet_free_safe(packet)
-                    continue
+                    return true
                 }
                 if stopRequested() {
                     av_packet_unref(packet)
                     av_packet_free_safe(packet)
-                    break
+                    return false
                 }
                 // Re-check generation after the back-pressure wait (seek can land there; pre-seek packet would clear skip thresholds).
                 if seekGeneration() != genBeforeRead {
                     av_packet_unref(packet)
                     av_packet_free_safe(packet)
-                    continue
+                    return true
                 }
                 videoDecoder.decode(packet: packet)
                 // Video-only / undecodable audio fallback: arm clock off first video packet (50+ audio packets with zero buffers = decoder not recovering).
@@ -1568,7 +1604,7 @@ final class SoftwarePlaybackHost {
                     if stopRequested() {
                         av_packet_unref(packet)
                         av_packet_free_safe(packet)
-                        break
+                        return false
                     }
                 }
                 audioPacketsSeen += 1
@@ -1602,6 +1638,14 @@ final class SoftwarePlaybackHost {
 
             av_packet_unref(packet)
             av_packet_free_safe(packet)
+            return true
+        }
+
+        while !stopRequested() {
+            let keepGoing: Bool = autoreleasepool {
+                demuxIteration()
+            }
+            if !keepGoing { break }
         }
     }
 


### PR DESCRIPTION
## Summary

Resolves memory leaks in `SoftwarePlaybackHost` / `AudioPlaybackHost` on long running loops by wrapping them in `autoreleasepool`.

Closes #205

## What changed

### `Sources/AetherEngine/Native/SoftwarePlaybackHost.swift` (130 lines, +88/-42)

   Extracted the body of each of the four dispatch-block loops into a local `*Iteration() -> Bool` function, replacing `break`/`continue` with `return false`/`return
 true`. The outer `while !stopRequested()` then calls it inside `autoreleasepool`:

   | Loop | Function | Queue |
   |------|----------|-------|
   | Live reader | `readerIteration()` | `demuxQueue` |
   | Audio look-ahead pump | `pumpIteration()` | `feedQueue` |
   | Live feeder | `feederIteration()` | `feedQueue` |
   | VOD / live-non-ring demux | `demuxIteration()` | `demuxQueue` |

   Additionally, 5 inner wait/poll loops that can spin for extended periods within a single outer iteration got their own `autoreleasepool` drains:

   - `feederIteration()` paused `condition.wait(until: Date(…))` (every 0.5 s)
   - `feederIteration()` live-edge `condition.wait(until: Date(…))` (single wait)
   - `feederIteration()` video back-pressure `Thread.sleep(0.005)` / `isReadyForMoreMediaData` spin
   - `demuxIteration()` paused `condition.wait(until: Date(…))` (every 0.5 s)
   - `demuxIteration()` back-pressure poll with nested paused wait — outer body wrapped in `autoreleasepool`, inner `condition.wait` also gets its own drain

   ### `Sources/AetherEngine/Audio/AudioPlaybackHost.swift` (45 lines, +31/-14)

   Same pattern applied to `runDemuxLoop`, which previously had zero `autoreleasepool` usage:

   - Extracted loop body into `demuxIteration() -> Bool`
   - Wrapped outer `while` call in `autoreleasepool { demuxIteration() }`
   - Wrapped 3 inner wait loops in `autoreleasepool`:
     - Paused `condition.wait(until: Date(…))`
     - Back-pressure `Thread.sleep(0.05)`
     - EOF drain `Thread.sleep(0.1)` — uses `autoreleasepool { if seekedAway { … } else { … } }` + post-pool `break` check so the `seekedAway` escape path works correctly

## Test plan

- Device / OS: Apple TV 4K (3rd Gen) / tvOS 26.5
- Source media (container / video codec + profile / audio / HDR-DV): Live TV / long Opus audio file
- Result: Leak is gone for live TV / Software host, negligible difference on audio only host

**Note: before/after memory logs attached.**

## Checklist

- [x] `CHANGELOG.md` updated
- [x] Commit messages follow Conventional Commits (`feat(...)`, `fix(...)`, `chore(...)`)
- [x] The fix lives in the engine, not in a host-side workaround
- [ ] Public API changes are intentional and documented

[memprobe-opus-audio-host-before.txt](https://github.com/user-attachments/files/30368625/memprobe-opus-audio-host-before.txt)
[memprobe-livetv-software-host-after.txt](https://github.com/user-attachments/files/30368622/memprobe-livetv-software-host-after.txt)
[memprobe-livetv-software-host-before.txt](https://github.com/user-attachments/files/30368623/memprobe-livetv-software-host-before.txt)
[memprobe-opus-audio-host-after.txt](https://github.com/user-attachments/files/30368624/memprobe-opus-audio-host-after.txt)
