### PR TITLE
fix(routing): reroute remote HLS classified by the loopback session's own open (#246)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@ the public-API contract.
 
 ## [Unreleased]
 
-_Nothing yet._
+### Fixed
+
+- **A remote HLS VOD source died when the load-time probe failed for an unrelated reason.** The AE#154 reroute onto the native remote-HLS bypass keys on the reader's typed `hlsPlaylistOnVODPath` classification, but that classification only reaches it when the load-time probe is the open that reads the playlist body. If the probe failed transiently first, the load fell through to the loopback path with no preopened demuxer, `HLSVideoEngine.start()` reopened the URL, and that second open produced the classification, which was then interpolated into `openFailed(reason:)` and lost its domain. A playable source failed terminally with `HLS playlist supplied to the VOD loopback path`, while a manual retry (whose first probe happened to see the body) played natively. The fallback open now rethrows both HLS classifications verbatim, and a load that reaches one takes the same AE#154 reroute, preserving URL, headers and resume position. Reported by qoli (#246).
+- **The remote-HLS bypass ignored the resume position.** `LoadOptions.nativeRemoteHLS` routes before the probe, and that branch never forwarded `startPosition`, so a VOD playlist restarted at zero whether the host requested the bypass directly or arrived on it through a reroute. VOD now honors the anchor; live keeps its no-initial-seek contract even when a host passes one.
 
 ## [5.28.2] - 2026-07-29
 

