### PR TITLE
Anchor the native subtitle readers' seek on the subtitle axis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ the public-API contract.
 
 ## [Unreleased]
 
+### Fixed
+
+- **The native subtitle readers anchor their positioning seek on the subtitle axis too.** Same defect as #234 reached from the other direction, and not part of that regression: these readers seek before they set their discard flags, so at seek time every stream is still `AVDISCARD_DEFAULT`, every stream collects `av_find_default_stream_index`'s +200 for `discard != AVDISCARD_ALL`, and video takes the reference on its own +75. There was never an accidental subtitle anchor here to lose, so this predates #230 entirely, but the consequence is the one #234 describes: on Matroska the seek lands in the cluster holding the last video keyframe, and a cue that starts further back is behind the read head before the first packet arrives. These readers feed the native WebVTT renditions, so what went missing was the line that should be on screen where a seek lands. The anchor is now the lowest routed subtitle stream, and the `native subtitle readers started` line carries `anchor=<index>`. A whole-program read (Sodalite#32) starts at 0 and is unaffected either way.
+
 ## [5.25.1] - 2026-07-28
 
 ([release notes](https://github.com/superuser404notfound/AetherEngine/releases/tag/5.25.1))

--- a/Sources/AetherEngine/AetherEngine+Subtitles.swift
+++ b/Sources/AetherEngine/AetherEngine+Subtitles.swift
@@ -1183,7 +1183,15 @@ extension AetherEngine {
         // #112 round 10: same bounded positioning + verified byte-estimate fallback as the embedded reader
         // (memory rule: both side readers share every positioning fix). A whole-program read (readToEOF)
         // starts at 0 and needs no fallback.
-        if !demuxer.seekBounded(to: seekTo, timeout: Self.sideReaderSeekBudgetSeconds) {
+        //
+        // #234: anchored on the routed subtitle axis for the same reason the prefetcher is, arrived at from
+        // the other direction. This seek runs before the discard flags below, so every stream still scores
+        // `av_find_default_stream_index`'s +200 for `discard != AVDISCARD_ALL` and video takes the reference
+        // on its own +75. Unlike the prefetcher there was never an accidental subtitle anchor here to lose,
+        // so this is not part of the #230 regression, but the landing cue it drops is the same one.
+        let seekAnchor = pairs.map(\.streamIndex).min() ?? -1
+        if !demuxer.seekBounded(to: seekTo, anchorStreamIndex: seekAnchor,
+                                timeout: Self.sideReaderSeekBudgetSeconds) {
             demuxer.markTimestampSeekUnreliable()
             let engineDisplayDuration = await MainActor.run { [weak self] in self?.duration ?? 0 }
             let fellBack = demuxer.seekByteEstimate(
@@ -1236,7 +1244,7 @@ extension AetherEngine {
         EngineLog.emit(
             "[AetherEngine] native subtitle readers started: streams=\(routes.keys.sorted()) " +
             "startAt=\(String(format: "%.2f", startAt))s effectiveStart=\(String(format: "%.2f", effectiveStart))s " +
-            "seekTo=\(String(format: "%.2f", seekTo))s",
+            "seekTo=\(String(format: "%.2f", seekTo))s anchor=\(seekAnchor)",
             category: .engine
         )
 

--- a/Tests/AetherEngineTests/Issue234SideReaderSeekAnchorTests.swift
+++ b/Tests/AetherEngineTests/Issue234SideReaderSeekAnchorTests.swift
@@ -220,7 +220,9 @@ struct Issue234SideReaderSeekAnchorTests {
                 "a target past the last cue must land on that cue, not back at the landing")
     }
 
-    private static let fixtureBase64 = """
+    /// Shared with `NativeSubtitleReaderSeekAnchorTests`, which models the other side reader's
+    /// setup order on the same bytes.
+    static let fixtureBase64 = """
 GkXfo6NChoEBQveBAULygQRC84EIQoKIbWF0cm9za2FCh4EEQoWBAhhTgGcBAAAAAAANYRFNm3TAv4QghbfcTbuLU6uEFUmp
     ZlOsgaFNu4tTq4QWVK5rU6yB8U27jFOrhBJUw2dTrIIBwU27jFOrhBxTu2tTrIIMHewBAAAAAAAAUwAAAAAAAAAAAAAAAAAA
     AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFUmp

--- a/Tests/AetherEngineTests/NativeSubtitleReaderSeekAnchorTests.swift
+++ b/Tests/AetherEngineTests/NativeSubtitleReaderSeekAnchorTests.swift
@@ -1,0 +1,99 @@
+import Foundation
+import Testing
+import Libavcodec
+import Libavformat
+import Libavutil
+@testable import AetherEngine
+
+/// The other half of #234, found while fixing it and not a regression: `runNativeSubtitleReaders`
+/// has the same unanchored positioning seek, for a different reason.
+///
+/// The forward prefetcher sets its discard flags and then seeks, so before #230 the subtitle stream
+/// was the sole survivor of `av_find_default_stream_index`'s +200 for `discard != AVDISCARD_ALL`
+/// and anchored the seek by accident. The native readers seek first and set discard afterwards, so
+/// at seek time every stream is still `AVDISCARD_DEFAULT`, every stream scores the +200, and video
+/// wins on its own +75. That has been true since the readers were written: there was never an
+/// accident to lose.
+///
+/// The consequence is the same as #234's. On Matroska the seek lands in the cluster holding the
+/// last video keyframe, so a cue that starts further back is behind the read head before the first
+/// packet arrives and the destination stays uncovered until the next cue. The readers feed the
+/// native WebVTT renditions, so what goes missing there is the line that should be on screen when a
+/// seek lands.
+///
+/// Both readers are meant to share every positioning fix, so this pins the same anchor down here.
+/// Fixture and shape are #234's: landing at 3 s running to 11 s, successor at 12 s, seek to 7.5 s.
+struct NativeSubtitleReaderSeekAnchorTests {
+
+    private static let seekTarget = 7.5
+    private static let landingCue = 3.0
+    private static let successorCue = 12.0
+
+    private static func makeDemuxer() throws -> Demuxer {
+        let data = try #require(Data(base64Encoded: Issue234SideReaderSeekAnchorTests.fixtureBase64,
+                                     options: .ignoreUnknownCharacters))
+        let demuxer = Demuxer()
+        try demuxer.open(reader: DataIOReader(data: data), formatHint: "matroska")
+        return demuxer
+    }
+
+    private static func firstDeliveredPTS(_ demuxer: Demuxer, streamIndex: Int32) -> Double? {
+        guard let tb = demuxer.stream(at: streamIndex)?.pointee.time_base,
+              tb.num > 0, tb.den > 0 else { return nil }
+        while let pkt = try? demuxer.readPacket() {
+            let idx = pkt.pointee.stream_index
+            let pts = pkt.pointee.pts
+            var p: UnsafeMutablePointer<AVPacket>? = pkt
+            trackedPacketFree(&p)
+            guard idx == streamIndex, pts != Int64.min else { continue }
+            return Double(pts) * Double(tb.num) / Double(tb.den)
+        }
+        return nil
+    }
+
+    private static func subtitleIndex(_ demuxer: Demuxer) throws -> Int32 {
+        Int32(try #require(demuxer.subtitleTrackInfos().first).id)
+    }
+
+    /// The readers' setup order stated as the score it produces: nothing is discarded yet when the
+    /// positioning seek runs, so the +200 is universal and video's +75 decides.
+    @Test("before any discard flag is set the default seek reference is video")
+    func defaultReferenceIsVideoBeforeDiscard() throws {
+        let demuxer = try Self.makeDemuxer()
+        defer { demuxer.close() }
+        #expect(demuxer.defaultSeekReferenceStreamIndex() == demuxer.videoStreamIndex)
+    }
+
+    /// The cost of that: the landing cue is behind the read head, exactly as in #234.
+    @Test("an unanchored seek in the readers' setup order drops the landing cue")
+    func unanchoredSeekDropsTheLandingCue() throws {
+        let demuxer = try Self.makeDemuxer()
+        defer { demuxer.close() }
+        let subtitle = try Self.subtitleIndex(demuxer)
+        _ = demuxer.seekBounded(to: Self.seekTarget, timeout: 5)
+        #expect(Self.firstDeliveredPTS(demuxer, streamIndex: subtitle) == Self.successorCue)
+    }
+
+    /// Anchored on the routed subtitle stream the landing survives, and it survives before the
+    /// discard flags exist, which is where the readers actually seek.
+    @Test("an explicit anchor keeps the landing cue in the readers' setup order")
+    func anchoredSeekKeepsTheLandingCue() throws {
+        let demuxer = try Self.makeDemuxer()
+        defer { demuxer.close() }
+        let subtitle = try Self.subtitleIndex(demuxer)
+        #expect(demuxer.seekBounded(to: Self.seekTarget, anchorStreamIndex: subtitle, timeout: 5))
+        #expect(Self.firstDeliveredPTS(demuxer, streamIndex: subtitle) == Self.landingCue)
+    }
+
+    /// A whole-program read (Sodalite#32) starts at 0 and has nothing to anchor away from, so the
+    /// anchor must be harmless there rather than special-cased.
+    @Test("anchoring a seek to zero changes nothing")
+    func anchorAtZeroIsHarmless() throws {
+        let demuxer = try Self.makeDemuxer()
+        defer { demuxer.close() }
+        let subtitle = try Self.subtitleIndex(demuxer)
+        #expect(demuxer.seekBounded(to: 0, anchorStreamIndex: subtitle, timeout: 5))
+        #expect(Self.firstDeliveredPTS(demuxer, streamIndex: subtitle) == Self.landingCue,
+                "the first cue in the file is still the first cue delivered")
+    }
+}


### PR DESCRIPTION
Follow-up to #236, found while fixing #234. **Not** part of that regression, and deliberately a separate commit.

## The difference

The forward prefetcher sets its discard flags and *then* seeks, so before #230 the subtitle stream was the sole survivor of `av_find_default_stream_index`'s +200 for `discard != AVDISCARD_ALL` and anchored the seek by accident. #230 took that accident away, which is #234.

`runNativeSubtitleReaders` seeks *first* and sets discard afterwards. At seek time every stream is still `AVDISCARD_DEFAULT`, so every stream scores the +200 and video wins on its own +75. There was never an accident here to lose: these readers have been video-anchored since they were written.

## Why it still matters

The consequence is identical. On Matroska `matroska_read_seek` jumps to the cluster holding the reference stream's index entry, so a cue that starts further back than that cluster is behind the read head before the first packet is delivered. These readers feed the native WebVTT renditions, so what goes missing is the line that should be on screen where a seek lands.

## Change

Anchor on the lowest routed subtitle stream (`pairs.map(\.streamIndex).min()`), the same rule the prefetcher now uses, and report it as `anchor=<index>` on the `native subtitle readers started` line. A whole-program read (Sodalite#32) starts at 0 and is unaffected either way, which is covered by a test rather than a special case.

## Cost

On a source whose subtitle track carries no cue points, an anchored Matroska seek falls through `matroska_read_seek`'s `goto err` into `seek_frame_generic`, which scans forward from `data_offset`. That is bounded by the existing side-reader seek budget and the verified byte-estimate fallback, the same net the prefetcher has relied on for this shape since 5.9.7. Worth knowing rather than worth special-casing.

## Verification

- `NativeSubtitleReaderSeekAnchorTests`, 4 cases on #234's Matroska fixture: the pre-discard reference really is video, the unanchored seek really drops the landing cue, the anchor restores it, and an anchored seek to 0 changes nothing.
- `swift test`: 1165 tests / 186 suites green.
- `swift build -Xswiftc -strict-concurrency=complete` clean, tvOS Simulator `xcodebuild` BUILD SUCCEEDED.