### PR TITLE
fix(reader): bound a chunk-fetch body by the request, not the declared length (#255)

### DIFF
--- a/Sources/AetherEngine/Demuxer/AVIOReader.swift
+++ b/Sources/AetherEngine/Demuxer/AVIOReader.swift
@@ -2174,8 +2174,60 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
         }
     }
 
+    // MARK: - Response Body Bounds (#255)
+
+    /// Reservation ceiling for a response whose request set no bounded `Range`. `Data` grows on
+    /// demand, so the cap costs at most one reallocation on a legitimately larger body, while a
+    /// bogus or whole-source declared length stays harmless.
+    static let maxBodyReserve = 8 * 1024 * 1024
+
+    /// Bytes the request can legitimately deliver: the span of a bounded `Range: bytes=a-b`, 0 for a
+    /// HEAD (bodyless by definition), nil when the request is open-ended and the body is whatever the
+    /// origin chooses to stream.
+    ///
+    /// #255: the declared `Content-Length` is not that number and never was. A HEAD answers with the
+    /// whole source's length and no body at all, and an origin that ignores `Range` answers a bounded
+    /// chunk request with `200` plus the whole source's length, so sizing an allocation from it asked
+    /// malloc for the entire 12.4 GB movie at open time. `Data`'s storage force-unwraps the NULL that
+    /// a failing malloc returns, so it traps: a host app can neither catch it nor degrade.
+    static func expectedBodyBytes(for request: URLRequest) -> Int? {
+        if request.httpMethod?.uppercased() == "HEAD" { return 0 }
+        guard let value = request.value(forHTTPHeaderField: "Range") else { return nil }
+        return boundedRangeSpan(value)
+    }
+
+    /// Span of a single bounded byte range (`bytes=a-b`). Nil for the open-ended (`bytes=a-`), suffix
+    /// (`bytes=-n`), multi-range and malformed forms: none of those bound the body, so they fall back
+    /// to the flat ceiling rather than a wrong limit.
+    static func boundedRangeSpan(_ headerValue: String) -> Int? {
+        let spec = headerValue.trimmingCharacters(in: .whitespaces)
+        guard spec.lowercased().hasPrefix("bytes=") else { return nil }
+        let set = spec.dropFirst("bytes=".count)
+        guard !set.contains(",") else { return nil }
+        let parts = set.split(separator: "-", omittingEmptySubsequences: false)
+        guard parts.count == 2,
+              let lower = Int64(parts[0]), let upper = Int64(parts[1]),
+              lower >= 0, upper >= lower else { return nil }
+        let span = upper - lower + 1
+        return span <= Int64(Int.max) ? Int(span) : nil
+    }
+
+    /// Bytes to reserve up front for a response body: the origin's declared length clamped to what
+    /// the request itself can deliver, or to `maxBodyReserve` when the request is open-ended.
+    static func bodyReservation(declaredLength: Int64, limit: Int?) -> Int {
+        guard declaredLength > 0 else { return 0 }
+        let ceiling = Int64(limit ?? maxBodyReserve)
+        guard ceiling > 0 else { return 0 }
+        return Int(min(declaredLength, ceiling))
+    }
+
+    /// #255 test hook: the largest up-front body reservation any chunk fetch has asked for since the
+    /// last reset. Written on the delegate queue, read once the fetch it belongs to has completed.
+    nonisolated(unsafe) static var peakBodyReserveForTesting = 0
+
     private func syncRequest(_ request: URLRequest, budget: TimeInterval = 35) throws -> (Data, URLResponse) {
-        let delegate = ChunkFetchDelegate(extraHeaders: extraHeaders)
+        let delegate = ChunkFetchDelegate(extraHeaders: extraHeaders,
+                                          bodyLimit: Self.expectedBodyBytes(for: request))
         let task = Self.chunkSession.dataTask(with: request)
         task.delegate = delegate
 
@@ -2197,8 +2249,16 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
             throw AVIOReaderError.requestTimeout
         }
 