--- a/Sources/AetherEngine/AetherEngine.swift
+++ b/Sources/AetherEngine/AetherEngine.swift
@@ -2002,7 +2002,12 @@ public final class AetherEngine: ObservableObject {
         // Routed before the probe because we never demux the m3u8.
         if options.nativeRemoteHLS {
             do {
-                try await loadRemoteHLS(url: url, options: options)
+                // AE#246: a VOD playlist honors the resume anchor here the same way the AE#154 reroute
+                // does; without it a rerouted (or directly requested) VOD bypass always restarted at 0.
+                // Live keeps the no-initial-seek contract every live caller relies on, so its anchor
+                // stays nil even when the host passes one.
+                try await loadRemoteHLS(url: url, options: options,
+                                        startPosition: options.isLive ? nil : startPosition)
             } catch is CancellationError {
                 throw CancellationError()
             } catch {
@@ -2114,7 +2119,7 @@ public final class AetherEngine: ObservableObject {
         // domain, so reroute this load onto the nativeRemoteHLS bypass instead of surfacing the
         // former bare AVERROR_INVALIDDATA. loadedOptions flips so every downstream consumer
         // (audio-tap reader selection, seek paths) sees a genuine remote-HLS session.
-        if RemoteHLSMediaSelection.shouldReroute(probeFailure: probeFailure, isCustomSource: isCustomSource),
+        if RemoteHLSMediaSelection.shouldReroute(failure: probeFailure, isCustomSource: isCustomSource),
            case .url(let hlsURL) = source {
             EngineLog.emit("[AetherEngine] AE#154: HLS playlist on the VOD loopback path; rerouting to the native remote-HLS bypass", category: .engine)
             loadedOptions.nativeRemoteHLS = true
@@ -2632,6 +2637,26 @@ public final class AetherEngine: ObservableObject {
             // Superseded.
             throw CancellationError()
         } catch {
+            // AE#246: the load-time probe failed for a reason that was not the HLS classification, so the
+            // AE#154 check above saw an inconclusive failure and this load fell through to the loopback
+            // path with no preopened demuxer. The session's own open is then the first one to read the
+            // body, and it has now classified the source as remote HLS after all. Take the same reroute
+            // rather than surfacing a terminal failure for a source AVPlayer can play. A full load()
+            // restart (the #168 reroute's shape) is what clears the half-built loopback session; the
+            // bypass runs no probe, so this cannot bounce back here a second time.
+            if RemoteHLSMediaSelection.shouldReroute(failure: error, isCustomSource: isCustomSource),
+               case .url(let hlsURL) = source,
+               loadGeneration == gen {
+                EngineLog.emit(
+                    "[AetherEngine] AE#246: the loopback session's own open classified the source as HLS; "
+                    + "taking the AE#154 reroute onto the native remote-HLS bypass",
+                    category: .engine
+                )
+                var rerouted = loadedOptions
+                rerouted.nativeRemoteHLS = true
+                _ = try await load(source: .url(hlsURL), startPosition: startPosition, options: rerouted)
+                return nil
+            }
             state = .error("Failed to load: \(error.localizedDescription)")
             throw error
         }

--- a/Sources/AetherEngine/Native/RemoteHLSMediaSelection.swift
+++ b/Sources/AetherEngine/Native/RemoteHLSMediaSelection.swift
@@ -26,9 +26,15 @@ enum RemoteHLSMediaSelection {
     /// Reroute only the typed VOD-path misroute, and only for URL sources: custom readers have no
     /// URL for AVPlayer to open, and the AE#140 live raw-path misroute keeps its fail-closed
     /// contract (live hosts choose their own DVR/rejoin options before going native).
-    static func shouldReroute(probeFailure: Error?, isCustomSource: Bool) -> Bool {
+    ///
+    /// AE#246: the classification can arrive from either open of the same source. The load-time probe
+    /// is the usual one, but when that probe failed for an unrelated (transient) reason the loopback
+    /// path reopens the URL, and that second open is then the first to read the playlist body. Both
+    /// carry the same typed error, so both are answered here; `isLive` needs no guard because the
+    /// reader only classifies as `hlsPlaylistOnVODPath` on the non-live path.
+    static func shouldReroute(failure: Error?, isCustomSource: Bool) -> Bool {
         guard !isCustomSource,
-              let readerError = probeFailure as? AVIOReaderError,
+              let readerError = failure as? AVIOReaderError,
               case .hlsPlaylistOnVODPath = readerError else { return false }
         return true
     }

--- a/Sources/AetherEngine/Video/HLSVideoEngine.swift
+++ b/Sources/AetherEngine/Video/HLSVideoEngine.swift
@@ -709,6 +709,27 @@ public final class HLSVideoEngine: @unchecked Sendable {
 
     // MARK: - Public API
 
+    /// AE#246: map a failed fallback open onto the error the caller sees.
+    ///
+    /// The fallback open runs when the load-time probe did not hand over a demuxer, which includes
+    /// the case where that probe failed for a transient reason. It is then the FIRST open to read
+    /// the source body, so it is the one that produces the reader's HLS classification. Interpolating
+    /// that typed error into `openFailed(reason:)` erased its domain and made a reroutable remote-HLS
+    /// source terminal; the classification is rethrown verbatim so `load()` can still reach the AE#154
+    /// reroute (`hlsPlaylistOnVODPath`) or the AE#140 fail-closed rejection (`hlsPlaylistOnRawLivePath`).
+    /// Every other failure keeps the historical wrapped shape.
+    static func openFailure(from error: Error) -> Error {
+        if let readerError = error as? AVIOReaderError {
+            switch readerError {
+            case .hlsPlaylistOnVODPath, .hlsPlaylistOnRawLivePath:
+                return readerError
+            default:
+                break
+            }
+        }
+        return HLSVideoEngineError.openFailed(reason: "\(error)")
+    }
+
     public func start() throws -> URL {
         guard demuxer == nil else { throw HLSVideoEngineError.alreadyStarted }
 
@@ -722,7 +743,7 @@ public final class HLSVideoEngine: @unchecked Sendable {
             do {
                 try dem.open(url: sourceURL, extraHeaders: sourceHTTPHeaders, profile: openProfile, isLive: isLiveSession)
             } catch {
-                throw HLSVideoEngineError.openFailed(reason: "\(error)")
+                throw Self.openFailure(from: error)
             }
         }
         demuxer = dem

--- a/Tests/AetherEngineTests/Issue246SecondOpenRerouteTests.swift
+++ b/Tests/AetherEngineTests/Issue246SecondOpenRerouteTests.swift
@@ -1,0 +1,67 @@
+import Testing
+import Foundation
+@testable import AetherEngine
+
+/// AE#246: the load-time probe can fail for a transient reason that is not the HLS classification,
+/// so `probeFailure` is inconclusive and the AE#154 reroute does not fire. The load then falls
+/// through to the loopback path with a nil preopened demuxer, and `HLSVideoEngine.start()` reopens
+/// the same URL. That second open is the first one to read the playlist body, so it is the one that
+/// produces `AVIOReaderError.hlsPlaylistOnVODPath`.
+///
+/// Interpolating that typed error into `HLSVideoEngineError.openFailed(reason:)` erased the domain,
+/// and a reroutable source died as a terminal `openFailed`. These cover the pure pieces: the open
+/// failure mapping, and the reroute decision on the error the mapping now preserves.
+struct Issue246SecondOpenRerouteTests {
+
+    // MARK: - Open-failure mapping
+
+    @Test("The VOD playlist classification survives the fallback open as a typed error")
+    func vodPlaylistErrorPassesThrough() {
+        let mapped = HLSVideoEngine.openFailure(from: AVIOReaderError.hlsPlaylistOnVODPath)
+        #expect(mapped as? AVIOReaderError == .hlsPlaylistOnVODPath)
+    }
+
+    @Test("The raw-live classification also survives, keeping AE#140 typed at every open")
+    func rawLiveErrorPassesThrough() {
+        let mapped = HLSVideoEngine.openFailure(from: AVIOReaderError.hlsPlaylistOnRawLivePath)
+        #expect(mapped as? AVIOReaderError == .hlsPlaylistOnRawLivePath)
+    }
+
+    @Test("Every other open failure keeps its openFailed(reason:) shape")
+    func unrelatedErrorsStayWrapped() {
+        let mapped = HLSVideoEngine.openFailure(from: DemuxerError.openFailed(code: -5))
+        guard let engineError = mapped as? HLSVideoEngine.HLSVideoEngineError,
+              case .openFailed(let reason) = engineError else {
+            Issue.record("expected openFailed, got \(mapped)")
+            return
+        }
+        #expect(reason.contains("openFailed"))
+    }
+
+    // MARK: - Reroute decision on the second-open error
+
+    @Test("A second-open VOD classification is a reroute candidate")
+    func secondOpenErrorReroutes() {
+        let failure = HLSVideoEngine.openFailure(from: AVIOReaderError.hlsPlaylistOnVODPath)
+        #expect(RemoteHLSMediaSelection.shouldReroute(failure: failure, isCustomSource: false))
+    }
+
+    @Test("A wrapped classification is not a reroute candidate, which is why it must not be wrapped")
+    func wrappedErrorDoesNotReroute() {
+        let wrapped = HLSVideoEngine.HLSVideoEngineError.openFailed(
+            reason: "\(AVIOReaderError.hlsPlaylistOnVODPath)")
+        #expect(!RemoteHLSMediaSelection.shouldReroute(failure: wrapped, isCustomSource: false))
+    }
+
+    @Test("A custom source still has no URL to reroute, whichever open produced the error")
+    func customSourceNeverReroutes() {
+        let failure = HLSVideoEngine.openFailure(from: AVIOReaderError.hlsPlaylistOnVODPath)
+        #expect(!RemoteHLSMediaSelection.shouldReroute(failure: failure, isCustomSource: true))
+    }
+
+    @Test("The raw-live misroute keeps its AE#140 fail-closed contract after the fallback open")
+    func rawLiveNeverReroutes() {
+        let failure = HLSVideoEngine.openFailure(from: AVIOReaderError.hlsPlaylistOnRawLivePath)
+        #expect(!RemoteHLSMediaSelection.shouldReroute(failure: failure, isCustomSource: false))
+    }
+}

--- a/Tests/AetherEngineTests/RemoteHLSMediaSelectionTests.swift
+++ b/Tests/AetherEngineTests/RemoteHLSMediaSelectionTests.swift
@@ -15,26 +15,26 @@ struct RemoteHLSMediaSelectionTests {
     @Test("VOD-path playlist misroute on a URL source reroutes")
     func rerouteOnVODPlaylistMisroute() {
         #expect(RemoteHLSMediaSelection.shouldReroute(
-            probeFailure: AVIOReaderError.hlsPlaylistOnVODPath, isCustomSource: false))
+            failure: AVIOReaderError.hlsPlaylistOnVODPath, isCustomSource: false))
     }
 
     @Test("Live raw-path misroute keeps the AE#140 fail-closed behavior")
     func noRerouteOnRawLiveMisroute() {
         #expect(!RemoteHLSMediaSelection.shouldReroute(
-            probeFailure: AVIOReaderError.hlsPlaylistOnRawLivePath, isCustomSource: false))
+            failure: AVIOReaderError.hlsPlaylistOnRawLivePath, isCustomSource: false))
     }
 
     @Test("Custom sources have no URL to reroute")
     func noRerouteForCustomSource() {
         #expect(!RemoteHLSMediaSelection.shouldReroute(
-            probeFailure: AVIOReaderError.hlsPlaylistOnVODPath, isCustomSource: true))
+            failure: AVIOReaderError.hlsPlaylistOnVODPath, isCustomSource: true))
     }
 
     @Test("Successful or unrelated probes never reroute")
     func noRerouteOtherwise() {
-        #expect(!RemoteHLSMediaSelection.shouldReroute(probeFailure: nil, isCustomSource: false))
+        #expect(!RemoteHLSMediaSelection.shouldReroute(failure: nil, isCustomSource: false))
         #expect(!RemoteHLSMediaSelection.shouldReroute(
-            probeFailure: DemuxerError.openFailed(code: -1), isCustomSource: false))
+            failure: DemuxerError.openFailed(code: -1), isCustomSource: false))
     }
 
     @Test("VOD-path misroute has an actionable description")


