### PR TITLE
fix(io): drain the reader's autorelease pool per read (#243)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ the public-API contract.
 
 ## [Unreleased]
 
+_Nothing yet._
+
+## [5.28.2] - 2026-07-29
+
+([release notes](https://github.com/superuser404notfound/AetherEngine/releases/tag/5.28.2))
+
 ### Fixed
 
 - **A disc image leaked every byte it read.** `HTTPDiscIOReader` and `FileIOReader` are driven from FFmpeg's read callback, which runs on a demux pump thread that stays inside one dispatch block for the whole session and so never drains its autorelease pool, so every body they bridged out on that thread was stranded until playback ended. On a remote Blu-ray ISO that is up to 8 MB per range request, several a second, once per reader fork (main demuxer, subtitle side demuxer, forward prefetcher), which is the ~30 MB/s of `mallocMB` growth the reporter measured; RSS looks flat because the pages are never touched again and go to the compressor, and the process is eventually jetsammed. Both readers now drain per read, and the SMB reader got the same treatment. Measured against a local range origin, 480 MB fetched left +968 MB in use before and 0 MB after, and 128 MB read through the file reader left +134 MB before and 0 MB after. A per-request `URLSession` fixes nothing here (+973 MB), which also retires the older reading of the AVIOReader leak as URLSession retaining completed bodies until invalidation: the owner was always the caller thread's pool. Reported by bitxeno (#243).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,13 @@ the public-API contract.
 
 ## [Unreleased]
 
-_Nothing yet._
+### Fixed
+
+- **A disc image leaked every byte it read.** `HTTPDiscIOReader` and `FileIOReader` are driven from FFmpeg's read callback, which runs on a demux pump thread that stays inside one dispatch block for the whole session and so never drains its autorelease pool, so every body they bridged out on that thread was stranded until playback ended. On a remote Blu-ray ISO that is up to 8 MB per range request, several a second, once per reader fork (main demuxer, subtitle side demuxer, forward prefetcher), which is the ~30 MB/s of `mallocMB` growth the reporter measured; RSS looks flat because the pages are never touched again and go to the compressor, and the process is eventually jetsammed. Both readers now drain per read, and the SMB reader got the same treatment. Measured against a local range origin, 480 MB fetched left +968 MB in use before and 0 MB after, and 128 MB read through the file reader left +134 MB before and 0 MB after. A per-request `URLSession` fixes nothing here (+973 MB), which also retires the older reading of the AVIOReader leak as URLSession retaining completed bodies until invalidation: the owner was always the caller thread's pool. Reported by bitxeno (#243).
+
+### Added
+
+- **`discFetchedMB` in the memprobe.** The disc pull path had no byte counter at all (`avioFetchedMB` covers the AVIOReader path only), so on a disc-image session every engine-tracked pool reads flat while the reader forks pull tens of MB/s. Printed only when the path is in use, session-scoped like `t=`, so two probe lines give a rate.
 
 ## [5.28.1] - 2026-07-29
 

--- a/Examples/README.md
+++ b/Examples/README.md
@@ -17,7 +17,7 @@ Two complementary samples covering different audiences:
    ```
    https://github.com/superuser404notfound/AetherEngine
    ```
-   Dependency Rule: Up to Next Major Version, starting from `5.28.1`. Add the `AetherEngine` library product to your app target.
+   Dependency Rule: Up to Next Major Version, starting from `5.28.2`. Add the `AetherEngine` library product to your app target.
 
 3. **Drop the file in.** Replace the Xcode template's default `App.swift` (or whatever the generated `@main` file is called) with the contents of [`MinimalPlayerApp.swift`](MinimalPlayer/MinimalPlayerApp.swift). The file is self-contained: it defines both the `@main App` struct and the `ContentView`.
 

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Subtitle cues land in raw source PTS; render the overlay against `player.sourceT
 Install via Swift Package Manager:
 
 ```swift
-.package(url: "https://github.com/superuser404notfound/AetherEngine", from: "5.28.1")
+.package(url: "https://github.com/superuser404notfound/AetherEngine", from: "5.28.2")
 ```
 
 Two complementary samples ship in `Examples/`:
@@ -322,10 +322,10 @@ Browse all of this as a searchable site at **[aetherengine.superuser404.de](http
 AetherEngine uses [Semantic Versioning](https://semver.org). The public API surface, every `public` declaration in `Sources/AetherEngine/`, is the stability contract. **Major** removes / renames public symbols or breaks adopters; **Minor** adds public API or codec / format support; **Patch** fixes bugs with no public API change. `internal` types are not part of the contract.
 
 ```swift
-.package(url: "https://github.com/superuser404notfound/AetherEngine", from: "5.28.1")
+.package(url: "https://github.com/superuser404notfound/AetherEngine", from: "5.28.2")
 ```
 
-Pin to `.upToNextMinor(from: "5.28.1")` for stricter teams that prefer to opt into minor bumps explicitly.
+Pin to `.upToNextMinor(from: "5.28.2")` for stricter teams that prefer to opt into minor bumps explicitly.
 
 ## Requirements
 

--- a/Sources/AetherEngine/AetherEngine+Diagnostics.swift
+++ b/Sources/AetherEngine/AetherEngine+Diagnostics.swift
@@ -53,6 +53,9 @@ extension AetherEngine {
     func startMemoryProbe() {
         memoryProbeTask?.cancel()
         let sessionStart = Date()
+        // #243: the disc pull path's byte tally is session-scoped like `elapsed`, so it can be read
+        // as a rate off two probe lines.
+        HTTPDiscIOReader.resetLifetimeFetchedBytes()
         // #134: currentTime()/loadedTimeRanges are sync XPC reads; hop them off the main actor.
         let probeReadQueue = DispatchQueue(label: "engine.memprobe.avfread", qos: .utility)
         memoryProbeTask = Task { @MainActor [weak self] in
@@ -88,6 +91,7 @@ extension AetherEngine {
                 // Zero on SW path or pre-start; 30 s cadence makes non-atomic field drift irrelevant.
                 let stats = self.nativeVideoSession?.diagnosticStats()
                 let avioMB = (stats?.avioBytesFetched ?? 0) / 1024 / 1024
+                let discFetchedMB = HTTPDiscIOReader.lifetimeFetchedBytes / 1024 / 1024
                 let cacheMB = (stats?.segmentCacheBytes ?? 0) / 1024 / 1024
                 let cacheCount = stats?.segmentCacheCount ?? 0
                 let packetsWritten = stats?.producerPacketsWritten ?? 0
@@ -153,6 +157,11 @@ extension AetherEngine {
                     + MallocBlockCensus.probeFragment()
                     + (MallocBlockCensus.isEnabled ? "peakMB=\(MallocBlockCensus.peakSizeInUseMB) " : "")
                     + "avioFetchedMB=\(avioMB) "
+                    // #243: only the disc pull path fills this, and only then is it printed. On a
+                    // remote ISO every reader fork pulls through HTTPDiscIOReader, which
+                    // `avioFetchedMB` does not see at all, so without it the one path doing the
+                    // reading is the one path with no counter.
+                    + (discFetchedMB > 0 ? "discFetchedMB=\(discFetchedMB) " : "")
                     + "cacheCount=\(cacheCount) cacheMB=\(cacheMB) "
                     + "packetsWritten=\(packetsWritten) "
                     + "audioFifo=\(audioFifo) "

--- a/Sources/AetherEngine/Demuxer/AVIOReader.swift
+++ b/Sources/AetherEngine/Demuxer/AVIOReader.swift
@@ -2123,8 +2123,9 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
 
     /// Long-lived session for seekable-path chunk fetches paired with per-task
     /// ChunkFetchDelegate. Delegate-based incremental delivery (not completion-handler)
-    /// releases source dispatch_data per delivery, avoiding the task-pool accumulation
-    /// that drove the original leak (completion-handler style). No invalidation overhead.
+    /// releases source dispatch_data per delivery on the delegate queue, so the body never
+    /// reaches the demux thread's autorelease pool, which is what drove the original leak.
+    /// No invalidation overhead.
     private static let chunkSession: URLSession = {
         let config = makeSessionConfig()
         return URLSession(configuration: config, delegate: nil, delegateQueue: nil)
@@ -2134,9 +2135,12 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
     /// `PersistentReadDelegate`. Bounded ranges end a connection every `persistentRangeBytes`,
     /// and a session per connection would make each of those a fresh TLS handshake against the
     /// origin. The delegate carries the connection generation, so per-task assignment is all
-    /// that was ever needed here. The per-request-session rule from the task-pool leak does not
-    /// apply: it was scoped to completion-handler tasks, and this path is delegate-based, which
-    /// is what removed the retention in the first place.
+    /// that was ever needed here. The old per-request-session rule does not apply, and #243
+    /// showed why it never could: measured against a range origin, a session per request leaks
+    /// exactly as much as a shared one (+973 MB vs +968 MB per 480 MB fetched). What retains a
+    /// completion-handler body is the never-draining autorelease pool of the demux thread that
+    /// bridges it out, not the session. This path is delegate-based, so the body is released on
+    /// the delegate queue and never reaches that pool.
     ///
     /// Never invalidated. Releasing a connection is `task.cancel()` now, not session teardown.
     private static let persistentSession: URLSession = {

--- a/Sources/AetherEngine/IO/FileIOReader.swift
+++ b/Sources/AetherEngine/IO/FileIOReader.swift
@@ -18,13 +18,20 @@ final class FileIOReader: IOReader, @unchecked Sendable {
         self.size = sz ?? 0
     }
 
+    /// #243 (local twin of the HTTP disc reader): `FileHandle.read` hands back an NSData-backed
+    /// `Data`, and this runs on FFmpeg's read callback, i.e. on a demux pump thread that spends the
+    /// whole session inside one dispatch block and never drains its autorelease pool. Without the
+    /// pool every read is stranded for the session: measured at 625 MB in-use after 624 MB read in
+    /// 32 KB chunks, i.e. one leaked byte per byte played, and 0 MB with it.
     func read(_ buffer: UnsafeMutablePointer<UInt8>?, size n: Int32) -> Int32 {
         guard let buffer, n > 0 else { return -1 }
         lock.lock(); defer { lock.unlock() }
-        guard let data = try? handle.read(upToCount: Int(n)) else { return -1 }
-        if data.isEmpty { return 0 }
-        data.copyBytes(to: buffer, count: data.count)
-        return Int32(data.count)
+        return autoreleasepool { () -> Int32 in
+            guard let data = try? handle.read(upToCount: Int(n)) else { return -1 }
+            if data.isEmpty { return 0 }
+            data.copyBytes(to: buffer, count: data.count)
+            return Int32(data.count)
+        }
     }
 
     func seek(offset: Int64, whence: Int32) -> Int64 {

--- a/Sources/AetherEngine/IO/HTTPDiscIOReader.swift
+++ b/Sources/AetherEngine/IO/HTTPDiscIOReader.swift
@@ -206,30 +206,76 @@ final class HTTPDiscIOReader: IOReader, @unchecked Sendable {
 
     private struct RangeResponse { let status: Int; let contentRange: String?; let body: Data }
 
+    /// #243: the pull path runs this synchronously on FFmpeg's read callback, i.e. on a demux pump
+    /// thread that lives for the whole session inside ONE dispatch block, so nothing ever drains
+    /// that thread's autorelease pool. Every response bridged out of the completion handler is then
+    /// stranded there for the session: up to 8 MB per request at the top of the adaptive window,
+    /// several requests a second, once per reader fork (main demuxer + subtitle side demuxer +
+    /// forward prefetcher), which is the ~30 MB/s of `mallocMB` growth reported on a remote UHD ISO.
+    ///
+    /// Draining per request is the fix. A per-request `URLSession` is NOT: measured against a local
+    /// range origin, 480 MB fetched leaves +968 MB in-use on a shared session and +973 MB with a
+    /// fresh session per request, and 0 MB with this pool. That also retires the older
+    /// "URLSession retains completed completion-handler bodies until invalidation" reading of the
+    /// AVIOReader leak (see `AVIOReader.persistentSession`): the owner was always the caller
+    /// thread's pool, and delegate-based delivery fixed that path by keeping the body off it.
     private static func rangeGet(url: URL, extraHeaders: [String: String], session: URLSession,
                                  timeout: TimeInterval, offset: Int64, length: Int) -> RangeResponse? {
-        var req = URLRequest(url: url, timeoutInterval: timeout)
-        req.httpMethod = "GET"
-        req.setValue(rangeHeader(offset: offset, length: length), forHTTPHeaderField: "Range")
-        for (k, v) in extraHeaders { req.setValue(v, forHTTPHeaderField: k) }
+        autoreleasepool {
+            var req = URLRequest(url: url, timeoutInterval: timeout)
+            req.httpMethod = "GET"
+            req.setValue(rangeHeader(offset: offset, length: length), forHTTPHeaderField: "Range")
+            for (k, v) in extraHeaders { req.setValue(v, forHTTPHeaderField: k) }
 
-        let sem = DispatchSemaphore(value: 0)
-        nonisolated(unsafe) var result: RangeResponse?
-        let task = session.dataTask(with: req) { data, response, _ in
-            if let http = response as? HTTPURLResponse {
-                result = RangeResponse(
-                    status: http.statusCode,
-                    contentRange: http.value(forHTTPHeaderField: "Content-Range"),
-                    body: data ?? Data()
-                )
+            let sem = DispatchSemaphore(value: 0)
+            nonisolated(unsafe) var result: RangeResponse?
+            let task = session.dataTask(with: req) { data, response, _ in
+                if let http = response as? HTTPURLResponse {
+                    result = RangeResponse(
+                        status: http.statusCode,
+                        contentRange: http.value(forHTTPHeaderField: "Content-Range"),
+                        body: data ?? Data()
+                    )
+                }
+                sem.signal()
             }
-            sem.signal()
+            task.resume()
+            if sem.wait(timeout: .now() + timeout + 5) == .timedOut {
+                task.cancel()
+                return nil
+            }
+            // The body escapes the pool inside a retained `Data`; the pool only balances the
+            // bridging autorelease, so the buffer still lives until `read` has copied it out.
+            Self.recordFetched(bytes: result?.body.count ?? 0)
+            return result
         }
-        task.resume()
-        if sem.wait(timeout: .now() + timeout + 5) == .timedOut {
-            task.cancel()
-            return nil
-        }
-        return result
+    }
+
+    // MARK: - Diagnostics
+
+    /// Lifetime bytes pulled by every live `HTTPDiscIOReader` of this session, for the memprobe.
+    /// The disc pull path had no byte counter at all (`avioFetchedMB` covers the AVIOReader path
+    /// only), so a report on this path could show every engine-tracked pool flat while the reader
+    /// forks pulled tens of MB/s, which is how #243 had to be argued from arithmetic instead of a
+    /// counter. Reset per session by the memory probe.
+    private static let fetchedLock = NSLock()
+    nonisolated(unsafe) private static var fetchedBytesTotal: Int64 = 0
+
+    private static func recordFetched(bytes: Int) {
+        guard bytes > 0 else { return }
+        fetchedLock.lock()
+        fetchedBytesTotal &+= Int64(bytes)
+        fetchedLock.unlock()
+    }
+
+    static var lifetimeFetchedBytes: Int64 {
+        fetchedLock.lock(); defer { fetchedLock.unlock() }
+        return fetchedBytesTotal
+    }
+
+    static func resetLifetimeFetchedBytes() {
+        fetchedLock.lock()
+        fetchedBytesTotal = 0
+        fetchedLock.unlock()
     }
 }

--- a/Sources/AetherEngineSMB/SMBIOReader.swift
+++ b/Sources/AetherEngineSMB/SMBIOReader.swift
@@ -74,11 +74,18 @@ public final class SMBIOReader: IOReader, @unchecked Sendable {
                            category: .demux, level: .verbose)
             return -1
         case .success(let data):
-            if data.isEmpty { return 0 } // EOF
-            let n = min(data.count, want)
-            data.copyBytes(to: buffer, count: n)
-            position += Int64(n)
-            return Int32(n)
+            // #243 (same family as the file and HTTP disc readers): this runs on FFmpeg's read
+            // callback, i.e. on a demux pump thread that never returns from its dispatch block and
+            // so never drains its autorelease pool. The SMB body arrives as a dispatch_data-backed
+            // `Data`, and anything the copy bridges out on this thread would be stranded for the
+            // whole session, at the source's read rate.
+            return autoreleasepool { () -> Int32 in
+                if data.isEmpty { return 0 } // EOF
+                let n = min(data.count, want)
+                data.copyBytes(to: buffer, count: n)
+                position += Int64(n)
+                return Int32(n)
+            }
         }
     }
 

--- a/Tests/AetherEngineTests/Issue243ReaderRetentionTests.swift
+++ b/Tests/AetherEngineTests/Issue243ReaderRetentionTests.swift
@@ -1,0 +1,178 @@
+// #243: an IOReader is driven from FFmpeg's read callback, which runs on a demux pump thread that
+// stays inside one dispatch block for the whole session and therefore never drains its autorelease
+// pool. Any response/read body the reader bridges out on that thread is stranded until the session
+// ends, at the source's read rate (~30 MB/s on the reported remote UHD ISO, with three reader forks).
+//
+// The regression is measured, not asserted structurally: the reads run inside a pool the test owns,
+// and the drop in malloc in-use across that pool's drain is what the caller's pool was holding. A
+// reader that drains per read frees ~nothing there; the pre-fix readers freed the full byte count
+// (verified by reverting the fix: 134.4 MB and 135.1 MB freed at the drain for 128 MB read).
+// Measuring the drain rather than the loop keeps the check immune to allocations from tests running
+// in parallel: concurrent allocation can only shrink the observed drop, never inflate it.
+import Foundation
+import Testing
+@testable import AetherEngine
+
+/// Serves byte ranges from its own static store. Deliberately not `MockRangeURLProtocol`: that one is
+/// shared with the #64 suite, which resets it, and these tests must not race it.
+final class RetentionRangeURLProtocol: URLProtocol, @unchecked Sendable {
+    nonisolated(unsafe) static var bytesByURL: [String: Data] = [:]
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        request.url.map { bytesByURL[$0.absoluteString] != nil } ?? false
+    }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+    override func stopLoading() {}
+
+    override func startLoading() {
+        guard let url = request.url, let data = Self.bytesByURL[url.absoluteString] else {
+            client?.urlProtocol(self, didFailWithError: URLError(.fileDoesNotExist))
+            return
+        }
+        let total = data.count
+        var lower = 0, upper = total - 1, status = 200
+        var headers = ["Content-Type": "application/octet-stream"]
+        if let rv = request.value(forHTTPHeaderField: "Range"), rv.hasPrefix("bytes=") {
+            let parts = rv.dropFirst(6).split(separator: "-", omittingEmptySubsequences: false)
+            lower = Int(parts.first ?? "0") ?? 0
+            upper = min((parts.count > 1 ? Int(parts[1]) : nil) ?? (total - 1), total - 1)
+            status = 206
+            headers["Content-Range"] = "bytes \(lower)-\(upper)/\(total)"
+        }
+        guard lower <= upper else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+        let body = data.subdata(in: lower..<(upper + 1))
+        headers["Content-Length"] = String(body.count)
+        let resp = HTTPURLResponse(url: url, statusCode: status, httpVersion: "HTTP/1.1",
+                                   headerFields: headers)!
+        client?.urlProtocol(self, didReceive: resp, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: body)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+}
+
+@Suite("#243 IOReader buffers do not strand in the caller's autorelease pool", .serialized)
+struct Issue243ReaderRetentionTests {
+
+    private static func mallocInUseBytes() -> Int64 {
+        var stats = malloc_statistics_t()
+        malloc_zone_statistics(nil, &stats)
+        return Int64(stats.size_in_use)
+    }
+
+    /// Bytes released when the pool the reads ran in is drained.
+    private static func bytesHeldByCallerPool(bytesRead: inout Int64, _ readLoop: () -> Int64) -> Int64 {
+        var beforeDrain: Int64 = 0
+        var moved: Int64 = 0
+        autoreleasepool {
+            moved = readLoop()
+            beforeDrain = mallocInUseBytes()
+        }
+        bytesRead = moved
+        return max(0, beforeDrain - mallocInUseBytes())
+    }
+
+    /// A tenth of the bytes moved: far above the fixed-size noise of a pool drain, far below the
+    /// one-leaked-byte-per-byte-read the defect produced.
+    private static func assertDrained(held: Int64, moved: Int64, _ what: String) {
+        #expect(held < moved / 10,
+                "\(what): draining the caller's pool freed \(held / 1024 / 1024) MB after \(moved / 1024 / 1024) MB read; the reader is stranding its buffers there")
+    }
+
+    @Test("FileIOReader drains each read")
+    func fileReaderDrainsPerRead() throws {
+        let url = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("issue243-\(UUID().uuidString).bin")
+        let chunk = 32 * 1024
+        try Data(count: 8 * 1024 * 1024).write(to: url)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let reader = try #require(FileIOReader(url: url))
+        defer { reader.close() }
+        let out = UnsafeMutablePointer<UInt8>.allocate(capacity: chunk)
+        defer { out.deallocate() }
+
+        var moved: Int64 = 0
+        let held = Self.bytesHeldByCallerPool(bytesRead: &moved) {
+            var total: Int64 = 0
+            for i in 0..<4096 {                        // 4096 x 32 KB = 128 MB
+                if i % 256 == 0 { _ = reader.seek(offset: 0, whence: SEEK_SET) }
+                let n = reader.read(out, size: Int32(chunk))
+                if n <= 0 { break }
+                total += Int64(n)
+            }
+            return total
+        }
+        #expect(moved == 128 * 1024 * 1024)
+        Self.assertDrained(held: held, moved: moved, "FileIOReader")
+    }
+
+    @Test("HTTPDiscIOReader drains each range request")
+    func httpDiscReaderDrainsPerRequest() throws {
+        let url = URL(string: "http://retention243.test/leak.iso")!
+        let fixture = 4 * 1024 * 1024
+        RetentionRangeURLProtocol.bytesByURL[url.absoluteString] = Data(count: fixture)
+        defer { RetentionRangeURLProtocol.bytesByURL[url.absoluteString] = nil }
+
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [RetentionRangeURLProtocol.self]
+        let reader = try #require(HTTPDiscIOReader(
+            url: url, baseChunkSize: 1024 * 1024, maxChunkSize: 1024 * 1024,
+            requestTimeout: 5, sessionConfiguration: config))
+        defer { reader.close() }
+
+        let chunk = 1024 * 1024
+        let out = UnsafeMutablePointer<UInt8>.allocate(capacity: chunk)
+        defer { out.deallocate() }
+
+        var moved: Int64 = 0
+        let held = Self.bytesHeldByCallerPool(bytesRead: &moved) {
+            var total: Int64 = 0
+            for i in 0..<128 {                         // 128 x 1 MB fetched, 4 MB fixture cycled
+                if i % 4 == 0 { _ = reader.seek(offset: 0, whence: SEEK_SET) }
+                let n = reader.read(out, size: Int32(chunk))
+                if n <= 0 { break }
+                total += Int64(n)
+            }
+            return total
+        }
+        #expect(moved == 128 * 1024 * 1024)
+        Self.assertDrained(held: held, moved: moved, "HTTPDiscIOReader")
+    }
+
+    @Test("The disc reader's fetch tally is session-scoped and counts every served range")
+    func fetchTallyTracksServedBytes() throws {
+        let url = URL(string: "http://retention243-tally.test/leak.iso")!
+        RetentionRangeURLProtocol.bytesByURL[url.absoluteString] = Data(count: 1024 * 1024)
+        defer { RetentionRangeURLProtocol.bytesByURL[url.absoluteString] = nil }
+
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [RetentionRangeURLProtocol.self]
+        HTTPDiscIOReader.resetLifetimeFetchedBytes()
+        // Deltas, not absolutes: the tally is process-wide, and a reader in another suite may be
+        // fetching in parallel. Concurrent fetches can only add to it.
+        let atStart = HTTPDiscIOReader.lifetimeFetchedBytes
+        let reader = try #require(HTTPDiscIOReader(
+            url: url, baseChunkSize: 256 * 1024, maxChunkSize: 256 * 1024,
+            requestTimeout: 5, sessionConfiguration: config))
+        defer { reader.close() }
+
+        // The size probe fetches one byte; four refills of 256 KB follow.
+        let out = UnsafeMutablePointer<UInt8>.allocate(capacity: 256 * 1024)
+        defer { out.deallocate() }
+        var read = 0
+        while read < 1024 * 1024 {
+            let n = reader.read(out, size: Int32(256 * 1024))
+            if n <= 0 { break }
+            read += Int(n)
+        }
+        #expect(read == 1024 * 1024)
+        // Four 256 KB refills plus the one-byte size probe from init.
+        #expect(HTTPDiscIOReader.lifetimeFetchedBytes - atStart >= Int64(1024 * 1024 + 1))
+
+        HTTPDiscIOReader.resetLifetimeFetchedBytes()
+        #expect(HTTPDiscIOReader.lifetimeFetchedBytes < Int64(1024 * 1024))
+    }
+}


### PR DESCRIPTION
Fixes the unbounded memory growth bitxeno reported when playing a remote Blu-ray ISO over HTTP (#243).

## Root cause

`HTTPDiscIOReader` is pull-based: FFmpeg's read callback runs the range GET synchronously on the demux pump thread, and that thread spends the whole session inside one dispatch block, so nothing ever drains its autorelease pool. Every response body bridged out of the completion handler is stranded there until playback ends: up to 8 MB per request at the top of the adaptive window, several requests a second, once per reader fork (main demuxer, subtitle side demuxer, forward prefetcher). That is the ~30 MB/s of `mallocMB` growth in the report. RSS looks flat because the pages are never touched again and go to the compressor, which is why `vmCmp` and `physFP` are the tell.

The reporter's diagnosis and suggested fix were correct. Two things came out of verifying them.

**The local twin has the same defect.** `FileIOReader.read` hands back an NSData-backed `Data` from `FileHandle.read` on the same thread, so a local disc image leaks one byte per byte played. `SMBIOReader` copies out of a dispatch_data-backed body on that thread too and gets the same wrapper.

**A per-request `URLSession` is not a fix.** Measured against a local range origin, 480 MB fetched:

| variant | malloc in use |
|---|---|
| shared session, completion handler, no pool | +968 MB |
| session per request + invalidate, no pool | +973 MB |
| shared session, completion handler, pool per request | 0 MB |
| shared session, delegate-based, no pool | 0 MB |

That retires the older reading of the AVIOReader leak (the `persistentSession` comment) as URLSession retaining completed completion-handler bodies until invalidation. The owner was always the caller thread's pool; delegate-based delivery fixed that path by keeping the body off it.

## Changes

- `HTTPDiscIOReader.rangeGet` drains per range request (covers `probeSize` and every retry).
- `FileIOReader.read` and `SMBIOReader.read` drain per read.
- `discFetchedMB` in the 30 s memprobe, printed only on a disc-image session and session-scoped like `t=`. The disc pull path had no byte counter at all (`avioFetchedMB` covers the AVIOReader path only), so this report had to be argued from arithmetic while every engine-tracked pool read flat.

## Tests

`Issue243ReaderRetentionTests` reads 128 MB through each reader inside a pool the test owns and asserts that draining it frees ~nothing. Reverting either wrapper frees 134.4 MB and 135.1 MB there, so the tests fail on the pre-fix readers. Measuring the drain rather than the loop keeps them immune to allocations from tests running in parallel: concurrent allocation can only shrink the observed drop.

Full suite green (1255 tests), plus `swift build -Xswiftc -strict-concurrency=complete` and a tvOS Simulator build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01At1agC2qU2Y2MX2BKLdT4N