-        if let err = delegate.error { throw err }
+        // A truncating cancel is this reader hanging up on purpose, so the cancellation error it
+        // produces is not a failed fetch: the prefix the request asked for is in hand (#255).
+        if let err = delegate.error, !delegate.truncated { throw err }
         guard let response = delegate.response else { throw AVIOReaderError.noResponse }
+        if delegate.truncated {
+            EngineLog.emit(
+                "[AVIOReader] response body ran past the requested range; kept \(delegate.body.count) bytes and hung up (origin ignored Range?)",
+                category: .demux, level: .verbose
+            )
+        }
         return (delegate.body, response)
     }
 }
@@ -2364,14 +2424,22 @@ private final class PersistentReadDelegate: NSObject, URLSessionDataDelegate, @u
 /// via semaphore ensures no concurrent access to mutable fields.
 private final class ChunkFetchDelegate: NSObject, URLSessionDataDelegate, @unchecked Sendable {
     let extraHeaders: [String: String]
+    /// Most this fetch will ever buffer, nil when the request is open-ended (#255). Derived from
+    /// the request, never from the response: a declared length is the origin's claim about the
+    /// whole source, not about this body.
+    let bodyLimit: Int?
     var body = Data()
     var response: URLResponse?
     var error: Error?
+    /// Set when the origin sent past `bodyLimit` and the task was cancelled mid-body, so the
+    /// caller reads the kept prefix as a success instead of a cancellation failure.
+    var truncated = false
     var onCompletion: (() -> Void)?
     var onResolved: ((URL) -> Void)?
 
-    init(extraHeaders: [String: String]) {
+    init(extraHeaders: [String: String], bodyLimit: Int?) {
         self.extraHeaders = extraHeaders
+        self.bodyLimit = bodyLimit
     }
 
     func urlSession(
@@ -2393,8 +2461,11 @@ private final class ChunkFetchDelegate: NSObject, URLSessionDataDelegate, @unche
     ) {
         self.response = response
         if let http = response as? HTTPURLResponse {
-            let len = Int(http.expectedContentLength)
-            if len > 0 { body.reserveCapacity(len) }
+            let reserve = AVIOReader.bodyReservation(
+                declaredLength: http.expectedContentLength, limit: bodyLimit)
+            AVIOReader.peakBodyReserveForTesting = max(
+                AVIOReader.peakBodyReserveForTesting, reserve)
+            if reserve > 0 { body.reserveCapacity(reserve) }
             let status = http.statusCode
             if status == 200 || status == 206,
                let resolved = dataTask.currentRequest?.url {
@@ -2409,17 +2480,34 @@ private final class ChunkFetchDelegate: NSObject, URLSessionDataDelegate, @unche
         dataTask: URLSessionDataTask,
         didReceive data: Data
     ) {
-        // Force-copy: body.append(data) may retain source dispatch_data via CoW,
-        // defeating the per-delivery release. Manual memcpy guarantees drop on return.
-        let count = data.count
-        let baseCount = body.count
-        body.count = baseCount + count
-        body.withUnsafeMutableBytes { dst in
-            data.withUnsafeBytes { src in
-                if let dstBase = dst.baseAddress, let srcBase = src.baseAddress {
-                    (dstBase + baseCount).copyMemory(from: srcBase, byteCount: count)
+        var count = data.count
+        var overshoot = false
+        if let bodyLimit {
+            // Past what the request asked for means the origin ignored the Range and is streaming
+            // the whole source at us. Keep the prefix the caller wanted and hang up, rather than
+            // buffer a 12 GB movie in order to reject it afterwards (#255).
+            let room = bodyLimit - body.count
+            if count > room {
+                count = max(0, room)
+                overshoot = true
+            }
+        }
+        if count > 0 {
+            // Force-copy: body.append(data) may retain source dispatch_data via CoW,
+            // defeating the per-delivery release. Manual memcpy guarantees drop on return.
+            let baseCount = body.count
+            body.count = baseCount + count
+            body.withUnsafeMutableBytes { dst in
+                data.withUnsafeBytes { src in
+                    if let dstBase = dst.baseAddress, let srcBase = src.baseAddress {
+                        (dstBase + baseCount).copyMemory(from: srcBase, byteCount: count)
+                    }
                 }
             }
+        }
+        if overshoot {
+            truncated = true
+            dataTask.cancel()
         }
     }
 

--- a/Tests/AetherEngineTests/Issue255BodyReserveTests.swift
+++ b/Tests/AetherEngineTests/Issue255BodyReserveTests.swift
@@ -1,0 +1,356 @@
+// #255 (dlev02): opening a 12.4 GB progressive HTTP source killed the app outright on a 6 GB iPhone,
+// EXC_BREAKPOINT on a URLSession delegate queue before a frame played. `ChunkFetchDelegate` reserved
+// whatever the response declared: `body.reserveCapacity(Int(http.expectedContentLength))`. One of the
+// requests that reaches that line is the HEAD size probe, which declares the entire source and
+// delivers no body at all, so the delegate asked malloc for 12.4 GB in order to buffer nothing. The
+// allocation returned NULL and `__DataStorage.init(capacity:)` force-unwrapped it: a trap, not a
+// throw, so a host app can neither catch it nor degrade.
+//
+// The same line is reached by ordinary bounded chunk fetches whenever an origin ignores `Range` and
+// answers `200` with the whole source's length, so the second half of the fix is that the body itself
+// is bounded by what the request asked for: past that, the reader hangs up instead of buffering a
+// movie it would only reject afterwards.
+//
+// The arithmetic is unit-tested without a network; the wiring is measured against a scripted origin,
+// because what must hold is that no response on the chunk path can size an allocation from a number
+// the origin made up. On macOS an oversized reservation succeeds as untouched VM (which is why the
+// crash is an iOS/tvOS report), so the observable here is the reservation itself, not a crash.
+import Foundation
+import Testing
+@testable import AetherEngine
+
+/// Minimal blocking HTTP origin on 127.0.0.1 whose reply to each request the test scripts. Keeps the
+/// connection alive by default, so the reader's pooled chunk session behaves as it does in the field.
+/// What a reply DECLARES and what it SENDS are independent, which is the whole point: both are the
+/// origin's choice, and neither is a safe allocation size.
+final class ScriptedOriginServer: @unchecked Sendable {
+    struct Recorded: Sendable {
+        let method: String
+        let range: String?
+    }
+
+    struct Reply {
+        var status: Int = 200
+        /// Content-Length to declare. Nil means no length header at all (a chunked / length-less
+        /// origin), which forces connection-close framing.
+        var declaredLength: Int64?
+        var contentRange: String?
+        /// Filler bytes actually written. May be far below or above `declaredLength`.
+        var bodyBytes: Int = 0
+        var close: Bool = false
+    }
+
+    private let listenFD: Int32
+    private let reply: @Sendable (Recorded) -> Reply
+    private let lock = NSLock()
+    private var _requests: [Recorded] = []
+    private var _bodyBytesWritten = 0
+    private var _connFDs: [Int32] = []
+    private var _stopped = false
+
+    let port: UInt16
+
+    var requests: [Recorded] {
+        lock.lock(); defer { lock.unlock() }
+        return _requests
+    }
+
+    var bodyBytesWritten: Int {
+        lock.lock(); defer { lock.unlock() }
+        return _bodyBytesWritten
+    }
+
+    private var stopped: Bool {
+        lock.lock(); defer { lock.unlock() }
+        return _stopped
+    }
+
+    init?(reply: @escaping @Sendable (Recorded) -> Reply) {
+        self.reply = reply
+        let fd = socket(AF_INET, SOCK_STREAM, 0)
+        guard fd >= 0 else { return nil }
+        var one: Int32 = 1
+        setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &one, socklen_t(MemoryLayout<Int32>.size))
+
+        var addr = sockaddr_in()
+        addr.sin_family = sa_family_t(AF_INET)
+        addr.sin_port = 0
+        addr.sin_addr.s_addr = inet_addr("127.0.0.1")
+        let bound = withUnsafePointer(to: &addr) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                bind(fd, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        guard bound == 0, listen(fd, 8) == 0 else {
+            close(fd)
+            return nil
+        }
+        var named = sockaddr_in()
+        var len = socklen_t(MemoryLayout<sockaddr_in>.size)
+        let gotName = withUnsafeMutablePointer(to: &named) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) { getsockname(fd, $0, &len) }
+        }
+        guard gotName == 0 else {
+            close(fd)
+            return nil
+        }
+        self.listenFD = fd
+        self.port = UInt16(bigEndian: named.sin_port)
+        Thread.detachNewThread { [self] in acceptLoop() }
+    }
+
+    func stop() {
+        lock.lock()
+        let fds = _connFDs
+        _connFDs = []
+        let already = _stopped
+        _stopped = true
+        lock.unlock()
+        guard !already else { return }
+        // shutdown unblocks a write parked on a full socket buffer; close alone may not.
+        for fd in fds {
+            shutdown(fd, SHUT_RDWR)
+            close(fd)
+        }
+        shutdown(listenFD, SHUT_RDWR)
+        close(listenFD)
+    }
+
+    private func acceptLoop() {
+        while true {
+            let fd = accept(listenFD, nil, nil)
+            if fd < 0 { return }
+            var one: Int32 = 1
+            setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, &one, socklen_t(MemoryLayout<Int32>.size))
+            lock.lock()
+            if _stopped {
+                lock.unlock()
+                shutdown(fd, SHUT_RDWR)
+                close(fd)
+                return
+            }
+            _connFDs.append(fd)
+            lock.unlock()
+            Thread.detachNewThread { [self] in
+                while serveOneRequest(fd) {}
+                shutdown(fd, SHUT_RDWR)
+                close(fd)
+            }
+        }
+    }
+
+    /// Returns false when the connection is done (client gone, malformed request, or a scripted close).
+    private func serveOneRequest(_ fd: Int32) -> Bool {
+        guard !stopped, let header = readRequestHeader(fd) else { return false }
+        let lines = header.components(separatedBy: "\r\n")
+        let method = lines.first?.split(separator: " ").first.map(String.init) ?? "GET"
+        let range = lines.first(where: { $0.lowercased().hasPrefix("range:") })
+            .map { String($0.dropFirst("range:".count)).trimmingCharacters(in: .whitespaces) }
+        let recorded = Recorded(method: method, range: range)
+        lock.lock()
+        _requests.append(recorded)
+        lock.unlock()
+
+        let r = reply(recorded)
+        let keepAlive = !r.close && r.declaredLength != nil
+        var head = "HTTP/1.1 \(r.status) \(r.status == 206 ? "Partial Content" : "OK")\r\n"
+        if let declared = r.declaredLength { head += "Content-Length: \(declared)\r\n" }
+        if let cr = r.contentRange { head += "Content-Range: \(cr)\r\n" }
+        head += "Accept-Ranges: bytes\r\n"
+        head += "Connection: \(keepAlive ? "keep-alive" : "close")\r\n\r\n"
+        guard writeFully(fd, Array(head.utf8)) else { return false }
+        // A HEAD carries no body no matter what it declares: that disagreement IS the defect.
+        guard method != "HEAD" else { return keepAlive }
+
+        let sliceBytes = 256 * 1024
+        let slice = [UInt8](repeating: 0x5A, count: sliceBytes)
+        var sent = 0
+        while sent < r.bodyBytes && !stopped {
+            let n = min(sliceBytes, r.bodyBytes - sent)
+            guard writeCounting(fd, Array(slice[0..<n])) else { return false }
+            sent += n
+            usleep(2000)                      // ~128 MB/s: leaves room for a cancel to land
+        }
+        return keepAlive
+    }
+
+    private func readRequestHeader(_ fd: Int32) -> String? {
+        var buf = [UInt8](repeating: 0, count: 16 * 1024)
+        var collected = Data()
+        let terminator = Data("\r\n\r\n".utf8)
+        while collected.range(of: terminator) == nil {
+            let n = recv(fd, &buf, buf.count, 0)
+            guard n > 0 else { return nil }
+            collected.append(contentsOf: buf[0..<n])
+            if collected.count > 64 * 1024 { return nil }
+        }
+        return String(data: collected, encoding: .utf8)
+    }
+
+    private func writeFully(_ fd: Int32, _ bytes: [UInt8]) -> Bool {
+        var sent = 0
+        while sent < bytes.count {
+            let n = bytes[sent...].withUnsafeBytes { raw in write(fd, raw.baseAddress, raw.count) }
+            guard n > 0 else { return false }
+            sent += n
+        }
+        return true
+    }
+
+    private func writeCounting(_ fd: Int32, _ bytes: [UInt8]) -> Bool {
+        var sent = 0
+        while sent < bytes.count {
+            let n = bytes[sent...].withUnsafeBytes { raw in write(fd, raw.baseAddress, raw.count) }
+            guard n > 0 else { return false }
+            lock.lock()
+            _bodyBytesWritten += n
+            lock.unlock()
+            sent += n
+        }
+        return true
+    }
+}
+
+@Suite("#255 a declared Content-Length never sizes an allocation", .serialized)
+struct Issue255BodyReserveTests {
+
+    /// The reported source: 12.4 GB, the number the HEAD declared and malloc refused.
+    private static let reportedLength: Int64 = 13_304_315_904
+    /// Far below the 12.4 GB reservation the defect made, far above any legitimate one on this path
+    /// (a chunk span or `maxBodyReserve`), so a parallel suite's own fetch cannot tip it.
+    private static let reserveCeiling = 64 * 1024 * 1024
+
+    // MARK: - What the request can deliver
+
+    @Test("a HEAD can deliver no body at all")
+    func headExpectsNothing() {
+        var request = URLRequest(url: URL(string: "https://example.test/big.mkv")!)
+        request.httpMethod = "HEAD"
+        #expect(AVIOReader.expectedBodyBytes(for: request) == 0)
+    }
+
+    @Test("a bounded Range can deliver exactly its span")
+    func boundedRangeExpectsSpan() {
+        var request = URLRequest(url: URL(string: "https://example.test/big.mkv")!)
+        request.setValue("bytes=0-4194303", forHTTPHeaderField: "Range")
+        #expect(AVIOReader.expectedBodyBytes(for: request) == 4 * 1024 * 1024)
+        request.setValue("bytes=8388608-8388608", forHTTPHeaderField: "Range")
+        #expect(AVIOReader.expectedBodyBytes(for: request) == 1)
+    }
+
+    @Test("an open-ended or absent Range bounds nothing")
+    func openEndedExpectsNil() {
+        var request = URLRequest(url: URL(string: "https://example.test/big.mkv")!)
+        #expect(AVIOReader.expectedBodyBytes(for: request) == nil)
+        request.setValue("bytes=0-", forHTTPHeaderField: "Range")
+        #expect(AVIOReader.expectedBodyBytes(for: request) == nil)
+    }
+
+    @Test("suffix, multi and malformed ranges bound nothing rather than the wrong thing")
+    func unusableRangeFormsExpectNil() {
+        #expect(AVIOReader.boundedRangeSpan("bytes=-500") == nil)
+        #expect(AVIOReader.boundedRangeSpan("bytes=0-99,200-299") == nil)
+        #expect(AVIOReader.boundedRangeSpan("bytes=100-0") == nil)
+        #expect(AVIOReader.boundedRangeSpan("bytes=0-1-2") == nil)
+        #expect(AVIOReader.boundedRangeSpan("items=0-10") == nil)
+        #expect(AVIOReader.boundedRangeSpan("garbage") == nil)
+    }
+
+    // MARK: - What gets reserved
+
+    @Test("the bodyless HEAD probe reserves nothing, whatever it declares")
+    func headReservesNothing() {
+        #expect(AVIOReader.bodyReservation(declaredLength: Self.reportedLength, limit: 0) == 0)
+    }
+
+    @Test("a whole-source declared length is clamped to the chunk the request asked for")
+    func wholeSourceLengthClampedToSpan() {
+        let reserve = AVIOReader.bodyReservation(
+            declaredLength: Self.reportedLength, limit: 4 * 1024 * 1024)
+        #expect(reserve == 4 * 1024 * 1024)
+    }
+
+    @Test("a short body still reserves exactly its own length, not the span")
+    func shortBodyKeepsItsLength() {
+        let reserve = AVIOReader.bodyReservation(
+            declaredLength: 1024 * 1024, limit: 4 * 1024 * 1024)
+        #expect(reserve == 1024 * 1024)
+    }
+
+    @Test("an unbounded request falls back to the flat ceiling")
+    func unboundedRequestUsesCeiling() {
+        #expect(AVIOReader.bodyReservation(declaredLength: Self.reportedLength, limit: nil)
+                == AVIOReader.maxBodyReserve)
+        #expect(AVIOReader.bodyReservation(declaredLength: 4096, limit: nil) == 4096)
+    }
+
+    @Test("an unknown or absurd declared length reserves nothing")
+    func unknownLengthReservesNothing() {
+        #expect(AVIOReader.bodyReservation(declaredLength: -1, limit: 4 * 1024 * 1024) == 0)
+        #expect(AVIOReader.bodyReservation(declaredLength: 0, limit: nil) == 0)
+    }
+
+    // MARK: - Wiring, against a scripted origin
+
+    /// The crash as reported: the range probes resolve no size, so the HEAD fallback runs, and its
+    /// response declares the whole 12.4 GB source while delivering nothing.
+    @Test("the HEAD size probe does not reserve the source it declares")
+    func headProbeReservesNothingEndToEnd() throws {
+        let server = try #require(ScriptedOriginServer { request in
+            if request.method == "HEAD" {
+                return .init(status: 200, declaredLength: Issue255BodyReserveTests.reportedLength)
+            }
+            // Length-less GET: no probe can resolve a size from it, which is what drives the
+            // reader down to the HEAD fallback.
+            return .init(status: 200, declaredLength: nil, bodyBytes: 8 * 1024 * 1024, close: true)
+        })
+        defer { server.stop() }
+
+        AVIOReader.peakBodyReserveForTesting = 0
+        let reader = AVIOReader(url: URL(string: "http://127.0.0.1:\(server.port)/big.mkv")!,
+                                chunkSize: 1024 * 1024, prefetchEnabled: false,
+                                chunkRequestTimeout: 5)
+        defer { reader.markClosed(); reader.close() }
+        try reader.open()
+
+        #expect(server.requests.contains { $0.method == "HEAD" },
+                "the HEAD fallback never ran, so this exercised nothing: \(server.requests)")
+        #expect(reader.isSeekable, "the HEAD probe stopped resolving the size")
+        let peak = AVIOReader.peakBodyReserveForTesting
+        #expect(peak <= Self.reserveCeiling,
+                "a response reserved \(peak / 1024 / 1024) MB up front")
+    }
+
+    /// The other way in: the origin ignores `Range` and answers a bounded chunk request with `200`
+    /// plus the whole source's length. Pre-fix that reserved 12.4 GB and then buffered the film in
+    /// order to hand it to a caller that rejects it.
+    @Test("an origin that ignores Range is hung up on at the requested span")
+    func rangeIgnoringOriginIsTruncated() throws {
+        let bodyBytes = 64 * 1024 * 1024
+        let server = try #require(ScriptedOriginServer { _ in
+            .init(status: 200, declaredLength: Issue255BodyReserveTests.reportedLength,
+                  bodyBytes: bodyBytes)
+        })
+        defer { server.stop() }
+
+        AVIOReader.peakBodyReserveForTesting = 0
+        let chunk = 1024 * 1024
+        let reader = AVIOReader(url: URL(string: "http://127.0.0.1:\(server.port)/big.mkv")!,
+                                chunkSize: chunk, prefetchEnabled: false,
+                                chunkRequestTimeout: 5, chunkMaxRetries: 1)
+        defer { reader.markClosed(); reader.close() }
+        try reader.open()
+
+        let want = 64 * 1024
+        let buf = UnsafeMutablePointer<UInt8>.allocate(capacity: want)
+        defer { buf.deallocate() }
+        #expect(reader.read(into: buf, size: Int32(want)) == Int32(want),
+                "the truncated chunk did not serve the reader's first read")
+
+        let peak = AVIOReader.peakBodyReserveForTesting
+        #expect(peak <= Self.reserveCeiling,
+                "a response reserved \(peak / 1024 / 1024) MB up front")
+        #expect(server.bodyBytesWritten < bodyBytes / 2,
+                "the reader kept reading past its own range: origin wrote \(server.bodyBytesWritten / 1024 / 1024) MB")
+    }
+}


