### PR TITLE
fix(airplay): keep the SDR master so native subtitles reach the receiver (#227)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ the public-API contract.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Native subtitles now reach a wireless AirPlay receiver instead of being dropped on the way there.** A `SUBTITLES` rendition can only be declared in a master playlist, but the AirPlay rewrite that moves the loopback onto the device's LAN IP also forced the media playlist for every source, so the receiver was handed a manifest with no `EXT-X-MEDIA` tags: `setNativeSubtitleSelected(track:)` had no legible group to select against, succeeded, and changed nothing. The blanket downgrade came from a real constraint that is narrower than the rule built on it, namely that AVPlayer rejects an HDR or Dolby Vision master on a receiver that is not in HDR or DV mode and will not switch by itself. An SDR variant is routing-safe on any receiver, so it now keeps its master and its renditions travel; the master's rendition URIs are relative and resolve against the LAN base with no further work. HDR and DV sources keep the media downgrade, because an SDR-signalled master over HDR content does not fool the compatibility gate either (it reads the real `colr` and codec, not the manifest string), and `nativeSubtitleRenditionsServed` now reports that honestly on the AirPlay hop rather than describing the local session, so a host can tell the user their subtitles will not travel to this route. The reactive master-rejection fallback also rewrites onto the LAN IP now: it previously reloaded the `127.0.0.1` media playlist, which a receiver cannot reach. Reported by thatcube. Covered by `AirPlayPlaylistDecisionTests`.
+
 ## [5.23.7] - 2026-07-26
 
 ([release notes](https://github.com/superuser404notfound/AetherEngine/releases/tag/5.23.7))

--- a/Sources/AetherEngine/AetherEngine+Loading.swift
+++ b/Sources/AetherEngine/AetherEngine+Loading.swift
@@ -686,23 +686,19 @@ extension AetherEngine {
         var playbackURL = try await Task.detached(priority: .userInitiated) { [session] in
             try session.start()
         }.value
-        #if os(iOS)
-        // AirPlay (#86): while external playback is active, serve the loopback over the device's LAN IP and
-        // force the media playlist, so the receiver reaches the engine-processed stream (DV/Atmos/subtitles
-        // preserved) and isn't handed a DV/HDR master it rejects on an SDR panel (DrHurt). Reverts on the
-        // reload when AirPlay ends.
-        if airPlayActive, let lanURL = airPlayPlaybackURL(base: playbackURL) {
-            EngineLog.emit("[AirPlay] loadNative serving via \(lanURL.absoluteString)", category: .engine)
-            playbackURL = lanURL
-        }
-        #endif
+        // AirPlay (#86): while external playback is active, serve the loopback over the device's LAN IP so
+        // the receiver reaches the engine-processed stream (DV/Atmos/subtitles preserved). An HDR/DV master
+        // is downgraded to the media playlist there (an SDR receiver rejects it, DrHurt); an SDR master is
+        // kept so its subtitle renditions survive the trip (#227). Reverts on the reload when AirPlay ends.
+        let served = airPlayAdjustedPlayback(url: playbackURL, session: session)
+        playbackURL = served.url
         // Superseded while starting: stop and unwind before touching shared state.
         if loadGeneration != generation {
             session.stop()
             try checkLoadCurrent(generation)
         }
         self.nativeVideoSession = session
-        nativeSubtitleRenditionsServed = session.servingMasterPlaylist
+        nativeSubtitleRenditionsServed = served.subtitleRenditionsServed
         extractorYieldState.activate(session: session)
 
         // #15: the stores were created before start() (above) so the VideoSegmentProvider got the references at

--- a/Sources/AetherEngine/AetherEngine.swift
+++ b/Sources/AetherEngine/AetherEngine.swift
@@ -1160,6 +1160,10 @@ public final class AetherEngine: ObservableObject {
         masterFallbackUsed = true
         session.markServingMediaAfterFallback()
         nativeSubtitleRenditionsServed = false
+        // #227: while AirPlaying, the item under the rejection is the LAN-IP URL; `mediaPlaylistURL` is the
+        // 127.0.0.1 loopback the receiver cannot reach, so the fallback has to be rewritten too or the
+        // recovery loads nothing. Media playlist already, so there is no master to keep.
+        let fallbackURL = airPlayActive ? (airPlayPlaybackURL(base: mediaURL) ?? mediaURL) : mediaURL
         // #130: a live fallback is a REJOIN of the running ingest (the window may have slid since
         // the failed master attempt); a stale explicit position can wedge AVPlayer against the
         // backlog, so skip the initial seek and let it pick edge-minus-holdback (LiveReloadPolicy).
@@ -1170,7 +1174,7 @@ public final class AetherEngine: ObservableObject {
             + "media playlist (no CC/subtitle renditions) at "
             + (isLive ? "the live edge" : "\(String(format: "%.2f", position))s"),
             category: .session)
-        host.load(url: mediaURL,
+        host.load(url: fallbackURL,
                   startPosition: isLive ? nil : position,
                   skipInitialSeek: LiveReloadPolicy.skipInitialSeek(isLive: isLive, isRejoin: true),
                   inPlaceSwap: true)
@@ -3277,8 +3281,9 @@ public final class AetherEngine: ObservableObject {
     }
 
     /// AirPlay (#86, DrHurt): true while the native AVPlayer reports external playback. loadNative reads it to
-    /// serve the loopback over the device's LAN IP (the receiver can't reach 127.0.0.1) AND to force the MEDIA
-    /// playlist (AVPlayer rejects a DV/HDR MASTER playlist on an SDR receiver and won't auto-switch, DrHurt).
+    /// serve the loopback over the device's LAN IP (the receiver can't reach 127.0.0.1), and for an HDR/DV
+    /// source also to force the MEDIA playlist (AVPlayer rejects a DV/HDR MASTER playlist on an SDR receiver
+    /// and won't auto-switch, DrHurt). An SDR master is kept so its subtitle renditions travel (#227).
     /// Loopback native path only; a remote-HLS source is already receiver-reachable, so it's left untouched.
     private(set) var airPlayActive = false
     private var externalPlaybackObservation: NSKeyValueObservation?
@@ -3326,15 +3331,39 @@ public final class AetherEngine: ObservableObject {
         #endif
     }
 
-    /// AirPlay loopback URL (#86): rewrite the loopback playback URL to the device's LAN IP and force the MEDIA
-    /// playlist, so the receiver reaches the engine-processed stream and isn't handed a DV/HDR master it rejects
-    /// on an SDR panel (DrHurt). nil if no LAN IP (caller keeps the original 127.0.0.1 URL).
-    func airPlayPlaybackURL(base: URL) -> URL? {
+    /// Playback URL and subtitle-rendition reality for a freshly started loopback session, after the AirPlay
+    /// rewrite (#86, #227). Identity outside iOS and whenever external playback is off; when the LAN IP scan
+    /// comes up empty the loopback URL stays as resolved (the receiver then simply cannot reach it, unchanged
+    /// from #86). `subtitleRenditionsServed` is what the served playlist actually carries, which is what
+    /// `nativeSubtitleRenditionsServed` promises hosts.
+    func airPlayAdjustedPlayback(url: URL, session: HLSVideoEngine) -> (url: URL, subtitleRenditionsServed: Bool) {
+        #if os(iOS)
+        guard airPlayActive else { return (url, session.servingMasterPlaylist) }
+        let keepMaster = AirPlayPlaylistDecision.servesMasterToReceiver(
+            servingMasterPlaylist: session.servingMasterPlaylist,
+            sourceIsHDR: session.servedSourceIsHDR)
+        guard let lanURL = airPlayPlaybackURL(base: url, keepMaster: keepMaster) else {
+            EngineLog.emit("[AirPlay] no LAN IP; keeping \(url.absoluteString)", category: .engine)
+            return (url, session.servingMasterPlaylist)
+        }
+        EngineLog.emit("[AirPlay] loadNative serving via \(lanURL.absoluteString) (keepMaster=\(keepMaster) "
+                       + "sourceIsHDR=\(session.servedSourceIsHDR) subtitle renditions "
+                       + "\(keepMaster ? "carried" : "dropped"))", category: .engine)
+        return (lanURL, keepMaster)
+        #else
+        return (url, session.servingMasterPlaylist)
+        #endif
+    }
+
+    /// AirPlay loopback URL (#86): rewrite the loopback playback URL to the device's LAN IP so the receiver
+    /// reaches the engine-processed stream. nil if no LAN IP (caller keeps the original 127.0.0.1 URL).
+    ///
+    /// `keepMaster` false also downgrades the path to the MEDIA playlist, for the HDR/DV master an SDR
+    /// receiver rejects (DrHurt). An SDR master is routing-safe on any receiver and is kept, because the
+    /// subtitle renditions live only there (#227); see `AirPlayPlaylistDecision`.
+    func airPlayPlaybackURL(base: URL, keepMaster: Bool = false) -> URL? {
         guard let lanIP = HLSLocalServer.localActiveIPAddress() else { return nil }
-        var c = URLComponents(url: base, resolvingAgainstBaseURL: false)
-        c?.host = lanIP
-        c?.path = "/media.m3u8"
-        return c?.url
+        return AirPlayPlaylistDecision.receiverURL(base: base, lanIP: lanIP, keepMaster: keepMaster)
     }
 
     #if os(tvOS) || os(iOS)

--- a/Sources/AetherEngine/Native/AirPlayPlaylistDecision.swift
+++ b/Sources/AetherEngine/Native/AirPlayPlaylistDecision.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// Pure playlist choice for the wireless-AirPlay loopback rewrite (#86, #227). Kept separate and pure
+/// so the gate is testable offline, matching `MasterFallbackDecision` / `StartupReadinessGate`.
+///
+/// #86 rewrites the loopback playback URL to the device's LAN IP (the receiver cannot reach 127.0.0.1)
+/// and originally forced the MEDIA playlist for every source, on DrHurt's caveat that "AVPlayer will
+/// reject a DV/HDR master playlist on an SDR receiver and will not automatically switch". That caveat is
+/// about the HDR/DV variant, not about masters as such, but the blanket downgrade also dropped the
+/// master-only `EXT-X-MEDIA:TYPE=SUBTITLES` renditions, so `setNativeSubtitleSelected(track:)` had no
+/// legible group to select against and native subtitles never reached any receiver (#227, thatcube).
+///
+/// An SDR variant is routing-safe on every receiver, so it keeps the master (and its subtitle
+/// renditions). HDR/DV keeps the media downgrade: an SDR-signalled master over HDR/DV content was tried
+/// and reverted in #98 Stage 1.5 (the compatibility gate reads the real colr/codec, not the manifest
+/// string), so there is no manifest that both survives an SDR receiver and carries renditions.
+enum AirPlayPlaylistDecision {
+
+    /// Whether the master playlist (with its subtitle renditions) can be served to a wireless AirPlay
+    /// receiver. False downgrades the rewritten URL to `media.m3u8`, which carries no renditions.
+    ///
+    /// - Parameters:
+    ///   - servingMasterPlaylist: what `HLSVideoEngine.start()` resolved for local playback. When it is
+    ///     already the media playlist there is no master to keep.
+    ///   - sourceIsHDR: the served variant carries HDR/DV signaling (`HLSVideoEngine.servedSourceIsHDR`).
+    static func servesMasterToReceiver(servingMasterPlaylist: Bool, sourceIsHDR: Bool) -> Bool {
+        servingMasterPlaylist && !sourceIsHDR
+    }
+
+    /// The loopback URL rewritten for the receiver: same port and query, the device's LAN IP for the host
+    /// (the receiver cannot reach 127.0.0.1), and the media playlist unless the master is kept. The master's
+    /// `EXT-X-MEDIA` URIs are relative, so the renditions resolve against the LAN base with no further work.
+    static func receiverURL(base: URL, lanIP: String, keepMaster: Bool) -> URL? {
+        var components = URLComponents(url: base, resolvingAgainstBaseURL: false)
+        components?.host = lanIP
+        if !keepMaster { components?.path = "/media.m3u8" }
+        return components?.url
+    }
+}

--- a/Sources/AetherEngine/Video/HLSVideoEngine.swift
+++ b/Sources/AetherEngine/Video/HLSVideoEngine.swift
@@ -1392,6 +1392,7 @@ public final class HLSVideoEngine: @unchecked Sendable {
             throw HLSVideoEngineError.openFailed(reason: "server URL not ready")
         }
         self.servingMasterPlaylist = useMasterPlaylist
+        self.servedSourceIsHDR = videoRange != .sdr || effectiveDvMode
         EngineLog.emit("[HLSVideoEngine] serving on \(url.absoluteString) (dvModeAvailable=\(dvModeAvailable) effectiveDvMode=\(effectiveDvMode) panelIsHDR=\(panelIsInHDRMode) displaySupportsHDR=\(displaySupportsHDR) matchContent=\(matchContentEnabled) sourceIsHDR=\(videoRange != .sdr || effectiveDvMode) useMaster=\(useMasterPlaylist) videoRange=\(videoRange) dvVariant=\(dvVariant))")
         return url
     }
@@ -1465,6 +1466,10 @@ public final class HLSVideoEngine: @unchecked Sendable {
 
     /// `true` when `start()` chose the master playlist (HDR/DV signaling). Read after `start()`.
     public private(set) var servingMasterPlaylist: Bool = false
+
+    /// `true` when the served variant carries HDR/DV signaling (`VIDEO-RANGE` other than SDR, or a DV
+    /// codec tag), i.e. the master an external receiver in SDR mode rejects (#227). Read after `start()`.
+    public private(set) var servedSourceIsHDR: Bool = false
 
     /// The loopback server's media (single-variant) playlist URL, for the reactive master->media
     /// fallback (#98). Nil before the server starts.

--- a/Tests/AetherEngineTests/AirPlayPlaylistDecisionTests.swift
+++ b/Tests/AetherEngineTests/AirPlayPlaylistDecisionTests.swift
@@ -1,0 +1,50 @@
+import Foundation
+import Testing
+@testable import AetherEngine
+
+struct AirPlayPlaylistDecisionTests {
+
+    @Test("#227: an SDR master survives the AirPlay rewrite, so its subtitle renditions travel")
+    func sdrMasterIsKept() {
+        #expect(AirPlayPlaylistDecision.servesMasterToReceiver(
+            servingMasterPlaylist: true, sourceIsHDR: false))
+    }
+
+    @Test("#86: an HDR/DV master is still downgraded (an SDR receiver rejects it)")
+    func hdrMasterIsDowngraded() {
+        #expect(!AirPlayPlaylistDecision.servesMasterToReceiver(
+            servingMasterPlaylist: true, sourceIsHDR: true))
+    }
+
+    @Test("A session already on the media playlist has no master to keep")
+    func mediaSessionStaysMedia() {
+        #expect(!AirPlayPlaylistDecision.servesMasterToReceiver(
+            servingMasterPlaylist: false, sourceIsHDR: false))
+        #expect(!AirPlayPlaylistDecision.servesMasterToReceiver(
+            servingMasterPlaylist: false, sourceIsHDR: true))
+    }
+
+    @Test("#86: the rewrite swaps the loopback host for the LAN IP and keeps the port")
+    func rewritesHostKeepsPort() throws {
+        let base = try #require(URL(string: "http://127.0.0.1:52341/master.m3u8"))
+        let url = try #require(AirPlayPlaylistDecision.receiverURL(
+            base: base, lanIP: "192.168.8.166", keepMaster: true))
+        #expect(url.absoluteString == "http://192.168.8.166:52341/master.m3u8")
+    }
+
+    @Test("#86: without keepMaster the path is forced to the media playlist")
+    func forcesMediaPath() throws {
+        let base = try #require(URL(string: "http://127.0.0.1:52341/master.m3u8"))
+        let url = try #require(AirPlayPlaylistDecision.receiverURL(
+            base: base, lanIP: "192.168.8.166", keepMaster: false))
+        #expect(url.absoluteString == "http://192.168.8.166:52341/media.m3u8")
+    }
+
+    @Test("#227: rewriting the media URL again (the fallback path) is idempotent")
+    func mediaRewriteIsIdempotent() throws {
+        let base = try #require(URL(string: "http://127.0.0.1:52341/media.m3u8"))
+        let url = try #require(AirPlayPlaylistDecision.receiverURL(
+            base: base, lanIP: "192.168.8.166", keepMaster: false))
+        #expect(url.absoluteString == "http://192.168.8.166:52341/media.m3u8")
+    }
+}