### PR DESCRIPTION
## Problem

The AE#154 reroute onto the native remote-HLS bypass keys on `AVIOReaderError.hlsPlaylistOnVODPath`. That typed classification only reaches the check when the **load-time probe** is the open that reads the playlist body.

When the first `probe.open` fails for an unrelated (transient) reason, `probeFailure` is inconclusive, `shouldReroute` returns false, and the load falls through to the loopback path with `preopenedDemuxer: nil`. `HLSVideoEngine.start()` then reopens the same URL, and *that* open is the first to see the body, so it is the one that produces `hlsPlaylistOnVODPath`. The fallback open interpolated it into `HLSVideoEngineError.openFailed(reason: "\(error)")`, erasing the domain, and the load died terminally with `HLS playlist supplied to the VOD loopback path` for a source AVPlayer plays fine (the reporter's manual retry, whose first probe happened to see the body, routed native and reached `readyToPlay`).

## Fix

- `HLSVideoEngine.openFailure(from:)` rethrows both HLS classifications verbatim and keeps the wrapped `openFailed(reason:)` shape for everything else. `hlsPlaylistOnRawLivePath` rides along so AE#140 stays typed at every open too.
- `load()`'s dispatch `catch` answers the classification from either open with the same AE#154 reroute. It is taken as a full `load()` restart, the shape the #168 reroute already uses, because the half-built loopback session has to be cleared; the bypass runs no probe, so it cannot bounce back here a second time.
- `RemoteHLSMediaSelection.shouldReroute` is renamed `probeFailure:` -> `failure:` since it now answers both origins. No `isLive` guard is needed: the reader only classifies as `hlsPlaylistOnVODPath` on the non-live path.

Also fixed, because the reroute would otherwise drop the resume anchor: the `nativeRemoteHLS` branch never forwarded `startPosition`, so a VOD playlist restarted at zero whether the host requested the bypass directly or arrived on it through a reroute. Live keeps its no-initial-seek contract even when a host passes an anchor.

## Tests

`Issue246SecondOpenRerouteTests` covers the open-failure mapping and the reroute decision on the error it preserves, including the regression direction (a wrapped classification must not reroute, which is why it must not be wrapped). Full suite 1262/1262 green, `-strict-concurrency=complete` clean, tvOS Simulator build succeeds.

Reported by qoli (#246).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01At1agC2qU2Y2MX2BKLdT4N