### PR TITLE
fix(subtitles): keep cue placement across every retained-store rebuild (#233)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ the public-API contract.
 
 _Nothing yet._
 
+## [5.28.1] - 2026-07-29
+
+([release notes](https://github.com/superuser404notfound/AetherEngine/releases/tag/5.28.1))
+
+### Fixed
+
+- **`SubtitleCue.placement` reached the host on sidecars but never on an embedded track.** 5.26.0 added the field and the decoders fill it correctly, but every operation on the retained cue store rebuilt the cue through the memberwise initializer to change one field, listing the fields it happened to know about. `placement` is defaulted there for source compatibility, so those call sites dropped it and still compiled. The decisive one stamps the session-monotonic id on every cue entering the store, so nothing arriving through the drained embedded path could carry a placement at all, and the #107 text trim would have dropped it a second time on each teletext page transition. That is the split the reporter saw: WebVTT placement worked because a sidecar's cues are published as decoded, teletext placement did not because it is an embedded track. Cue rebuilds now go through one copy helper that carries every field it is not asked to change. Reported by tresby (#233).
+
 ## [5.28.0] - 2026-07-28
 
 ([release notes](https://github.com/superuser404notfound/AetherEngine/releases/tag/5.28.0))

--- a/Examples/README.md
+++ b/Examples/README.md
@@ -17,7 +17,7 @@ Two complementary samples covering different audiences:
    ```
    https://github.com/superuser404notfound/AetherEngine
    ```
-   Dependency Rule: Up to Next Major Version, starting from `5.28.0`. Add the `AetherEngine` library product to your app target.
+   Dependency Rule: Up to Next Major Version, starting from `5.28.1`. Add the `AetherEngine` library product to your app target.
 
 3. **Drop the file in.** Replace the Xcode template's default `App.swift` (or whatever the generated `@main` file is called) with the contents of [`MinimalPlayerApp.swift`](MinimalPlayer/MinimalPlayerApp.swift). The file is self-contained: it defines both the `@main App` struct and the `ContentView`.
 

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Subtitle cues land in raw source PTS; render the overlay against `player.sourceT
 Install via Swift Package Manager:
 
 ```swift
-.package(url: "https://github.com/superuser404notfound/AetherEngine", from: "5.28.0")
+.package(url: "https://github.com/superuser404notfound/AetherEngine", from: "5.28.1")
 ```
 
 Two complementary samples ship in `Examples/`:
@@ -322,10 +322,10 @@ Browse all of this as a searchable site at **[aetherengine.superuser404.de](http
 AetherEngine uses [Semantic Versioning](https://semver.org). The public API surface, every `public` declaration in `Sources/AetherEngine/`, is the stability contract. **Major** removes / renames public symbols or breaks adopters; **Minor** adds public API or codec / format support; **Patch** fixes bugs with no public API change. `internal` types are not part of the contract.
 
 ```swift
-.package(url: "https://github.com/superuser404notfound/AetherEngine", from: "5.28.0")
+.package(url: "https://github.com/superuser404notfound/AetherEngine", from: "5.28.1")
 ```
 
-Pin to `.upToNextMinor(from: "5.28.0")` for stricter teams that prefer to opt into minor bumps explicitly.
+Pin to `.upToNextMinor(from: "5.28.1")` for stricter teams that prefer to opt into minor bumps explicitly.
 
 ## Requirements
 

--- a/Sources/AetherEngine/AetherEngine+ClosedCaptions.swift
+++ b/Sources/AetherEngine/AetherEngine+ClosedCaptions.swift
@@ -192,7 +192,7 @@ final class ClosedCaptionTap: @unchecked Sendable {
         if let id = openCueID, let idx = cues.firstIndex(where: { $0.id == id }) {
             let c = cues[idx]
             if c.endTime > pts, c.startTime <= pts {
-                cues[idx] = SubtitleCue(id: c.id, startTime: c.startTime, endTime: pts, body: c.body)
+                cues[idx] = c.with(endTime: pts)
             }
             openCueID = nil
         }

--- a/Sources/AetherEngine/AetherEngine+Subtitles.swift
+++ b/Sources/AetherEngine/AetherEngine+Subtitles.swift
@@ -657,12 +657,7 @@ extension AetherEngine {
                 guard case .image = cues[i].body else { continue }
                 let cue = cues[i]
                 if cue.startTime < trimAt && cue.endTime > trimAt {
-                    cues[i] = SubtitleCue(
-                        id: cue.id,
-                        startTime: cue.startTime,
-                        endTime: trimAt,
-                        body: cue.body
-                    )
+                    cues[i] = cue.with(endTime: trimAt)
                 }
             }
             // #100: this event is the held stale arrival's successor; its start closes the held
@@ -719,12 +714,7 @@ extension AetherEngine {
             if case .image = cues[i].body { continue }
             let cue = cues[i]
             if cue.startTime < trimAt && cue.endTime > trimAt {
-                cues[i] = SubtitleCue(
-                    id: cue.id,
-                    startTime: cue.startTime,
-                    endTime: trimAt,
-                    body: cue.body
-                )
+                cues[i] = cue.with(endTime: trimAt)
             }
         }
     }
@@ -761,7 +751,7 @@ extension AetherEngine {
             return
         }
 
-        let stamped = SubtitleCue(id: nextID, startTime: cue.startTime, endTime: cue.endTime, body: cue.body)
+        let stamped = cue.with(id: nextID)
         nextID += 1
 
         if case .image(let stampedImage) = stamped.body,

--- a/Sources/AetherEngine/Decoder/SubtitleDecoder.swift
+++ b/Sources/AetherEngine/Decoder/SubtitleDecoder.swift
@@ -243,7 +243,7 @@ enum SubtitleDecoder {
                 // only survives for a final composition with no successor.
                 for idx in pendingImageCueIndices where cues[idx].startTime < pktPTS && cues[idx].endTime > pktPTS {
                     let open = cues[idx]
-                    cues[idx] = SubtitleCue(id: open.id, startTime: open.startTime, endTime: pktPTS, body: open.body)
+                    cues[idx] = open.with(endTime: pktPTS)
                 }
                 pendingImageCueIndices.removeAll()
 

--- a/Sources/AetherEngine/PlayerState.swift
+++ b/Sources/AetherEngine/PlayerState.swift
@@ -725,6 +725,25 @@ public struct SubtitleCue: Identifiable, Sendable {
     }
 }
 
+extension SubtitleCue {
+    /// Copy of this cue with only the named fields changed; everything else is carried across.
+    ///
+    /// #233 follow-up (tresby): the store operations rebuild a cue to change one field, and every
+    /// one of them did it by calling the memberwise initializer with the fields it happened to know
+    /// about. `placement` is defaulted there for source compatibility, so each of those call sites
+    /// dropped it and still compiled, and `insertCueSorted` stamps every cue entering the retained
+    /// store, which meant no embedded track could ever deliver a placement to a host. Rebuilding
+    /// through here instead makes the carry-over the default and the drop impossible to write by
+    /// accident, including for whatever field is added to the cue next.
+    func with(id: Int? = nil, endTime: Double? = nil, body: Body? = nil) -> SubtitleCue {
+        SubtitleCue(id: id ?? self.id,
+                    startTime: startTime,
+                    endTime: endTime ?? self.endTime,
+                    body: body ?? self.body,
+                    placement: placement)
+    }
+}
+
 extension SubtitleCue: Equatable {
     public static func == (lhs: SubtitleCue, rhs: SubtitleCue) -> Bool {
         // ID monotonic per session; sufficient for SwiftUI diffing without comparing CGImage refs.

--- a/Sources/AetherEngine/Subtitles/Issue100PGSStaleArrival.swift
+++ b/Sources/AetherEngine/Subtitles/Issue100PGSStaleArrival.swift
@@ -60,13 +60,11 @@ struct PGSStaleArrivalGate {
     mutating func resolveHeld(trimAt: Double, playhead: Double) -> [SubtitleCue] {
         reconstructionCandidates = reconstructionCandidates.map { candidate in
             guard candidate.startTime < trimAt, candidate.endTime > trimAt else { return candidate }
-            return SubtitleCue(id: candidate.id, startTime: candidate.startTime,
-                               endTime: trimAt, body: candidate.body)
+            return candidate.with(endTime: trimAt)
         }
         guard !heldCues.isEmpty else { return [] }
         let resolved = heldCues.map { cue in
-            SubtitleCue(id: cue.id, startTime: cue.startTime,
-                        endTime: min(cue.endTime, trimAt), body: cue.body)
+            cue.with(endTime: min(cue.endTime, trimAt))
         }
         heldCues = []
         return resolved.filter { $0.startTime <= playhead && playhead < $0.endTime }
@@ -129,8 +127,7 @@ struct PGSStaleArrivalGate {
         // window stays and the store trim owns it, as before.
         let successorStart = out.map(\.startTime).min()
         for line in active where line.startTime <= playhead && playhead < line.endTime {
-            out.append(SubtitleCue(id: line.id, startTime: line.startTime,
-                                   endTime: min(line.endTime, successorStart ?? line.endTime), body: line.body))
+            out.append(line.with(endTime: min(line.endTime, successorStart ?? line.endTime)))
         }
         return out
     }

--- a/Sources/AetherEngine/Subtitles/SubtitleImageOCR.swift
+++ b/Sources/AetherEngine/Subtitles/SubtitleImageOCR.swift
@@ -84,8 +84,7 @@ enum SubtitleImageOCR {
             switch cue.body {
             case .image(let image):
                 if let text = recognizeText(in: image.cgImage, language: language) {
-                    out.append(SubtitleCue(id: cue.id, startTime: cue.startTime,
-                                           endTime: cue.endTime, body: .text(text)))
+                    out.append(cue.with(body: .text(text)))
                 }
             case .text, .richText:
                 out.append(cue)

--- a/Sources/AetherEngine/Subtitles/SubtitleOCRPendingState.swift
+++ b/Sources/AetherEngine/Subtitles/SubtitleOCRPendingState.swift
@@ -21,7 +21,7 @@ struct SubtitleOCRPendingState: Sendable {
         for cue in pending {
             guard cue.startTime < closeAt else { kept.append(cue); continue }
             let end = cue.endTime > closeAt ? closeAt : cue.endTime
-            closed.append(SubtitleCue(id: cue.id, startTime: cue.startTime, endTime: end, body: cue.body))
+            closed.append(cue.with(endTime: end))
         }
         pending = kept
         pending.append(contentsOf: cues.filter { if case .image = $0.body { return true } else { return false } })

--- a/Tests/AetherEngineTests/Issue233PlacementRetentionTests.swift
+++ b/Tests/AetherEngineTests/Issue233PlacementRetentionTests.swift
@@ -1,0 +1,135 @@
+import Testing
+import CoreGraphics
+@testable import AetherEngine
+
+/// #233 follow-up, reported by tresby: no cue reached the host with a `placement` on an embedded
+/// track, while the same field survived fine on sidecars.
+///
+/// The decoders were right. Every reconstruction between them and `$subtitleCues` rebuilt the cue
+/// through the memberwise initializer to change one field, and `placement` defaults to nil there
+/// (deliberately, for source compatibility), so each of those call sites dropped it and still
+/// compiled. `insertCueSorted` is the decisive one: it stamps the session-monotonic id on every
+/// cue entering the retained store, so nothing on the embedded path could keep a placement. The
+/// #107 text trim would then have dropped it a second time on every teletext page transition.
+///
+/// The split explains the reporter seeing WebVTT placement work and teletext placement not: a
+/// sidecar's cues are published as decoded (`subtitleCues = result.cues`), a native rendition's go
+/// into a store verbatim, and only the drained embedded path goes through the retained store.
+///
+/// These assert the invariant on the store operations rather than on any one format, since the
+/// defect was never format-specific.
+@Suite("#233: cue placement survives the retained store")
+struct Issue233PlacementRetentionTests {
+
+    private let top = SubtitleTextPlacement(alignment: 8, position: nil)
+    private let anchored = SubtitleTextPlacement(alignment: 5, position: CGPoint(x: 0.25, y: 0.75))
+
+    private func textCue(id: Int, start: Double, end: Double, _ text: String = "line",
+                         placement: SubtitleTextPlacement?) -> SubtitleCue {
+        SubtitleCue(id: id, startTime: start, endTime: end, body: .text(text), placement: placement)
+    }
+
+    private func tinyImage() -> SubtitleImage {
+        let ctx = CGContext(data: nil, width: 1, height: 1, bitsPerComponent: 8, bytesPerRow: 4,
+                            space: CGColorSpaceCreateDeviceRGB(),
+                            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue)!
+        return SubtitleImage(cgImage: ctx.makeImage()!, position: .zero)
+    }
+
+    // MARK: - The id stamp
+
+    @Test("the id stamp keeps the placement it restamps")
+    func insertKeepsPlacement() {
+        var cues: [SubtitleCue] = []
+        var nextID = 7
+        AetherEngine.insertCueSorted(textCue(id: 0, start: 10, end: 12, placement: top),
+                                     into: &cues, nextID: &nextID)
+        #expect(cues.count == 1)
+        #expect(cues[0].id == 7)
+        #expect(cues[0].placement?.alignment == 8)
+    }
+
+    @Test("an anchor point survives the stamp intact")
+    func insertKeepsAnchor() {
+        var cues: [SubtitleCue] = []
+        var nextID = 0
+        AetherEngine.insertCueSorted(textCue(id: 0, start: 10, end: 12, placement: anchored),
+                                     into: &cues, nextID: &nextID)
+        #expect(cues[0].placement?.position == CGPoint(x: 0.25, y: 0.75))
+        #expect(cues[0].placement?.alignment == 5)
+    }
+
+    @Test("rich-text cues keep placement too (the teletext shape)")
+    func insertKeepsPlacementOnRichText() {
+        var cues: [SubtitleCue] = []
+        var nextID = 0
+        let runs = [SubtitleTextRun(text: "CAPTION", color: SubtitleColor(r: 255, g: 255, b: 0))]
+        AetherEngine.insertCueSorted(
+            SubtitleCue(id: 0, startTime: 10, endTime: 12, body: .richText(runs), placement: top),
+            into: &cues, nextID: &nextID)
+        #expect(cues[0].placement?.alignment == 8)
+    }
+
+    @Test("a placementless cue still arrives placementless")
+    func insertKeepsNil() {
+        var cues: [SubtitleCue] = []
+        var nextID = 0
+        AetherEngine.insertCueSorted(textCue(id: 0, start: 10, end: 12, placement: nil),
+                                     into: &cues, nextID: &nextID)
+        #expect(cues[0].placement == nil)
+    }
+
+    // MARK: - The #107 text trim
+
+    @Test("closing a cue at a page transition keeps its placement")
+    func trimKeepsPlacement() {
+        var cues = [textCue(id: 0, start: 100, end: 100 + 4_294_967, placement: top)]
+        AetherEngine.trimTextCues(&cues, at: 110)
+        #expect(cues[0].endTime == 110)
+        #expect(cues[0].placement?.alignment == 8)
+    }
+
+    // MARK: - Both, in the order the drain applies them
+
+    @Test("a teletext page and its successor both keep their placement end to end")
+    func drainOrderKeepsPlacement() {
+        var cues: [SubtitleCue] = []
+        var nextID = 0
+        let openEnded = 4_294_967.0
+        AetherEngine.insertCueSorted(textCue(id: 0, start: 100, end: 100 + openEnded, "FIRST", placement: top),
+                                     into: &cues, nextID: &nextID)
+        AetherEngine.trimTextCues(&cues, at: 110)
+        AetherEngine.insertCueSorted(textCue(id: 0, start: 110, end: 110 + openEnded, "SECOND",
+                                             placement: SubtitleTextPlacement(alignment: 2, position: nil)),
+                                     into: &cues, nextID: &nextID)
+        #expect(cues.count == 2)
+        #expect(cues[0].placement?.alignment == 8)
+        #expect(cues[0].endTime == 110)
+        #expect(cues[1].placement?.alignment == 2)
+    }
+
+    // MARK: - The other reconstructions
+
+    @Test("the PGS trim keeps the fields it does not change")
+    func pgsTrimKeepsBody() {
+        // Image cues carry geometry on SubtitleImage rather than in placement, so this asserts the
+        // shape rather than a live regression: the trim must not become a field-dropping rebuild.
+        var cues = [SubtitleCue(id: 3, startTime: 100, endTime: 100 + 4_294_967, body: .image(tinyImage()))]
+        AetherEngine.trimTextCues(&cues, at: 110)
+        #expect(cues[0].endTime == 100 + 4_294_967)  // image cues are not the text trim's business
+        #expect(cues[0].id == 3)
+    }
+
+    @Test("the OCR pending close keeps the fields it does not change")
+    func ocrPendingCloseKeepsFields() {
+        var state = SubtitleOCRPendingState()
+        _ = state.consume(eventPts: 100,
+                          cues: [SubtitleCue(id: 1, startTime: 100, endTime: 100 + 4_294_967,
+                                             body: .image(tinyImage()))],
+                          trimAt: nil)
+        let closed = state.consume(eventPts: 110, cues: [], trimAt: nil)
+        #expect(closed.count == 1)
+        #expect(closed[0].endTime == 110)
+        #expect(closed[0].id == 1)
+    }
+}


### PR DESCRIPTION
Follow-up to #233, reported by tresby: no cue reached the host with a `placement` on an embedded track, while the same field survived fine on sidecars.

## What was wrong

5.26.0 added `SubtitleCue.placement` and the decoders fill it correctly (`EmbeddedSubtitleDecoder.swift:305`, `SubtitleDecoder.swift:301`). Every operation that rebuilds a cue to change one field did it by calling the memberwise initializer with the fields it happened to know about. `placement` is defaulted there for source compatibility, so each of those call sites dropped it and still compiled.

`insertCueSorted` is the decisive one: it stamps the session-monotonic id (#121) on every cue entering the retained store, so nothing arriving through the drained embedded path could deliver a placement to a host at all. `trimTextCues` (#107) would have dropped it a second time on each teletext page transition.

## Why it looked like it worked

Three publishing paths, only one goes through the retained store:

| Path | Publishing | `placement` |
| --- | --- | --- |
| Sidecar / external subtitle URL | `subtitleCues = result.cues` | survived |
| Native rendition route | `route.store.appendCues` | survived |
| Drained embedded track | `applyEventMutations` -> `insertCueSorted` | dropped |

That is exactly the split the reporter saw: WebVTT placement worked through a sidecar, teletext placement did not because it is an embedded track. Colour and the other run attributes were never affected, since they live in the cue body, which every rebuild did carry.

## The fix

One internal copy helper, `SubtitleCue.with(id:endTime:body:)`, which carries every field it is not asked to change. All eight rebuild sites converted, including the image-only ones (PGS trim, `Issue100PGSStaleArrival`, OCR) where placement is nil by construction today. The next field added to the cue cannot repeat this.

Considered and rejected: making the initializer parameter required, which would have caught all eight at compile time but is source-breaking for hosts constructing a cue.

## Tests

`Issue233PlacementRetentionTests`, 8 cases asserting the invariant on the store operations rather than on any one format, since the defect was never format-specific: the id stamp, the anchor point, rich-text bodies, the nil case, the #107 trim, both in the order the drain applies them, plus the shape of the image-only rebuilds.

Full suite green: 1252 Swift Testing in 193 suites, 392 XCTest, 0 failures. tvOS Simulator build succeeded.