### PR TITLE
fix(subtitles): trim the grid padding off teletext rows at interior line breaks (#233)

### DIFF
--- a/Sources/AetherEngine/Subtitles/SubtitleRectText.swift
+++ b/Sources/AetherEngine/Subtitles/SubtitleRectText.swift
@@ -289,6 +289,70 @@ enum SubtitleRectText {
     /// can land in a whitespace-only run of its own and break the chain (`line` / whitespace run /
     /// `line`).
     private static func collapseInteriorBlankLines(_ runs: [SubtitleTextRun]) -> [SubtitleTextRun] {
+        rewritingFlattened(runs) { chars, keep in
+            var i = 0
+            while i < chars.count {
+                guard chars[i].isNewline else { i += 1; continue }
+                // Scan past horizontal whitespace and further newlines; everything up to and
+                // including the last newline found is one blank-row gap and collapses onto the
+                // first newline.
+                var probe = i + 1
+                var lastNewline = i
+                while probe < chars.count {
+                    let c = chars[probe]
+                    if c.isNewline { lastNewline = probe }
+                    else if !c.isWhitespace { break }
+                    probe += 1
+                }
+                if lastNewline > i {
+                    for k in (i + 1)...lastNewline { keep[k] = false }
+                }
+                i = lastNewline + 1
+            }
+        }
+    }
+
+    /// Trim the column padding off both ends of every row of a raw teletext grid dump (#233).
+    ///
+    /// On a page libzvbi does not flag as a subtitle page, `gen_sub_ass` writes each row at full
+    /// column width (`decode_string(row, 0, columns)`, with `\h` for every grid space) and appends
+    /// `" \N"` after it. `edgeTrimmed` only reaches the outer edges of the whole sequence, so the
+    /// padding on the inside of every line break survives: a two-row caption arrives with trailing
+    /// spaces on row 1 and leading spaces on row 2, which pushes a centred row off centre and makes
+    /// the cue's background box wider than its text.
+    ///
+    /// Deliberately does NOT run on flagged pages, where the padding is the opposite of noise: there
+    /// `gen_sub_ass` already trims each row and the residue it leaves is the relative indentation
+    /// that carries the alignment it chose (`leading = min_leading` for left, `trailing =
+    /// min_trailing` for right, both for its non-centrable centre case). See `teletextBody`.
+    private static func trimGridRows(_ runs: [SubtitleTextRun]) -> [SubtitleTextRun] {
+        rewritingFlattened(runs) { chars, keep in
+            // A row holds no newline by construction, so any whitespace inside one is horizontal.
+            func trimRow(from start: Int, to end: Int) {
+                var head = start
+                while head < end, chars[head].isWhitespace { keep[head] = false; head += 1 }
+                var tail = end - 1
+                while tail >= head, chars[tail].isWhitespace { keep[tail] = false; tail -= 1 }
+            }
+            var rowStart = 0
+            for (index, ch) in chars.enumerated() where ch.isNewline {
+                trimRow(from: rowStart, to: index)
+                rowStart = index + 1
+            }
+            trimRow(from: rowStart, to: chars.count)
+        }
+    }
+
+    /// Let `marking` decide which characters survive on the FLATTENED sequence, then re-split the
+    /// survivors along the original run boundaries.
+    ///
+    /// Both whitespace passes need the flattening rather than a per-run walk: the padding of a
+    /// teletext row carries the spacing attribute that changes colour, so it lands in a
+    /// whitespace-only run of its own and a per-run or adjacent-pair check steps right over it.
+    private static func rewritingFlattened(
+        _ runs: [SubtitleTextRun],
+        marking: ([Character], inout [Bool]) -> Void
+    ) -> [SubtitleTextRun] {
         var chars: [Character] = []
         var owner: [Int] = []
         for (index, run) in runs.enumerated() {
@@ -299,24 +363,7 @@ enum SubtitleRectText {
         }
 
         var keep = [Bool](repeating: true, count: chars.count)
-        var i = 0
-        while i < chars.count {
-            guard chars[i].isNewline else { i += 1; continue }
-            // Scan past horizontal whitespace and further newlines; everything up to and including
-            // the last newline found is one blank-row gap and collapses onto the first newline.
-            var probe = i + 1
-            var lastNewline = i
-            while probe < chars.count {
-                let c = chars[probe]
-                if c.isNewline { lastNewline = probe }
-                else if !c.isWhitespace { break }
-                probe += 1
-            }
-            if lastNewline > i {
-                for k in (i + 1)...lastNewline { keep[k] = false }
-            }
-            i = lastNewline + 1
-        }
+        marking(chars, &keep)
 
         var texts = [String](repeating: "", count: runs.count)
         for (index, ch) in chars.enumerated() where keep[index] {
@@ -335,16 +382,34 @@ enum SubtitleRectText {
         return body(for: parsed.runs).map { ($0, parsed.placement) }
     }
 
-    /// Teletext variant (#107): identical, plus the interior blank-line fold libzvbi's row joining
-    /// requires, plus the grid-row placement fallback below. Both are deliberately teletext-only,
-    /// since a blank line in an ASS or SRT cue can be intentional and a leading one is never a row
-    /// ordinal.
+    /// Teletext variant (#107, #233): identical, plus the two whitespace passes libzvbi's raw grid
+    /// dump requires and the grid-row placement fallback below. All three are deliberately
+    /// teletext-only, since a blank line in an ASS or SRT cue can be intentional, interior
+    /// indentation there can be deliberate, and a leading blank line is never a row ordinal.
+    ///
+    /// The passes run only on a page libzvbi did NOT flag as a subtitle page, which is exactly the
+    /// page that arrives without an `\an`. `gen_sub_ass` writes such a page out as the raw grid: one
+    /// full-width row per grid row, empty ones included, and the row ordinal as the only carrier of
+    /// the position. On a flagged page it instead curates the output, and both of the things these
+    /// passes remove become decisions there: the `empty_lines / 2` fillers are its vertical
+    /// fine-positioning inside the block, and the residual padding is the relative indentation that
+    /// carries the horizontal alignment it picked. Folding or trimming those deletes information
+    /// rather than noise, so a curated body is passed through whole, down to the one separator
+    /// space `gen_sub_ass` writes ahead of every `\N`.
+    ///
+    /// The two gates are the same gate. `gen_sub_ass` emits `{\anN}` on the first row of a flagged
+    /// page that holds any character, and a flagged page holding none produces no cue at all, so an
+    /// arriving `\an` and a curated body are equivalent.
     static func teletextBody(fromASSEventLine line: String,
                              playRes: CGSize = SubtitleRectText.defaultASSPlayRes)
         -> (body: SubtitleCue.Body, placement: SubtitleTextPlacement?)? {
         guard let parsed = styledRuns(fromASSEventLine: line, playRes: playRes) else { return nil }
+        let isCurated = parsed.placement?.alignment != nil
         let placement = parsed.placement ?? gridPlacement(firstTextRow: parsed.firstTextRow)
-        return body(for: collapseInteriorBlankLines(parsed.runs)).map { ($0, placement) }
+        let runs = isCurated
+            ? parsed.runs
+            : trimGridRows(collapseInteriorBlankLines(parsed.runs))
+        return body(for: runs).map { ($0, placement) }
     }
 
     /// Vertical anchor for a teletext page that carried no `\an` (#233).
@@ -360,10 +425,15 @@ enum SubtitleRectText {
     ///     an             = alignment + vertical_align * 3
     ///
     /// with `i` the grid row (emitted row + 1, since `txt_chop_top` defaults to 1) and the
-    /// horizontal alignment left at ffmpeg's own default of 2, centre: the column analysis it does
-    /// for subtitle pages needs the per-row trim that this path never ran. Coarse on purpose. Three
-    /// bands is what the source encodes; mapping each row to its own offset makes consecutive cues
-    /// of different heights sit at different heights, which reads as a blink.
+    /// horizontal alignment left at ffmpeg's own default of 2, centre. Deriving that one too is
+    /// measurable now that `trimGridRows` runs, since the leading and trailing pad of each row is
+    /// the column count `can_align_left` / `_right` / `_center` compare, but the analysis is not
+    /// self-contained: where it leaves more than one of the three viable it resolves the tie from
+    /// `last_ass_alignment`, the answer given to the PREVIOUS cue. A stateless parser has to fall
+    /// back to centre there, so an unambiguous left-aligned cue followed by an ambiguous one would
+    /// jump. Coarse on purpose, on both axes: three bands is what the source encodes, and mapping
+    /// each row to its own offset makes consecutive cues of different heights sit at different
+    /// heights, which reads as a blink.
     ///
     /// Never overrides an `\an` that arrived, including `{\an2}`: bottom is a real answer and it
     /// looks exactly like no answer.

--- a/Tests/AetherEngineTests/Issue233TeletextRowPaddingTests.swift
+++ b/Tests/AetherEngineTests/Issue233TeletextRowPaddingTests.swift
@@ -1,0 +1,173 @@
+import Testing
+import Foundation
+@testable import AetherEngine
+
+/// #233 round 4, reported by tresby: teletext rows kept their column padding at interior line
+/// breaks, so a two-row caption arrived as `row one␣␣\n␣␣␣␣␣␣␣␣row two`. A renderer that centres
+/// each line puts row two visibly off centre and draws the background box wider than the text.
+///
+/// The padding is the grid. On a page libzvbi does not flag as a subtitle page, `gen_sub_ass`
+/// (`libavcodec/libzvbi-teletextdec.c:378`) writes every row at full column width
+/// (`decode_string(page, row, &buf, 0, page->columns, ...)`, one `\h` per grid space) and appends
+/// `" \N"` after it. `edgeTrimmed` reaches the outer edges of the whole run sequence only, and
+/// `collapseInteriorBlankLines` looks at the characters BETWEEN two newlines, never the ones
+/// touching a single retained one, so both walked past it.
+///
+/// The pass is gated on the same signal as the vertical fallback: no `\an` means the raw grid
+/// dump. A flagged page is curated by `gen_sub_ass` itself (`:357-376`), where the surviving pad is
+/// the relative indentation that carries the alignment it chose, and the blank lines are its
+/// `empty_lines / 2` vertical fine-positioning. Trimming those would delete information.
+struct Issue233TeletextRowPaddingTests {
+
+    /// One emitted row of an unflagged page: full column width in `\h`, then the `" \N"` separator.
+    private func gridRow(_ text: String, leading: Int, columns: Int = 40) -> String {
+        let trailing = max(0, columns - leading - text.count)
+        return String(repeating: #"\h"#, count: leading)
+            + text
+            + String(repeating: #"\h"#, count: trailing)
+            + #" \N"#
+    }
+
+    private func unflaggedPage(_ rows: String...) -> String {
+        "0,0,Teletext,,0,0,0,," + rows.joined()
+    }
+
+    private func text(_ line: String) -> String? {
+        SubtitleRectText.teletextBody(fromASSEventLine: line)?.body.flattenedText
+    }
+
+    // MARK: - The report
+
+    @Test("a two-row grid dump loses the padding on both sides of the line break")
+    func interiorPaddingTrimmed() {
+        let page = unflaggedPage(
+            gridRow("Waxy, buttery potatoes with chicken", leading: 3),
+            gridRow("and peas.", leading: 8)
+        )
+        #expect(text(page) == "Waxy, buttery potatoes with chicken\nand peas.")
+    }
+
+    @Test("the separator space gen_sub_ass writes before every newline goes too")
+    func separatorSpaceTrimmed() {
+        // Even a row that fills its columns exactly still carries the " " from `" \N"`.
+        let page = unflaggedPage(
+            gridRow("one", leading: 0, columns: 3),
+            gridRow("two", leading: 0, columns: 3)
+        )
+        #expect(text(page) == "one\ntwo")
+    }
+
+    @Test("padding split off into its own run by a colour change is still padding")
+    func paddingInItsOwnRun() {
+        // decode_string emits the colour change at the column it happens on, so a row's pad
+        // routinely lands in a whitespace-only run: a per-run trim steps over it, and a trim that
+        // only looked at the run touching the newline would keep the rest.
+        let line = #"0,0,Teletext,,0,0,0,,{\c&H0000FF&}one\h\h{\c&H00FF00&}\h\h \N{\c&H0000FF&}\h\htwo"#
+        #expect(text(line) == "one\ntwo")
+    }
+
+    @Test("the trailing pad of the last row and the leading pad of the first are still gone")
+    func outerEdgesUnaffected() {
+        let page = unflaggedPage(gridRow("only row", leading: 12))
+        #expect(text(page) == "only row")
+    }
+
+    // MARK: - What the trim must not eat
+
+    @Test("indentation inside a row survives")
+    func interiorIndentationSurvives() {
+        // Only the run of whitespace touching a row edge is grid pad. What sits between two
+        // characters is spacing the broadcaster laid out.
+        let page = unflaggedPage(gridRow("A     B", leading: 4))
+        #expect(text(page) == "A     B")
+    }
+
+    @Test("a single line break still survives, an interior blank row still folds")
+    func foldStillApplies() {
+        let adjacent = unflaggedPage(gridRow("line one", leading: 2), gridRow("line two", leading: 2))
+        #expect(text(adjacent) == "line one\nline two")
+
+        let gapped = unflaggedPage(
+            gridRow("line one", leading: 2),
+            gridRow("", leading: 0),
+            gridRow("line two", leading: 2)
+        )
+        #expect(text(gapped) == "line one\nline two")
+    }
+
+    @Test("colours survive the trim on the runs that keep text")
+    func coloursSurvive() {
+        let line = #"0,0,Teletext,,0,0,0,,{\c&H0000FF&}\h\hred\h\h \N{\c&H00FF00&}\h\hgreen\h\h"#
+        guard case .richText(let runs)? =
+                SubtitleRectText.teletextBody(fromASSEventLine: line)?.body else {
+            Issue.record("expected richText")
+            return
+        }
+        #expect(runs.map(\.text).joined() == "red\ngreen")
+        #expect(runs.compactMap(\.color).count == 2)
+    }
+
+    // MARK: - The gate
+
+    @Test("a curated page keeps the relative indentation that carries its alignment")
+    func curatedPageUntouched() {
+        // Left-aligned subtitle page: gen_sub_ass emits from min_leading, so what is left of the
+        // pad is the offset of that row against the block, not grid noise.
+        let line = #"0,0,Subtitle,,0,0,0,,{\an1}line one \N\h\h\h\h\hline two \N"#
+        #expect(text(line) == "line one \n     line two")
+    }
+
+    @Test("a curated page keeps its empty_lines fillers")
+    func curatedFillersUntouched() {
+        // `if (len && empty_lines > 1) for (empty_lines /= 2; ...) av_bprintf(&buf, " \\N");`
+        // is deliberate vertical spacing inside the block, not a row the page happened to skip.
+        let line = #"0,0,Subtitle,,0,0,0,,{\an5}line one \N \N \Nline two \N"#
+        #expect(text(line) == "line one \n \n \nline two")
+    }
+
+    @Test("an explicit an2 counts as curated, though it looks like the derived answer")
+    func explicitBottomIsCurated() {
+        // The same trap the vertical fallback has: {\an2} is a real answer that reads like none.
+        let line = #"0,0,Subtitle,,0,0,0,,{\an2}line one \N\h\hline two \N"#
+        #expect(text(line) == "line one \n  line two")
+    }
+
+    @Test("the trim is teletext only")
+    func teletextOnly() {
+        // Interior indentation in an ASS or SRT cue can be deliberate, and nothing there is a grid.
+        let line = #"0,0,Default,,0,0,0,,line one  \N   line two"#
+        #expect(SubtitleRectText.styledBody(fromASSEventLine: line)?.body.flattenedText
+                == "line one  \n   line two")
+    }
+
+    // MARK: - Degenerate input
+
+    @Test("a page of nothing but padding still produces no cue")
+    func allPadding() {
+        let page = unflaggedPage(gridRow("", leading: 0), gridRow("", leading: 0))
+        #expect(SubtitleRectText.teletextBody(fromASSEventLine: page) == nil)
+    }
+
+    @Test("the placement derivation still sees the untrimmed row ordinal")
+    func placementUnaffected() {
+        // firstTextRow is measured before any of this runs, so the trim cannot move the caption.
+        let page = unflaggedPage(
+            gridRow("", leading: 0),
+            gridRow("", leading: 0),
+            gridRow("caption", leading: 6)
+        )
+        let parsed = SubtitleRectText.teletextBody(fromASSEventLine: page)
+        #expect(parsed?.placement?.alignment == 8)
+        #expect(parsed?.body.flattenedText == "caption")
+    }
+}
+
+private extension SubtitleCue.Body {
+    var flattenedText: String {
+        switch self {
+        case .text(let t): return t
+        case .richText(let runs): return runs.map(\.text).joined()
+        case .image: return ""
+        }
+    }
+}


### PR DESCRIPTION
Reported by tresby on #233. A two-row teletext caption reached the host as `row one<pad>\n<pad>row two`, so a renderer that centres each line put row two off centre and drew the background box wider than its text.

## Where it comes from

On a page libzvbi does not flag as a subtitle page, `gen_sub_ass` writes each row at full column width (`decode_string(page, row, &buf, 0, page->columns, ...)`, one `\h` per grid space) and appends `" \N"` after it. Two passes handled whitespace and neither reached the inside of a line break:

- `edgeTrimmed` trims the leading and trailing edge of the whole run sequence, so the first row's leading pad and the last row's trailing pad only.
- `collapseInteriorBlankLines` folds what sits BETWEEN two newlines. Against a single retained newline it drops nothing, and it never looks at the characters before one at all.

## The fix

`trimGridRows` takes the padding off both ends of every row. Like the fold it works on the flattened character sequence and re-splits along the original run boundaries, since a row's pad carries the spacing attribute that changes colour and therefore lands in a whitespace-only run of its own, which a per-run walk steps over. Both passes share one `rewritingFlattened` helper now.

## The gate, and why the fold moves behind it too

Both passes only correct a raw grid dump, which is exactly the page that arrives without an `\an`. The equivalence holds by construction: `gen_sub_ass` emits `{\anN}` on the first row of a flagged page that holds any character, and a flagged page holding none produces no cue at all.

On a curated page both of the things these passes remove are decisions rather than noise:

| | curated page | raw grid dump |
| --- | --- | --- |
| blank lines | `empty_lines / 2` fillers, vertical fine-positioning inside the block | every skipped grid row, emitted |
| residual padding | relative indentation carrying the chosen alignment (`leading = min_leading` left, `trailing = min_trailing` right, both for the non-centrable centre case) | the grid, at full column width |

So a curated body is passed through whole now, including through the fold, which had been folding those fillers away since #107. That half is unreported and there is no flagged-page source here to shoot it against, but leaving the fold unconditional while gating the trim would give two passes with the same premise two different answers.

## Not taken

Deriving the horizontal anchor the way `can_align_left` / `_right` / `_center` do, which the trim does make measurable. Where that analysis leaves more than one of the three viable it resolves the tie from `last_ass_alignment`, the answer given to the previous cue. A stateless parser has to fall back to centre there, so an unambiguous left-aligned cue followed by an ambiguous one would jump, which is the same blink the vertical derivation already refuses. The comment on `gridPlacement` now says that instead of the stale reason.

## Tests

13 new in `Issue233TeletextRowPaddingTests`, built on a `gridRow` helper that reproduces ffmpeg's emission shape rather than a hand-written string: the reported two-row case, the separator space, padding that lands in its own coloured run, indentation inside a row surviving, colours surviving, and the curated page keeping both its indentation and its fillers. Full suite green, 1328 Swift Testing + 392 XCTest (1 skipped).

Closes nothing yet, the reporter retest on page 801 is what settles it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01At1agC2qU2Y2MX2BKLdT4N
