### PR TITLE
fix(video): bound the buffer frontier anchor to the consumer's fetch sequence

### DIFF
--- a/Sources/AetherEngine/Video/HLSVideoEngine.swift
+++ b/Sources/AetherEngine/Video/HLSVideoEngine.swift
@@ -1548,11 +1548,16 @@ public final class HLSVideoEngine: @unchecked Sendable {
     /// (#207 follow-up). A frontier below the playhead still reports 0, which keeps the #54 contract that
     /// the frontier never trails the rendered frame.
     ///
+    /// The target anchor holds only inside the consumer's current fetch sequence; a seek ends it, since
+    /// `declareTarget` lands at the destination while `currentTime()` still reports the position the seek
+    /// left, and the target would otherwise measure the band at the destination against that stale
+    /// playhead. What remains is bounded rather than seek-sized: a scrub shorter than the backward window
+    /// stays inside the sequence, so a tick or two around it can still anchor on the old target, and the
+    /// error is at most that window.
+    ///
     /// segmentIndexForPlaylistTime and the plan read each take restartLock briefly and sequentially
     /// (no nesting); a plan rebuilt between them at worst yields one transiently wrong tick, acceptable
-    /// for a visual bar. One residual of the same kind: between a backward seek and the consumer's first
-    /// fetch at the new position the target is still the old one, so a tick or two can report the stale
-    /// band before `declareTarget` lands.
+    /// for a visual bar.
     func contiguousForwardReadAheadSeconds(playlistSeconds: Double) -> Double {
         guard let cache = subsystemSnapshot().cache else { return 0 }
         let playheadIdx = segmentIndexForPlaylistTime(playlistSeconds)

--- a/Sources/AetherEngine/Video/SegmentCache.swift
+++ b/Sources/AetherEngine/Video/SegmentCache.swift
@@ -38,6 +38,13 @@ final class SegmentCache: @unchecked Sendable {
     /// Declared by provider at top of each mediaSegment(at:); non-monotonic (backward scrub is valid).
     private var currentTargetIndex: Int = -1
 
+    /// Lowest index of the consumer's current uninterrupted fetch sequence, and the highest index it has
+    /// reached in it. A seek flushes the consumer's buffer, so only within one sequence does everything
+    /// between the playhead and the target sit in that buffer, which is what
+    /// `contiguousForwardFrontier(fromPlayhead:)` rests on.
+    private var fetchFloor: Int = -1
+    private var fetchFront: Int = -1
+
     let sessionDir: URL
 
     private var _totalBytes: Int = 0
@@ -214,6 +221,7 @@ final class SegmentCache: @unchecked Sendable {
     func declareTarget(_ index: Int) {
         condition.lock()
         var doomed: [URL] = []
+        trackFetchSequenceLocked(index)
         if index != currentTargetIndex {
             currentTargetIndex = index
             doomed = pruneOutsideWindow()
@@ -221,6 +229,23 @@ final class SegmentCache: @unchecked Sendable {
         }
         condition.unlock()
         for url in doomed { try? FileManager.default.removeItem(at: url) }
+    }
+
+    /// Must be called with condition held.
+    ///
+    /// A fetch that leaves a gap above the front, or that drops further back than a handover refetch
+    /// reaches, is the consumer arriving from somewhere else: it flushed its buffer and starts a new
+    /// sequence here. Anything else extends the current one, including the ~7-10 segment backward
+    /// refetch of the Continuous-Audio handover and its return to the front, which must NOT count as a
+    /// jump: under an opt-in prefetch the playhead sits below the retained low end, so falling back to
+    /// the playhead anchor there would re-open the #207 collapse the anchor exists to prevent.
+    private func trackFetchSequenceLocked(_ index: Int) {
+        if index > fetchFront + 1 || index < fetchFront - backwardWindow {
+            fetchFloor = index
+            fetchFront = index
+        } else {
+            fetchFront = max(fetchFront, index)
+        }
     }
 
     func peek(index: Int) -> Data? {
@@ -368,10 +393,20 @@ final class SegmentCache: @unchecked Sendable {
     ///
     /// Anchor and walk share one lock hold: reading `targetIndex` separately would let a target change
     /// land between the two and walk from an anchor that does not match the entries observed.
+    ///
+    /// The target anchor only holds while the playhead is inside the consumer's current fetch sequence.
+    /// AVPlayer fetches no further ahead than its own buffer reaches, which is what keeps everything
+    /// between the playhead and the target genuinely held; a seek removes that bound, and since
+    /// `declareTarget` lands at the destination before `currentTime()` reports it, the target would
+    /// otherwise measure the band at the destination against the position the seek jumped away from and
+    /// claim a lead the size of the seek distance (#207 field report on 5.23.4). Outside the sequence the
+    /// walk falls back to the playhead, which reports the band that is genuinely reachable from there,
+    /// or nothing when its own segment is gone.
     func contiguousForwardFrontier(fromPlayhead playheadIdx: Int) -> Int {
         condition.lock()
         defer { condition.unlock() }
-        return frontierLocked(from: max(playheadIdx, currentTargetIndex))
+        let anchor = playheadIdx >= fetchFloor ? max(playheadIdx, currentTargetIndex) : playheadIdx
+        return frontierLocked(from: anchor)
     }
 
     /// Must be called with condition held.

--- a/Tests/AetherEngineTests/Issue207FrontierAnchorTests.swift
+++ b/Tests/AetherEngineTests/Issue207FrontierAnchorTests.swift
@@ -20,7 +20,10 @@ struct Issue207FrontierAnchorTests {
         // which is exactly the #207 condition that makes the extras eviction run at all.
         let c = SegmentCache(forwardWindow: 2700, backwardWindow: 20, retentionBudgetBytes: 100)
         for i in 0...40 { c.store(index: i, data: makeData(10)) }
-        c.declareTarget(30)   // AVPlayer's fetch target runs ahead of the playhead (~120 s)
+        // The consumer fetches sequentially up to its target (~120 s ahead of the playhead). Declaring
+        // only the final index would model a jump, which is a different situation entirely: the target
+        // anchor rests on the consumer having fetched *across* the playhead, so the sequence matters.
+        for t in 0...30 { c.declareTarget(t) }
         return c
     }
 
@@ -86,6 +89,73 @@ struct Issue207FrontierAnchorTests {
         c.declareTarget(5)
         #expect(c.contiguousForwardFrontier(fromPlayhead: 5) == 8)   // stops before the hole at 9
         #expect(c.contiguousForwardFrontier(fromPlayhead: 5) == c.contiguousForwardFrontier(from: 5))
+    }
+
+    /// Field report on 5.23.4: a far seek made the frontier claim a lead the size of the seek distance
+    /// for one tick. `declareTarget` lands at the seek destination while `currentTime()` still reads the
+    /// old position, so the target anchor walked the freshly produced band and measured it against a
+    /// playhead the consumer never fetched across. The target anchor only holds inside an uninterrupted
+    /// fetch sequence: AVPlayer fetches no further ahead than its buffer reaches, which is what bounds
+    /// `target - playhead` during normal playback and what a seek removes.
+    @Test("Forward seek: the fresh target does not claim a lead over the playhead it jumped away from")
+    func forwardSeekDoesNotClaimLeadOverStalePlayhead() {
+        let c = SegmentCache(forwardWindow: 2700, backwardWindow: 20, retentionBudgetBytes: 1_000_000)
+        defer { c.close() }
+        for i in 0...40 { c.store(index: i, data: makeData(10)) }
+        for t in 0...30 { c.declareTarget(t) }
+        // Seek to segment 200; the consumer fetches there and the restarted producer writes 200/201
+        // while the clock still reads segment 20.
+        c.declareTarget(200)
+        c.store(index: 200, data: makeData(10))
+        c.store(index: 201, data: makeData(10))
+        #expect(c.peek(index: 40) != nil, "the budget has room, so the old band must still be resident")
+        #expect(c.contiguousForwardFrontier(fromPlayhead: 20) == 40)
+    }
+
+    /// Same jump under the field's actual eviction pressure: the old band is gone, so the honest answer
+    /// is that nothing is available ahead of the stale playhead. Returning below it fails the caller's
+    /// `frontier >= playheadIdx` guard, which reports a read-ahead of 0.
+    @Test("Forward seek with the old band evicted reports nothing ahead, not the band at the destination")
+    func forwardSeekWithEvictedOldBandReportsNothingAhead() {
+        let c = makeOptInPrefetchCache()
+        defer { c.close() }
+        c.declareTarget(200)
+        c.store(index: 200, data: makeData(10))
+        c.store(index: 201, data: makeData(10))
+        #expect(c.peek(index: 20) == nil, "the playhead's segment must be evicted for this to be the field case")
+        #expect(c.contiguousForwardFrontier(fromPlayhead: 20) == 19)
+    }
+
+    /// A backward seek ends the sequence too, otherwise a later forward seek that lands *below* the old
+    /// fetch front would look like a segment the consumer had already fetched and the stale band above
+    /// it would be reported as buffered.
+    @Test("Forward seek below the pre-seek fetch front is still a jump")
+    func forwardSeekBelowOldFrontIsStillAJump() {
+        let c = SegmentCache(forwardWindow: 2700, backwardWindow: 20, retentionBudgetBytes: 1_000_000)
+        defer { c.close() }
+        for i in 45...60 { c.store(index: i, data: makeData(10)) }   // band left by the first pass
+        for t in 0...50 { c.declareTarget(t) }
+        c.declareTarget(10)                                          // backward seek, producer restarts
+        for i in 10...25 { c.store(index: i, data: makeData(10)) }
+        for t in 10...20 { c.declareTarget(t) }
+        c.declareTarget(45)                                          // forward seek, below the old front
+        #expect(c.contiguousForwardFrontier(fromPlayhead: 20) == 25)
+    }
+
+    /// Guard against tightening the rule into a plain "any non-sequential index ends the sequence":
+    /// the Continuous-Audio handover refetches ~7-10 segments backward and returns to the fetch front,
+    /// which must not be read as a seek. Treating it as one would re-open #207 itself, since the playhead
+    /// under an opt-in prefetch sits below the retained low end and its segment really is evicted.
+    @Test("Handover refetch and the return to the fetch front keep the target anchor")
+    func handoverRefetchKeepsTheTargetAnchor() {
+        let c = SegmentCache(forwardWindow: 2700, backwardWindow: 20, retentionBudgetBytes: 100)
+        defer { c.close() }
+        for i in 0...60 { c.store(index: i, data: makeData(10)) }
+        for t in 0...50 { c.declareTarget(t) }
+        c.declareTarget(42)   // handover refetch, inside the backward window
+        c.declareTarget(51)   // back to the fetch front
+        #expect(c.peek(index: 21) == nil, "the playhead's own segment is an evicted extra (lo = 51 - 20)")
+        #expect(c.contiguousForwardFrontier(fromPlayhead: 21) == 60)
     }
 
     @Test("Fresh cache with no declared target walks from the playhead")


### PR DESCRIPTION
Follow-up to #223, from the field report on 5.23.4 in #207.

## The report

With the opt-in prefetch active, a far seek made `clock.bufferedPosition` claim a lead the size of the seek distance for one tick: jumping out of the resident band and then forward to segment 729, the tick taken while the clock still read the old position showed ~35 min of lead over a playhead with nothing resident ahead of it. It corrected as soon as the clock landed.

## Root cause

The #223 anchor is `max(playhead, consumer fetch target)`, and its safety rests on everything below the target sitting in the consumer's own buffer. That is true only inside an uninterrupted fetch sequence: AVPlayer fetches no further ahead than its buffer reaches, which is what keeps `target - playhead` bounded during normal playback (~30 segments, ~120 s).

A seek removes that bound. `declareTarget` lands at the destination before `currentTime()` reports it (AVPlayer needs the data to seek), so for the ticks in between the walk starts at the destination, runs through the freshly produced band, and measures it against the position the seek jumped away from.

Worth noting for the reading of the report: the quoted `fwd=2089.6` is AVPlayer's own `loadedTimeRanges` value, not `bufferedPosition`; AVPlayer makes the same axis error during the seek. The engine-side number lands in the same magnitude for the reason above.

## The change

`SegmentCache` tracks the current fetch sequence (`fetchFloor`, `fetchFront`), and the anchor falls back to the playhead outside it:

```swift
let anchor = playheadIdx >= fetchFloor ? max(playheadIdx, currentTargetIndex) : playheadIdx
```

A jump is an index above `fetchFront + 1` or more than `backwardWindow` below the front. The second clause is load-bearing: the Continuous-Audio handover refetches ~7-10 segments backward and returns to the fetch front, and reading that as a seek would re-open the #207 collapse this anchor exists to prevent (the guard test covers it, and it fails against the naive "any non-sequential index ends the sequence" rule).

Ending the sequence on a backward seek is what lets a later forward seek that lands *below* the pre-seek front still be recognised as a jump.

The four #223 invariants are unchanged: no unbounded hole skip, `max` still keeps a backward refetch from dragging the anchor back, anchor and walk still share one lock hold, and the caller's guard still measures against the playhead (#54 clamp).

## Residual

A scrub shorter than the backward window stays inside the sequence, so a tick or two around it can still anchor on the old target. The error is bounded by that window instead of by the seek distance, and it is documented at the call site.

## Verification

- 4 new tests in `Issue207FrontierAnchorTests` (forward-seek claim with the old band resident and with it evicted, forward seek below the pre-seek front, handover guard), each watched failing first
- `Issue207FrontierAnchorTests` also now models the consumer's sequential fetches instead of a single declared target, which is what the anchor's premise is about
- 1100 tests green (baseline 1096)
- `swift build -Xswiftc -strict-concurrency=complete` clean
- tvOS Simulator build green

Analysis and device logs by @fxndxs, credited as co-author.