--- a/docs/formats.md
+++ b/docs/formats.md
@@ -126,6 +126,8 @@ Host-rendered subtitle overlays are invisible in Picture-in-Picture, AirPlay, an
 
 **Routing scope.** A `SUBTITLES` rendition can only live in a master playlist, so native subtitles ride the master-routing rules: SDR sources on any panel, HDR / DV sources on HDR-ready panels. HDR-on-SDR-panel and DV Profile 5 on non-DV panels stay media-direct (no master, hence no native subtitles there); the host overlay still covers fullscreen. Bitmap subtitles (PGS / DVB / DVD) join as OCR-fed renditions: while a bitmap track is selected, a worker decodes its harvested packets ahead of the playhead (composition ends resolved at the next composition/clear event, the 5.14.1 sidecar semantics) and recognizes them on-device (Vision, track-language hinted) into plain-text cues for the track's rendition. Recognition is lossy by design; a failed or empty read drops that line from the rendition while fullscreen keeps the pixel-accurate bitmap overlay. External .sup sidecars fill their store from the selection-time sidecar decode's own image cues (no second fetch). Live sources are out of scope.
 
+**Wireless AirPlay (#86, #227).** While an iOS session plays to a wireless AirPlay receiver, the engine reloads its loopback over the device's LAN IP (the receiver cannot reach `127.0.0.1`). An SDR source keeps the master there, so its `SUBTITLES` renditions travel to the receiver and `setNativeSubtitleSelected(track:)` has a legible group to select against; the `EXT-X-MEDIA` URIs are relative, so the renditions resolve against the LAN base. An HDR / DV source is downgraded to the media playlist on that hop, because AVPlayer rejects an HDR / DV master on a receiver that is not in HDR or DV mode and will not switch by itself, and an SDR-signalled master over HDR content does not fool the compatibility gate either (see the fallback below). Native subtitles therefore do not reach the receiver for HDR / DV sources; `$nativeSubtitleRenditionsServed` reports that honestly (false on that hop), so a host can tell the user instead of silently dropping them. A wired HDMI external display is a different route and keeps the loopback plus its master.
+
 **Master-rejection fallback (#98, #130).** When AVPlayer rejects the served master (`-11868` AVErrorNoCompatibleAlternatesForExternalDisplay, `-11848` for an SDR-parked panel, or `-1002` when every variant was filtered at master parse time), the engine reloads the bare media playlist in place; a live session rejoins at the edge instead of replaying its stale start position. HDR / DV on an SDR external display is therefore media-playlist-driven (an AVKit limitation: forcing `VIDEO-RANGE=SDR` does not fool the external-display compatibility gate, which checks the real `colr` / codec rather than the manifest string), so the `SUBTITLES` renditions do not travel there. The separate `#35` cold-DV-start readiness gate, whose scenario is an HDR TV, first tries an HDR-preserving reduced master (`SUPPLEMENTAL-CODECS` dropped so it is plain HDR10, source range and `SUBTITLES` group kept) before the bare media playlist, so a cold DV start keeps HDR10 plus subtitles instead of dropping straight to subtitle-less media.
 
 **Rich ASS styling.** With `LoadOptions.preserveASSMarkup` the tap keeps raw ASS event lines so the host overlay renders full styling (positions, colours); the WebVTT renditions strip the markup at serve time, so PiP shows plain text in the system caption style.
@@ -141,8 +143,10 @@ Host-rendered subtitle overlays are invisible in Picture-in-Picture, AirPlay, an
 engine.$nativeSubtitleRenditionAvailable   // @Published var Bool
 
 // true while the loopback session serves a master carrying the SUBTITLES group;
-// goes false on a media-playlist fallback. Hosts use it to decide whether to draw
-// their own subtitle window on a wired external display instead (#98)
+// goes false on a media-playlist fallback and on the wireless-AirPlay hop for an
+// HDR / DV source (#227). Hosts use it to decide whether to draw their own subtitle
+// window on a wired external display instead (#98), or to tell the user that
+// subtitles will not travel to this route
 engine.$nativeSubtitleRenditionsServed     // @Published var Bool
 
 // ordered list of all native subtitle renditions (ordinal, language tag, display name)


### PR DESCRIPTION
Refs #227 (reported by @thatcube).

## Root cause

The reporter's reading of the code is correct. `HLSVideoEngine.resolveUseMasterPlaylist` already forces the master playlist for any routing-safe subtitled source (#15), so an SDR source with text tracks resolves to `master.m3u8` with its `EXT-X-MEDIA:TYPE=SUBTITLES` renditions. The #86 AirPlay rewrite then discarded that: while external playback is active it rebuilt the playback URL on the device's LAN IP **and** forced `/media.m3u8` for every source. A media playlist has no `EXT-X-MEDIA` tags, so the receiver was handed a manifest with no legible group, `setNativeSubtitleSelected(track:)` had nothing to select against, and the call succeeded while changing nothing. Mutually exclusive by construction, exactly as described.

The constraint that motivated the blanket downgrade is narrower than the rule built on it. DrHurt's caveat in #86 was specifically that "AVPlayer will reject a DV/HDR master playlist on an SDR receiver and will not automatically switch"; the safe-universal media routing was his suggestion on top of it. An SDR variant is routing-safe on any receiver.

## Fix

- **SDR keeps the master on the AirPlay hop**, so its subtitle renditions travel. The master's `EXT-X-MEDIA` URIs are relative, so they resolve against the LAN base with no extra work.
- **HDR/DV keeps the media downgrade.** The reporter's first direction (a master with a single SDR variant) was tried and reverted in #98 Stage 1.5: forcing `VIDEO-RANGE=SDR` does not fool the external-display compatibility gate, which reads the real `colr`/codec rather than the manifest string. So the second direction, master only when the source is SDR, is the one the manifests actually allow.
- **The constraint is now exposed** rather than silent, which is the reporter's third direction: `nativeSubtitleRenditionsServed` reports the playlist actually served to the receiver instead of the one the local session resolved, so it goes false on an HDR/DV AirPlay hop and a host can tell the user their subtitles will not travel. No new API needed; the flag already promised exactly this and was simply lying on that path.
- **The master-rejection fallback is AirPlay-aware.** It reloaded `session.mediaPlaylistURL`, the `127.0.0.1` loopback the receiver cannot reach. A receiver that rejects the kept SDR master (an older receiver with no 4K HEVC, say) now recovers onto the LAN media playlist instead of loading nothing. This was latent before the change: `servingMasterPlaylist` read true on the AirPlay path while media was actually served, so a rejection already routed into that dead fallback.

`AirPlayPlaylistDecision` holds the keep-master gate and the URL rewrite as pure functions, in the style of `MasterFallbackDecision` / `StartupReadinessGate`. `HLSVideoEngine.servedSourceIsHDR` publishes what the served variant signals so the gate does not re-derive it.

The `#35` startup-readiness gate also loads loopback URLs, but it arms only on a real display-criteria panel switch, which is tvOS-only, so it cannot collide with the iOS AirPlay path.

## Verification

- `AirPlayPlaylistDecisionTests`, 6 new cases (keep/downgrade gate, host swap keeps the port, media path forcing, idempotent re-rewrite).
- Full suite 1106 tests green; `swift build -Xswiftc -strict-concurrency=complete` clean; standalone iOS and tvOS builds clean, no warnings.
- Not device-verified yet: the behaviour change is on the wireless AirPlay hop, which needs an iPad plus receiver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QYhPvBB1sLCYoZNasEXFeB