### PR TITLE
fix(video): anchor the buffer frontier at the consumer fetch target

### DIFF
--- a/Sources/AetherEngine/AetherEngine+Loading.swift
+++ b/Sources/AetherEngine/AetherEngine+Loading.swift
@@ -816,13 +816,15 @@ extension AetherEngine {
                 // #65: mirror AVPlayer's rendered (playlist-axis) position for off-main wedge re-anchoring.
                 self.renderedPositionMirror.set(value)
                 self.clock.sourceTime = value + shift
-                // bufferedPosition = the disk SegmentCache read-ahead frontier (origin -> disk), which is
-                // what the Network Buffer setting controls, expressed on the display axis as the playhead
-                // plus the seconds of contiguously cached-ahead content. Replaces AVPlayer's shallow ~4 s
+                // bufferedPosition = the end of the contiguous safe range (origin -> disk), expressed on
+                // the display axis as the playhead plus contiguously available seconds ahead of it: the
+                // segments AVPlayer already fetched, plus the disk SegmentCache band above them, which is
+                // what the Network Buffer setting controls. Replaces AVPlayer's shallow ~4 s
                 // loadedTimeRanges end (pinned by preferredForwardBufferDuration), which did not move with
                 // the setting. readAhead >= 0 keeps the #54 contract that bufferedPosition never trails the
                 // rendered frame. Drawn against the 0-based duration, so map onto the display axis to keep
-                // the buffer bar aligned with currentTime (0 off disc). AE#105. See docs issue #33 follow-up.
+                // the buffer bar aligned with currentTime (0 off disc). AE#105, #207 follow-up.
+                // See docs issue #33 follow-up.
                 let renderedDisplay = PresentationAxis.display(
                     sourcePTS: value + shift, origin: self.sourcePresentationOrigin)
                 let readAhead = self.nativeVideoSession?

--- a/Sources/AetherEngine/PlaybackClock.swift
+++ b/Sources/AetherEngine/PlaybackClock.swift
@@ -26,9 +26,13 @@ public final class PlaybackClock: ObservableObject {
     /// Seconds behind the live edge. 0 at the edge.
     @Published public internal(set) var behindLiveSeconds: Double = 0
 
-    /// Source-axis buffer frontier (AetherEngine#54). Same axis as `sourceTime`; draw as `bufferedPosition / duration`. Clamped to never trail the rendered frame.
+    /// Source-axis buffer frontier (AetherEngine#54): the end of the contiguous *safe* range ahead of the
+    /// playhead, i.e. what is guaranteed available without another fetch. Same axis as `sourceTime`; draw
+    /// as `bufferedPosition / duration`. Clamped to never trail the rendered frame.
     ///
-    /// - Native: end of the contiguous `loadedTimeRanges` span, seam-shifted.
+    /// - Native: what AVPlayer already holds, plus the contiguous disk SegmentCache band above it (#105,
+    ///   #207 follow-up). Grows with the Network Buffer setting, unlike AVPlayer's `loadedTimeRanges`
+    ///   alone, which stays pinned by `preferredForwardBufferDuration`.
     /// - Software: newest demuxed source PTS.
     /// - Audio: mirrors `currentTime` (no buffer-ahead surface).
     @Published public internal(set) var bufferedPosition: Double = 0

--- a/Sources/AetherEngine/Video/HLSVideoEngine.swift
+++ b/Sources/AetherEngine/Video/HLSVideoEngine.swift
@@ -1524,17 +1524,28 @@ public final class HLSVideoEngine: @unchecked Sendable {
     /// On-disk segment bytes (freshly stat-ed). Used by `aetherctl live --report-cache-bytes`.
     var segmentCacheDiskBytes: Int64 { subsystemSnapshot().cache?.diskBytes() ?? 0 }
 
-    /// Seconds of contiguously cached content ahead of the playhead on the media-playlist axis.
-    /// Reflects the disk SegmentCache read-ahead (what the Network Buffer setting controls), NOT
-    /// AVPlayer's shallow forward buffer. Returns 0 when nothing is cached ahead or the plan is empty.
+    /// Seconds of contiguous *safe* content ahead of the playhead on the media-playlist axis: what the
+    /// consumer already holds, plus what sits contiguously above it in the disk SegmentCache (which is
+    /// what the Network Buffer setting controls). Returns 0 when nothing is cached ahead or the plan is
+    /// empty.
+    ///
+    /// The frontier walk is anchored at `max(playhead, consumer fetch target)`, see
+    /// `SegmentCache.contiguousForwardFrontier(fromPlayhead:)`: the cache retains from
+    /// `fetchTarget - backwardWindow` upward, so under an opt-in whole-source prefetch the playhead's own
+    /// segment is evicted and a playhead-anchored walk collapsed to 0 while the whole band was resident
+    /// (#207 follow-up). A frontier below the playhead still reports 0, which keeps the #54 contract that
+    /// the frontier never trails the rendered frame.
+    ///
     /// segmentIndexForPlaylistTime and the plan read each take restartLock briefly and sequentially
     /// (no nesting); a plan rebuilt between them at worst yields one transiently wrong tick, acceptable
-    /// for a visual bar.
+    /// for a visual bar. One residual of the same kind: between a backward seek and the consumer's first
+    /// fetch at the new position the target is still the old one, so a tick or two can report the stale
+    /// band before `declareTarget` lands.
     func contiguousForwardReadAheadSeconds(playlistSeconds: Double) -> Double {
         guard let cache = subsystemSnapshot().cache else { return 0 }
-        let targetIdx = segmentIndexForPlaylistTime(playlistSeconds)
-        let frontier = cache.contiguousForwardFrontier(from: targetIdx)
-        guard frontier >= targetIdx else { return 0 }
+        let playheadIdx = segmentIndexForPlaylistTime(playlistSeconds)
+        let frontier = cache.contiguousForwardFrontier(fromPlayhead: playheadIdx)
+        guard frontier >= playheadIdx else { return 0 }
         restartLock.lock()
         defer { restartLock.unlock() }
         guard frontier >= 0, frontier < segmentPlan.count else { return 0 }

--- a/Sources/AetherEngine/Video/SegmentCache.swift
+++ b/Sources/AetherEngine/Video/SegmentCache.swift
@@ -340,13 +340,43 @@ final class SegmentCache: @unchecked Sendable {
         return _highestStoredIndex
     }
 
-    /// Largest K such that every index in [targetIdx ... K] is resident, walking forward from the
-    /// playhead until the first gap. Returns targetIdx - 1 when targetIdx itself is absent (nothing
-    /// cached ahead). Used to express the disk read-ahead frontier as a segment index. Thread-safe.
-    func contiguousForwardFrontier(from targetIdx: Int) -> Int {
+    /// Largest K such that every index in [startIdx ... K] is resident, walking forward until the first
+    /// gap. Returns startIdx - 1 when startIdx itself is absent (nothing cached from there). Used to
+    /// express the disk read-ahead frontier as a segment index. Thread-safe.
+    func contiguousForwardFrontier(from startIdx: Int) -> Int {
         condition.lock()
         defer { condition.unlock() }
-        var k = targetIdx
+        return frontierLocked(from: startIdx)
+    }
+
+    /// Frontier of the contiguous *safe* range for a playhead at `playheadIdx`, anchored at
+    /// `max(playheadIdx, currentTargetIndex)` (#207 follow-up).
+    ///
+    /// Walking from the playhead alone under-reports whenever the consumer's fetch target runs ahead of
+    /// it: `pruneOutsideWindow` retains from `currentTargetIndex - backwardWindow` upward, so the
+    /// playhead's own segment is an evictable extra, and an opt-in whole-source prefetch (which is the
+    /// only case that reaches the retention budget) really does evict it. The walk then starts on a hole
+    /// and reports nothing ahead while the whole band is resident.
+    ///
+    /// Anchoring on the fetch target is safe rather than merely optimistic: `declareTarget` is only ever
+    /// called from the segment-serve path, so everything below `currentTargetIndex` has been handed to
+    /// the consumer and sits in its own buffer. Skipping the leading hole *without* that bound would
+    /// instead land on a stale band above a backward seek (nothing forces its eviction while the budget
+    /// has room) and report it as buffered, which fails in the dangerous direction; anchoring at the new
+    /// target stops the walk at the hole above the freshly produced segments. `max` keeps a backward
+    /// refetch behind the playhead (Continuous-Audio handover) from dragging the anchor back.
+    ///
+    /// Anchor and walk share one lock hold: reading `targetIndex` separately would let a target change
+    /// land between the two and walk from an anchor that does not match the entries observed.
+    func contiguousForwardFrontier(fromPlayhead playheadIdx: Int) -> Int {
+        condition.lock()
+        defer { condition.unlock() }
+        return frontierLocked(from: max(playheadIdx, currentTargetIndex))
+    }
+
+    /// Must be called with condition held.
+    private func frontierLocked(from startIdx: Int) -> Int {
+        var k = startIdx
         while entries[k] != nil { k += 1 }
         return k - 1
     }

--- a/Tests/AetherEngineTests/Issue207FrontierAnchorTests.swift
+++ b/Tests/AetherEngineTests/Issue207FrontierAnchorTests.swift
@@ -1,0 +1,99 @@
+import Foundation
+import Testing
+@testable import AetherEngine
+
+/// AetherEngine#207 follow-up: the reported buffer frontier collapsed to the playhead once an opt-in
+/// whole-source prefetch reached its retention budget. The frontier walk anchored on the playhead's
+/// segment while `pruneOutsideWindow` anchors on the consumer's fetch target (`lo = target - backwardWindow`),
+/// so the playhead's own segment is evictable and really was evicted, leaving the walk to start on a hole
+/// every tick. Anchoring the walk at `max(playhead, consumerTarget)` reports the end of the contiguous
+/// safe range instead: everything below the fetch target is by definition already in the consumer's buffer.
+@Suite("Issue #207 buffer frontier anchor")
+struct Issue207FrontierAnchorTests {
+
+    private func makeData(_ n: Int, fill: UInt8 = 0xAA) -> Data { Data(repeating: fill, count: n) }
+
+    /// Reproduces the field report: window past the budget, fetch target ~30 segments ahead of the
+    /// playhead, so the playhead's segment falls below `lo` and is evicted as an extra.
+    private func makeOptInPrefetchCache() -> SegmentCache {
+        // forwardWindow = opt-in whole-source; the kept window alone (31 x 10 B) exceeds the budget,
+        // which is exactly the #207 condition that makes the extras eviction run at all.
+        let c = SegmentCache(forwardWindow: 2700, backwardWindow: 20, retentionBudgetBytes: 100)
+        for i in 0...40 { c.store(index: i, data: makeData(10)) }
+        c.declareTarget(30)   // AVPlayer's fetch target runs ahead of the playhead (~120 s)
+        return c
+    }
+
+    @Test("Extras eviction really does drop the playhead's own segment (the #207 precondition)")
+    func playheadSegmentIsEvictedUnderOptInPrefetch() {
+        let c = makeOptInPrefetchCache()
+        defer { c.close() }
+        // lo = 30 - 20 = 10, so 0...9 are extras and the kept window is already over budget.
+        #expect(c.peek(index: 0) == nil)
+        #expect(c.peek(index: 9) == nil)
+        #expect(c.peek(index: 10) != nil)
+        #expect(c.peek(index: 40) != nil)
+    }
+
+    @Test("Playhead-anchored walk reports nothing cached ahead while 31 segments are resident")
+    func playheadAnchoredWalkCollapses() {
+        let c = makeOptInPrefetchCache()
+        defer { c.close() }
+        // The bug: the walk starts on a hole and returns playhead - 1, which fails the caller's
+        // `frontier >= playheadIdx` guard and yields a read-ahead of 0.
+        #expect(c.contiguousForwardFrontier(from: 0) == -1)
+    }
+
+    @Test("Target-anchored walk reports the resident band ahead of the consumer")
+    func targetAnchoredWalkReportsFullBand() {
+        let c = makeOptInPrefetchCache()
+        defer { c.close() }
+        #expect(c.contiguousForwardFrontier(fromPlayhead: 0) == 40)
+    }
+
+    /// The trap the reporter flagged: simply skipping the leading hole would land on a stale band that
+    /// survives a backward seek (nothing forces its eviction while the budget has room) and report it as
+    /// buffered, i.e. fail in the dangerous direction. Anchoring on the fetch target must stop at the
+    /// hole above the freshly produced band instead.
+    @Test("Backward seek does not report the stale band left above the new target")
+    func backwardSeekStopsBelowStaleBand() {
+        let c = makeOptInPrefetchCache()
+        defer { c.close() }
+        // Seek back to segment 2. hi = max(2 + 2700, highestStored 40) keeps the old band resident,
+        // and the producer has only restarted far enough to write 2 and 3.
+        c.declareTarget(2)
+        c.store(index: 2, data: makeData(10))
+        c.store(index: 3, data: makeData(10))
+        #expect(c.peek(index: 40) != nil, "the stale band must still be resident for this to be a real trap")
+        #expect(c.contiguousForwardFrontier(fromPlayhead: 2) == 3)
+    }
+
+    @Test("A refetch behind the playhead does not drag the anchor backwards")
+    func backwardRefetchKeepsPlayheadAnchor() {
+        let c = SegmentCache(forwardWindow: 10, backwardWindow: 20)
+        defer { c.close() }
+        for i in 0...8 { c.store(index: i, data: makeData(10)) }
+        // Continuous-Audio handover refetches a segment behind the playhead; the playhead is at 8.
+        c.declareTarget(5)
+        #expect(c.contiguousForwardFrontier(fromPlayhead: 8) == 8)
+    }
+
+    @Test("Default window: anchor stays the playhead, behaviour unchanged")
+    func defaultWindowUnchanged() {
+        let c = SegmentCache(forwardWindow: 10, backwardWindow: 20)
+        defer { c.close() }
+        for i in [5, 6, 7, 8, 10] { c.store(index: i, data: makeData(10)) }
+        c.declareTarget(5)
+        #expect(c.contiguousForwardFrontier(fromPlayhead: 5) == 8)   // stops before the hole at 9
+        #expect(c.contiguousForwardFrontier(fromPlayhead: 5) == c.contiguousForwardFrontier(from: 5))
+    }
+
+    @Test("Fresh cache with no declared target walks from the playhead")
+    func noTargetDeclaredYet() {
+        let c = SegmentCache(forwardWindow: 10, backwardWindow: 20)
+        defer { c.close() }
+        for i in 0...3 { c.store(index: i, data: makeData(10)) }
+        // currentTargetIndex is still -1 here; max() must not pull the anchor below the playhead.
+        #expect(c.contiguousForwardFrontier(fromPlayhead: 0) == 3)
+    }
+}


### PR DESCRIPTION
Follow-up to #207, reported and root-caused by @fxndxs.

## Symptom

With the opt-in whole-source prefetch active, `clock.bufferedPosition` collapses to exactly the playhead a few minutes into a session and stays there, while ~15 min of content is resident on disk. A host drawing a buffer bar from it watches the bar shrink to zero and vanish. Playback is unaffected: nothing is actually missing, only the reported frontier is wrong.

## Root cause

An anchor mismatch between the frontier walk and the eviction window, not a byte-accounting problem.

- `SegmentCache.contiguousForwardFrontier(from:)` started the walk at the **playhead's** segment and returns `startIdx - 1` when that entry is absent. `contiguousForwardReadAheadSeconds` then fails its `frontier >= playheadIdx` guard and returns 0.
- `pruneOutsideWindow` anchors on the **consumer's fetch target**: `lo = currentTargetIndex - backwardWindow`. AVPlayer's fetch target runs ~120 s (~30 segments) ahead of the playhead, so the retained low end sits around `playhead + 10` segments. The playhead's own segment is an evictable extra.

Only an opt-in prefetch reaches the retention budget, so only there does the extras eviction actually run. With the historical 10-segment window the whole footprint stayed under the 2 GiB budget, the extras below `lo` always survived, and the walk found its starting entry. That is why this surfaces now rather than being an old bug.

From the reporter's session: resident span ~[131, 371] with the playhead at segment ~120, so the walk started below the resident range on every tick.

## Fix

`contiguousForwardFrontier(fromPlayhead:)` anchors at `max(playhead, currentTargetIndex)`. Everything below the fetch target has been handed to the consumer and sits in its own buffer, which makes the anchor safe rather than merely optimistic: `declareTarget` is only ever called from the segment-serve path (`VideoSegmentProvider.mediaSegment(at:)` / `mediaSegmentURL(at:)`), never speculatively.

Two properties worth keeping:

- **Skipping the leading hole unbounded would be unsafe.** Playing at 10 min with 10-25 min resident, seek back to 2 min: the producer restarts at 2 min while the old band survives, because `hi = max(target + forwardWindow, highestStoredIndex)` keeps it and nothing forces its eviction while the budget has room. A walk that just skips the hole lands on that stale band and reports ~25 min buffered when almost nothing is available, i.e. it fails in the dangerous direction. Anchoring at the new target stops the walk at the hole above the freshly produced segments.
- **`max`, not the target alone.** A backward refetch behind the playhead (Continuous-Audio handover) must not drag the anchor back below it.

Anchor and walk share one lock hold. Reading `targetIndex` separately, then walking, would let a target change land between the two and walk from an anchor that does not match the entries observed.

Nothing changes for sessions that do not opt in, and the frontier still never trails the rendered frame (#54).

## Contract

The published contract had drifted and is settled here. `PlaybackClock.bufferedPosition` documented the native path as "end of the contiguous `loadedTimeRanges` span", which #105 replaced with the disk frontier, while the engine-side comment described disk only. It is the end of the contiguous **safe** range ahead of the playhead: what the consumer already holds, plus what sits contiguously above it on disk. The anchor change produces exactly that, and it also removes the under-report in the first seconds before the cache has built.

## Residual

Between a backward seek and the consumer's first fetch at the new position the declared target is still the old one, so a tick or two can report the stale band before `declareTarget` lands. Same class as the plan-rebuild race the function already documents, transient by construction rather than the permanent mis-report a hole-skipping walk would produce, and it self-corrects on the next fetch. Documented at the call site rather than papered over with a separate seek-state bound.

## Verification

- 7 new tests in `Issue207FrontierAnchorTests`: the eviction precondition, the collapse, the target-anchored band, the backward-seek trap, the backward refetch, the unchanged default window, and a fresh cache with no declared target.
- Full suite: 1081 tests in 174 suites green.
- `swift build -Xswiftc -strict-concurrency=complete` clean.
- tvOS Simulator build green.

Device verification of the buffer bar under an opt-in prefetch session is still outstanding and is what #207 stays open for.