### PR TITLE
feat(audio): bounded opt-in E-AC-3 JOC/Atmos decode-detection probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ the public-API contract.
 
 ## [Unreleased]
 
+### Added
+
+- **`AetherEngine.probeDetectingAtmos(url:/source:)`: opt-in, authoritative E-AC-3 JOC (Dolby Atmos) detection.** FFmpeg only populates `AVCodecContext.profile == AV_PROFILE_EAC3_DDP_ATMOS` (30) after decoding an audio frame, so the lightweight `probe(url:)`/`probe(source:)` path (demux + `avformat_find_stream_info` only, no decoders) cannot reliably report `TrackInfo.isAtmos` for JOC. The new API opens the EAC3 decoder and decodes the minimum packets needed to read the authoritative post-decode profile, bounded by `AtmosDetectionOptions` (packet / byte / wall-clock caps, default 64 packets / 8 MiB / 2 s) with no video decode, no HLS server, and no playback session. Non-target streams are discarded for the pass, so the caps are a budget over the *audio* rather than the interleaved container — otherwise a UHD remux's multi-MB video packets exhaust the byte cap before any audio reaches the decoder and a genuinely Atmos track reports as not-Atmos. It tolerates malformed / no-audio / non-EAC3 sources by degrading to "not confirmed" rather than throwing, and only ever flips a track's `isAtmos` from `false` to `true` (never overwrites an existing `true`). `probe(url:)`/`probe(source:)` themselves are completely unmodified — this is a separate, strictly opt-in entry point for hosts (e.g. a details screen) that need an authoritative Atmos badge, not a flag on the default probe.
+
 ## [5.20.8] - 2026-07-25
 
 ([release notes](https://github.com/superuser404notfound/AetherEngine/releases/tag/5.20.8))

--- a/Sources/AetherEngine/AetherEngine+Probe.swift
+++ b/Sources/AetherEngine/AetherEngine+Probe.swift
@@ -41,6 +41,105 @@ extension AetherEngine {
         return makeSourceProbe(demuxer: demuxer, displayURL: displayURL)
     }
 
+    // MARK: - Bounded, opt-in Atmos/JOC detail probe
+
+    /// `probe(url:)` plus a bounded, OPT-IN decode pass that authoritatively resolves E-AC-3 JOC (Dolby Atmos)
+    /// on the default (or explicitly named) audio track.
+    ///
+    /// FFmpeg's E-AC-3 decoder only populates `AVCodecContext.profile == AV_PROFILE_EAC3_DDP_ATMOS` (30) AFTER
+    /// decoding at least one audio frame. The lightweight `probe(url:)` / `probe(source:)` path never opens a
+    /// decoder -- it only demuxes and runs `avformat_find_stream_info` -- so `TrackInfo.isAtmos` from those
+    /// calls reflects only whatever `codecpar.profile` the container already carries pre-decode, which is
+    /// unresolved for JOC in the common case. Call `probeDetectingAtmos` instead of `probe(url:)` ONLY when a
+    /// host specifically needs an authoritative "Dolby Atmos" badge (e.g. a details screen): it is strictly
+    /// more expensive than `probe(url:)` (it opens a real EAC3 decoder and decodes at least one frame) and
+    /// MUST NOT be used on the playback-start critical path. `probe(url:)` / `probe(source:)` themselves are
+    /// completely unmodified by this API and remain byte-for-byte the same lightweight demux-only probe --
+    /// this is an additive, separate entry point, not a flag on the existing one.
+    ///
+    /// The decode pass is bounded by `atmosDetection` (packet-count / byte / wall-clock caps -- see
+    /// `AtmosDetectionOptions`): it stops at the first successfully decoded audio frame, or at whichever cap
+    /// is hit first. There is no video decode, no HLS server, and no playback session. The demuxer, decoder
+    /// context, packet, and frame are all closed / freed before returning on every path, including error
+    /// paths. A malformed / no-audio / non-EAC3 source is tolerated: the decode pass simply degrades to "not
+    /// authoritatively Atmos" (the base probe's `TrackInfo.isAtmos`, which a pre-existing container-declared
+    /// profile 30 can still leave `true` -- this API only ever ADDS confirmation, never removes a pre-decode
+    /// signal) instead of throwing or hanging.
+    ///
+    /// - Parameters:
+    ///   - url: Media source, forwarded verbatim to `probe(url:)`.
+    ///   - options: Forwarded verbatim to `probe(url:)` (`httpHeaders` only; other flags ignored, same as `probe(url:)`).
+    ///   - atmosDetection: Bounds + optional explicit track override for the decode pass. Defaults resolve the
+    ///     demuxer's own default audio track (`Demuxer.audioStreamIndex`) and cap the decode attempt at 64
+    ///     packets / 8 MiB / 2 s wall clock (soft -- see `AtmosDetectionOptions` doc for the same
+    ///     AVIO-blocking caveat `Demuxer.seekBounded` already documents: a single blocking `av_read_frame()`
+    ///     on a stalled remote socket can still run past the wall-clock budget before the next check fires).
+    /// - Throws: Any error the demuxer raises during open / probe -- identical to `probe(url:)`. Decode-side
+    ///   failures (bad EAC3 extradata, no decoder built, a malformed frame, EOF before any frame decodes) are
+    ///   NEVER thrown; they only affect whether Atmos gets confirmed.
+    public nonisolated static func probeDetectingAtmos(
+        url: URL,
+        options: LoadOptions = .init(),
+        atmosDetection: AtmosDetectionOptions = .init()
+    ) throws -> SourceProbe {
+        try probeDetectingAtmos(source: .url(url), options: options, atmosDetection: atmosDetection)
+    }
+
+    /// `probeDetectingAtmos(url:)` for a custom byte source. Same reader-ownership contract as `probe(source:)`:
+    /// the caller retains ownership, the cursor is left at an unspecified position, and `close()` is NOT called.
+    public nonisolated static func probeDetectingAtmos(
+        source: MediaSource,
+        options: LoadOptions = .init(),
+        atmosDetection: AtmosDetectionOptions = .init()
+    ) throws -> SourceProbe {
+        let demuxer = Demuxer()
+        let displayURL: URL
+        switch source {
+        case .url(let u):
+            try demuxer.open(url: u, extraHeaders: options.httpHeaders)
+            displayURL = u
+        case .custom(let reader, let formatHint):
+            try demuxer.open(reader: reader, formatHint: formatHint)
+            displayURL = URL(string: "aether-custom://source")!
+        }
+        defer { demuxer.close() }
+
+        let base = makeSourceProbe(demuxer: demuxer, displayURL: displayURL)
+        let targetIndex = Self.atmosDecodeTargetIndex(
+            options: atmosDetection, defaultAudioStreamIndex: demuxer.audioStreamIndex)
+        let outcome = Self.detectAtmos(demuxer: demuxer, targetIndex: targetIndex, options: atmosDetection)
+        guard outcome.confirmedAtmos else { return base }
+        return Self.enrichAtmos(base: base, confirmedTrackID: Int(targetIndex))
+    }
+
+    /// Flip `isAtmos` to `true` on exactly the one confirmed audio track, leaving everything else identical.
+    ///
+    /// Pure and `internal` so the field-by-field rebuild below is directly testable: it hand-copies every
+    /// `TrackInfo` and `SourceProbe` field, and the compiler cannot tell us if one is dropped (silently
+    /// losing e.g. `assHeader`, `dvProfile`, or `subtitleTracks`).
+    nonisolated static func enrichAtmos(base: SourceProbe, confirmedTrackID: Int) -> SourceProbe {
+        // Additive only: a track already marked isAtmos by the base probe (a container that pre-declares
+        // profile 30) is left untouched; this only ever flips false -> true for the one confirmed track.
+        let enrichedTracks = base.audioTracks.map { track -> TrackInfo in
+            guard track.id == confirmedTrackID, !track.isAtmos else { return track }
+            return TrackInfo(
+                id: track.id, name: track.name, codec: track.codec, language: track.language,
+                channels: track.channels, bitrate: track.bitrate, isDefault: track.isDefault,
+                isForced: track.isForced, isHearingImpaired: track.isHearingImpaired,
+                isCommentary: track.isCommentary, isAtmos: true, assHeader: track.assHeader,
+                isExternal: track.isExternal
+            )
+        }
+        return SourceProbe(
+            url: base.url, durationSeconds: base.durationSeconds, videoFormat: base.videoFormat,
+            videoCodecID: base.videoCodecID, videoCodecName: base.videoCodecName,
+            videoWidth: base.videoWidth, videoHeight: base.videoHeight, videoFrameRate: base.videoFrameRate,
+            isDolbyVision: base.isDolbyVision, dvProfile: base.dvProfile,
+            audioTracks: enrichedTracks, subtitleTracks: base.subtitleTracks,
+            metadata: base.metadata, isLive: base.isLive
+        )
+    }
+
     /// Assemble a `SourceProbe` from an open demuxer. Shared by static probe entry points and `load(source:)`'s internal probe stage so all report identical metadata.
     nonisolated static func makeSourceProbe(
         demuxer: Demuxer,

--- a/Sources/AetherEngine/Audio/AtmosDetectionProbe.swift
+++ b/Sources/AetherEngine/Audio/AtmosDetectionProbe.swift
@@ -1,0 +1,233 @@
+import Foundation
+import Libavformat
+import Libavcodec
+import Libavutil
+
+/// Bounds (and optional track override) for `AetherEngine.probeDetectingAtmos`'s bounded EAC3/JOC decode pass.
+///
+/// This is entirely separate from `LoadOptions` / the lightweight `probe(url:)` path: it exists so a host can
+/// opt into a strictly more expensive, decode-based Atmos check without ever touching the default probe's
+/// behavior or performance. See `AetherEngine.probeDetectingAtmos` for the full contract.
+public struct AtmosDetectionOptions: Sendable, Equatable {
+    /// Explicit AVStream index (== `TrackInfo.id`) to test. `nil` resolves the demuxer's own default audio
+    /// pick (`Demuxer.audioStreamIndex`), the same stream `probe(url:)` already reports via its container
+    /// default. Set this when a host is badging a NON-default track the user explicitly selected (e.g. via
+    /// `AetherEngine.selectAudioIndex`), so the decode targets the track that will actually play.
+    public var targetTrackID: Int?
+
+    /// Stop after this many demuxed packets even if none decode. Bounds a malformed / truncated / silent
+    /// stream to a fixed amount of work. Default 64: generous for E-AC-3 (~1536-sample frames per packet at
+    /// typical container interleave -- a real track decodes its first frame within the first handful of
+    /// packets), while still finite on an adversarial or empty-audio source.
+    public var maxPackets: Int
+
+    /// Stop after this many cumulative packet bytes, independent of packet count. Guards a stream with
+    /// abnormally large packets from exhausting the `maxPackets` budget slowly. Default 8 MiB.
+    public var maxBytes: Int64
+
+    /// Soft wall-clock budget checked BETWEEN packet reads. This is NOT preemptive: a single blocking
+    /// `av_read_frame()` call (e.g. a stalled remote socket) can still run past it before the next check
+    /// fires -- the same AVIO-layer-only limitation `Demuxer.seekBounded` already documents for its deadline.
+    /// Default 2 seconds.
+    public var timeBudget: TimeInterval
+
+    public init(
+        targetTrackID: Int? = nil,
+        maxPackets: Int = 64,
+        maxBytes: Int64 = 8 * 1024 * 1024,
+        timeBudget: TimeInterval = 2.0
+    ) {
+        self.targetTrackID = targetTrackID
+        self.maxPackets = maxPackets
+        self.maxBytes = maxBytes
+        self.timeBudget = timeBudget
+    }
+}
+
+/// Result of the bounded EAC3/JOC decode attempt run by `AetherEngine.detectAtmos`. Internal: hosts consume
+/// the enriched `SourceProbe.audioTracks` from `probeDetectingAtmos` instead of this directly; it is exposed
+/// at module-internal visibility purely so the stop-condition / authority logic is unit-testable without a
+/// real decode (`@testable import AetherEngine`).
+struct AtmosDetectionOutcome: Sendable, Equatable {
+    enum StopReason: Sendable, Equatable {
+        /// No audio stream at `targetIndex` (out of range, or the source has no audio at all).
+        case noAudioTrack
+        /// The target track's `codec_id` is not `AV_CODEC_ID_EAC3`. Per spec, only EAC3 JOC is ever Atmos --
+        /// no other codec is decoded or inferred.
+        case notEAC3
+        /// `avcodec_find_decoder` / `avcodec_open2` failed (no EAC3 decoder built, or bad extradata).
+        case decoderOpenFailed
+        /// A frame was successfully decoded; `decodedProfile` reflects the post-decode `AVCodecContext.profile`.
+        case frameDecoded
+        /// `maxPackets` demuxed packets were read without ever decoding a frame for the target stream.
+        case packetCap
+        /// `maxBytes` cumulative packet bytes were read without ever decoding a frame.
+        case byteCap
+        /// `timeBudget` elapsed (checked between reads) without ever decoding a frame.
+        case timeCap
+        /// The demuxer reached EOF before a frame decoded (very short / audio-less-from-here source).
+        case demuxEOF
+        /// `Demuxer.readPacket()` threw (this is tolerated, never rethrown -- see `probeDetectingAtmos` doc).
+        case demuxError
+    }
+
+    let stopReason: StopReason
+    let packetsRead: Int
+    let bytesRead: Int64
+    /// Post-decode `AVCodecContext.profile`. Only meaningful when `stopReason == .frameDecoded`.
+    let decodedProfile: Int32?
+
+    /// EAC3 profile 30 (FFmpeg's `AV_PROFILE_EAC3_DDP_ATMOS`, `defs.h`) observed on the FIRST successfully
+    /// decoded frame. This is the ONLY authoritative signal the whole feature produces -- everything else on
+    /// this type is diagnostic. A plain (non-JOC) EAC3 track that decodes cleanly reports `frameDecoded` with
+    /// a `decodedProfile` other than 30, so `confirmedAtmos` is correctly `false`.
+    var confirmedAtmos: Bool {
+        stopReason == .frameDecoded && decodedProfile == AtmosDetectionOutcome.eac3JOCProfile
+    }
+
+    /// EAC3 profile 30 = Dolby Digital Plus JOC (Atmos). Mirrors FFmpeg's `AV_PROFILE_EAC3_DDP_ATMOS` macro
+    /// (`defs.h`) as a literal: simple `#define` integer constants are not guaranteed to bridge into Swift,
+    /// and `Demuxer.trackInfo`'s existing pre-decode check already hardcodes this same literal.
+    static let eac3JOCProfile: Int32 = 30
+}
+
+extension AetherEngine {
+    /// How many total demuxed packets to tolerate per unit of decode budget before giving up, when a
+    /// demuxer ignores `AVDISCARD_ALL` and keeps yielding foreign streams.
+    nonisolated static let foreignPacketFuseMultiplier = 8
+
+    /// Pure stop-condition check for the bounded decode loop: given how much work has been done, which cap
+    /// (if any) has been hit. Extracted so the cap-selection PRIORITY (packets, then bytes, then time) is
+    /// unit-testable without a real demuxer/decoder. Returns `nil` while still within all three budgets.
+    nonisolated static func atmosDecodeCapReached(
+        packetsRead: Int,
+        bytesRead: Int64,
+        elapsed: TimeInterval,
+        options: AtmosDetectionOptions
+    ) -> AtmosDetectionOutcome.StopReason? {
+        if packetsRead >= options.maxPackets { return .packetCap }
+        if bytesRead >= options.maxBytes { return .byteCap }
+        if elapsed >= options.timeBudget { return .timeCap }
+        return nil
+    }
+
+    /// Resolve which AVStream index the decode pass should target: an explicit `targetTrackID` always wins
+    /// (even if it does not (yet) name a real stream -- the caller finds out via `.noAudioTrack`); otherwise
+    /// the demuxer's own default audio pick. Pure so the override-vs-default precedence is unit-testable.
+    nonisolated static func atmosDecodeTargetIndex(options: AtmosDetectionOptions, defaultAudioStreamIndex: Int32) -> Int32 {
+        if let explicit = options.targetTrackID {
+            return Int32(explicit)
+        }
+        return defaultAudioStreamIndex
+    }
+
+    /// Bounded EAC3/JOC decode attempt. Opens ONE audio decoder for `targetIndex`, reads packets from
+    /// `demuxer` (skipping any not addressed to that stream), and stops at the first successfully decoded
+    /// frame or whichever cap in `options` is hit first. No video decode, no HLS server, no playback. The
+    /// decoder context, `AVPacket`, and `AVFrame` are all freed before returning on every path, including
+    /// early-outs and thrown-away errors -- this never leaves FFmpeg resources alive past the call.
+    ///
+    /// Tolerates a malformed / no-audio / non-EAC3 source: each of those degrades to a distinct
+    /// non-`frameDecoded` `stopReason` rather than throwing or hanging. `Demuxer.readPacket()` failures are
+    /// caught and folded into `.demuxError`, never rethrown -- an unreadable stream simply fails to confirm
+    /// Atmos instead of failing the whole probe.
+    nonisolated static func detectAtmos(
+        demuxer: Demuxer,
+        targetIndex: Int32,
+        options: AtmosDetectionOptions
+    ) -> AtmosDetectionOutcome {
+        guard targetIndex >= 0, let stream = demuxer.stream(at: targetIndex) else {
+            return AtmosDetectionOutcome(stopReason: .noAudioTrack, packetsRead: 0, bytesRead: 0, decodedProfile: nil)
+        }
+        guard let codecpar = stream.pointee.codecpar,
+              codecpar.pointee.codec_type == AVMEDIA_TYPE_AUDIO else {
+            return AtmosDetectionOutcome(stopReason: .noAudioTrack, packetsRead: 0, bytesRead: 0, decodedProfile: nil)
+        }
+        // Only EAC3 ever carries JOC. Every other codec (including plain AC-3/TrueHD/DTS) is left untouched --
+        // never inferred, never decoded on this path.
+        guard codecpar.pointee.codec_id == AV_CODEC_ID_EAC3 else {
+            return AtmosDetectionOutcome(stopReason: .notEAC3, packetsRead: 0, bytesRead: 0, decodedProfile: nil)
+        }
+
+        guard let codec = avcodec_find_decoder(AV_CODEC_ID_EAC3),
+              let ctx = avcodec_alloc_context3(codec) else {
+            return AtmosDetectionOutcome(stopReason: .decoderOpenFailed, packetsRead: 0, bytesRead: 0, decodedProfile: nil)
+        }
+        var mutableCtx: UnsafeMutablePointer<AVCodecContext>? = ctx
+        defer { avcodec_free_context(&mutableCtx) }
+
+        guard avcodec_parameters_to_context(ctx, codecpar) >= 0,
+              avcodec_open2(ctx, codec, nil) >= 0 else {
+            return AtmosDetectionOutcome(stopReason: .decoderOpenFailed, packetsRead: 0, bytesRead: 0, decodedProfile: nil)
+        }
+
+        var frame: UnsafeMutablePointer<AVFrame>? = av_frame_alloc()
+        defer { av_frame_free(&frame) }
+        guard let f = frame else {
+            return AtmosDetectionOutcome(stopReason: .decoderOpenFailed, packetsRead: 0, bytesRead: 0, decodedProfile: nil)
+        }
+
+        let start = Date()
+        var packetsRead = 0
+        var bytesRead: Int64 = 0
+        // Demuxed-but-discarded packets still cost wall clock and I/O, so they need their own fuse --
+        // but they must NOT consume the decode budget (see below).
+        var packetsSeen = 0
+
+        // Tell the demuxer to drop every other stream. Without this the caps are a budget over the whole
+        // INTERLEAVED container rather than over the audio we care about: on the exact content this
+        // feature targets (a UHD remux carrying an E-AC-3 JOC track) a few hundred-KB-to-MB video packets
+        // exhaust the 8 MiB byte cap in well under a second of container data, and the probe returns
+        // .byteCap having fed the decoder nothing -- reporting "not Atmos" for genuinely Atmos media.
+        demuxer.discardAllStreamsExcept([targetIndex])
+
+        while true {
+            if let cap = Self.atmosDecodeCapReached(
+                packetsRead: packetsRead, bytesRead: bytesRead,
+                elapsed: Date().timeIntervalSince(start), options: options
+            ) {
+                return AtmosDetectionOutcome(stopReason: cap, packetsRead: packetsRead, bytesRead: bytesRead, decodedProfile: nil)
+            }
+
+            let packet: UnsafeMutablePointer<AVPacket>?
+            do {
+                packet = try demuxer.readPacket()
+            } catch {
+                return AtmosDetectionOutcome(stopReason: .demuxError, packetsRead: packetsRead, bytesRead: bytesRead, decodedProfile: nil)
+            }
+            guard let pkt = packet else {
+                return AtmosDetectionOutcome(stopReason: .demuxEOF, packetsRead: packetsRead, bytesRead: bytesRead, decodedProfile: nil)
+            }
+
+            var decodedThisPacket = false
+            packetsSeen += 1
+            if pkt.pointee.stream_index == targetIndex {
+                // Charge the decode budget only for packets actually offered to the decoder, so a coarse
+                // interleave or a large leading video run can never starve the probe of audio.
+                packetsRead += 1
+                bytesRead += Int64(pkt.pointee.size)
+                let sendRet = avcodec_send_packet(ctx, pkt)
+                if sendRet >= 0, avcodec_receive_frame(ctx, f) >= 0 {
+                    decodedThisPacket = true
+                }
+            }
+            av_packet_unref(pkt)
+            av_packet_free_safe(pkt)
+
+            // Independent fuse: AVDISCARD_ALL is honoured by most demuxers but is advisory, so a container
+            // that keeps handing back foreign packets still terminates.
+            if packetsSeen >= options.maxPackets * Self.foreignPacketFuseMultiplier {
+                return AtmosDetectionOutcome(
+                    stopReason: .packetCap, packetsRead: packetsRead, bytesRead: bytesRead,
+                    decodedProfile: nil)
+            }
+
+            if decodedThisPacket {
+                return AtmosDetectionOutcome(
+                    stopReason: .frameDecoded, packetsRead: packetsRead, bytesRead: bytesRead,
+                    decodedProfile: ctx.pointee.profile
+                )
+            }
+        }
+    }
+}

--- a/Tests/AetherEngineTests/AtmosDetectionOptionsTests.swift
+++ b/Tests/AetherEngineTests/AtmosDetectionOptionsTests.swift
@@ -1,0 +1,232 @@
+import Testing
+import Foundation
+@testable import AetherEngine
+
+/// Pure unit tests for the bounded EAC3/JOC decode pass's control-flow logic (cap selection, track-target
+/// resolution, and the authoritative-Atmos truth table). No real media / decoder needed: these exercise the
+/// same seams `AetherEngine.detectAtmos` calls internally, per the "no redistributable Atmos fixture" note --
+/// the actual decode plumbing is covered separately in `AtmosDetectionProbeIntegrationTests` against a
+/// synthesized (non-Atmos) EAC3 fixture.
+@Suite("AtmosDetectionOptions defaults + bounded decode cap selection")
+struct AtmosDetectionOptionsTests {
+
+    // MARK: - AtmosDetectionOptions defaults
+
+    @Test("default options: no explicit track, generous-but-finite caps")
+    func defaultOptions() {
+        let options = AtmosDetectionOptions()
+        #expect(options.targetTrackID == nil)
+        #expect(options.maxPackets == 64)
+        #expect(options.maxBytes == 8 * 1024 * 1024)
+        #expect(options.timeBudget == 2.0)
+    }
+
+    @Test("options are independently overridable")
+    func customOptions() {
+        let options = AtmosDetectionOptions(targetTrackID: 3, maxPackets: 10, maxBytes: 1024, timeBudget: 0.5)
+        #expect(options.targetTrackID == 3)
+        #expect(options.maxPackets == 10)
+        #expect(options.maxBytes == 1024)
+        #expect(options.timeBudget == 0.5)
+    }
+
+    // MARK: - atmosDecodeTargetIndex (explicit override vs demuxer default)
+
+    @Test("nil targetTrackID resolves the demuxer's own default audio stream")
+    func targetIndexDefaultsToDemuxerPick() {
+        let options = AtmosDetectionOptions()
+        let resolved = AetherEngine.atmosDecodeTargetIndex(options: options, defaultAudioStreamIndex: 2)
+        #expect(resolved == 2)
+    }
+
+    @Test("an explicit targetTrackID always wins over the demuxer default")
+    func explicitTargetWinsOverDefault() {
+        let options = AtmosDetectionOptions(targetTrackID: 5)
+        let resolved = AetherEngine.atmosDecodeTargetIndex(options: options, defaultAudioStreamIndex: 2)
+        #expect(resolved == 5)
+    }
+
+    @Test("an explicit targetTrackID of 0 still wins (not confused with the nil/default case)")
+    func explicitZeroTargetWins() {
+        let options = AtmosDetectionOptions(targetTrackID: 0)
+        let resolved = AetherEngine.atmosDecodeTargetIndex(options: options, defaultAudioStreamIndex: 4)
+        #expect(resolved == 0)
+    }
+
+    @Test("no default audio stream (-1) surfaces unchanged when no override is given")
+    func noAudioStreamPropagatesAsNegativeOne() {
+        let options = AtmosDetectionOptions()
+        let resolved = AetherEngine.atmosDecodeTargetIndex(options: options, defaultAudioStreamIndex: -1)
+        #expect(resolved == -1)
+    }
+
+    // MARK: - atmosDecodeCapReached (packet / byte / time cap priority)
+
+    @Test("no cap reached while within every budget")
+    func noCapWithinBudget() {
+        let options = AtmosDetectionOptions(maxPackets: 64, maxBytes: 1_000_000, timeBudget: 2.0)
+        let cap = AetherEngine.atmosDecodeCapReached(packetsRead: 5, bytesRead: 1000, elapsed: 0.1, options: options)
+        #expect(cap == nil)
+    }
+
+    @Test("packet cap fires at the exact threshold, checked first")
+    func packetCapFiresAtThreshold() {
+        let options = AtmosDetectionOptions(maxPackets: 10, maxBytes: 1_000_000, timeBudget: 100)
+        #expect(AetherEngine.atmosDecodeCapReached(packetsRead: 9, bytesRead: 0, elapsed: 0, options: options) == nil)
+        #expect(AetherEngine.atmosDecodeCapReached(packetsRead: 10, bytesRead: 0, elapsed: 0, options: options) == .packetCap)
+        #expect(AetherEngine.atmosDecodeCapReached(packetsRead: 11, bytesRead: 0, elapsed: 0, options: options) == .packetCap)
+    }
+
+    @Test("byte cap fires at the exact threshold when packets are still under budget")
+    func byteCapFiresAtThreshold() {
+        let options = AtmosDetectionOptions(maxPackets: 1000, maxBytes: 4096, timeBudget: 100)
+        #expect(AetherEngine.atmosDecodeCapReached(packetsRead: 1, bytesRead: 4095, elapsed: 0, options: options) == nil)
+        #expect(AetherEngine.atmosDecodeCapReached(packetsRead: 1, bytesRead: 4096, elapsed: 0, options: options) == .byteCap)
+    }
+
+    @Test("time cap fires at the exact threshold when packets and bytes are still under budget")
+    func timeCapFiresAtThreshold() {
+        let options = AtmosDetectionOptions(maxPackets: 1000, maxBytes: 1_000_000, timeBudget: 1.5)
+        #expect(AetherEngine.atmosDecodeCapReached(packetsRead: 1, bytesRead: 0, elapsed: 1.49, options: options) == nil)
+        #expect(AetherEngine.atmosDecodeCapReached(packetsRead: 1, bytesRead: 0, elapsed: 1.5, options: options) == .timeCap)
+    }
+
+    @Test("packet cap takes priority over byte and time caps when several are simultaneously exceeded")
+    func packetCapHasPriority() {
+        let options = AtmosDetectionOptions(maxPackets: 5, maxBytes: 10, timeBudget: 0.01)
+        let cap = AetherEngine.atmosDecodeCapReached(packetsRead: 5, bytesRead: 100, elapsed: 10, options: options)
+        #expect(cap == .packetCap)
+    }
+
+    @Test("byte cap takes priority over time cap when both are exceeded but packets are not")
+    func byteCapHasPriorityOverTime() {
+        let options = AtmosDetectionOptions(maxPackets: 1000, maxBytes: 10, timeBudget: 0.01)
+        let cap = AetherEngine.atmosDecodeCapReached(packetsRead: 1, bytesRead: 100, elapsed: 10, options: options)
+        #expect(cap == .byteCap)
+    }
+
+    // MARK: - AtmosDetectionOutcome.confirmedAtmos truth table
+
+    @Test("confirmedAtmos is true only for a decoded frame with profile 30")
+    func confirmedAtmosTrueOnJOCProfile() {
+        let outcome = AtmosDetectionOutcome(stopReason: .frameDecoded, packetsRead: 3, bytesRead: 900, decodedProfile: 30)
+        #expect(outcome.confirmedAtmos == true)
+    }
+
+    @Test("a decoded frame with a non-30 profile (plain EAC3) is never Atmos")
+    func confirmedAtmosFalseOnPlainEAC3Profile() {
+        // -99 == AV_PROFILE_UNKNOWN; a real plain-EAC3 decode reports this or another non-JOC value.
+        let outcome = AtmosDetectionOutcome(stopReason: .frameDecoded, packetsRead: 2, bytesRead: 400, decodedProfile: -99)
+        #expect(outcome.confirmedAtmos == false)
+    }
+
+    @Test("hitting any cap without a decoded frame is never Atmos, regardless of decodedProfile")
+    func confirmedAtmosFalseWhenCapReachedBeforeDecode() {
+        for reason: AtmosDetectionOutcome.StopReason in [.packetCap, .byteCap, .timeCap, .demuxEOF, .demuxError] {
+            let outcome = AtmosDetectionOutcome(stopReason: reason, packetsRead: 64, bytesRead: 8_000_000, decodedProfile: nil)
+            #expect(outcome.confirmedAtmos == false, "\(reason) must never confirm Atmos")
+        }
+    }
+
+    @Test("a non-EAC3 / no-audio / decoder-open-failure source is never Atmos")
+    func confirmedAtmosFalseForSkippedOrFailedSources() {
+        for reason: AtmosDetectionOutcome.StopReason in [.noAudioTrack, .notEAC3, .decoderOpenFailed] {
+            let outcome = AtmosDetectionOutcome(stopReason: reason, packetsRead: 0, bytesRead: 0, decodedProfile: nil)
+            #expect(outcome.confirmedAtmos == false, "\(reason) must never confirm Atmos")
+        }
+    }
+
+    @Test("eac3JOCProfile mirrors FFmpeg's AV_PROFILE_EAC3_DDP_ATMOS (30)")
+    func jocProfileConstant() {
+        #expect(AtmosDetectionOutcome.eac3JOCProfile == 30)
+    }
+
+    // MARK: - enrichAtmos: the feature's actual output path
+    //
+    // enrichAtmos hand-copies all 13 TrackInfo fields and all 14 SourceProbe fields, so a dropped field
+    // compiles fine and silently ships. These pin the positive path the integration tests can't reach
+    // without a redistributable Atmos fixture.
+
+    private func makeTrack(
+        id: Int, isAtmos: Bool = false, assHeader: String? = nil, name: String = "Surround"
+    ) -> TrackInfo {
+        TrackInfo(
+            id: id, name: name, codec: "eac3", language: "eng", channels: 6, bitrate: 768_000,
+            isDefault: true, isForced: false, isHearingImpaired: false, isCommentary: false,
+            isAtmos: isAtmos, assHeader: assHeader, isExternal: false
+        )
+    }
+
+    private func makeProbe(audioTracks: [TrackInfo]) -> SourceProbe {
+        SourceProbe(
+            url: URL(string: "file:///tmp/movie.mkv")!, durationSeconds: 7261.5,
+            videoFormat: .dolbyVision, videoCodecID: 173, videoCodecName: "hevc",
+            videoWidth: 3840, videoHeight: 2160, videoFrameRate: 23.976,
+            isDolbyVision: true, dvProfile: 7,
+            audioTracks: audioTracks,
+            subtitleTracks: [makeTrack(id: 9, name: "English SDH")],
+            metadata: MediaMetadata(title: "T", artist: "A", album: "Al", artworkData: Data([0x1])),
+            isLive: false
+        )
+    }
+
+    @Test("enrichAtmos flips only the confirmed track and leaves its siblings alone")
+    func enrichFlipsOnlyConfirmedTrack() {
+        let probe = makeProbe(audioTracks: [makeTrack(id: 1), makeTrack(id: 2), makeTrack(id: 3)])
+        let out = AetherEngine.enrichAtmos(base: probe, confirmedTrackID: 2)
+        #expect(out.audioTracks.map(\.isAtmos) == [false, true, false])
+    }
+
+    @Test("enrichAtmos never overwrites a track the base probe already marked Atmos")
+    func enrichIsAdditiveOnly() {
+        let probe = makeProbe(audioTracks: [makeTrack(id: 1, isAtmos: true)])
+        let out = AetherEngine.enrichAtmos(base: probe, confirmedTrackID: 1)
+        #expect(out.audioTracks[0].isAtmos)
+    }
+
+    @Test("enrichAtmos with an id matching no track is a no-op")
+    func enrichNoMatchingTrack() {
+        let probe = makeProbe(audioTracks: [makeTrack(id: 1), makeTrack(id: 2)])
+        let out = AetherEngine.enrichAtmos(base: probe, confirmedTrackID: 99)
+        #expect(out.audioTracks.allSatisfy { !$0.isAtmos })
+    }
+
+    @Test("enrichAtmos round-trips every other SourceProbe and TrackInfo field unchanged")
+    func enrichPreservesAllOtherFields() {
+        let probe = makeProbe(audioTracks: [makeTrack(id: 1, assHeader: "[Script Info]")])
+        let out = AetherEngine.enrichAtmos(base: probe, confirmedTrackID: 1)
+
+        // SourceProbe fields.
+        #expect(out.url == probe.url)
+        #expect(out.durationSeconds == probe.durationSeconds)
+        #expect(out.videoFormat == probe.videoFormat)
+        #expect(out.videoCodecID == probe.videoCodecID)
+        #expect(out.videoCodecName == probe.videoCodecName)
+        #expect(out.videoWidth == probe.videoWidth)
+        #expect(out.videoHeight == probe.videoHeight)
+        #expect(out.videoFrameRate == probe.videoFrameRate)
+        #expect(out.isDolbyVision == probe.isDolbyVision)
+        #expect(out.dvProfile == probe.dvProfile)
+        #expect(out.isLive == probe.isLive)
+        #expect(out.subtitleTracks.map(\.id) == probe.subtitleTracks.map(\.id))
+        #expect(out.metadata.title == probe.metadata.title)
+        #expect(out.metadata.artworkData == probe.metadata.artworkData)
+
+        // TrackInfo fields on the flipped track: everything except isAtmos survives.
+        let before = probe.audioTracks[0]
+        let after = out.audioTracks[0]
+        #expect(after.isAtmos)
+        #expect(after.id == before.id)
+        #expect(after.name == before.name)
+        #expect(after.codec == before.codec)
+        #expect(after.language == before.language)
+        #expect(after.channels == before.channels)
+        #expect(after.bitrate == before.bitrate)
+        #expect(after.isDefault == before.isDefault)
+        #expect(after.isForced == before.isForced)
+        #expect(after.isHearingImpaired == before.isHearingImpaired)
+        #expect(after.isCommentary == before.isCommentary)
+        #expect(after.assHeader == before.assHeader)
+        #expect(after.isExternal == before.isExternal)
+    }
+}

--- a/Tests/AetherEngineTests/AtmosDetectionProbeIntegrationTests.swift
+++ b/Tests/AetherEngineTests/AtmosDetectionProbeIntegrationTests.swift
@@ -1,0 +1,253 @@
+import Testing
+import Foundation
+import Libavformat
+import Libavcodec
+@testable import AetherEngine
+
+/// Fixture-backed tests for the bounded EAC3/JOC decode-detection path (`AetherEngine.detectAtmos` /
+/// `AetherEngine.probeDetectingAtmos`). All media below is synthesized locally (silent, sub-2KB) via the
+/// `ffmpeg` CLI -- none of it is Dolby Atmos/JOC content (no such fixture is created or embedded, per the
+/// task's copyrighted-media constraint). The genuinely-Atmos (`profile == 30`) case is instead covered by
+/// `AtmosDetectionOptionsTests.confirmedAtmosTrueOnJOCProfile`, a pure test over a synthesized
+/// `AtmosDetectionOutcome` -- this is the "test seam around the bounded decode/profile result" the task calls
+/// for in lieu of a real JOC bitstream.
+@Suite("AtmosDetectionProbe: bounded decode against synthesized fixtures")
+struct AtmosDetectionProbeIntegrationTests {
+
+    // MARK: - Fixtures (synthetic silence, non-Atmos, ffmpeg-generated)
+
+    /// 0.1s stereo silence, EAC3 @ 64kbps, plain (non-JOC) -- `ffprobe` reports `profile=unknown` pre-decode,
+    /// matching the exact ambiguity this feature exists to resolve.
+    private static let eac3PlainBase64 = """
+    AAAAIGZ0eXBpc29tAAACAGlzb21kYnkxaXNvMm1wNDEAAAKwbW9vdgAAAGxtdmhkAAAAAAAAAAAA
+    AAAAAAAD6AAAAF8AAQAAAQAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAA
+    AABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAdp0cmFrAAAAXHRraGQAAAADAAAA
+    AAAAAAAAAAABAAAAAAAAAF8AAAAAAAAAAAAAAAEBAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAA
+    AAAAAAAAAABAAAAAAAAAAAAAAAAAAAAkZWR0cwAAABxlbHN0AAAAAAAAAAEAAABeAAABAAABAAAA
+    AAFSbWRpYQAAACBtZGhkAAAAAAAAAAAAAAAAAAC7gAAAEsBVxAAAAAAALWhkbHIAAAAAAAAAAHNv
+    dW4AAAAAAAAAAAAAAABTb3VuZEhhbmRsZXIAAAAA/W1pbmYAAAAQc21oZAAAAAAAAAAAAAAAJGRp
+    bmYAAAAcZHJlZgAAAAAAAAABAAAADHVybCAAAAABAAAAwXN0YmwAAABVc3RzZAAAAAAAAAABAAAA
+    RWVjLTMAAAAAAAAAAQAAAAAAAAAAAAIAEAAAAAC7gAAAAAAADWRlYzMCACAEAAAAABRidHJ0AAAA
+    AAABQAAAAUAAAAAAIHN0dHMAAAAAAAAAAgAAAAMAAAYAAAAAAQAAAMAAAAAcc3RzYwAAAAAAAAAB
+    AAAAAQAAAAQAAAABAAAAFHN0c3oAAAAAAAABAAAAAAQAAAAUc3RjbwAAAAAAAAABAAAC4AAAAGJ1
+    ZHRhAAAAWm1ldGEAAAAAAAAAIWhkbHIAAAAAAAAAAG1kaXJhcHBsAAAAAAAAAAAAAAAALWlsc3QA
+    AAAlqXRvbwAAAB1kYXRhAAAAAQAAAABMYXZmNjIuMTIuMTAyAAAACGZyZWUAAAQIbWRhdAt3AH80
+    h8AAIAAAAEGAAAQEBAEBAQGPnz58+fPnz58+ff86vnz58+fPnz58f86vnz58+fPnz58AAAAAA3z5
+    8+bbbbbbx48ePAAAAA3z58ybbbbbbx48ePAAAAAAb58+fNttttt48ePHgAAAAb58+ZNttttt48eP
+    HgAAAAAN8+fPm222228ePHjwAAAAN8+fMm222228ePHjwAAAAAG+fPnzbbbbbePHjx4AAAAG+fPm
+    TbbbbbePHjx4AAAAADfPnz5tttttvHjx48AAAADfPnzJtttttvHjx48AAAAABvnz58222223jx48
+    eAAAABvnz5k222223jx48eAAAAAAzg4LdwB/NIfAACAAAABBgAAEBAQBAQEBj58+fPnz58+fPn3/
+    Or58+fPnz58+fH/Or58+fPnz58+fAAAAAAN8+fPm222228ePHjwAAAAN8+fMm222228ePHjwAAAA
+    AG+fPnzbbbbbePHjx4AAAAG+fPmTbbbbbePHjx4AAAAADfPnz5tttttvHjx48AAAADfPnzJttttt
+    vHjx48AAAAABvnz58222223jx48eAAAABvnz5k222223jx48eAAAAAA3z58+bbbbbbx48ePAAAAA
+    3z58ybbbbbbx48ePAAAAAAb58+fNttttt48ePHgAAAAb58+ZNttttt48ePHgAAAAAM4OC3cAfzSH
+    wAAgAAAAQYAABAQEAQEBAY+fPnz58+fPnz59/zq+fPnz58+fPnx/zq+fPnz58+fPnwAAAAADfPnz
+    5tttttvHjx48AAAADfPnzJtttttvHjx48AAAAABvnz58222223jx48eAAAABvnz5k222223jx48e
+    AAAAAA3z58+bbbbbbx48ePAAAAA3z58ybbbbbbx48ePAAAAAAb58+fNttttt48ePHgAAAAb58+ZN
+    ttttt48ePHgAAAAAN8+fPm222228ePHjwAAAAN8+fMm222228ePHjwAAAAAG+fPnzbbbbbePHjx4
+    AAAAG+fPmTbbbbbePHjx4AAAAADODgt3AH80h8AAIAAAAEGAAAQEBAEBAQGPnz58+fPnz58+ff86
+    vnz58+fPnz58f86vnz58+fPnz58AAAAAA3z58+bbbbbbx48ePAAAAA3z58ybbbbbbx48ePAAAAAA
+    b58+fNttttt48ePHgAAAAb58+ZNttttt48ePHgAAAAAN8+fPm222228ePHjwAAAAN8+fMm222228
+    ePHjwAAAAAG+fPnzbbbbbePHjx4AAAAG+fPmTbbbbbePHjx4AAAAADfPnz5tttttvHjx48AAAADf
+    PnzJtttttvHjx48AAAAABvnz58222223jx48eAAAABvnz5k222223jx48eAAAAAAzg4=
+    """
+
+    /// 0.5s stereo silence, AAC @ 96kbps -- exercises the `.notEAC3` skip path (no decoder is ever opened).
+    private static let aacBase64 = """
+    AAAAHGZ0eXBpc29tAAACAGlzb21pc28ybXA0MQAAA3Ntb292AAAAbG12aGQAAAAAAAAAAAAAAAAA
+    AAPoAAAB9AABAAABAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAEAA
+    AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAACnXRyYWsAAABcdGtoZAAAAAMAAAAAAAAA
+    AAAAAAEAAAAAAAAB9AAAAAAAAAAAAAAAAQEAAAAAAQAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAA
+    AAAAAEAAAAAAAAAAAAAAAAAAACRlZHRzAAAAHGVsc3QAAAAAAAAAAQAAAfQAAAQAAAEAAAAAAhVt
+    ZGlhAAAAIG1kaGQAAAAAAAAAAAAAAAAAALuAAABhwFXEAAAAAAAtaGRscgAAAAAAAAAAc291bgAA
+    AAAAAAAAAAAAAFNvdW5kSGFuZGxlcgAAAAHAbWluZgAAABBzbWhkAAAAAAAAAAAAAAAkZGluZgAA
+    ABxkcmVmAAAAAAAAAAEAAAAMdXJsIAAAAAEAAAGEc3RibAAAAH5zdHNkAAAAAAAAAAEAAABubXA0
+    YQAAAAAAAAABAAAAAAAAAAAAAgAQAAAAALuAAAAAAAA2ZXNkcwAAAAADgICAJQABAASAgIAXQBUA
+    AAAAAXcAAAAKAgWAgIAFEZBW5QAGgICAAQIAAAAUYnRydAAAAAAAAXcAAAAKAgAAACBzdHRzAAAA
+    AAAAAAIAAAAYAAAEAAAAAAEAAAHAAAAAHHN0c2MAAAAAAAAAAQAAAAEAAAAZAAAAAQAAAHhzdHN6
+    AAAAAAAAAAAAAAAZAAAAFwAAAAYAAAAGAAAABgAAAAYAAAAGAAAABgAAAAYAAAAGAAAABgAAAAYA
+    AAAGAAAABgAAAAYAAAAGAAAABgAAAAYAAAAGAAAABgAAAAYAAAAGAAAABgAAAAYAAAAGAAAABgAA
+    ABRzdGNvAAAAAAAAAAEAAAOfAAAAGnNncGQBAAAAcm9sbAAAAAIAAAAB//8AAAAcc2JncAAAAABy
+    b2xsAAAAAQAAABkAAAABAAAAYnVkdGEAAABabWV0YQAAAAAAAAAhaGRscgAAAAAAAAAAbWRpcmFw
+    cGwAAAAAAAAAAAAAAAAtaWxzdAAAACWpdG9vAAAAHWRhdGEAAAABAAAAAExhdmY2Mi4xMi4xMDIA
+    AAAIZnJlZQAAAK9tZGF03gIATGF2YzYyLjI4LjEwMgBCIAjBGDghEARgjBwhEARgjBwhEARgjBwh
+    EARgjBwhEARgjBwhEARgjBwhEARgjBwhEARgjBwhEARgjBwhEARgjBwhEARgjBwhEARgjBwhEARg
+    jBwhEARgjBwhEARgjBwhEARgjBwhEARgjBwhEARgjBwhEARgjBwhEARgjBwhEARgjBwhEARgjBwh
+    EARgjBwhEARgjBw=
+    """
+
+    /// 0.1s of black video, H.264 16x16, no audio stream at all -- exercises `.noAudioTrack`.
+    private static let videoOnlyBase64 = """
+    AAAAIGZ0eXBpc29tAAACAGlzb21pc28yYXZjMW1wNDEAAANdbW9vdgAAAGxtdmhkAAAAAAAAAAAA
+    AAAAAAAD6AAAAHgAAQAAAQAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAA
+    AABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAod0cmFrAAAAXHRraGQAAAADAAAA
+    AAAAAAAAAAABAAAAAAAAAHgAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAA
+    AAAAAAAAAABAAAAAABAAAAAQAAAAAAAkZWR0cwAAABxlbHN0AAAAAAAAAAEAAAB4AAAEAAABAAAA
+    AAH/bWRpYQAAACBtZGhkAAAAAAAAAAAAAAAAAAAyAAAACABVxAAAAAAALWhkbHIAAAAAAAAAAHZp
+    ZGUAAAAAAAAAAAAAAABWaWRlb0hhbmRsZXIAAAABqm1pbmYAAAAUdm1oZAAAAAEAAAAAAAAAAAAA
+    ACRkaW5mAAAAHGRyZWYAAAAAAAAAAQAAAAx1cmwgAAAAAQAAAWpzdGJsAAAAvnN0c2QAAAAAAAAA
+    AQAAAK5hdmMxAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAABAAEABIAAAASAAAAAAAAAABFUxhdmM2
+    Mi4yOC4xMDIgbGlieDI2NAAAAAAAAAAAAAAAGP//AAAANGF2Y0MBZAAK/+EAF2dkAAqs2V7ARAAA
+    AwAEAAADAMg8SJZYAQAGaOvjyyLA/fj4AAAAABBwYXNwAAAAAQAAAAEAAAAUYnRydAAAAAAAAL7i
+    AAAAAAAAABhzdHRzAAAAAAAAAAEAAAADAAACAAAAABRzdHNzAAAAAAAAAAEAAAABAAAAKGN0dHMA
+    AAAAAAAAAwAAAAEAAAQAAAAAAQAABgAAAAABAAACAAAAABxzdHNjAAAAAAAAAAEAAAABAAAAAwAA
+    AAEAAAAgc3RzegAAAAAAAAAAAAAAAwAAAsUAAAAMAAAADAAAABRzdGNvAAAAAAAAAAEAAAONAAAA
+    YnVkdGEAAABabWV0YQAAAAAAAAAhaGRscgAAAAAAAAAAbWRpcmFwcGwAAAAAAAAAAAAAAAAtaWxz
+    dAAAACWpdG9vAAAAHWRhdGEAAAABAAAAAExhdmY2Mi4xMi4xMDIAAAAIZnJlZQAAAuVtZGF0AAAC
+    rgYF//+q3EXpvebZSLeWLNgg2SPu73gyNjQgLSBjb3JlIDE2NSByMzIyMiBiMzU2MDVhIC0gSC4y
+    NjQvTVBFRy00IEFWQyBjb2RlYyAtIENvcHlsZWZ0IDIwMDMtMjAyNSAtIGh0dHA6Ly93d3cudmlk
+    ZW9sYW4ub3JnL3gyNjQuaHRtbCAtIG9wdGlvbnM6IGNhYmFjPTEgcmVmPTMgZGVibG9jaz0xOjA6
+    MCBhbmFseXNlPTB4MzoweDExMyBtZT1oZXggc3VibWU9NyBwc3k9MSBwc3lfcmQ9MS4wMDowLjAw
+    IG1peGVkX3JlZj0xIG1lX3JhbmdlPTE2IGNocm9tYV9tZT0xIHRyZWxsaXM9MSA4eDhkY3Q9MSBj
+    cW09MCBkZWFkem9uZT0yMSwxMSBmYXN0X3Bza2lwPTEgY2hyb21hX3FwX29mZnNldD0tMiB0aHJl
+    YWRzPTEgbG9va2FoZWFkX3RocmVhZHM9MSBzbGljZWRfdGhyZWFkcz0wIG5yPTAgZGVjaW1hdGU9
+    MSBpbnRlcmxhY2VkPTAgYmx1cmF5X2NvbXBhdD0wIGNvbnN0cmFpbmVkX2ludHJhPTAgYmZyYW1l
+    cz0zIGJfcHlyYW1pZD0yIGJfYWRhcHQ9MSBiX2JpYXM9MCBkaXJlY3Q9MSB3ZWlnaHRiPTEgb3Bl
+    bl9nb3A9MCB3ZWlnaHRwPTIga2V5aW50PTI1MCBrZXlpbnRfbWluPTI1IHNjZW5lY3V0PTQwIGlu
+    dHJhX3JlZnJlc2g9MCByY19sb29rYWhlYWQ9NDAgcmM9Y3JmIG1idHJlZT0xIGNyZj0yMy4wIHFj
+    b21wPTAuNjAgcXBtaW49MCBxcG1heD02OSBxcHN0ZXA9NCBpcF9yYXRpbz0xLjQwIGFxPTE6MS4w
+    MACAAAAAD2WIhAAz//727L4FNhTIwQAAAAhBmiJsQr/+wAAAAAgBnkF5Cv/EgQ==
+    """
+
+    private static func data(_ base64: String) -> Data {
+        guard let d = Data(base64Encoded: base64, options: .ignoreUnknownCharacters) else {
+            Issue.record("failed to decode embedded base64 fixture")
+            return Data()
+        }
+        return d
+    }
+
+    // MARK: - detectAtmos internal seam, exercised end-to-end against real (non-Atmos) media
+
+    @Test("plain EAC3 decodes a frame but is never confirmed Atmos (profile != 30)")
+    func plainEAC3DecodesButIsNotAtmos() throws {
+        let demuxer = Demuxer()
+        defer { demuxer.close() }
+        try demuxer.open(reader: DataIOReader(data: Self.data(Self.eac3PlainBase64)), formatHint: "mp4")
+
+        let targetIndex = AetherEngine.atmosDecodeTargetIndex(
+            options: AtmosDetectionOptions(), defaultAudioStreamIndex: demuxer.audioStreamIndex)
+        #expect(targetIndex >= 0, "fixture has an audio stream")
+
+        let outcome = AetherEngine.detectAtmos(demuxer: demuxer, targetIndex: targetIndex, options: AtmosDetectionOptions())
+        #expect(outcome.stopReason == .frameDecoded)
+        #expect(outcome.decodedProfile != 30)
+        #expect(outcome.confirmedAtmos == false)
+    }
+
+    @Test("AAC audio never opens an EAC3 decoder (.notEAC3), never confirmed Atmos")
+    func aacIsSkippedAsNotEAC3() throws {
+        let demuxer = Demuxer()
+        defer { demuxer.close() }
+        try demuxer.open(reader: DataIOReader(data: Self.data(Self.aacBase64)), formatHint: "mp4")
+
+        let targetIndex = AetherEngine.atmosDecodeTargetIndex(
+            options: AtmosDetectionOptions(), defaultAudioStreamIndex: demuxer.audioStreamIndex)
+        #expect(targetIndex >= 0, "fixture has an audio stream")
+
+        let outcome = AetherEngine.detectAtmos(demuxer: demuxer, targetIndex: targetIndex, options: AtmosDetectionOptions())
+        #expect(outcome.stopReason == .notEAC3)
+        #expect(outcome.packetsRead == 0, "no packets are read once the codec is known not to be EAC3")
+        #expect(outcome.confirmedAtmos == false)
+    }
+
+    @Test("a video-only source (no audio stream) reports .noAudioTrack, never confirmed Atmos")
+    func videoOnlySourceReportsNoAudioTrack() throws {
+        let demuxer = Demuxer()
+        defer { demuxer.close() }
+        try demuxer.open(reader: DataIOReader(data: Self.data(Self.videoOnlyBase64)), formatHint: "mp4")
+        #expect(demuxer.audioStreamIndex == -1, "fixture has no audio stream")
+
+        let targetIndex = AetherEngine.atmosDecodeTargetIndex(
+            options: AtmosDetectionOptions(), defaultAudioStreamIndex: demuxer.audioStreamIndex)
+        let outcome = AetherEngine.detectAtmos(demuxer: demuxer, targetIndex: targetIndex, options: AtmosDetectionOptions())
+        #expect(outcome.stopReason == .noAudioTrack)
+        #expect(outcome.confirmedAtmos == false)
+    }
+
+    @Test("an out-of-range explicit targetTrackID reports .noAudioTrack rather than crashing")
+    func outOfRangeExplicitTargetIsTolerated() throws {
+        let demuxer = Demuxer()
+        defer { demuxer.close() }
+        try demuxer.open(reader: DataIOReader(data: Self.data(Self.eac3PlainBase64)), formatHint: "mp4")
+
+        let outcome = AetherEngine.detectAtmos(
+            demuxer: demuxer, targetIndex: 99, options: AtmosDetectionOptions(targetTrackID: 99))
+        #expect(outcome.stopReason == .noAudioTrack)
+        #expect(outcome.confirmedAtmos == false)
+    }
+
+    @Test("a packet cap of 0 stops before any packet is read, never confirmed Atmos")
+    func zeroPacketCapStopsImmediately() throws {
+        let demuxer = Demuxer()
+        defer { demuxer.close() }
+        try demuxer.open(reader: DataIOReader(data: Self.data(Self.eac3PlainBase64)), formatHint: "mp4")
+
+        let options = AtmosDetectionOptions(maxPackets: 0)
+        let targetIndex = AetherEngine.atmosDecodeTargetIndex(options: options, defaultAudioStreamIndex: demuxer.audioStreamIndex)
+        let outcome = AetherEngine.detectAtmos(demuxer: demuxer, targetIndex: targetIndex, options: options)
+        #expect(outcome.stopReason == .packetCap)
+        #expect(outcome.packetsRead == 0)
+        #expect(outcome.confirmedAtmos == false)
+    }
+
+    // MARK: - Public API: probeDetectingAtmos wiring + default-probe compatibility
+
+    @Test("probeDetectingAtmos(source:) on plain EAC3 matches probe(source:) exactly (isAtmos stays false)")
+    func probeDetectingAtmosMatchesBaseProbeWhenNotConfirmed() throws {
+        let bytes = Self.data(Self.eac3PlainBase64)
+
+        let base = try AetherEngine.probe(source: .custom(DataIOReader(data: bytes), formatHint: "mp4"))
+        let enriched = try AetherEngine.probeDetectingAtmos(source: .custom(DataIOReader(data: bytes), formatHint: "mp4"))
+
+        #expect(base.audioTracks.count == enriched.audioTracks.count)
+        #expect(base.audioTracks.map(\.isAtmos) == enriched.audioTracks.map(\.isAtmos))
+        #expect(enriched.audioTracks.allSatisfy { $0.isAtmos == false })
+        #expect(base.videoCodecID == enriched.videoCodecID)
+        #expect(base.durationSeconds == enriched.durationSeconds)
+    }
+
+    @Test("probeDetectingAtmos(source:) on AAC-only media matches probe(source:) exactly")
+    func probeDetectingAtmosMatchesBaseProbeForNonEAC3() throws {
+        let bytes = Self.data(Self.aacBase64)
+
+        let base = try AetherEngine.probe(source: .custom(DataIOReader(data: bytes), formatHint: "mp4"))
+        let enriched = try AetherEngine.probeDetectingAtmos(source: .custom(DataIOReader(data: bytes), formatHint: "mp4"))
+
+        #expect(base.audioTracks.map(\.codec) == enriched.audioTracks.map(\.codec))
+        #expect(enriched.audioTracks.allSatisfy { $0.isAtmos == false })
+    }
+
+    @Test("probeDetectingAtmos(source:) on a video-only source does not throw and leaves audioTracks empty")
+    func probeDetectingAtmosToleratesNoAudioTrack() throws {
+        let bytes = Self.data(Self.videoOnlyBase64)
+        let enriched = try AetherEngine.probeDetectingAtmos(source: .custom(DataIOReader(data: bytes), formatHint: "mp4"))
+        #expect(enriched.audioTracks.isEmpty)
+    }
+
+    @Test("a malformed (non-media) source throws identically from probe(source:) and probeDetectingAtmos(source:)")
+    func malformedSourceThrowsLikeBaseProbe() {
+        let garbage = Data((0..<256).map { UInt8($0 % 256) })
+
+        var baseThrew = false
+        var enrichedThrew = false
+        do { _ = try AetherEngine.probe(source: .custom(DataIOReader(data: garbage), formatHint: nil)) }
+        catch { baseThrew = true }
+        do { _ = try AetherEngine.probeDetectingAtmos(source: .custom(DataIOReader(data: garbage), formatHint: nil)) }
+        catch { enrichedThrew = true }
+
+        #expect(baseThrew == true)
+        #expect(enrichedThrew == true)
+    }
+
+    @Test("probeDetectingAtmos(source:) never opens a decoder budget beyond what atmosDetection specifies (0-packet cap is honored end-to-end)")
+    func probeDetectingAtmosHonorsExplicitZeroPacketCap() throws {
+        let bytes = Self.data(Self.eac3PlainBase64)
+        let enriched = try AetherEngine.probeDetectingAtmos(
+            source: .custom(DataIOReader(data: bytes), formatHint: "mp4"),
+            atmosDetection: AtmosDetectionOptions(maxPackets: 0)
+        )
+        // A 0-packet cap can never decode a frame, so isAtmos must stay exactly as the base probe left it (false).
+        #expect(enriched.audioTracks.allSatisfy { $0.isAtmos == false })
+    }
+}


### PR DESCRIPTION
## Summary

Adds an opt-in `probeDetectingAtmos(url:/source:)` that can authoritatively answer "is this E-AC-3 track Atmos (JOC)?", which the existing demux-only `probe()` cannot. Useful for hosts that want to badge Dolby Atmos on a details screen.

## What changed

- New `probeDetectingAtmos(url:)` / `probeDetectingAtmos(source:)`. FFmpeg only sets `AVCodecContext.profile == AV_PROFILE_EAC3_DDP_ATMOS` (30) *after* a frame is decoded, and `probe()` runs `avformat_find_stream_info` with no decoders, so JOC is invisible to it. The new path opens the EAC3 decoder and decodes the minimum packets needed to read the authoritative post-decode profile.
- `probe(url:)` / `probe(source:)` are **completely unmodified** — this is a separate entry point, not a flag on the default probe.
- Bounded by `AtmosDetectionOptions`: 64 packets / 8 MiB / 2 s wall clock by default. No video decode, no HLS server, no playback session.
- Non-target streams are set to `AVDISCARD_ALL` for the pass, and the budget is charged only for packets actually handed to the decoder, so the caps bound the *audio* rather than the interleaved container. Without this, a UHD remux's multi-MB video packets exhaust the byte cap before any audio arrives and a genuinely Atmos track reports as not-Atmos. A separate fuse bounds demuxers that ignore `AVDISCARD_ALL`.
- Degrades instead of throwing: no audio track, non-EAC3, decoder that will not open, demux error, or any cap hit all return "not confirmed".
- Enrichment is additive only — it flips exactly the confirmed track's `isAtmos` from `false` to `true`, and never overwrites an existing `true`.

## Test plan

- **Device / OS:** Apple TV 4K (3rd generation, AppleTV14,1), tvOS 27.0. Also `swift build` / `swift test` on macOS.
- **Source media (container / video codec + profile / audio / HDR-DV):** MKV, HEVC Dolby Vision Profile 7, E-AC-3 JOC (Atmos), streamed over SMB; plus synthesized single-stream EAC3 and malformed / no-audio fixtures in the test suite.
- **Result:** JOC tracks are confirmed and badge correctly. Non-Atmos E-AC-3, AC-3, and no-audio sources return "not confirmed" without throwing. Playback is unaffected — the probe opens no HLS server and no playback session. Full suite green: 31 tests across the two new Atmos suites, 1004 in the repo suite. Also verified the caps hold on a large remux where the earlier whole-container accounting produced a false negative.

## Checklist

- [x] `CHANGELOG.md` updated
- [x] Commit messages follow Conventional Commits (`feat(...)`, `fix(...)`, `chore(...)`)
- [x] The fix lives in the engine, not in a host-side workaround
- [x] Public API changes are intentional and documented
