### PR TITLE
fix(video): prime moov from a real audio frame when the first segment has none (#222)

### DIFF
--- a/Sources/AetherEngine/Video/HLSSegmentProducer.swift
+++ b/Sources/AetherEngine/Video/HLSSegmentProducer.swift
@@ -237,6 +237,19 @@ final class HLSSegmentProducer: @unchecked Sendable {
     private var loggedFirstDiscontinuity: Bool = false
 
     private let targetSegmentDurationSeconds: Double
+    /// AE#222: real audio frame handed to every muxer this producer builds, so moov (with its packet-derived
+    /// dec3/dac3/dmlp) is written at init instead of at the first cut. nil on a normal session.
+    private let audioMoovPrimeFrame: [UInt8]?
+    /// Latched when a cut deferred for want of an audio sample entry; the pump then scans forward for one
+    /// real audio frame and exits with `.needsAudioSampleEntryPrime` so the host can rebuild primed.
+    private var cutDeferredAwaitingAudioSampleEntry: Bool = false
+    private var _capturedAudioMoovPrimeFrame: [UInt8]?
+    /// Frame captured by the pump's prime scan; read by the host after the pump exits.
+    var capturedAudioMoovPrimeFrame: [UInt8]? {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return _capturedAudioMoovPrimeFrame
+    }
     private var currentMuxer: MP4SegmentMuxer?
     private var currentMuxerSegmentIndex: Int = .min
 
@@ -393,6 +406,11 @@ final class HLSSegmentProducer: @unchecked Sendable {
     private var lastPregateVideoLog: Int = 0
     private var lastPregateAudioLog: Int = 0
     private static let pregateLogInterval = 200
+    /// AE#222 prime-scan bounds. 128 MiB is ~17 s of 60 Mbit/s UHD video, well past any real interleave gap
+    /// (the reported source's audio starts ~4 s in), and the timeout covers a slow source rather than a
+    /// far-away audio track.
+    private static let moovPrimeScanByteCap = 128 * 1024 * 1024
+    private static let moovPrimeScanTimeoutSeconds: TimeInterval = 30
 
     /// Desired tfdt for each stream: 0 for baseIndex==0; plan[baseIndex].startSeconds for restarts.
     private let desiredFirstVideoTfdtPts: Int64
@@ -533,6 +551,11 @@ final class HLSSegmentProducer: @unchecked Sendable {
         case stopRequested
         case readError(code: Int32)
         case muxerFailed
+        /// AE#222: the first cut could not write moov because the audio sample entry is packet-derived
+        /// (E-AC-3/AC-3/TrueHD) and the source's first segment carries no audio packet. The pump captured a
+        /// real audio frame on its way out (`capturedAudioMoovPrimeFrame`); the host rebuilds with it as the
+        /// muxer's moov prime, which keeps the stream-copy (and any Atmos) instead of falling back.
+        case needsAudioSampleEntryPrime
         /// No AV_PKT_FLAG_KEY video packet within timeout; live only (VOD waits unbounded).
         case keyframeStarvation
         /// Backward PTS reset to session origin after unplanned reconnect: server replay-from-start, exits terminally.
@@ -550,6 +573,7 @@ final class HLSSegmentProducer: @unchecked Sendable {
             case .stopRequested: return "stopRequested"
             case .readError(let code): return "readError(\(code))"
             case .muxerFailed: return "muxerFailed"
+            case .needsAudioSampleEntryPrime: return "needsAudioSampleEntryPrime"
             case .keyframeStarvation: return "keyframeStarvation"
             case .sourceReplay: return "sourceReplay"
             case .segmentStall: return "segmentStall"
@@ -680,8 +704,10 @@ final class HLSSegmentProducer: @unchecked Sendable {
         packedSideAudioStartPts: Int64? = nil,
         packedSideAudioFallbackDurationPts: Int64 = 0,
         bufferAheadSegments: Int = 10,
-        prefetchDiskBudgetBytes: Int = 0
+        prefetchDiskBudgetBytes: Int = 0,
+        audioMoovPrimeFrame: [UInt8]? = nil
     ) throws {
+        self.audioMoovPrimeFrame = audioMoovPrimeFrame
         self.bufferAheadSegments = bufferAheadSegments
         self.prefetchDiskBudgetBytes = prefetchDiskBudgetBytes
         self.demuxer = demuxer
@@ -1138,6 +1164,8 @@ final class HLSSegmentProducer: @unchecked Sendable {
                 // Floored at 8s (the historical 2 x 4s value): a sub-second fastZap cut target (AE#195)
                 // must not shrink the cap below typical TS A/V interleave skew.
                 maxBufferedFragmentSeconds: max(8.0, 2 * targetSegmentDurationSeconds),
+                // AE#222: only set on a session that already proved its first segment carries no audio.
+                audioMoovPrimeFrame: audioMoovPrimeFrame,
                 onInitCaptured: { [weak self] initBytes in
                     guard let self = self else { return }
                     if versionedInit {
@@ -1193,17 +1221,81 @@ final class HLSSegmentProducer: @unchecked Sendable {
         }
     }
 
+    /// AE#222 prime scan: read forward from wherever the pump stopped until the muxed audio stream yields one
+    /// packet, and copy its bytes. That single frame is all movenc needs to build the real `dec3` / `dac3` /
+    /// `dmlp` sample entry, so the rebuilt session keeps its stream-copy (Atmos included) instead of bridging.
+    ///
+    /// Scoped to single-demuxer stream-copy audio: a bridged session's muxed frames come from the encoder, not
+    /// the source, and feeding the bridge here would consume the very encoder state a restart depends on (#99
+    /// root cause B). Bounded so a source whose audio never arrives (or arrives absurdly late) gives up and
+    /// leaves the host's fallbacks in charge instead of stalling the session on an unbounded read.
+    private func scanForAudioMoovPrimeFrame() -> [UInt8]? {
+        guard let audio = audioConfig, audio.bridge == nil, sideAudioDemuxer == nil else { return nil }
+        let deadline = Date().addingTimeInterval(Self.moovPrimeScanTimeoutSeconds)
+        var bytesRead = 0
+        var packetsRead = 0
+
+        while true {
+            if checkShouldStop() { return nil }
+            if bytesRead >= Self.moovPrimeScanByteCap || Date() > deadline {
+                EngineLog.emit(
+                    "[HLSSegmentProducer] AE#222 prime scan gave up after \(packetsRead) packet(s) / "
+                    + "\(bytesRead / (1024 * 1024)) MiB without an audio packet",
+                    category: .session
+                )
+                return nil
+            }
+            let pkt: UnsafeMutablePointer<AVPacket>?
+            do {
+                pkt = try demuxer.readPacket()
+            } catch {
+                EngineLog.emit(
+                    "[HLSSegmentProducer] AE#222 prime scan read failed: \(error)",
+                    category: .session
+                )
+                return nil
+            }
+            guard let packet = pkt else {
+                EngineLog.emit(
+                    "[HLSSegmentProducer] AE#222 prime scan hit EOF after \(packetsRead) packet(s) "
+                    + "without an audio packet",
+                    category: .session
+                )
+                return nil
+            }
+            var owned: UnsafeMutablePointer<AVPacket>? = packet
+            defer { trackedPacketFree(&owned) }
+            packetsRead += 1
+            bytesRead += Int(max(packet.pointee.size, 0))
+
+            guard packet.pointee.stream_index == audio.sourceStreamIndex,
+                  packet.pointee.size > 0,
+                  let data = packet.pointee.data
+            else { continue }
+
+            let frame = [UInt8](UnsafeBufferPointer(start: data, count: Int(packet.pointee.size)))
+            EngineLog.emit(
+                "[HLSSegmentProducer] AE#222 prime scan captured a \(frame.count) B audio frame after "
+                + "\(packetsRead) packet(s) / \(bytesRead / (1024 * 1024)) MiB "
+                + "(srcDts=\(packet.pointee.dts))",
+                category: .session
+            )
+            return frame
+        }
+    }
+
     private func advanceMuxer(to newIdx: Int) -> MP4SegmentMuxer? {
         guard let muxer = currentMuxer else { return nil }
 
-        if let result = muxer.cutFragmentForNextSegment(newIdx) {
+        switch muxer.cutFragmentForNextSegment(newIdx) {
+        case .completed(let path, let bytesWritten):
             EngineLog.emit(
-                "[HLSSegmentProducer] seg-\(currentMuxerSegmentIndex).m4s captured (\(result.bytesWritten) B)",
+                "[HLSSegmentProducer] seg-\(currentMuxerSegmentIndex).m4s captured (\(bytesWritten) B)",
                 category: .session, level: .verbose
             )
             cache.adopt(index: currentMuxerSegmentIndex,
-                        stagingPath: result.path,
-                        byteCount: result.bytesWritten)
+                        stagingPath: path,
+                        byteCount: bytesWritten)
             if isLive {
                 reportLiveSegmentFinalized(index: currentMuxerSegmentIndex,
                                            nextIndex: newIdx)
@@ -1217,7 +1309,19 @@ final class HLSSegmentProducer: @unchecked Sendable {
                 )
                 return nil
             }
-        } else {
+        case .deferredAwaitingAudioSampleEntry:
+            // AE#222: not a failure. moov cannot carry dec3/dac3/dmlp until one audio packet has been muxed,
+            // and this source's first segment has none (its audio blocks sit behind seconds of video in file
+            // order). Nothing was written, so the pump exits to let the host rebuild with a prime frame; the
+            // scan for that frame happens on the way out.
+            cutDeferredAwaitingAudioSampleEntry = true
+            EngineLog.emit(
+                "[HLSSegmentProducer] AE#222 seg-\(currentMuxerSegmentIndex).m4s cut deferred: audio sample "
+                + "entry needs a parsed packet and none has been muxed; scanning forward for a prime frame",
+                category: .session
+            )
+            return nil
+        case .failed:
             // Failed cut: muxer has no open staging fd, every byte is silently discarded. Fatal.
             EngineLog.emit(
                 "[HLSSegmentProducer] seg-\(currentMuxerSegmentIndex).m4s cut FAILED; "
@@ -2561,6 +2665,21 @@ final class HLSSegmentProducer: @unchecked Sendable {
             stateLock.unlock()
             if stopped { exitReason = .stopRequested }
             else if wedged { exitReason = .backpressureWedge }
+        }
+
+        // AE#222: a cut that deferred for want of a packet-derived audio sample entry is recoverable, but only
+        // with one real audio frame in hand. Scan for it here, on the way out: the bytes this reads are the
+        // same ones the rebuilt producer will re-read for its own first segments, and every alternative
+        // (bridging to FLAC, stretching the first segment past its plan boundary) either downgrades the audio
+        // or breaks the playlist. If no frame turns up, the reason stays .muxerFailed and the host's existing
+        // fallbacks own the session.
+        if case .muxerFailed = exitReason, cutDeferredAwaitingAudioSampleEntry {
+            if let prime = scanForAudioMoovPrimeFrame() {
+                stateLock.lock()
+                _capturedAudioMoovPrimeFrame = prime
+                stateLock.unlock()
+                exitReason = .needsAudioSampleEntryPrime
+            }
         }
 
         freeMergeLookaheads()

--- a/Sources/AetherEngine/Video/HLSVideoEngine+LiveReopen.swift
+++ b/Sources/AetherEngine/Video/HLSVideoEngine+LiveReopen.swift
@@ -71,7 +71,8 @@ extension HLSVideoEngine {
             return true
         case .eof, .readError, .keyframeStarvation:
             return !sourceReopenable
-        case .stopRequested, .muxerFailed, .backpressureWedge:
+        case .stopRequested, .muxerFailed, .backpressureWedge, .needsAudioSampleEntryPrime:
+            // AE#222 rebuilds into the same provider with a primed muxer, so production continues.
             return false
         }
     }
@@ -100,6 +101,14 @@ extension HLSVideoEngine {
         // Re-anchor the producer on AVPlayer's real position so the segments it is starved for get produced.
         if case .backpressureWedge = reason {
             handleBackpressureWedge()
+            return
+        }
+        // AE#222: the pump deferred its first cut because the audio sample entry is packet-derived
+        // (E-AC-3/AC-3/TrueHD) and this source's first segment carries no audio packet, then captured one real
+        // audio frame on its way out. Rebuild with that frame as the muxer's moov prime, which keeps the
+        // stream-copy (and any Atmos) rather than bridging to FLAC or stretching the first segment.
+        if case .needsAudioSampleEntryPrime = reason {
+            handleAudioSampleEntryPrimeNeeded(prod)
             return
         }
         // #99 failure mode B: a VOD muxer death (e.g. first cut before any bridged audio packet, so
@@ -158,7 +167,8 @@ extension HLSVideoEngine {
             provider?.markLiveProductionHalted()
         }
         switch reason {
-        case .stopRequested, .muxerFailed, .backpressureWedge:
+        case .stopRequested, .muxerFailed, .backpressureWedge, .needsAudioSampleEntryPrime:
+            // needsAudioSampleEntryPrime never reaches here (its arm above returns first).
             return
         case .sourceReplay:
             // Server restarted stream from beginning (Jellyfin transcode respawn); URL reopen would replay stale content. Delegate to host for fresh negotiation.
@@ -296,6 +306,59 @@ extension HLSVideoEngine {
             "[HLSVideoEngine] #169 VOD gate starved to EOF at seg\(prod.anchoredBaseIndex): "
             + "no keyframe at/after the plan boundary; re-anchoring on the last real keyframe "
             + "(pts=\(lastKeyPts)) -> seg\(idx) (attempt \(attempts)/\(cap))",
+            category: .session
+        )
+        requestRestart(at: idx, authoritative: true)
+    }
+
+    /// AE#222: rebuild the session with the captured audio frame as the muxer's moov prime.
+    ///
+    /// The prime is stored on the session, not just handed to the next producer, so every later restart (seek,
+    /// audio switch, revive) gets it too: the same video-first interleave defers the first cut of every fresh
+    /// muxer, not only the session's first one.
+    ///
+    /// Aimed like the other revive arms, at the pending seek target or AVPlayer's real position, so a defer
+    /// that happens after a scrub resumes where the viewer is.
+    func handleAudioSampleEntryPrimeNeeded(_ prod: HLSSegmentProducer) {
+        guard let prime = prod.capturedAudioMoovPrimeFrame, !prime.isEmpty else {
+            // No frame: the source's audio never showed up inside the scan bounds. Nothing here can keep the
+            // stream-copy, so hand the session to the existing muxerFailed recovery.
+            EngineLog.emit(
+                "[HLSVideoEngine] AE#222 first cut deferred but no audio frame was captured; "
+                + "falling back to the muxerFailed recovery",
+                category: .session
+            )
+            if isLiveSession { return }
+            handleVODMuxerFailure()
+            return
+        }
+
+        restartLock.lock()
+        let admitted = audioSampleEntryPrimeGate.admit()
+        let attempts = audioSampleEntryPrimeGate.attempts
+        let cap = audioSampleEntryPrimeGate.maxAttempts
+        if admitted { sessionAudioMoovPrimeFrame = prime }
+        restartLock.unlock()
+
+        guard admitted else {
+            EngineLog.emit(
+                "[HLSVideoEngine] AE#222 moov-prime rebuild cap reached (\(attempts) attempts, cap \(cap)); "
+                + "falling back to the muxerFailed recovery",
+                category: .session
+            )
+            if isLiveSession { return }
+            handleVODMuxerFailure()
+            return
+        }
+
+        let frozen = currentPlaybackPositionProvider?() ?? 0
+        let anchor = AetherEngine.recoveryAnchorPosition(
+            frozenPosition: frozen, pendingSeekTarget: recoverySeekTargetProvider?(),
+            currentRendered: frozen)
+        let idx = segmentIndexForPlaylistTime(anchor)
+        EngineLog.emit(
+            "[HLSVideoEngine] AE#222 rebuilding producer + muxer with a \(prime.count) B audio moov prime at "
+            + "\(String(format: "%.2f", anchor))s -> seg\(idx) (audio stream-copy preserved)",
             category: .session
         )
         requestRestart(at: idx, authoritative: true)

--- a/Sources/AetherEngine/Video/HLSVideoEngine.swift
+++ b/Sources/AetherEngine/Video/HLSVideoEngine.swift
@@ -454,6 +454,18 @@ public final class HLSVideoEngine: @unchecked Sendable {
     /// that just failed (a sticky pb error would burn the revive gate without one fresh attempt).
     var mainDemuxerSuspectDead = false
 
+    /// AE#222 (under `restartLock`): one real audio frame from this source, kept for the whole session so
+    /// every muxer built from here on writes moov (with the packet-derived dec3/dac3/dmlp built from THIS
+    /// frame) at init. Set only after a pump proved the source cuts its first segment before any audio packet
+    /// arrives, which no probe can predict: movenc rejects an immediate moov for E-AC-3 regardless of
+    /// extradata, so a pre-flight cannot tell a video-first interleave apart from a healthy source.
+    var sessionAudioMoovPrimeFrame: [UInt8]?
+
+    /// AE#222 (under `restartLock`): bounded rebuild for a pump that deferred its first cut. One attempt is
+    /// enough by construction (the prime is captured before the restart and reused for the session's whole
+    /// life); the gate exists so a source that somehow defers again cannot restart-storm.
+    var audioSampleEntryPrimeGate = MuxerFailureReviveGate(maxAttempts: 1)
+
     /// AE#169 round 3 (under `restartLock`): bounded re-anchor for a VOD pump whose restart
     /// scan-forward gate starved to EOF (no runtime keyframe at/after the targeted plan boundary,
     /// the unproducible tail segment). Same gate shape as #99.
@@ -1756,7 +1768,10 @@ public final class HLSVideoEngine: @unchecked Sendable {
             packedSideAudioStartPts: packedSideAudioStartPts,
             packedSideAudioFallbackDurationPts: packedSideAudioFallbackDurationPts,
             bufferAheadSegments: forwardWindowSegments,
-            prefetchDiskBudgetBytes: retentionBudgetBytes
+            prefetchDiskBudgetBytes: retentionBudgetBytes,
+            // AE#222: nil until a pump proved this source cuts its first segment before any audio packet
+            // arrives; from then on every producer of the session muxes moov from this frame.
+            audioMoovPrimeFrame: sessionAudioMoovPrimeFrame
         )
         prod.onFirstHDR10PlusDetected = { [weak self] in
             self?.notifyHDR10PlusOnce()

--- a/Sources/AetherEngine/Video/MP4SegmentMuxer.swift
+++ b/Sources/AetherEngine/Video/MP4SegmentMuxer.swift
@@ -15,6 +15,11 @@ import Libavutil
 /// and losing Atmos JOC). NOT +dash (session-long sidx) or +frag_keyframe (interferes with
 /// explicit cut control).
 ///
+/// AE#222: +delay_moov alone is not enough for a source whose FIRST segment carries no audio packet (audio
+/// blocks sitting behind seconds of video in file order). Such a session is built with an
+/// `audioMoovPrimeFrame`: one real audio frame muxed at init writes moov (with a genuine dec3/dac3/dmlp) up
+/// front, and the primed fragment's bytes are then discarded so the delivered segment is unchanged.
+///
 /// Cut sequence: av_interleaved_write_frame(nil) drains the interleaver, then
 /// av_write_frame(nil) triggers mov_flush_fragment (moof+mdat). First cut only: a second
 /// av_write_frame(nil) (gated by `moovFlushed`) handles FFmpeg splitting ftyp+moov and
@@ -75,6 +80,15 @@ final class MP4SegmentMuxer {
     struct AudioConfig {
         let codecpar: UnsafePointer<AVCodecParameters>
         let timeBase: AVRational
+    }
+
+    /// Result of a segment cut. `deferredAwaitingAudioSampleEntry` is a THIRD state, distinct from both
+    /// success and failure: nothing was written, the muxer is intact, and the caller must retry the cut
+    /// once an audio packet has been muxed. Collapsing it into nil (= failure) is what wedged AE#222.
+    enum CutOutcome: Equatable {
+        case completed(path: URL, bytesWritten: Int)
+        case deferredAwaitingAudioSampleEntry
+        case failed
     }
 
     enum MuxerError: Error, CustomStringConvertible {
@@ -161,6 +175,7 @@ final class MP4SegmentMuxer {
         video: VideoConfig,
         audio: AudioConfig?,
         maxBufferedFragmentSeconds: Double = 8.0,
+        audioMoovPrimeFrame: [UInt8]? = nil,
         onInitCaptured: @escaping (Data) -> Void
     ) throws {
         self.currentSegmentIndex = initialSegmentIndex
@@ -263,6 +278,14 @@ final class MP4SegmentMuxer {
             seconds: maxBufferedFragmentSeconds,
             timeBase: muxerVideoTimeBase
         )
+
+        // AE#222: prime moov from one real audio frame when the audio sample entry is packet-derived. Without
+        // it, a source whose first segment carries no audio packet (video-first interleave: the audio blocks sit
+        // physically behind seconds of video) cannot emit moov at the first cut at all, and no codecpar or
+        // extradata can substitute (movenc builds dec3/dac3/dmlp in handle_eac3 from a PARSED frame only).
+        if let prime = audioMoovPrimeFrame, audio != nil, audioNeedsParsedPacketForMoov {
+            primeMoovWithAudioFrame(prime)
+        }
     }
 
     private let byteCounter: ByteCounter
@@ -502,12 +525,116 @@ final class MP4SegmentMuxer {
         }
     }
 
+    /// Bytes staged for the segment currently being written. Zero right after a moov prime, whose fragment
+    /// bytes are deliberately discarded.
+    var stagedSegmentByteCount: Int { byteCounter.bytesWrittenCurrentSegment }
+
+    /// AE#222: mux one real audio frame and flush, so ftyp+moov (with a packet-derived dec3/dac3/dmlp)
+    /// is emitted here rather than at the first cut, then drop the primed fragment's bytes from the staging
+    /// file. The frame is genuine source audio, so the sample entry describes the real bitstream (Atmos/JOC
+    /// signaling included); discarding its fragment keeps the delivered segment exactly as planned, with no
+    /// out-of-place audio sample and no disjoint track ranges.
+    private func primeMoovWithAudioFrame(_ frame: [UInt8]) {
+        guard let ctx = formatContext, headerWritten, fd >= 0, !frame.isEmpty, !moovFlushed else { return }
+
+        // The prime is only safe if +frag_discont can be re-armed afterwards (see below), so prove that first:
+        // the flag is still set at this point (movenc consumes it on the first packet written), which makes
+        // this a no-op that only reports whether the option is reachable on this build.
+        guard let priv = ctx.pointee.priv_data,
+              av_opt_set(priv, "movflags", "+frag_discont", 0) >= 0 else {
+            EngineLog.emit(
+                "[MP4SegmentMuxer] AE#222 cannot re-arm +frag_discont on this build; skipping the moov prime "
+                + "(a prime without it would place the first real audio fragment at tfdt 0)",
+                category: .session
+            )
+            return
+        }
+
+        var pktOpt: UnsafeMutablePointer<AVPacket>? = av_packet_alloc()
+        guard let pkt = pktOpt else { return }
+        defer { av_packet_free(&pktOpt) }
+        guard av_new_packet(pkt, Int32(frame.count)) == 0, let dst = pkt.pointee.data else { return }
+        frame.withUnsafeBytes { src in
+            if let base = src.baseAddress { memcpy(dst, base, frame.count) }
+        }
+
+        // dts 0, deliberately, even though the frame's real position is later: the primed fragment is
+        // discarded, so its timestamp is never presented, and re-arming +frag_discont below makes the first
+        // REAL audio fragment carry its own dts regardless of what the prime claimed. Carrying the frame's
+        // real position instead would be wrong on a restart muxer, whose output axis starts mid-title, and
+        // would still need the same re-arm.
+        let dts: Int64 = 0
+        pkt.pointee.stream_index = audioOutputStreamIndex
+        pkt.pointee.pts = dts
+        pkt.pointee.dts = dts
+        pkt.pointee.duration = 0
+        pkt.pointee.flags |= AV_PKT_FLAG_KEY
+
+        let rc = av_interleaved_write_frame(ctx, pkt)
+        guard rc >= 0 else {
+            EngineLog.emit(
+                "[MP4SegmentMuxer] AE#222 moov prime write failed (\(rc)); first cut will defer instead",
+                category: .session
+            )
+            return
+        }
+        // Drain before the fragment flush: handle_eac3 runs in mov_write_packet, so the frame must leave the
+        // interleaver before mov_write_moov looks for its parsed bitstream.
+        _ = av_interleaved_write_frame(ctx, nil)
+        _ = av_write_frame(ctx, nil)
+        moovFlushed = true
+        _ = av_write_frame(ctx, nil)
+        audioPacketWritten = true
+
+        // Re-arm +frag_discont, which movenc consumed on the prime packet. Without this the next first-sample
+        // of each track is treated as CONTINUING the primed fragment: movenc rewrites it to
+        // `start_dts + track_duration` (movenc.c mov_write_single_packet) and tfdt is
+        // `cluster[0].dts - start_dts`, so the first real audio fragment would land at tfdt 0 no matter where
+        // its samples actually belong (measured: a 12 s audio start rendered at 0, i.e. 12 s out of sync).
+        // Re-armed, every track keeps the absolute-dts behaviour the session relies on (see the movflags
+        // comment in configureStreamsAndWriteHeader), primed or not.
+        _ = av_opt_set(ctx.pointee.priv_data, "movflags", "+frag_discont", 0)
+
+        discardStagedFragmentBytes()
+        EngineLog.emit(
+            "[MP4SegmentMuxer] AE#222 moov primed from a \(frame.count) B audio frame; "
+            + "primed fragment discarded",
+            category: .session
+        )
+    }
+
+    /// Reset the current staging file to empty. Used after a moov prime, whose fragment must not be served.
+    private func discardStagedFragmentBytes() {
+        guard fd >= 0 else { return }
+        guard ftruncate(fd, 0) == 0, lseek(fd, 0, SEEK_SET) == 0 else {
+            // Leaving primed bytes in front of the real fragment would serve a segment with an out-of-place
+            // audio sample; a wedge is recoverable, a mis-served segment is not.
+            EngineLog.emit(
+                "[MP4SegmentMuxer] AE#222 could not discard the primed fragment (errno=\(errno)); wedging",
+                category: .session
+            )
+            isWedged = true
+            return
+        }
+        byteCounter.bytesWrittenCurrentSegment = 0
+    }
+
     /// Finalize the current segment and rotate fd to a fresh staging file for `nextIdx`.
-    /// Returns `(path, bytes)` for the completed segment, or nil on any write failure.
+    /// Returns `.completed` for the finished segment, `.failed` on a write failure, or
+    /// `.deferredAwaitingAudioSampleEntry` when moov cannot be written yet (AE#222).
     /// +delay_moov first-cut wrinkle: second av_write_frame(nil) (gated by moovFlushed) handles
     /// FFmpeg splitting ftyp+moov and moof+mdat across calls; safe no-op if both arrived in one call.
-    func cutFragmentForNextSegment(_ nextIdx: Int) -> (path: URL, bytesWritten: Int)? {
-        guard let ctx = formatContext, headerWritten, fd >= 0 else { return nil }
+    func cutFragmentForNextSegment(_ nextIdx: Int) -> CutOutcome {
+        guard let ctx = formatContext, headerWritten, fd >= 0 else { return .failed }
+
+        // AE#222: the same precondition flushPendingFragment enforces. A first cut that would write moov for a
+        // packet-derived audio sample entry with no audio packet muxed yet fails -22 inside mov_write_moov,
+        // leaves zero bytes, and used to surface as a failed cut (= a dead pump, three identical revives, and
+        // a host fallback to server transcode). Reporting it as its own state lets the producer fetch a prime
+        // frame and retry, keeping the E-AC-3 / AC-3 / TrueHD stream-copy (and any Atmos) intact.
+        if audioNeedsParsedPacketForMoov, !audioPacketWritten, !moovFlushed {
+            return .deferredAwaitingAudioSampleEntry
+        }
 
         // Drain the interleaver first: av_write_frame(nil) bypasses it, so audio packets buffered
         // waiting for video DTS catch-up would spill into the next fragment (~4 trailing AC-3 frames
@@ -532,7 +659,7 @@ final class MP4SegmentMuxer {
 
         if completedFailed || completedBytes == 0 {
             try? FileManager.default.removeItem(at: completedPath)
-            return nil
+            return .failed
         }
 
         byteCounter.fragmentCuts += 1
@@ -551,10 +678,10 @@ final class MP4SegmentMuxer {
                 category: .session
             )
             isWedged = true
-            return (path: completedPath, bytesWritten: completedBytes)
+            return .completed(path: completedPath, bytesWritten: completedBytes)
         }
 
-        return (path: completedPath, bytesWritten: completedBytes)
+        return .completed(path: completedPath, bytesWritten: completedBytes)
     }
 
     /// Final teardown: flush remaining packets, write trailer (mfra discarded by splitter), close fd.
@@ -562,7 +689,11 @@ final class MP4SegmentMuxer {
     func finalize() -> (path: URL, bytesWritten: Int)? {
         defer { cleanup() }
 
-        guard let ctx = formatContext, headerWritten else {
+        // AE#222: same precondition as the cut. A teardown flush on a muxer that never got an audio packet
+        // cannot write moov either, so it would only emit two more -22s and a truncated file; there is nothing
+        // to salvage (no moov means no playable segment).
+        guard let ctx = formatContext, headerWritten,
+              !(audioNeedsParsedPacketForMoov && !audioPacketWritten && !moovFlushed) else {
             if fd >= 0 { close(fd); fd = -1 }
             try? FileManager.default.removeItem(at: currentStagingPath)
             return nil

--- a/Tests/AetherEngineTests/AtmosDetectionProbeIntegrationTests.swift
+++ b/Tests/AetherEngineTests/AtmosDetectionProbeIntegrationTests.swift
@@ -54,7 +54,8 @@ struct AtmosDetectionProbeIntegrationTests {
     """
 
     /// 0.5s stereo silence, AAC @ 96kbps -- exercises the `.notEAC3` skip path (no decoder is ever opened).
-    private static let aacBase64 = """
+    /// Internal so `Issue222EAC3MoovPrimeTests` can mux the same bytes as a codecpar-derived sample entry.
+    static let aacBase64 = """
     AAAAHGZ0eXBpc29tAAACAGlzb21pc28ybXA0MQAAA3Ntb292AAAAbG12aGQAAAAAAAAAAAAAAAAA
     AAPoAAAB9AABAAABAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAEAA
     AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAACnXRyYWsAAABcdGtoZAAAAAMAAAAAAAAA
@@ -78,7 +79,8 @@ struct AtmosDetectionProbeIntegrationTests {
     """
 
     /// 0.1s of black video, H.264 16x16, no audio stream at all -- exercises `.noAudioTrack`.
-    private static let videoOnlyBase64 = """
+    /// Internal so `Issue222EAC3MoovPrimeTests` can use it as the video track of a muxer under test.
+    static let videoOnlyBase64 = """
     AAAAIGZ0eXBpc29tAAACAGlzb21pc28yYXZjMW1wNDEAAANdbW9vdgAAAGxtdmhkAAAAAAAAAAAA
     AAAAAAAD6AAAAHgAAQAAAQAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAA
     AABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAod0cmFrAAAAXHRraGQAAAADAAAA

--- a/Tests/AetherEngineTests/Issue222EAC3MoovPrimeTests.swift
+++ b/Tests/AetherEngineTests/Issue222EAC3MoovPrimeTests.swift
@@ -1,0 +1,290 @@
+import Testing
+import Foundation
+import Libavformat
+import Libavcodec
+import Libavutil
+@testable import AetherEngine
+
+/// AE#222: an E-AC-3 source whose first segment contains no audio packet wedged the muxer. movenc builds
+/// the `ec-3` sample entry's `dec3` box in `handle_eac3`, i.e. only from a PARSED bitstream frame (never
+/// from codecpar or extradata), so a first fragment flush with video only fails -22 "Cannot write moov atom
+/// before EAC3 packets parsed". `flushPendingFragment` already refuses that flush; `cutFragmentForNextSegment`
+/// did not, and its only "not now" return was nil, which the producer reads as a fatal wedge.
+///
+/// The fix gives a cut a third outcome (`deferredAwaitingAudioSampleEntry`, muxer left intact) and lets a
+/// muxer be primed with one real audio frame at init, which writes moov up front and then discards the
+/// primed fragment's bytes, so the delivered segment stays exactly as planned.
+///
+/// Media is the existing synthesized, non-Atmos base64 fixtures (see AtmosDetectionProbeIntegrationTests):
+/// H.264 16x16 video for the video track, 0.1s stereo E-AC-3 / AAC for the audio track.
+@Suite("AE#222: EAC3 moov prime and deferred first cut")
+struct Issue222EAC3MoovPrimeTests {
+
+    // MARK: - Harness
+
+    /// One muxer under test plus the demuxers whose codecpar it points at (they must outlive it).
+    private final class Rig {
+        let videoDemuxer = Demuxer()
+        let audioDemuxer = Demuxer()
+        let sessionDir: URL
+        var initBytes: Data?
+        var muxer: MP4SegmentMuxer?
+
+        init() throws {
+            sessionDir = FileManager.default.temporaryDirectory
+                .appendingPathComponent("ae222-\(UUID().uuidString)")
+            try FileManager.default.createDirectory(at: sessionDir, withIntermediateDirectories: true)
+        }
+
+        deinit {
+            muxer = nil
+            videoDemuxer.close()
+            audioDemuxer.close()
+            try? FileManager.default.removeItem(at: sessionDir)
+        }
+
+        func open(audioFixture: String?) throws {
+            try videoDemuxer.open(
+                reader: DataIOReader(data: Self.data(Issue222EAC3MoovPrimeTests.videoOnlyBase64)),
+                formatHint: "mp4"
+            )
+            if let audioFixture {
+                try audioDemuxer.open(reader: DataIOReader(data: Self.data(audioFixture)), formatHint: "mp4")
+            }
+        }
+
+        /// First audio packet's payload from the audio fixture: a real E-AC-3 / AAC frame, which is exactly
+        /// what the producer captures in production.
+        func firstAudioFrameBytes() throws -> [UInt8] {
+            let idx = audioDemuxer.audioStreamIndex
+            while true {
+                guard let pkt = try audioDemuxer.readPacket() else { return [] }
+                defer {
+                    var p: UnsafeMutablePointer<AVPacket>? = pkt
+                    trackedPacketFree(&p)
+                }
+                if pkt.pointee.stream_index == idx, pkt.pointee.size > 0, let data = pkt.pointee.data {
+                    return [UInt8](UnsafeBufferPointer(start: data, count: Int(pkt.pointee.size)))
+                }
+            }
+        }
+
+        func makeMuxer(audioPrime: [UInt8]?, withAudio: Bool = true) throws -> MP4SegmentMuxer {
+            guard let vStream = videoDemuxer.stream(at: videoDemuxer.videoStreamIndex) else {
+                throw MuxerRigError.noVideoStream
+            }
+            let video = MP4SegmentMuxer.VideoConfig(
+                codecpar: UnsafePointer(vStream.pointee.codecpar),
+                timeBase: vStream.pointee.time_base,
+                codecTagOverride: nil
+            )
+            var audio: MP4SegmentMuxer.AudioConfig?
+            if withAudio, let aStream = audioDemuxer.stream(at: audioDemuxer.audioStreamIndex) {
+                audio = MP4SegmentMuxer.AudioConfig(
+                    codecpar: UnsafePointer(aStream.pointee.codecpar),
+                    timeBase: aStream.pointee.time_base
+                )
+            }
+            let m = try MP4SegmentMuxer(
+                initialSegmentIndex: 0,
+                sessionDir: sessionDir,
+                video: video,
+                audio: audio,
+                audioMoovPrimeFrame: audioPrime,
+                onInitCaptured: { [self] bytes in self.initBytes = bytes }
+            )
+            muxer = m
+            return m
+        }
+
+        /// Feeds every video packet of the fixture into the muxer, rescaled like the producer does.
+        @discardableResult
+        func writeAllVideoPackets(into muxer: MP4SegmentMuxer) throws -> Int {
+            guard let vStream = videoDemuxer.stream(at: videoDemuxer.videoStreamIndex) else { return 0 }
+            let sourceTb = vStream.pointee.time_base
+            var written = 0
+            while let pkt = try videoDemuxer.readPacket() {
+                var p: UnsafeMutablePointer<AVPacket>? = pkt
+                defer { trackedPacketFree(&p) }
+                guard pkt.pointee.stream_index == videoDemuxer.videoStreamIndex else { continue }
+                pkt.pointee.stream_index = muxer.videoOutputStreamIndex
+                av_packet_rescale_ts(pkt, sourceTb, muxer.muxerVideoTimeBase)
+                _ = muxer.writePacket(pkt)
+                written += 1
+            }
+            return written
+        }
+
+        /// Muxes one audio frame at an explicit dts, the way a source whose audio starts late does.
+        func writeAudioFrame(_ frame: [UInt8], dts: Int64, into muxer: MP4SegmentMuxer) throws {
+            var pktOpt: UnsafeMutablePointer<AVPacket>? = av_packet_alloc()
+            guard let pkt = pktOpt else { throw MuxerRigError.noVideoStream }
+            defer { av_packet_free(&pktOpt) }
+            guard av_new_packet(pkt, Int32(frame.count)) == 0, let dst = pkt.pointee.data else {
+                throw MuxerRigError.noVideoStream
+            }
+            frame.withUnsafeBytes { src in
+                if let base = src.baseAddress { memcpy(dst, base, frame.count) }
+            }
+            pkt.pointee.stream_index = muxer.audioOutputStreamIndex
+            pkt.pointee.pts = dts
+            pkt.pointee.dts = dts
+            pkt.pointee.duration = 1536
+            pkt.pointee.flags |= AV_PKT_FLAG_KEY
+            _ = muxer.writePacket(pkt)
+        }
+
+        static func data(_ base64: String) -> Data {
+            Data(base64Encoded: base64, options: .ignoreUnknownCharacters) ?? Data()
+        }
+    }
+
+    private enum MuxerRigError: Error { case noVideoStream }
+
+    private static let videoOnlyBase64 = AtmosDetectionProbeIntegrationTests.videoOnlyBase64
+    private static let eac3Base64 = AtmosDetectionProbeIntegrationTests.eac3PlainBase64
+    private static let aacBase64 = AtmosDetectionProbeIntegrationTests.aacBase64
+
+    private static func containsBox(_ data: Data?, _ fourCC: String) -> Bool {
+        guard let data else { return false }
+        return data.range(of: Data(fourCC.utf8)) != nil
+    }
+
+    /// Every `tfdt` baseMediaDecodeTime in the buffer (one per traf). Version 1 (64-bit) is what movenc writes.
+    private static func allTfdts(in data: Data) -> [Int64] {
+        var out: [Int64] = []
+        var searchStart = data.startIndex
+        while let r = data.range(of: Data("tfdt".utf8), in: searchStart..<data.endIndex) {
+            searchStart = r.upperBound
+            let versionOffset = r.upperBound
+            guard versionOffset + 12 <= data.endIndex, data[versionOffset] == 1 else { continue }
+            var value: UInt64 = 0
+            for i in 0..<8 {
+                value = (value << 8) | UInt64(data[versionOffset + 4 + i])
+            }
+            out.append(Int64(bitPattern: value))
+        }
+        return out
+    }
+
+    // MARK: - The wedge: a video-only first cut on a packet-derived audio sample entry
+
+    @Test("EAC3 first cut with no audio packet defers instead of failing, and leaves the muxer usable")
+    func eac3FirstCutWithoutAudioDefers() throws {
+        let rig = try Rig()
+        try rig.open(audioFixture: Self.eac3Base64)
+        let muxer = try rig.makeMuxer(audioPrime: nil)
+
+        let written = try rig.writeAllVideoPackets(into: muxer)
+        #expect(written > 0, "fixture must contribute video packets")
+
+        let outcome = muxer.cutFragmentForNextSegment(1)
+        #expect(outcome == .deferredAwaitingAudioSampleEntry,
+                "a moov that cannot carry dec3 yet is 'not now', not a failed cut")
+        #expect(!muxer.isWedged, "deferring must not wedge the muxer")
+        #expect(rig.initBytes == nil, "no moov can have been emitted")
+    }
+
+    @Test("AAC keeps cutting a video-only first segment (sample entry comes from codecpar)")
+    func aacFirstCutWithoutAudioStillCompletes() throws {
+        let rig = try Rig()
+        try rig.open(audioFixture: Self.aacBase64)
+        let muxer = try rig.makeMuxer(audioPrime: nil)
+
+        try rig.writeAllVideoPackets(into: muxer)
+        let outcome = muxer.cutFragmentForNextSegment(1)
+
+        guard case .completed(_, let bytes) = outcome else {
+            Issue.record("AAC must not defer, got \(outcome)")
+            return
+        }
+        #expect(bytes > 0)
+        #expect(Self.containsBox(rig.initBytes, "moov"), "init.mp4 is emitted at the first cut")
+    }
+
+    // MARK: - The fix: prime moov with one real audio frame, discard the primed fragment
+
+    @Test("priming with one real EAC3 frame writes a dec3-carrying moov before any packet is muxed")
+    func primeWritesMoovWithDec3UpFront() throws {
+        let rig = try Rig()
+        try rig.open(audioFixture: Self.eac3Base64)
+        let prime = try rig.firstAudioFrameBytes()
+        #expect(!prime.isEmpty, "fixture must yield a real EAC3 frame")
+
+        let muxer = try rig.makeMuxer(audioPrime: prime)
+
+        #expect(Self.containsBox(rig.initBytes, "moov"), "moov is written at init, not at the first cut")
+        #expect(Self.containsBox(rig.initBytes, "dec3"),
+                "dec3 must come from the parsed prime frame, so Atmos/JOC signaling survives")
+        #expect(muxer.stagedSegmentByteCount == 0,
+                "the primed fragment's bytes must not be delivered as segment payload")
+    }
+
+    @Test("a primed muxer cuts a video-only first segment exactly as planned")
+    func primedMuxerCutsVideoOnlyFirstSegment() throws {
+        let rig = try Rig()
+        try rig.open(audioFixture: Self.eac3Base64)
+        let prime = try rig.firstAudioFrameBytes()
+        let muxer = try rig.makeMuxer(audioPrime: prime)
+
+        try rig.writeAllVideoPackets(into: muxer)
+        let outcome = muxer.cutFragmentForNextSegment(1)
+
+        guard case .completed(let path, let bytes) = outcome else {
+            Issue.record("primed cut must complete, got \(outcome)")
+            return
+        }
+        #expect(bytes > 0)
+        let segment = try Data(contentsOf: path)
+        #expect(segment.count == bytes)
+        #expect(Self.containsBox(segment, "moof"), "the delivered segment is a plain fragment")
+        #expect(!Self.containsBox(segment, "moov"), "moov already went to init.mp4")
+    }
+
+    /// The regression this guards: movenc rewrites a fragment's first sample dts to
+    /// `start_dts + track_duration` unless the track is flagged discontinuous, and it consumes the
+    /// +frag_discont flag on the prime packet. Un-rearmed, an audio track whose real samples start seconds in
+    /// gets tfdt 0, i.e. the audio plays that far ahead of picture. Measured on the repro fixture before the
+    /// re-arm: a 12 s audio start wrote tfdt=0.
+    @Test("audio muxed after a prime keeps its own timestamp (no tfdt collapse to 0)")
+    func primedMuxerKeepsRealAudioTimestamps() throws {
+        let rig = try Rig()
+        try rig.open(audioFixture: Self.eac3Base64)
+        let prime = try rig.firstAudioFrameBytes()
+        let muxer = try rig.makeMuxer(audioPrime: prime)
+
+        try rig.writeAllVideoPackets(into: muxer)
+
+        // One audio packet, deliberately far from the prime's dts 0, exactly like a source whose audio starts
+        // seconds after its video.
+        let audioDts: Int64 = 12 * 48000
+        try rig.writeAudioFrame(prime, dts: audioDts, into: muxer)
+
+        guard case .completed(let path, _) = muxer.cutFragmentForNextSegment(1) else {
+            Issue.record("primed cut must complete")
+            return
+        }
+        let segment = try Data(contentsOf: path)
+        let tfdts = Self.allTfdts(in: segment)
+        #expect(tfdts.contains(audioDts),
+                "the audio fragment must carry its real baseMediaDecodeTime, got \(tfdts)")
+        #expect(!tfdts.isEmpty)
+    }
+
+    @Test("a prime frame is ignored when the session has no audio stream")
+    func primeIgnoredWithoutAudioStream() throws {
+        let rig = try Rig()
+        try rig.open(audioFixture: Self.eac3Base64)
+        let prime = try rig.firstAudioFrameBytes()
+        let muxer = try rig.makeMuxer(audioPrime: prime, withAudio: false)
+
+        try rig.writeAllVideoPackets(into: muxer)
+        let outcome = muxer.cutFragmentForNextSegment(1)
+
+        guard case .completed(_, let bytes) = outcome else {
+            Issue.record("video-only session must cut normally, got \(outcome)")
+            return
+        }
+        #expect(bytes > 0)
+    }
+}

--- a/Tests/AetherEngineTests/LiveProductionHaltTests.swift
+++ b/Tests/AetherEngineTests/LiveProductionHaltTests.swift
@@ -52,6 +52,9 @@ final class LiveProductionHaltTests: XCTestCase {
             reason: .muxerFailed, sourceReopenable: false))
         XCTAssertFalse(HLSVideoEngine.shouldHaltLiveProduction(
             reason: .backpressureWedge, sourceReopenable: false))
+        XCTAssertFalse(HLSVideoEngine.shouldHaltLiveProduction(
+            reason: .needsAudioSampleEntryPrime, sourceReopenable: false),
+            "AE#222 rebuilds into the same provider with a primed muxer, so production continues")
     }
 
     // MARK: - Provider halt latch


### PR DESCRIPTION
## Problem

An E-AC-3 source whose first segment carries no audio packet never produces a frame. movenc builds the `ec-3` sample entry's `dec3` box in `handle_eac3`, i.e. only from a PARSED bitstream frame, never from codecpar or extradata (#222 verified: a valid `dec3` in extradata still returns -22). Under `+delay_moov` the moov is written at the first fragment flush, so a first cut with video only fails -22 "Cannot write moov atom before EAC3 packets parsed", `completedBytes` stays 0, and the cut reported plain failure.

`flushPendingFragment` already refuses that flush. `cutFragmentForNextSegment` did not, and its only "not now" signal was nil, which the producer reads as a fatal wedge: the VOD revive rebuilt the identical configuration twice more, gave up with "source not muxable in this session", and the host fell back to a server transcode of a file it should have played untouched.

## Repro

Synthetic MKV, HEVC Main10 + E-AC-3 5.1, audio starting behind ~12 s of video in file order (`-itsoffset`), which reproduces the reporter's trace exactly:

```
[HLSSegmentProducer] seg-0.m4s cut FAILED; muxer is wedged, ending pump
[HLSSegmentProducer] pump finished: reason=muxerFailed packetsRead=95 packetsWritten=93
... x3 ...
[HLSVideoEngine] #99 VOD muxerFailed revive cap reached; giving up (source not muxable in this session)
```

The EAC3 bridge wedges identically (its encoder output is also E-AC-3). Only the FLAC bridge played, at the cost of the passthrough, which is why bridging is not the fix.

## Fix

- A cut gets a third outcome, `deferredAwaitingAudioSampleEntry`: nothing written, muxer intact.
- The pump treats it as recoverable: it scans forward (bounded: 128 MiB / 30 s, discarding everything else) for one real audio frame and exits with it.
- The host keeps that frame for the whole session, so every later muxer (seek, audio switch, revive) is primed too, and rebuilds. A primed muxer muxes the frame at init, which writes moov with a genuine `dec3`, then discards the primed fragment's bytes. The delivered segment is unchanged: no out-of-place audio sample, no disjoint track ranges, plan boundaries untouched, E-AC-3 stream-copy and Atmos preserved.
- No frame inside the bounds, or a second defer, falls through to the existing muxerFailed recovery.
- `finalize()` gets the same precondition, so a teardown on a never-primed muxer stops emitting -22s for a moov it cannot write.

### Why re-arming +frag_discont is load-bearing

movenc consumes the flag on the primed packet, after which each track's next fragment-opening sample is rewritten to `start_dts + track_duration`, and `tfdt` is `cluster[0].dts - start_dts`. Un-rearmed, the first real audio fragment lands at tfdt 0 no matter where its samples belong: measured on the fixture, a 12 s audio start rendered 12 s early. Re-armed, timestamps match an unprimed session exactly.

## Verification

- `Issue222EAC3MoovPrimeTests` (6 tests): deferral instead of failure, AAC unaffected, `dec3` present in the primed init, primed fragment not served, video-only first segment cuts, and the tfdt regression (proven to fail without the re-arm: `tfdt=[-1024, 0]` instead of 576000).
- Full suite 1087/1087, strict-concurrency clean, tvOS simulator build succeeds.
- E2E on the repro fixture: `audioTrack codec='ec-3'`, first frame 0.15 s, 20 s of playback with no stall, `VERDICT: OK`. Produced segments: seg0 video-only at 0.000s, seg3 video 11.792s + audio 11.995s, seg4 continuous. 40-seek burst settles at 0.00s error with no second defer.
- Control fixture (healthy interleave): primes nothing, logs nothing, fragment timestamps unchanged.

Reported and root-caused by @thatcube, who pinned the missing guard and ruled out both dec3-in-extradata and dropping `+delay_moov`.

Refs #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QYhPvBB1sLCYoZNasEXFeB