### PR TITLE
fix(captions): put A/53 caption timestamps back on the source axis (#259)

### DIFF
--- a/Scripts/fetch-fixtures.sh
+++ b/Scripts/fetch-fixtures.sh
@@ -16,6 +16,7 @@
 #   restart-witness-av.mp4        - H.264 B-frames + AAC, 12 s (3 segments)
 #   restart-witness-leadaudio.mp4 - same, video delayed 0.3 s so audio leads
 #   restart-witness-subs.mkv      - same as MKV with an embedded SRT track (pump tap)
+#   a53-captions.mp4              - H.264 with in-picture A/53 CEA-608 SEI (#131, #259)
 #   hev1-inband-xps.mp4           - HEVC with in-band VPS/SPS/PPS and an empty hvcC
 #
 # Real-world DV / Atmos / multichannel sources have to come from your
@@ -140,6 +141,97 @@ ffmpeg -hide_banner -loglevel error -y \
     -metadata:s:s:0 language=eng \
     "$FIXTURES_DIR/restart-witness-subs.mkv"
 rm -f "$SRT_TMP"
+
+# A/53 in-picture captions (#131, #259): US broadcast sources carry CEA-608 inside the
+# video as user_data_registered_itu_t_t35 SEI, and no encoder emits those from a synthetic
+# source, so they are injected here. Every access unit gets a cc_data SEI: the null pad pair
+# real encoders send continuously, except every 48th AU (2 s at 24 fps), which carries a
+# COMPLETE pop-on sequence (RCL, ENM, PAC, characters, EOC) in one SEI, so the caption is
+# atomic inside a single access unit and survives B-frame reordering. B-frames stay on
+# (-bf 3): they give the producer a non-zero playlist shift, which is what the axis witness
+# in Issue259A53CaptionAxisTests measures.
+echo "→ a53-captions.mp4 (H.264 with in-picture A/53 CEA-608 SEI, 12s)"
+A53_RAW="$(mktemp -t a53-raw).264"
+A53_CC="$(mktemp -t a53-cc).264"
+ffmpeg -hide_banner -loglevel error -y \
+    -f lavfi -i "testsrc2=duration=12:size=320x180:rate=24" \
+    -c:v libx264 -preset veryfast -bf 3 -g 48 -pix_fmt yuv420p -b:v 200k \
+    -bsf:v "h264_metadata=aud=insert" -f h264 "$A53_RAW"
+python3 - "$A53_RAW" "$A53_CC" <<'PY'
+import sys
+
+def odd_parity(v):
+    v &= 0x7F
+    return v if bin(v).count('1') % 2 == 1 else (v | 0x80)
+
+# A complete pop-on caption: RCL, ENM, PAC row 1 col 0, character pairs, EOC.
+def caption_pairs(text):
+    pairs = [(0x14, 0x20), (0x14, 0x2E), (0x11, 0x40)]
+    b = text.encode('ascii')
+    for i in range(0, len(b), 2):
+        pairs.append((b[i], b[i + 1] if i + 1 < len(b) else 0x00))
+    pairs.append((0x14, 0x2F))
+    return [(odd_parity(a), odd_parity(c)) for a, c in pairs]
+
+# cc_data SEI: country 0xB5, provider 0x0031, "GA94", user_data_type_code 0x03, then
+# process_cc_data_flag | cc_count, em_data, cc_count * (0xFC marker + 608 pair), marker.
+def sei_nal(pairs):
+    payload = bytearray([0xB5, 0x00, 0x31, 0x47, 0x41, 0x39, 0x34, 0x03])
+    payload += bytes([0x40 | len(pairs), 0xFF])
+    for d0, d1 in pairs:
+        payload += bytes([0xFC, d0, d1])
+    payload += b'\xFF'
+    rbsp = bytearray([4])                      # payload_type: user_data_registered_itu_t_t35
+    n = len(payload)
+    while n >= 255:
+        rbsp.append(0xFF)
+        n -= 255
+    rbsp.append(n)
+    rbsp += payload
+    rbsp.append(0x80)                          # rbsp_trailing_bits
+    escaped = bytearray()
+    zeros = 0
+    for byte in rbsp:                          # emulation prevention
+        if zeros >= 2 and byte <= 0x03:
+            escaped.append(0x03)
+            zeros = 0
+        escaped.append(byte)
+        zeros = zeros + 1 if byte == 0 else 0
+    return b'\x00\x00\x00\x01\x06' + bytes(escaped)
+
+src, dst = sys.argv[1], sys.argv[2]
+data = open(src, 'rb').read()
+out = bytearray()
+prev = 0
+au = 0
+captions = 0
+i = 0
+while i + 3 <= len(data):
+    if data[i] == 0 and data[i + 1] == 0 and data[i + 2] == 1:
+        payload = i + 3
+        if data[payload] & 0x1F == 9:          # access unit delimiter: AU boundary
+            end = payload + 2                  # AUD is header + primary_pic_type
+            out += data[prev:end]
+            if au % 48 == 0:
+                captions += 1
+                out += sei_nal(caption_pairs('CUE %d' % captions))
+            else:
+                out += sei_nal([(0x80, 0x80)])
+            prev = end
+            au += 1
+        i += 3
+    else:
+        i += 1
+out += data[prev:]
+open(dst, 'wb').write(bytes(out))
+print('    %d access units, %d captions' % (au, captions))
+PY
+ffmpeg -hide_banner -loglevel error -y \
+    -f h264 -r 24 -i "$A53_CC" \
+    -f lavfi -i "sine=frequency=440:sample_rate=44100:duration=12" \
+    -map 0:v -map 1:a -c:v copy -c:a aac -b:a 48k -ac 1 -shortest \
+    "$FIXTURES_DIR/a53-captions.mp4"
+rm -f "$A53_RAW" "$A53_CC"
 
 # HEVC whose parameter sets live IN-BAND only: hev1 sample entry, hvcC header with
 # numOfArrays = 0. That is what `MP4Box ...:xps_inband` and the common Dolby-Vision MP4

--- a/Sources/AetherEngine/Video/HLSSegmentProducer.swift
+++ b/Sources/AetherEngine/Video/HLSSegmentProducer.swift
@@ -857,6 +857,14 @@ final class HLSSegmentProducer: @unchecked Sendable {
         return baseIndex + Self.segmentOffset(forAbsolutePts: absolute, boundaries: segmentBoundaries)
     }
 
+    /// Source-axis value of a timestamp the pump has already rebased onto the output axis
+    /// (`pts -= videoShiftPts`). Anything the producer hands to a consumer that works in source
+    /// PTS has to come back through here (#259). NOPTS and an unresolved shift pass through.
+    static func foldingShiftBack(_ value: Int64, shift: Int64) -> Int64 {
+        guard value != Int64.min, shift != Int64.min else { return value }
+        return value &+ shift
+    }
+
     /// 0-based segment offset for `absolute` within the sorted-ascending `boundaries`: segment i spans
     /// [boundaries[i], boundaries[i+1]), clamped to [0, count-2]. Binary search, exactly equivalent to the
     /// former linear "first i where absolute < boundaries[i+1]" scan but O(log n) instead of O(n) per packet
@@ -2843,13 +2851,21 @@ final class HLSSegmentProducer: @unchecked Sendable {
 
         // #131: A53 caption extraction rides the same per-packet spot as the HDR10+ scan: decode
         // order, repaired DTS, timestamps still in the source time base (the rescale below).
+        // #259: the source time BASE, but no longer the source AXIS. The pump rebased this packet
+        // onto the output axis long before it got here, so the shift is folded back: the tap's cues
+        // are rendered against the source-PTS clock (as the c608 tap's and the SW path's are), and
+        // the shift is recomputed per producer session, so leaving it in would displace every
+        // caption by a different amount after each seek.
         if let kind = a53CodecKind, let observe = a53CaptionObserver,
            let data = packet.pointee.data, packet.pointee.pts != Int64.min {
             let size = Int(packet.pointee.size)
             if A53SEIParser.mayContainA53(data, size) {
                 let extracted = A53SEIParser.triplets(in: data, size: size, codec: kind, framing: a53NALFraming)
                 if !extracted.isEmpty {
-                    observe(extracted, packet.pointee.pts, packet.pointee.dts, sourceVideoTimeBase)
+                    observe(extracted,
+                            Self.foldingShiftBack(packet.pointee.pts, shift: videoShiftPts),
+                            Self.foldingShiftBack(packet.pointee.dts, shift: videoShiftPts),
+                            sourceVideoTimeBase)
                 }
             }
         }

--- a/Tests/AetherEngineTests/Issue259A53CaptionAxisTests.swift
+++ b/Tests/AetherEngineTests/Issue259A53CaptionAxisTests.swift
@@ -1,0 +1,114 @@
+// Tests/AetherEngineTests/Issue259A53CaptionAxisTests.swift
+// #259: A/53 in-picture captions are extracted in `finalizeAndWriteVideo`, which runs AFTER the
+// pump has rebased the packet onto the output (item) axis with `videoShiftPts`. Everything
+// downstream of the observer treats those timestamps as source PTS: the tap's cue buffer feeds
+// `subtitleCues`, and the host renders that against `currentTime`, which folds the same shift
+// back in. Handing the observer post-shift timestamps therefore displaces every A/53 caption by
+// `playlistShiftSeconds`, and the shift is recomputed per producer session, so the error changes
+// after every seek. The demuxable c608 tap (#77) and the SW-path A53 tap both feed source PTS;
+// this pins the producer path to the same axis.
+import Foundation
+import Testing
+import Libavcodec
+@testable import AetherEngine
+
+/// Fixtures/ is local-only by design (gitignored; Scripts/fetch-fixtures.sh regenerates the
+/// synthetic clips). The tests skip via `.enabled(if:)` when a clip is absent, e.g. on CI.
+private func fixtureURL(_ name: String) -> URL {
+    URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .appendingPathComponent("Fixtures")
+        .appendingPathComponent(name)
+}
+
+private func fixtureExists(_ name: String) -> Bool {
+    FileManager.default.fileExists(atPath: fixtureURL(name).path)
+}
+
+/// The observer fires on the producer pump thread; the test reads from the main one.
+private final class PTSCollector: @unchecked Sendable {
+    private let lock = NSLock()
+    private var values: [Int64] = []
+    private var timeBase = AVRational(num: 0, den: 0)
+
+    func append(_ pts: Int64, timeBase tb: AVRational) {
+        lock.lock(); values.append(pts); timeBase = tb; lock.unlock()
+    }
+    var count: Int { lock.lock(); defer { lock.unlock() }; return values.count }
+    func snapshot() -> [Int64] { lock.lock(); defer { lock.unlock() }; return values }
+    func lastTimeBase() -> AVRational { lock.lock(); defer { lock.unlock() }; return timeBase }
+}
+
+@Suite("A53 caption timestamp axis", .serialized)
+struct Issue259A53CaptionAxisTests {
+
+    /// Source-axis pts of the first `limit` video packets carrying A/53 cc_data, in decode order.
+    private func sourceA53PacketPTS(_ name: String, limit: Int) throws -> (pts: [Int64], timeBase: AVRational) {
+        let demuxer = Demuxer()
+        try demuxer.open(url: fixtureURL(name), profile: .playback)
+        defer { demuxer.close() }
+        let videoIdx = demuxer.videoStreamIndex
+        let stream = try #require(demuxer.stream(at: videoIdx))
+        let codecpar = try #require(stream.pointee.codecpar)
+        let framing = A53SEIParser.nalFraming(
+            codec: .h264,
+            extradata: codecpar.pointee.extradata.map { UnsafePointer($0) },
+            size: Int(codecpar.pointee.extradata_size))
+
+        var out: [Int64] = []
+        while out.count < limit, let pkt = try demuxer.readPacket() {
+            var toFree: UnsafeMutablePointer<AVPacket>? = pkt
+            defer { trackedPacketFree(&toFree) }
+            guard Int(pkt.pointee.stream_index) == videoIdx,
+                  let data = pkt.pointee.data, pkt.pointee.pts != Int64.min else { continue }
+            let triplets = A53SEIParser.triplets(
+                in: data, size: Int(pkt.pointee.size), codec: .h264, framing: framing)
+            if !triplets.isEmpty { out.append(pkt.pointee.pts) }
+        }
+        return (out, stream.pointee.time_base)
+    }
+
+    @Test("The A53 observer is fed source PTS, not the shifted output timestamps",
+          .enabled(if: fixtureExists("a53-captions.mp4"),
+                   "run Scripts/fetch-fixtures.sh to generate the A/53 caption clip"),
+          .timeLimit(.minutes(2)))
+    func a53ObservationsStayOnTheSourceAxis() throws {
+        let witnessCount = 24
+        let (expected, sourceTimeBase) = try sourceA53PacketPTS("a53-captions.mp4", limit: witnessCount)
+        #expect(expected.count == witnessCount,
+                "fixture must carry A/53 cc_data on every picture, got \(expected.count)")
+
+        let engine = HLSVideoEngine(url: fixtureURL("a53-captions.mp4"), dvModeAvailable: false)
+        let collector = PTSCollector()
+        engine.a53CaptionObserverForSession = { _, pts, _, tb in
+            collector.append(pts, timeBase: tb)
+        }
+        _ = try engine.start()
+        defer { engine.stop() }
+        let prov = try #require(engine.provider)
+        #expect(prov.mediaSegment(at: 0) != nil)
+
+        let deadline = Date().addingTimeInterval(30)
+        while collector.count < witnessCount, Date() < deadline { usleep(50_000) }
+        let observed = Array(collector.snapshot().prefix(witnessCount))
+        try #require(observed.count == witnessCount,
+                     "producer emitted only \(observed.count)/\(witnessCount) A/53 observations")
+
+        // Without a shift the witness proves nothing: the two axes coincide.
+        let shift = engine.playlistShiftSeconds
+        #expect(shift != 0, "fixture produced a zero playlist shift, the axis witness is vacuous")
+
+        let tb = collector.lastTimeBase()
+        #expect(tb.num == sourceTimeBase.num && tb.den == sourceTimeBase.den,
+                "observer must report the source video time base, got \(tb.num)/\(tb.den)")
+
+        let scale = tb.den > 0 ? Double(tb.num) / Double(tb.den) : 0
+        let worst = zip(observed, expected).map { abs(Double($0 - $1) * scale) }.max() ?? 0
+        let detail = "A53 timestamps are off the source axis by up to "
+            + "\(String(format: "%.3f", worst))s (playlist shift \(String(format: "%.3f", shift))s); "
+            + "observed \(observed.prefix(4)) expected \(expected.prefix(4))"
+        #expect(observed == expected, "\(detail)")
+    }
+}