### PR DESCRIPTION
## What

`ChunkFetchDelegate` reserved whatever the response declared, with no ceiling:

```swift
let len = Int(http.expectedContentLength)
if len > 0 { body.reserveCapacity(len) }
```

One of the requests that reaches that line is the HEAD size probe. A HEAD declares the entire source and delivers **zero** body bytes, so opening a 12.4 GB progressive HTTP source asked malloc for 12.4 GB in order to buffer nothing. On a 6 GB iPhone the allocation returned NULL and `__DataStorage.init(capacity:)` force-unwrapped it: `EXC_BREAKPOINT` on the URLSession delegate queue before a frame played. It traps rather than throwing, so a host app can neither catch it nor degrade.

The surface is wider than the reported case. `probeFileSize()` launches the HEAD fallback 0.75 s after the range probes and runs it whenever they have not resolved a size yet, so any non-prefetch open (still extraction, one-shot seekable) against a slow origin could take the crash, not only origins that reject Range outright.

## Fix

Both halves now come from the request instead of the response:

- **Reservation:** the declared length clamped to what the request itself can deliver. The span of a bounded `Range: bytes=a-b`, nothing at all for a HEAD, a flat 8 MB ceiling when the request is open-ended. `Data` grows on demand, so the cap costs at most one reallocation.
- **Body:** truncated at that same span. An origin that ignores `Range` and answers a bounded chunk request with `200` plus the whole source's length used to be buffered in full and only then rejected by the caller's status check; the reader now keeps the prefix it asked for and hangs up. The truncating cancel is not read as a failed fetch.

`HTTPDiscIOReader` is not affected: it never reserves from a declared length, and its init requires working Range support.

## Verification

`Issue255BodyReserveTests`: the arithmetic without a network, plus the wiring against a scripted origin (one that resolves no size from GETs and answers HEAD with the 12.4 GB length, one that ignores `Range` and answers 200 with the full length while streaming 64 MB).

Red before the fix, on the same tests:

| | pre-fix | post-fix |
|---|---|---|
| peak up-front reservation, HEAD probe path | 13,304,315,904 B | chunk span |
| peak up-front reservation, Range-ignoring path | 13,304,315,904 B | chunk span |
| origin body bytes written, Range-ignoring path | 134 MB | single-digit MB |
| first read off the chunk | fails (-541478725) | serves |

- 1315 tests, 201 suites green
- `swift build --build-tests -Xswiftc -strict-concurrency=complete` clean
- `xcodebuild -scheme AetherEngine -destination 'generic/platform=tvOS Simulator'` succeeded

Reported by @dlev02 with a symbolicated crash report and register state (`x0` NULL, `x19`/`x2` = 0x318ffc000 = the source's full length).

Refs #255

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01At1agC2qU2Y2MX2BKLdT4N