### PR TITLE
feat(audio): optionally deactivate AVAudioSession on final teardown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ the public-API contract.
 
 ## [Unreleased]
 
+### Added
+
+- **`AetherEngine.deactivatesAudioSessionOnStop` (default `false`): optionally release the shared `AVAudioSession` on final teardown.** On an E-AC-3 / Atmos BITSTREAM PASSTHROUGH route the HDMI sink keeps its own decode ring, and while the session stays active it can keep looping the last MAT frame after the player is released — audio stutters on after leaving playback, and persists even off-screen. Opting in deactivates the session (with `.notifyOthersOnDeactivation`) once playback is torn down for good, which closes that ring. It is off by default because the native path deliberately never *activates* the session (AVKit does, per playback, #24), so deactivating one the host app owns must be the host's decision — an app playing its own audio (UI sounds, TTS, `AVAudioEngine`, a background music player) would otherwise have its session torn out from under it. Only a genuine final teardown honours it: `stop(resetDisplayCriteria: true)`, never a native→native reload, a native→audio/software handoff, or a live retune. `stop(resetDisplayCriteria:finalTeardown:)` lets a host that keeps display criteria across a stop/load pair still declare a genuine final teardown. An `AVAudioSessionErrorCodeIsBusy` result is logged as the informational diagnostic it is, not retried: per `AVAudioSession.h` the session is deactivated regardless and the code only flags that I/O was still running (and iOS/tvOS 26 stopped returning it altogether).
+
 ## [5.22.0] - 2026-07-25
 
 ([release notes](https://github.com/superuser404notfound/AetherEngine/releases/tag/5.22.0))

--- a/Sources/AetherEngine/AetherEngine.swift
+++ b/Sources/AetherEngine/AetherEngine.swift
@@ -147,6 +147,21 @@ public final class AetherEngine: ObservableObject {
     /// Forwarder; for push updates subscribe to `clock.$currentTime` (objectWillChange does NOT fire on ticks).
     public var currentTime: Double { clock.currentTime }
 
+    /// Deactivate the shared `AVAudioSession` when playback is torn down for good. Default `false`.
+    ///
+    /// Opt in only if your app owns the audio session. On an E-AC-3/Atmos BITSTREAM PASSTHROUGH route the
+    /// HDMI sink keeps its own decode ring, and with the session still active it can loop the last MAT
+    /// frame after the player is released (audio keeps stuttering after leaving the video, even off-screen).
+    /// Deactivating on final teardown closes that ring.
+    ///
+    /// It is off by default because the native path deliberately never *activates* the session -- AVKit
+    /// does that per playback (#24) -- so switching this on makes the engine mutate process-global state it
+    /// did not create, using `.notifyOthersOnDeactivation`. An app that plays its own audio (UI sounds, TTS,
+    /// an `AVAudioEngine`, a background music player) would have its session torn out from under it. Only
+    /// a genuine final teardown honours this: `stop()` (with `resetDisplayCriteria: true`), never a
+    /// handoff, reload, or retune.
+    public var deactivatesAudioSessionOnStop: Bool = false
+
     @Published public internal(set) var duration: Double = 0
 
     /// Forwarder; see `clock.progress`.
@@ -2920,8 +2935,15 @@ public final class AetherEngine: ObservableObject {
     ///   through SDR (#128). The caller owns the follow-up; if no load() happens after all, the app UI
     ///   stays in the playback mode until a plain stop() clears it. Note that back-to-back load() calls
     ///   preserve the criteria on their own; the flag only matters when stop() is called between items.
-    public func stop(resetDisplayCriteria: Bool = true) {
-        stopInternal(resetDisplayCriteria: resetDisplayCriteria)
+    ///
+    /// - Parameter finalTeardown: whether this stop means "leaving playback entirely" rather than handing
+    ///   off to another `load()`. Defaults to `resetDisplayCriteria`, which is the right answer for almost
+    ///   every caller, but the two are separable: a host that keeps display criteria across a stop/load
+    ///   pair (`resetDisplayCriteria: false`) and *is* genuinely leaving playback can pass
+    ///   `finalTeardown: true`. Only a final teardown honours `deactivatesAudioSessionOnStop`.
+    public func stop(resetDisplayCriteria: Bool = true, finalTeardown: Bool? = nil) {
+        stopInternal(resetDisplayCriteria: resetDisplayCriteria,
+                     finalTeardown: finalTeardown ?? resetDisplayCriteria)
         state = .idle
         clock.currentTime = 0
         clock.bufferedPosition = 0
@@ -3250,7 +3272,7 @@ public final class AetherEngine: ObservableObject {
     ///   never settles and burns the full settle timeout (~12 s of
     ///   black-screen latency per audio switch on the old fixed 5 s
     ///   poll; capped at ~2 s since #117, but still worth skipping).
-    func stopInternal(resetDisplayCriteria: Bool = true, keepNativeHost: Bool = false, keepCustomReader: Bool = false, keepCurrentItem: Bool = false) {
+    func stopInternal(resetDisplayCriteria: Bool = true, keepNativeHost: Bool = false, keepCustomReader: Bool = false, keepCurrentItem: Bool = false, finalTeardown: Bool = false) {
         // Bump generation to invalidate in-flight load() checkpoints.
         loadGeneration &+= 1
         resumeAfterInterruption = false
@@ -3279,8 +3301,17 @@ public final class AetherEngine: ObservableObject {
         // AE#158: keepCurrentItem defers the item detach to the next host.load(inPlaceSwap:) so a
         // system PiP window never sees a nil-item gap across a native->native load. Only meaningful
         // together with keepNativeHost; load() computes it via shouldHandOverItemInPlace.
+        //
+        // The AVAudioSession deactivation is opt-in twice over: the caller must declare an actual
+        // final teardown (`finalTeardown`), AND the host app must have opted into the policy
+        // (`deactivatesAudioSessionOnStop`, default false). `!keepNativeHost` is NOT a usable proxy for
+        // "leaving playback" -- it defaults to false, so every bare `stopInternal()` (e.g. the live-reload
+        // watchdog, which expects the host to retune immediately) would deactivate a process-wide session
+        // mid-retune. And since the native path deliberately never ACTIVATES the session (#24, AVKit does
+        // it per playback), deactivating one the host app owns is only safe when the host says so.
         if !keepCurrentItem {
-            nativeHost?.tearDown()
+            nativeHost?.tearDown(
+                deactivateAudioSession: finalTeardown && !keepNativeHost && deactivatesAudioSessionOnStop)
         }
         if !keepNativeHost {
             nativeHost = nil

--- a/Sources/AetherEngine/Native/NativeAVPlayerHost.swift
+++ b/Sources/AetherEngine/Native/NativeAVPlayerHost.swift
@@ -503,8 +503,16 @@ final class NativeAVPlayerHost {
         }
     }
 
-    func tearDown() {
-        unloadCurrentItem()
+    /// - Parameter deactivateAudioSession: on a TRUE final teardown (leaving playback entirely, not a
+    ///   native->native / native->audio / native->software handoff where audio keeps playing) release the
+    ///   AVAudioSession after the item is unloaded. The native path never explicitly activates the session
+    ///   (issue #24: AVKit / implicit activation drives per-playback HDMI route negotiation), so it also never
+    ///   deactivated it -- which strands an EAC3/JOC Atmos bitstream-passthrough render ring on the HDMI sink:
+    ///   releasing the AVPlayer without deactivating leaves the receiver looping the last MAT frame ("audio
+    ///   stutters/loops after leaving the video"). Deactivation is the counterpart to that implicit activation
+    ///   and only fires on final teardown so handoffs/reloads (which must keep audio alive) are untouched.
+    func tearDown(deactivateAudioSession: Bool = false) {
+        unloadCurrentItem(deactivateAudioSession: deactivateAudioSession)
     }
 
     // MARK: - Failure handling
@@ -792,7 +800,7 @@ final class NativeAVPlayerHost {
 
     // MARK: - Internal
 
-    private func unloadCurrentItem(inPlaceSwap: Bool = false) {
+    private func unloadCurrentItem(inPlaceSwap: Bool = false, deactivateAudioSession: Bool = false) {
         if let to = timeObserver {
             avPlayer.removeTimeObserver(to)
             timeObserver = nil
@@ -845,6 +853,43 @@ final class NativeAVPlayerHost {
         renderedTime = 0
         duration = 0
         rate = 0
+        // Final teardown only: release the AVAudioSession now that the item is unloaded and the player paused.
+        // pause() + replaceCurrentItem(nil) flush AVPlayer's own render pipeline, but on an EAC3/JOC Atmos
+        // BITSTREAM PASSTHROUGH route the HDMI sink keeps its own decode ring and, with the session still
+        // active, loops the last MAT frame after the player is released (Brandon: audio stutters/loops after
+        // pressing Back to leave the video, persists off-screen). Deactivating is the counterpart to the
+        // native path's implicit/AVKit per-playback activation (issue #24) and closes that ring. Gated to true
+        // teardown so native->native / native->audio / native->software handoffs and #93 reloads -- which must
+        // keep audio alive -- never hit it. Best-effort + .notifyOthersOnDeactivation so other audio resumes.
+        #if os(iOS) || os(tvOS)
+        if deactivateAudioSession {
+            do {
+                try AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+                EngineLog.emit(
+                    "[NativeAVPlayerHost] #\(sessionID) deactivated AVAudioSession on final teardown "
+                    + "(release passthrough render ring)",
+                    category: .engine)
+            } catch {
+                // `.isBusy` is NOT a failure and must not be retried. Per AVAudioSession.h: since iOS 8,
+                // deactivating with running I/O still DEACTIVATES the session and returns this code purely
+                // "to indicate the misuse of the API" -- and since iOS/tvOS 26 it is not returned at all.
+                // The ring is released either way; the only actionable part is that we were asked to
+                // deactivate before AVPlayer finished releasing its I/O.
+                let nsError = error as NSError
+                if nsError.code == AVAudioSession.ErrorCode.isBusy.rawValue {
+                    EngineLog.emit(
+                        "[NativeAVPlayerHost] #\(sessionID) deactivated AVAudioSession on final teardown "
+                        + "(session released; I/O was still running)",
+                        category: .engine)
+                } else {
+                    EngineLog.emit(
+                        "[NativeAVPlayerHost] #\(sessionID) AVAudioSession deactivate on teardown failed: "
+                        + "\(error) (passthrough ring may keep looping)",
+                        category: .engine)
+                }
+            }
+        }
+        #endif
     }
 
     /// Dump asset URL + track FourCCs on .failed and asset.load failure; d9b8aa5 added the asset.load path because item.status never went .failed in DrHurt's P5 MKV session.


### PR DESCRIPTION
## Summary

Adds an opt-in `deactivatesAudioSessionOnStop` so hosts that own their audio session can have the engine release the shared `AVAudioSession` on final teardown. Without it, an E-AC-3 / Atmos bitstream-passthrough route can keep looping audio on the HDMI sink after playback ends.

## What changed

- New public `AetherEngine.deactivatesAudioSessionOnStop`, **default `false`**. When enabled, a genuine final teardown calls `setActive(false, options: .notifyOthersOnDeactivation)` after the item is unloaded.
- **Why it exists:** on an E-AC-3 / Atmos bitstream-passthrough route the HDMI sink keeps its own decode ring. With the session still active, that ring can keep looping the last MAT frame after the `AVPlayer` is released — audio stutters on after leaving playback and persists even with the app off-screen.
- **Why it is off by default:** the native path deliberately never *activates* the session (AVKit does, per playback, #24). Deactivating one the host app owns therefore has to be the host's decision — an app that plays its own audio (UI sounds, TTS, `AVAudioEngine`, a background music player) would otherwise have its session torn out from under it when engine playback ends.
- **Teardown intent is now explicit rather than inferred.** `!keepNativeHost` is not a usable proxy for "leaving playback": it defaults to `false`, so every bare `stopInternal()` — including the live-reload watchdog, which expects the host to retune immediately — would deactivate a process-wide session mid-cycle. `stopInternal()` now takes `finalTeardown`, set only by `stop(resetDisplayCriteria: true)`. Native→native reloads, native→audio/software handoffs, and live retunes are all excluded.
- **`AVAudioSessionErrorCodeIsBusy` is logged, not retried.** Per `AVAudioSession.h`, since iOS 8 deactivating with running I/O *still deactivates the session* and returns that code only "to indicate the misuse of the API" — and since iOS/tvOS 26 it is not returned at all. So it is surfaced as the informational diagnostic it is. (An earlier revision of this PR retried it; that was wrong on the platform behaviour, and a retry landing after a subsequent `load()` could have deactivated the *new* session.)
- **`stop(resetDisplayCriteria:finalTeardown:)`** lets a host that keeps display criteria across a stop/load pair still declare a genuine teardown, so the opt-in isn't silently inert for that (documented, correct) calling pattern. `finalTeardown` defaults to `resetDisplayCriteria`, so existing callers are unchanged.

## Test plan

- **Device / OS:** Apple TV 4K (3rd generation, AppleTV14,1), tvOS 27.0.
- **Source media (container / video codec + profile / audio / HDR-DV):** MKV, HEVC Dolby Vision Profile 7, E-AC-3 JOC (Atmos) with bitstream passthrough to an HDMI AVR, streamed over SMB.
- **Result:** With the flag enabled, leaving playback no longer leaves the receiver looping the last MAT frame; audio stops cleanly and stays stopped off-screen. With the flag at its default `false`, behaviour is byte-for-byte unchanged. Verified the excluded paths keep audio alive: a same-display-mode next-episode handoff (`stop(resetDisplayCriteria: false)`) no longer deactivates mid-transition, and native→audio / native→software handoffs are untouched. Rebased onto 5.22.0; full suite green (1050 tests) plus iOS/tvOS simulator builds.

## Checklist

- [x] `CHANGELOG.md` updated
- [x] Commit messages follow Conventional Commits (`feat(...)`, `fix(...)`, `chore(...)`)
- [x] The fix lives in the engine, not in a host-side workaround
- [x] Public API changes are intentional and documented