### PR DESCRIPTION
## What

The A/53 caption observer was fed post-shift timestamps.

`finalizeAndWriteVideo` extracts the in-picture `cc_data` well below the pump's
`packet.pointee.pts -= activeShift`, so the timestamps handed out were on the output
(item) axis. Every consumer treats them as source PTS: the tap's cue buffer feeds
`subtitleCues`, and the host renders that against `currentTime`, which folds
`playlistShiftSeconds` back in. Net effect, every A/53 caption is displaced by the
shift, and since the shift is recomputed per producer session, the displacement
changes after each seek.

The two sibling feeds were already correct: the demuxable c608 tap (#77) is handed its
packet before the rebase, and the software path reads decoded-frame side data where no
shift exists.

## Fix

`foldingShiftBack` folds the shift back at the observation site, mirroring
`segmentIndex(forSourcePts:)`, which already does this before comparing against
source-axis segment boundaries. NOPTS and an unresolved shift pass through.

## Witness

No encoder emits A/53 from a synthetic source, so `Scripts/fetch-fixtures.sh` builds
one: an H.264 clip with a `cc_data` SEI on every access unit, a complete pop-on caption
every 2 s held inside a single access unit (so it survives B-frame reordering), and
B-frames left on so the producer has a non-zero shift to get wrong. FFmpeg's own
CEA-608 decoder reads the captions back out of it.

`Issue259A53CaptionAxisTests` compares the observer's timestamps against the source
demuxer's for the same packets. Before the fix it fails by exactly the playlist shift:

```
observed [0, 512, 1024, 1536] expected [-1024, -512, 0, 512]
off the source axis by up to 0.083s (playlist shift -0.083s)
```

Full suite green (1329 tests), strict-concurrency build and tvOS Simulator build green.

Reported by @edde746.