### PR TITLE
fix(seek): run the software/audio host demuxer reposition off the main actor (#254)

### DIFF
--- a/Sources/AetherEngine/AetherEngine.swift
+++ b/Sources/AetherEngine/AetherEngine.swift
@@ -3161,12 +3161,17 @@ public final class AetherEngine: ObservableObject {
             nativeClockSeconds = clockTarget
             clock.currentTime = target
         }
+        // #254: the SW/audio hosts reposition their demuxer under a read deadline, off the main actor.
+        // A reposition that spends its budget leaves the read position undefined and nothing re-issues
+        // it, unlike the native recovery path whose ticket stays open for a late landing, so that case
+        // closes this ticket terminally as `.stalled` instead of claiming a landing it cannot back up.
+        var hostReposition: Demuxer.RepositionOutcome = .landed
         if audioAVPlayerActive, let host = audioAVPlayerHost {
             await host.seek(to: clockTarget)
         } else if let host = audioHost {
-            await host.seek(to: clockTarget)
+            hostReposition = await host.seek(to: clockTarget)
         } else if let host = softwareHost {
-            await host.seek(to: clockTarget)
+            hostReposition = await host.seek(to: clockTarget)
         } else {
             // #93 retest: remember the target as recovery intent BEFORE awaiting; a wedged seek
             // never lands and the recovery chain must aim here, not at the frozen clock.
@@ -3496,7 +3501,20 @@ public final class AetherEngine: ObservableObject {
         setProgrammaticSeek(inFlight: false, target: nil)
         // `sourceTime` is the on-screen frame (#49/#123): the honest landing position, which keyframe
         // granularity or a still-draining chase can put a little off the target.
-        closeSeekTicket(&programmaticSeekTicket, with: .landed(renderedTime: clock.sourceTime))
+        closeSeekTicket(&programmaticSeekTicket,
+                        with: Self.seekTicketOutcome(hostReposition: hostReposition,
+                                                     renderedTime: clock.sourceTime))
+    }
+
+    /// #254: how a SW/audio-host reposition maps onto this seek's ticket. A reposition that spent its
+    /// read-deadline budget left the read position undefined, and nothing on that path re-issues it:
+    /// the native recovery loop can leave its ticket open because AVPlayer keeps aiming at the target
+    /// and a late `.landed` still arrives, while here no one does. So it closes terminally as
+    /// `.stalled` rather than claiming a landing it cannot back up.
+    nonisolated static func seekTicketOutcome(
+        hostReposition: Demuxer.RepositionOutcome, renderedTime: Double
+    ) -> SeekEvent.Outcome {
+        hostReposition == .stalled ? .stalled : .landed(renderedTime: renderedTime)
     }
 
     /// #112 rework: the playhead jumped (seek landing or wedge reconcile). Reset the PGS

--- a/Sources/AetherEngine/Audio/AudioPlaybackHost.swift
+++ b/Sources/AetherEngine/Audio/AudioPlaybackHost.swift
@@ -31,6 +31,18 @@ final class AudioPlaybackHost {
     /// One demux queue per host so rapid load() calls don't fight over the same execution context.
     private let demuxQueue = DispatchQueue(label: "engine.audio.demux", qos: .userInitiated)
 
+    /// #254: every demuxer reposition runs here, never on the main actor. See
+    /// `Demuxer.seekBounded(to:anchorStreamIndex:timeout:on:isSuperseded:)` for why the main actor is
+    /// the wrong thread for it. Serial and separate from `demuxQueue`, whose block never returns.
+    private let seekQueue = DispatchQueue(label: "engine.audio.seek", qos: .userInitiated)
+
+    /// Read-deadline budget for a reposition (#254). Matches `SoftwarePlaybackHost`.
+    private static let seekBudgetSeconds: TimeInterval = 8.0
+
+    /// True while a reposition is awaiting `seekQueue`; gates the 250 ms tick so it cannot republish
+    /// the pre-seek synchronizer position over the target this seek already committed to.
+    private var seekInFlight = false
+
     /// Guards playing/stop flags: read on demux thread every iteration, written on main actor.
     private let flagsLock = NSLock()
     nonisolated(unsafe) private var _isPlaying: Bool = false
@@ -129,7 +141,10 @@ final class AudioPlaybackHost {
         self.audioOutput = AudioOutput()
 
         if let start = startPosition, start > 0 {
-            dem.seek(to: start)
+            // #254: same off-main, deadline-bounded reposition the transport seek uses. Also load()'s
+            // only suspension point, so the only place a stop() can land mid-load.
+            _ = await dem.seekBounded(to: start, timeout: Self.seekBudgetSeconds, on: seekQueue)
+            guard !stopRequested else { return }
             initialClockTime = CMTime(seconds: start, preferredTimescale: 90000)
             currentTime = start
         } else {
@@ -176,26 +191,45 @@ final class AudioPlaybackHost {
         rate = newRate
     }
 
-    func seek(to seconds: Double) async {
-        guard let dem = demuxer else { return }
+    /// #254: the demuxer reposition is awaited off the main actor, for the reason
+    /// `Demuxer.seekBounded(to:anchorStreamIndex:timeout:on:isSuperseded:)` documents. Same defect as
+    /// `SoftwarePlaybackHost.seek`, same shape, only without the video half.
+    @discardableResult
+    func seek(to seconds: Double) async -> Demuxer.RepositionOutcome {
+        guard let dem = demuxer else { return .stalled }
+        // Drop the demux loop's enqueue high-water mark; after a backward seek the stale mark would park the
+        // back-pressure gate until the clock walked back up to the pre-seek position (minutes of silence).
+        // Hoisted above the reposition (#254): it is also the fence the reposition tests for supersession,
+        // and it invalidates in-flight packets from the moment the seek starts rather than after it.
+        bumpSeekGeneration()
+        let generation = seekGeneration
         let wasPlaying = isPlaying
         isPlaying = false
 
         audioDecoder?.flush()
         audioOutput?.flush()
 
-        dem.seek(to: seconds)
         currentTime = seconds
-
-        // Drop the demux loop's enqueue high-water mark; after a backward seek the stale mark would park the
-        // back-pressure gate until the clock walked back up to the pre-seek position (minutes of silence).
-        bumpSeekGeneration()
+        seekInFlight = true
+        let outcome = await dem.seekBounded(
+            to: seconds, timeout: Self.seekBudgetSeconds, on: seekQueue,
+            isSuperseded: { [weak self] in self?.seekGeneration != generation })
+        guard seekGeneration == generation, !stopRequested else { return .superseded }
+        seekInFlight = false
+        if outcome == .stalled {
+            EngineLog.emit(
+                "[AudioHost] reposition to \(String(format: "%.2f", seconds))s did not complete within "
+                + "\(String(format: "%.0f", Self.seekBudgetSeconds))s; read position is undefined",
+                category: .swPlayback
+            )
+        }
+        currentTime = seconds
 
         let targetTime = CMTime(seconds: seconds, preferredTimescale: 90000)
         guard demuxLoopStarted else {
             // Cold seek (no play() yet): stash target so the loop's first decoded packet anchors there, not at .zero.
             initialClockTime = targetTime
-            return
+            return outcome
         }
         if wasPlaying {
             audioOutput?.seekClock(to: targetTime, rate: lastRate)
@@ -208,11 +242,13 @@ final class AudioPlaybackHost {
         }
         // Clock is now positioned; demux loop must not re-arm it at the stale initial anchor.
         clockArmed = true
+        return outcome
     }
 
     func stop() {
         stopRequested = true
         isPlaying = false
+        seekInFlight = false
         timeTimer?.cancel()
         timeTimer = nil
 
@@ -431,6 +467,9 @@ final class AudioPlaybackHost {
             .autoconnect()
             .sink { [weak self] _ in
                 guard let self, let aOut = self.audioOutput else { return }
+                // #254: a reposition in flight holds `currentTime` at its target; the synchronizer is
+                // still on the pre-seek anchor and would drag the published position backwards.
+                guard !self.seekInFlight else { return }
                 let t = aOut.currentTimeSeconds
                 if t.isFinite, t >= 0 {
                     self.currentTime = t

--- a/Sources/AetherEngine/Demuxer/Demuxer.swift
+++ b/Sources/AetherEngine/Demuxer/Demuxer.swift
@@ -1175,6 +1175,47 @@ public final class Demuxer: @unchecked Sendable {
         return ret >= 0 && !capped
     }
 
+    /// How an off-actor reposition ended (#254). Named to mirror `SeekEvent.Outcome` so the engine's
+    /// mapping onto the public seek-event stream is one line.
+    enum RepositionOutcome: Sendable, Equatable {
+        /// `avformat_seek_file` completed inside the budget; the read position is at the target.
+        case landed
+        /// The reposition did not complete: the read deadline fired, `avformat_seek_file` failed, or
+        /// there was no open format context. The read position is undefined.
+        case stalled
+        /// A newer seek arrived before this one reached the demuxer, so it never ran.
+        case superseded
+    }
+
+    /// `seekBounded` off the caller's actor (#254).
+    ///
+    /// `readPacket` holds `accessLock` for the whole of `av_read_frame`, so the `accessLock.lock()`
+    /// inside every seek first waits out whatever read is in flight, up to `AVIOReader.connStallTimeout`
+    /// (20 s), BEFORE the deadline armed inside `seekBounded` starts counting. A `@MainActor` host that
+    /// calls the synchronous form therefore blocks the main thread for the length of one remote read;
+    /// the field saw 4.4 s and 5.2 s "Fully Blocked" App Hangs on a WAN source that way. The deadline
+    /// on its own does not fix that class, because it is armed on the far side of the lock.
+    ///
+    /// `queue` must be serial, so repositions stay in issue order, and must not be the queue the
+    /// caller's demux loop occupies (that block never returns, so the seek would never run).
+    /// `isSuperseded` is evaluated ON that queue, immediately before the FFmpeg call: a scrub burst
+    /// then collapses onto its last target instead of paying one lock wait per seek.
+    func seekBounded(to seconds: Double, anchorStreamIndex: Int32 = -1, timeout: TimeInterval,
+                     on queue: DispatchQueue,
+                     isSuperseded: (@Sendable () -> Bool)? = nil) async -> RepositionOutcome {
+        await withCheckedContinuation { continuation in
+            queue.async { [self] in
+                guard isSuperseded?() != true else {
+                    continuation.resume(returning: .superseded)
+                    return
+                }
+                let completed = seekBounded(to: seconds, anchorStreamIndex: anchorStreamIndex,
+                                            timeout: timeout)
+                continuation.resume(returning: completed ? .landed : .stalled)
+            }
+        }
+    }
+
     /// #112 round 8/10: byte-position seek for an index-less container. On a remote MPEG-TS with no index, a
     /// timestamp `avformat_seek_file` binary-searches via read_timestamp: dozens of remote range reads, each
     /// able to ride a starved connection's full timeout while the video pipeline competes for the origin

--- a/Sources/AetherEngine/Native/SoftwarePlaybackHost.swift
+++ b/Sources/AetherEngine/Native/SoftwarePlaybackHost.swift
@@ -87,6 +87,19 @@ final class SoftwarePlaybackHost {
 
     private let demuxQueue = DispatchQueue(label: "engine.sw.demux", qos: .userInitiated)
 
+    /// #254: every demuxer reposition runs here, never on the main actor. See
+    /// `Demuxer.seekBounded(to:anchorStreamIndex:timeout:on:isSuperseded:)` for why the main actor is
+    /// the wrong thread for it. Serial and separate from `demuxQueue`, whose block never returns.
+    private let seekQueue = DispatchQueue(label: "engine.sw.seek", qos: .userInitiated)
+
+    /// Read-deadline budget for a reposition (#254). Matches the side reader's positioning budget.
+    private static let seekBudgetSeconds: TimeInterval = 8.0
+
+    /// True while a reposition is awaiting `seekQueue`. Gates the 0.25 s time tick: the synchronizer
+    /// still carries the pre-seek anchor, so an ungated tick would walk the OLD position forward for
+    /// the length of the reposition and then snap to the target.
+    private var seekInFlight = false
+
     /// Guards isPlaying/stopRequested across demux thread reads and main-actor writes.
     private let flagsLock = NSLock()
     nonisolated(unsafe) private var _isPlaying: Bool = false
@@ -500,7 +513,13 @@ final class SoftwarePlaybackHost {
         resetFeederState()
 
         if let start = startPosition, start > 0 {
-            dem.seek(to: start)
+            // #254: same off-main, deadline-bounded reposition the transport seek uses. A resume into a
+            // remote source that has to scan for its landing would otherwise block the main thread here.
+            _ = await dem.seekBounded(to: start, timeout: Self.seekBudgetSeconds, on: seekQueue)
+            // This is load()'s only suspension point, so it is also the only place a stop() can land
+            // mid-load. Arming the clock and publishing isReady on a session already torn down would
+            // hand the engine a host it has stopped.
+            guard !stopRequested else { return }
             // Mirror seek() skip-PTS + clock alignment so demux drops pre-keyframe frames and synchronizer starts at the resume offset.
             let startTime = CMTime(seconds: start, preferredTimescale: 90000)
             videoDecoder.skipUntilPTS = startTime
@@ -619,10 +638,17 @@ final class SoftwarePlaybackHost {
         }
     }
 
-    func seek(to seconds: Double) async {
-        guard let dem = demuxer else { return }
-        // Stop loop + bump generation to invalidate in-flight packets.
+    /// #254: the demuxer reposition is awaited off the main actor. It used to run inline here, and
+    /// because `Demuxer.readPacket` holds the access lock across the whole `av_read_frame`, a seek
+    /// issued while the demux loop sat in a slow remote read parked the main thread for the length of
+    /// that read (App Hangs of 4.4 s and 5.2 s in the field on a WAN source).
+    @discardableResult
+    func seek(to seconds: Double) async -> Demuxer.RepositionOutcome {
+        guard let dem = demuxer else { return .stalled }
+        // Stop loop + bump generation to invalidate in-flight packets. Captured right after, so the
+        // reposition can tell on `seekQueue` whether a newer seek has already taken over.
         bumpSeekGeneration()
+        let generation = seekGeneration
         let wasPlaying = isPlaying
         isPlaying = false
 
@@ -637,10 +663,28 @@ final class SoftwarePlaybackHost {
         // Live source is forward-only; DVR rewind reseeds decoders from the ring without touching the live demuxer's read position.
         if isLive, let ring = dvrRing {
             await seekLiveDVR(to: seconds, ring: ring, wasPlaying: wasPlaying)
-            return
+            return .landed
         }
 
-        dem.seek(to: seconds)
+        // Publish the target and hold it across the await, so the scrub clock snaps the way the native
+        // path's optimistic publish does instead of drifting on the stale synchronizer anchor.
+        currentTime = seconds
+        seekInFlight = true
+        let outcome = await dem.seekBounded(
+            to: seconds, timeout: Self.seekBudgetSeconds, on: seekQueue,
+            isSuperseded: { [weak self] in self?.seekGeneration != generation })
+        // A newer seek owns the state from here: it published its own target and clears the hold itself.
+        // stop() can also land in the await now that this suspends, and re-arming the clock or flipping
+        // isPlaying on a torn-down session would resurrect a loop that has already been told to quit.
+        guard seekGeneration == generation, !stopRequested else { return .superseded }
+        seekInFlight = false
+        if outcome == .stalled {
+            EngineLog.emit(
+                "[SWHost] reposition to \(String(format: "%.2f", seconds))s did not complete within "
+                + "\(String(format: "%.0f", Self.seekBudgetSeconds))s; read position is undefined",
+                category: .swPlayback
+            )
+        }
 
         let targetTime = CMTime(seconds: seconds, preferredTimescale: 90000)
         videoDecoder.skipUntilPTS = targetTime
@@ -659,6 +703,7 @@ final class SoftwarePlaybackHost {
         }
         // Arm now so the demux loop doesn't re-arm at stale initialClockTime (a pre-first-audio seek snapped back to session start without this).
         clockArmed = true
+        return outcome
     }
 
     /// Live DVR rewind: reseeds decoder from the ring (source PTS axis; maps via sessionStartPts) without touching the live demuxer. After return, the loop reads new packets forward and plays back to live.
@@ -750,6 +795,7 @@ final class SoftwarePlaybackHost {
     func stop() {
         stopRequested = true
         isPlaying = false
+        seekInFlight = false
         timeTimer?.cancel()
         timeTimer = nil
         renderer.subtitleCompositor.reset()
@@ -1672,6 +1718,9 @@ final class SoftwarePlaybackHost {
             .autoconnect()
             .sink { [weak self] _ in
                 guard let self, let aOut = self.audioOutput else { return }
+                // #254: a reposition in flight holds `currentTime` at its target; the synchronizer is
+                // still on the pre-seek anchor and would drag the published position backwards.
+                guard !self.seekInFlight else { return }
                 let raw = aOut.currentTimeSeconds
                 if raw.isFinite, raw >= 0 {
                     // Raw clock = source/subtitle axis; published alongside the mapped position (#107).

--- a/Tests/AetherEngineTests/Issue254OffMainRepositionTests.swift
+++ b/Tests/AetherEngineTests/Issue254OffMainRepositionTests.swift
@@ -1,0 +1,85 @@
+import Foundation
+import Testing
+@testable import AetherEngine
+
+/// #254: `SoftwarePlaybackHost.seek` ran the demuxer reposition inline, and the host is `@MainActor`.
+/// `Demuxer.readPacket` holds the access lock across the whole of `av_read_frame`, so a seek issued
+/// while the demux loop sat in a slow remote read parked the MAIN thread until that read returned:
+/// two field App Hangs, "Fully Blocked", 4.4 s and 5.2 s, on a WAN source over the software path. The
+/// missing read deadline is a second, latent hazard; it could not have caused those two, because
+/// `seekBounded` arms its deadline on the far side of the lock the seek never got past.
+struct Issue254OffMainRepositionTests {
+
+    /// One-shot flag a sent closure can write. A mutable local captured by such a closure is the
+    /// `#SendingRisksDataRace` shape the CI toolchain rejects.
+    private final class Flag: @unchecked Sendable {
+        private let lock = NSLock()
+        private var value = false
+        func set(_ newValue: Bool) { lock.lock(); value = newValue; lock.unlock() }
+        var isSet: Bool { lock.lock(); defer { lock.unlock() }; return value }
+    }
+
+    @MainActor
+    @Test("the reposition runs off the main thread")
+    func repositionRunsOffMain() async {
+        let demuxer = Demuxer()
+        let queue = DispatchQueue(label: "test.issue254.offmain")
+        let sawOffMain = Flag()
+        // The supersede predicate is evaluated ON `queue`, immediately before the FFmpeg call, so it
+        // observes the thread the reposition itself runs on.
+        _ = await demuxer.seekBounded(to: 10, timeout: 1, on: queue, isSuperseded: {
+            sawOffMain.set(!Thread.isMainThread)
+            return false
+        })
+        #expect(sawOffMain.isSet)
+    }
+
+    @MainActor
+    @Test("a reposition waiting on the demuxer leaves the main actor free")
+    func blockedRepositionKeepsMainActorLive() async {
+        let demuxer = Demuxer()
+        let queue = DispatchQueue(label: "test.issue254.blocked")
+        let release = DispatchSemaphore(value: 0)
+        let finished = Flag()
+        // Stands in for the demux loop holding `accessLock` across a slow remote read: the reposition
+        // cannot begin until this returns. Generous backstop, never a discriminator; the signal below
+        // is what actually ends it.
+        queue.async { _ = release.wait(timeout: .now() + 90) }
+
+        let reposition = Task { @MainActor in
+            _ = await demuxer.seekBounded(to: 10, timeout: 1, on: queue)
+            finished.set(true)
+        }
+
+        // 100 ms of main-actor work while the reposition is stuck behind the queue. The inline call
+        // this replaces could not reach here at all: it held the thread these hops need.
+        for _ in 0..<5 { try? await Task.sleep(for: .milliseconds(20)) }
+        #expect(finished.isSet == false)
+
+        release.signal()
+        await reposition.value
+        #expect(finished.isSet)
+    }
+
+    @MainActor
+    @Test("a superseded reposition never reaches the demuxer")
+    func supersededSkipsTheDemuxer() async {
+        let demuxer = Demuxer()
+        let queue = DispatchQueue(label: "test.issue254.superseded")
+        // A scrub burst (the report's trigger: 20+ relative seeks in 10 s) collapses onto its last
+        // target instead of paying one lock wait per seek.
+        let outcome = await demuxer.seekBounded(to: 10, timeout: 1, on: queue, isSuperseded: { true })
+        #expect(outcome == .superseded)
+    }
+
+    @Test("a reposition that spends its budget reports stalled, not a landing")
+    func stalledRepositionDoesNotClaimALanding() {
+        #expect(AetherEngine.seekTicketOutcome(hostReposition: .stalled, renderedTime: 42) == .stalled)
+        #expect(AetherEngine.seekTicketOutcome(hostReposition: .landed, renderedTime: 42)
+                == .landed(renderedTime: 42))
+        // Supersession is settled by the engine's own generation guard before the ticket is closed;
+        // if it ever does reach here it is a landing, not a give-up.
+        #expect(AetherEngine.seekTicketOutcome(hostReposition: .superseded, renderedTime: 42)
+                == .landed(renderedTime: 42))
+    }
+}


### PR DESCRIPTION
Two field App Hangs, "Fully Blocked", 4.4 s and 5.2 s, both a seek on the software path against a remote HTTP source over a WAN link, both with the main thread parked in `Demuxer.seek`. Reported by @rrgomes with crash-reporter evidence in #254.

## What actually blocked

`SoftwarePlaybackHost` is `@MainActor` and its VOD seek ran `dem.seek(to:)` inline, with no suspension point between the generation bump and the call. Two host seeks therefore cannot overlap, so the lock the main thread waited on was never another seek. `Demuxer.readPacket` holds `accessLock` across the whole of `av_read_frame`, and a remote read may sit there for up to `AVIOReader.connStallTimeout` (20 s). The main thread was waiting out one slow network read.

That also means swapping `seek` for `seekBounded` would not have prevented these two hangs on its own: `seekBounded` arms its read deadline **after** `accessLock.lock()`, on the far side of the wait that actually blocked. The missing deadline is a real second hazard, just not the one these reports evidence.

## Change

- `Demuxer` gains an async `seekBounded(to:anchorStreamIndex:timeout:on:isSuperseded:)` that runs on a caller-owned serial queue and reports `landed` / `stalled` / `superseded`.
- Both `@MainActor` hosts await it instead of calling the synchronous form: on the transport seek, and on `load()`'s `startPosition` resume, which had the same shape and covers every resume into a remote source.
- The supersede predicate is evaluated on that queue immediately before the FFmpeg call, so the reporter's trigger (20+ relative seeks in 10 s) collapses onto its last target instead of paying one lock wait per seek.
- The 0.25 s time tick is gated while a reposition is in flight: the synchronizer still carries the pre-seek anchor and would otherwise drag the published position backwards over the target for the length of the reposition.
- Both hosts re-check `stopRequested` after the await, since a `stop()` can now land inside it. In `load()` that await is the only suspension point, so it is the only place a mid-load teardown can interleave.
- A reposition that spends its 8 s budget closes the #38 ticket as `.stalled`. Nothing on this path re-issues it, unlike the native recovery loop whose ticket stays open because AVPlayer keeps aiming at the target, so claiming `.landed` there would be a landing the engine cannot back up.

`HLSVideoEngine` (`@unchecked Sendable`) and the #232 interlace probe (already in a detached task) share the unbounded-seek property but not the main thread, so they are untouched.

## Verification

`Tests/AetherEngineTests/Issue254OffMainRepositionTests.swift`: the reposition runs off the main thread; a reposition waiting on a busy demuxer leaves the main actor free (the inline call could not reach that assertion at all); a superseded reposition never reaches the demuxer; a stalled reposition does not close the ticket as a landing.

1304 tests green, `swift build -Xswiftc -strict-concurrency=complete` clean, tvOS + iOS Simulator builds clean. Device retest of the hang itself is with the reporter (it needs a real WAN source and is not reproducible on demand).

Refs #254