### PR TITLE
Report presentation times on both the source and item axes (native path)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,13 @@ the public-API contract.
 
 ## [Unreleased]
 
-_Nothing yet._
+### Added
+
+- **The native path now states the relation between its two time axes, instead of leaving a host to infer it.** Cue times, chapter marks and `sourceTime` are source PTS; `AVPlayerItem.currentTime()` and its timebase are the axis the producer muxes into the segments. They differ by the producer shift, and nothing published closed that gap for a host compositing its own overlay: adding `playlistShiftSeconds` is correct only until the next producer epoch, the clock ticks at ~10 Hz and a clock reading is not a frame boundary, and the per-segment pair is a genuine pair but six seconds apart. `player.presentationAxisMap` converts either way at any position and is readable off the main actor, and `setNativeVideoFrameTimeObserver` reports both axes for every muxed frame, with its segment index, keyframe flag and producer epoch. Frames arrive in decode order, so `source` is not monotonic under B-frames. Both surfaces answer nothing rather than zero when no axis has been established, since at the call site a defaulted shift is indistinguishable from a measured one, which is what #259 cost. `player.currentAVPlayerItem` publishes alongside, because items are swapped in place and a host holding a timebase otherwise gets no signal. Requested by edde746 for frame-accurate libass rendering, with the axis measurement that showed the gap.
+
+### Fixed
+
+- **A VOD producer restart no longer folds the whole timeline with its new shift.** Each producer computes its own shift when its video gate opens, and a restart lands wherever the source seek lands, so a restart can change it. The shift history was rebuilt from scratch on every VOD restart with one entry covering everything, so content muxed by the previous producer, which AVPlayer can still hold in its buffer and put on screen, was folded with the incoming shift: the published playhead then leads or trails the picture by the difference for as long as that buffer lasts. The history now records the item-axis position each producer starts writing at and keeps the entries below it, and a backward restart drops only the entries it actually rewrites. Live already worked this way for program boundaries; that path is unchanged. Note that the shift-fold hypotheses in #65 were refuted by measurement at the time: that burst ran with an invariant shift, so this mechanism was inactive there and is not a retroactive explanation for it.
 
 ## [6.1.4] - 2026-07-30
 

--- a/README.md
+++ b/README.md
@@ -192,9 +192,23 @@ player.$mediaChapters                          // [ChapterInfo]; startSeconds ar
 
 // Info panel / Now Playing (iOS / tvOS)
 player.setExternalMetadata([ AVMetadataItem(/* title, artwork, etc. */) ])
+
+// Frame-accurate host rendering on the native path (#260). Cue times, chapters and sourceTime live on
+// the SOURCE axis; AVPlayerItem.currentTime() and its timebase read the ITEM axis. They differ by the
+// producer shift, which steps at every producer epoch (a seek restart, a live program boundary).
+player.presentationAxisMap                        // conversion both ways, readable off the main actor
+player.presentationAxisMap.itemSeconds(forSourceSeconds: cue.startTime)   // stamp an overlay sample
+player.presentationAxisMap.sourceSeconds(forItemSeconds: item.currentTime().seconds)
+player.$currentAVPlayerItem                       // items swap in place; this is the signal for it
+
+// Per muxed video frame, on both axes at once. Called on the producer's pump thread in DECODE order,
+// so `source` is not monotonic under B-frames; sort before using it as a frame-boundary list.
+player.setNativeVideoFrameTimeObserver { frame in
+    frame.source; frame.item; frame.segmentIndex; frame.isKeyframe; frame.epoch
+}
 ```
 
-Subtitle cues land in raw source PTS; render the overlay against `player.sourceTime` (see [docs/formats.md › Subtitles](docs/formats.md#subtitles)). The 1 Hz diagnostics snapshot lives on `player.diagnostics.liveTelemetry`, off-the-engine for the same render-stability reason. Frame extraction, authored-ASS styling, and the full published surface are documented in [docs/formats.md](docs/formats.md).
+Subtitle cues land in raw source PTS; render the overlay against `player.sourceTime` (see [docs/formats.md › Subtitles](docs/formats.md#subtitles)). A host compositing its own overlay onto the native path (libass and friends) needs the item axis too, since that is what the compositor pairs its samples against: `presentationAxisMap` converts arbitrary positions, `setNativeVideoFrameTimeObserver` reports the frames themselves. Both return nothing rather than a guess when no axis is established, because a defaulted shift is indistinguishable from a measured one at the call site. The 1 Hz diagnostics snapshot lives on `player.diagnostics.liveTelemetry`, off-the-engine for the same render-stability reason. Frame extraction, authored-ASS styling, and the full published surface are documented in [docs/formats.md](docs/formats.md).
 
 Install via Swift Package Manager:
 

--- a/Sources/AetherEngine/AetherEngine+Diagnostics.swift
+++ b/Sources/AetherEngine/AetherEngine+Diagnostics.swift
@@ -180,13 +180,15 @@ extension AetherEngine {
                     + "subActive=\(self.isSubtitleActive) "
                     + "avBufAhead=\(String(format: "%.1f", bufferAheadSec))s "
                     + "avBufBehind=\(String(format: "%.1f", bufferBehindSec))s "
-                    // #65 shift-coherence: frameAhead/prodShift/hostShift all 0 while avBufAhead holds
-                    // multiple seconds is the bidirectional-seek-burst signature (presented frame ahead of
-                    // the folded clock). seams=1 is the degenerate VOD seam history (no positional fold).
+                    // Shift coherence: prodShift is the producer edge, hostShift the shift the clock folds
+                    // with, and frameAhead their difference. Since #260 a VOD restart records a seam instead
+                    // of collapsing the history, so a non-zero frameAhead now means the producer has moved to
+                    // a new epoch while AVPlayer still presents the previous one, which is a real state and
+                    // not a defect on its own; seams counts the epochs still on record.
                     + "frameAhead=\(String(format: "%.2f", self.frameAhead))s "
                     + "prodShift=\(String(format: "%.2f", self.activeProducerShiftSeconds))s "
                     + "hostShift=\(String(format: "%.2f", self.playlistShiftSeconds))s "
-                    + "seams=\(self.liveShiftSeams.count)"
+                    + "seams=\(self.presentationAxis.seams.count)"
 
                 EngineLog.emit(line, category: .engine)
 

--- a/Sources/AetherEngine/AetherEngine+FrameTimes.swift
+++ b/Sources/AetherEngine/AetherEngine+FrameTimes.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+extension AetherEngine {
+
+    /// Report the presentation time of every muxed video frame on both axes (#260).
+    ///
+    /// Only the native (loopback HLS) path produces these: it is the path where the engine muxes and
+    /// AVPlayer presents, so the two axes exist and differ. The software and audio paths present what
+    /// they decode, with no shift to reconcile.
+    ///
+    /// The observer is called on the producer's pump thread and must not block. It survives producer
+    /// restarts and outlives a `load()`, so install it once; pass nil to remove it. Use
+    /// `presentationAxisMap` to convert positions that are not frames (a cue time, a clock reading).
+    public func setNativeVideoFrameTimeObserver(_ observer: NativeVideoFrameTimeObserver?) {
+        nativeVideoFrameTimeObserver = observer
+        nativeVideoSession?.setNativeVideoFrameTimeObserver(observer)
+    }
+}

--- a/Sources/AetherEngine/AetherEngine+Live.swift
+++ b/Sources/AetherEngine/AetherEngine+Live.swift
@@ -8,11 +8,8 @@ extension AetherEngine {
         guard isLive, let session = nativeVideoSession else { return nil }
         // seekableLiveRange is output-time + seam shift; segment table and tfdt live on raw output. Resolve newest seam (inverts $currentTime fold).
         let outputSeconds: Double
-        if let seam = liveShiftSeams.last(where: { seconds - $0.shift >= $0.activateAt }) {
-            outputSeconds = seconds - seam.shift
-        } else {
-            outputSeconds = seconds - playlistShiftSeconds
-        }
+        outputSeconds = presentationAxis.itemSeconds(forSourceSeconds: seconds)
+            ?? (seconds - playlistShiftSeconds)
         let gen = loadGeneration
         let source = await Task.detached(priority: .userInitiated) { [session] in
             session.scrubThumbnailSource(atSeconds: outputSeconds)

--- a/Sources/AetherEngine/AetherEngine+Loading.swift
+++ b/Sources/AetherEngine/AetherEngine+Loading.swift
@@ -21,8 +21,8 @@ extension AetherEngine {
         // nativeClockSeconds preserves the raw AVPlayer clock for onPlaylistShiftChanged to re-derive against.
         nativeClockSeconds = value
         // Newest seam at or before the raw clock wins: activates seams on forward play, re-applies pre-seam shift on backward DVR seeks.
-        if let active = liveShiftSeams.last(where: { value >= $0.activateAt }) {
-            playlistShiftSeconds = active.shift
+        if let active = presentationAxis.shiftSeconds(atItemSeconds: value) {
+            playlistShiftSeconds = active
         }
         if pendingRecoverySeekClockTarget == nil {
             // AE#105: fold the disc's clip-0 STC base back out so the published playhead sits on the same
@@ -181,7 +181,7 @@ extension AetherEngine {
         applyDesiredVolume(to: host)
         // No loopback producer; playhead is the raw AVPlayer clock. Shift stays 0.
         self.playlistShiftSeconds = 0
-        self.liveShiftSeams.removeAll()
+        self.setPresentationAxis(PresentationAxisMap())
         if currentAVPlayer !== host.avPlayer {
             self.currentAVPlayer = host.avPlayer
         }
@@ -428,35 +428,48 @@ extension AetherEngine {
         // #240: the pump claims the source link through this gate while it is fetching, so the
         // subtitle side readers can stay out of its way. Set before start().
         session.sideReaderLinkGate = sideReaderLinkGate
+        // #260: an observer installed before load has to reach this session's producers too.
+        session.setNativeVideoFrameTimeObserver(nativeVideoFrameTimeObserver)
         session.onFirstHDR10PlusDetected = { [weak self] in
             Task { @MainActor in self?.handleHDR10PlusDetected() }
         }
-        session.onPlaylistShiftChanged = { [weak self] seconds in
+        session.onPlaylistShiftChanged = { [weak self] seconds, seamItemSeconds in
             Task { @MainActor in
                 guard let self = self else { return }
                 let prevShift = self.playlistShiftSeconds
                 let delta = seconds - prevShift
-                self.playlistShiftSeconds = seconds
                 // AE#105: a disc title's raw source PTS starts at clip 0's STC base (= this constant VOD shift)
                 // while its duration is the 0-based MPLS/IFO playlist length. Anchor the display origin to that
                 // base so the published playhead is 0-based like the total. Normal/live sources keep origin 0
                 // (their public axis already equals source PTS), so this whole change is a no-op off disc.
                 self.sourcePresentationOrigin = (!self.discTitles.isEmpty && !self.isLive) ? seconds : 0
-                // Seed seam history: activateAt=-.infinity covers the full output timeline from the start.
-                self.liveShiftSeams = [(activateAt: -.infinity, shift: seconds)]
+                // #260: a live retune/reopen replaces the whole timeline (nothing older comes back on screen), so
+                // the history re-anchors. A VOD producer only writes from `seamItemSeconds` forward; whatever sits
+                // below that on the item axis was muxed by the previous producer, can still be in AVPlayer's
+                // buffer, and has to keep folding with the previous shift. Collapsing the history here (as this
+                // did before) hands every consumer the new shift for old-epoch bytes.
+                if self.isLive {
+                    self.setPresentationAxis(.anchored(shiftSeconds: seconds))
+                } else {
+                    var map = self.presentationAxis
+                    map.appendSeam(shiftSeconds: seconds, activatingAtItemSeconds: seamItemSeconds)
+                    self.setPresentationAxis(map)
+                }
+                // Fold with the shift in effect AT the raw clock, not with the newest one: while old-epoch buffer
+                // is still on screen those differ, and the picture is what the clock has to describe.
+                let activeShift = self.presentationAxis.shiftSeconds(atItemSeconds: self.nativeClockSeconds) ?? seconds
+                self.playlistShiftSeconds = activeShift
                 // Re-fold immediately so currentTime doesn't lag the next periodic tick (origin-corrected).
-                self.clock.currentTime = PresentationAxis.display(sourcePTS: self.nativeClockSeconds + seconds,
+                self.clock.currentTime = PresentationAxis.display(sourcePTS: self.nativeClockSeconds + activeShift,
                                                                   origin: self.sourcePresentationOrigin)
                 // sourceTime re-folds on next $renderedTime tick; keeping it there tracks the rendered picture, not the optimistic clock (#49).
-                // #65 diag: every VOD producer (re)start collapses the seam history to one entry here. If `delta`
-                // is non-zero while AVPlayer still holds old-epoch buffer (avBufAhead > 0), the buffered bytes
-                // keep folding with the NEW shift, so the picture leads the folded clock by ~delta. A burst that
-                // logs two distinct shift= values confirms the cross-epoch divergence (Root A); an invariant
-                // shift across the burst points at the orthogonal playlist-startSeconds-vs-tfdt root (Root B).
                 EngineLog.emit(
-                    "[AetherEngine] #65 VOD shift published: \(String(format: "%.3f", seconds))s "
+                    "[AetherEngine] VOD shift published: \(String(format: "%.3f", seconds))s "
                     + "(prev \(String(format: "%.3f", prevShift))s, delta \(String(format: "%.3f", delta))s, "
-                    + "changed=\(abs(delta) > 0.001 ? "YES" : "no")) seams->1 "
+                    + "changed=\(abs(delta) > 0.001 ? "YES" : "no")) "
+                    + "seamAt=\(String(format: "%.3f", seamItemSeconds))s "
+                    + "seams=\(self.presentationAxis.seams.count) "
+                    + "foldShift=\(String(format: "%.3f", activeShift))s "
                     + "presentationOrigin=\(String(format: "%.3f", self.sourcePresentationOrigin))s "
                     + "rawClock=\(String(format: "%.2f", self.nativeClockSeconds))s "
                     + "avBufAhead=\(String(format: "%.2f", self.avPlayerBufferAheadSeconds()))s",
@@ -528,13 +541,10 @@ extension AetherEngine {
             Task { @MainActor in
                 guard let self = self else { return }
                 // Program boundary: producer rebased but AVPlayer is still rendering old program (buffer + holdback). Record the seam so $currentTime resolves the active shift from history, keeping currentTime/sourceTime behind what is on screen. Backward DVR seeks re-apply the pre-seam shift. Seams append in output-timeline order (continuation dts is monotonic).
-                self.liveShiftSeams.append(
-                    (activateAt: seamOutputSeconds, shift: seconds)
-                )
-                if self.liveShiftSeams.count > 64 {
-                    // Cap history; losing the oldest only reduces fidelity for DVR positions past 60+ program boundaries.
-                    self.liveShiftSeams.removeFirst(self.liveShiftSeams.count - 64)
-                }
+                var map = self.presentationAxis
+                // Cap inside appendSeam; losing the oldest only reduces fidelity for DVR positions past 60+ program boundaries.
+                map.appendSeam(shiftSeconds: seconds, activatingAtItemSeconds: seamOutputSeconds)
+                self.setPresentationAxis(map)
             }
         }
         session.onLiveSourceReset = { [weak self, weak session] in
@@ -793,7 +803,7 @@ extension AetherEngine {
         host.$renderedTime
             .sink { [weak self] value in
                 guard let self = self else { return }
-                let shift = self.liveShiftSeams.last(where: { value >= $0.activateAt })?.shift
+                let shift = self.presentationAxis.shiftSeconds(atItemSeconds: value)
                     ?? self.playlistShiftSeconds
                 // #93 PiP skips: AVKit-side seeks never reach the engine seek API; a far rendered-
                 // time jump is the engine-visible signal to re-anchor the subtitle readers.
@@ -1144,7 +1154,7 @@ extension AetherEngine {
         }
         // SW path has no AVPlayer-clock fold; the host's synchronizer is the only clock.
         self.playlistShiftSeconds = 0
-        self.liveShiftSeams.removeAll()
+        self.setPresentationAxis(PresentationAxisMap())
 
         softwareCancellables.removeAll()
         host.$currentTime
@@ -1218,7 +1228,7 @@ extension AetherEngine {
         self.audioHost = host
         applyDesiredVolume(to: host)
         self.playlistShiftSeconds = 0
-        self.liveShiftSeams.removeAll()
+        self.setPresentationAxis(PresentationAxisMap())
 
         audioCancellables.removeAll()
         host.$currentTime
@@ -1283,7 +1293,7 @@ extension AetherEngine {
         applyDesiredVolume(to: host)
         self.audioAVPlayerActive = true
         self.playlistShiftSeconds = 0
-        self.liveShiftSeams.removeAll()
+        self.setPresentationAxis(PresentationAxisMap())
         // Reclaim Now-Playing ownership for this session on each track start,
         // so the Home badge + remote commands stay bound across a pause.
         host.becomeActiveNowPlaying()

--- a/Sources/AetherEngine/AetherEngine.swift
+++ b/Sources/AetherEngine/AetherEngine.swift
@@ -1095,12 +1095,33 @@ public final class AetherEngine: ObservableObject {
         }
     }
 
-    /// Live program-boundary shift seam history in output-timeline order. The producer rebases immediately on
-    /// reading a boundary; AVPlayer renders it ~buffer+holdback later. Each entry holds the new shift and the
-    /// raw-clock position from which it applies. currentTime sink resolves the active shift by looking up the
-    /// newest seam at or before the raw clock (a history, not a queue: backward DVR seeks must fold pre-seam
-    /// content with pre-seam shift). Seeded with a baseline entry at -infinity. Cleared on load/stop.
-    var liveShiftSeams: [(activateAt: Double, shift: Double)] = []
+    /// Shift seam history on the item axis. The producer rebases immediately (live program boundary) or starts a
+    /// fresh epoch (VOD restart); AVPlayer renders that content ~buffer+holdback later. The currentTime sink
+    /// resolves the active shift by looking up the newest seam at or before the raw clock (a history, not a
+    /// queue: backward DVR seeks must fold pre-seam content with pre-seam shift). Cleared on load/stop.
+    ///
+    /// Write only through `setPresentationAxis`, which keeps the off-main mirror in step.
+    private(set) var presentationAxis = PresentationAxisMap()
+
+    /// Off-main mirror of `presentationAxis`. Read by hosts converting between axes on their own thread
+    /// (subtitle rasterisation, #260); the map itself is main-actor state.
+    let presentationAxisMirror = AtomicPresentationAxisMap()
+
+    /// Conversion between the source-PTS axis (subtitle cues, chapters, `sourceTime`) and the item axis
+    /// (`AVPlayerItem.currentTime()`, its timebase, `NativeVideoFrameTime.item`) for the native path.
+    /// Readable off the main actor. Empty on the SW and audio paths, which have no producer shift (#260).
+    public nonisolated var presentationAxisMap: PresentationAxisMap {
+        presentationAxisMirror.get()
+    }
+
+    /// Host observer for per-frame presentation times (#260). Held here so it survives across loads and is
+    /// re-installed on each new native session; see `setNativeVideoFrameTimeObserver`.
+    var nativeVideoFrameTimeObserver: NativeVideoFrameTimeObserver?
+
+    func setPresentationAxis(_ map: PresentationAxisMap) {
+        presentationAxis = map
+        presentationAxisMirror.set(map)
+    }
 
     /// 1 Hz live-window updater, independent of the periodic time observer (which only fires while playing).
     /// Without this, liveEdgeTime/behindLiveSeconds/isAtLiveEdge/seekableLiveRange all freeze on pause:
@@ -3690,7 +3711,30 @@ public final class AetherEngine: ObservableObject {
     /// Active AVPlayer on the native path, nil on SW path or when idle. Published so hosts driving an
     /// AVPlayerViewController can rebind `.player` on every audio-track reload (one-shot assignment goes stale).
     @Published public internal(set) var currentAVPlayer: AVPlayer? {
-        didSet { observeExternalPlayback() }
+        didSet {
+            observeExternalPlayback()
+            observeCurrentItem()
+        }
+    }
+
+    /// Item currently loaded into `currentAVPlayer` (#260). Published separately because items are swapped in
+    /// place (`replaceCurrentItem`, on every audio-track reload and episode autoplay) without the player itself
+    /// changing, so a host holding the item or its timebase gets no signal from `currentAVPlayer` alone.
+    @Published public internal(set) var currentAVPlayerItem: AVPlayerItem?
+    private var currentItemObservation: NSKeyValueObservation?
+
+    private func observeCurrentItem() {
+        currentItemObservation?.invalidate()
+        currentItemObservation = nil
+        guard let player = currentAVPlayer else {
+            currentAVPlayerItem = nil
+            return
+        }
+        currentAVPlayerItem = player.currentItem
+        currentItemObservation = player.observe(\.currentItem, options: [.new]) { [weak self] _, change in
+            guard let item = change.newValue else { return }
+            Task { @MainActor in self?.currentAVPlayerItem = item }
+        }
     }
 
     /// AirPlay (#86, DrHurt): true while the native AVPlayer reports external playback. loadNative reads it to
@@ -4424,7 +4468,7 @@ public final class AetherEngine: ObservableObject {
         activeAudioDecoder = nil
         lastDetectedVideoCodec = AV_CODEC_ID_NONE
         playlistShiftSeconds = 0
-        liveShiftSeams.removeAll()
+        setPresentationAxis(PresentationAxisMap())
         nativeClockSeconds = 0
         clock.sourceTime = 0
         clock.bufferedPosition = 0

--- a/Sources/AetherEngine/NativeVideoFrameTime.swift
+++ b/Sources/AetherEngine/NativeVideoFrameTime.swift
@@ -1,0 +1,47 @@
+import CoreMedia
+
+/// Presentation time of one muxed video frame on the native path, on both axes (#260).
+///
+/// A host that renders its own overlay (libass, a burned-in badge) needs two things the engine holds
+/// together and nothing else does: the media instant a frame represents (`source`, the axis subtitle
+/// cues and chapters live on) and the instant the compositor will show it (`item`, the axis
+/// `AVPlayerItem.currentTime()` and its timebase read). Both are reported for the same frame so a
+/// consumer never has to reconstruct one from the other through a convention. `PresentationAxisMap`
+/// converts arbitrary positions between the axes; this reports the frames themselves.
+///
+/// Frames arrive in **decode order**, so with B-frames `source` is not monotonic across successive
+/// callbacks. Sort by `source` before using the sequence as a frame-boundary list.
+public struct NativeVideoFrameTime: Sendable, Equatable {
+
+    /// Demuxed presentation timestamp, in the source video time base.
+    public let source: CMTime
+
+    /// Presentation timestamp as written into the segment, in the muxer time base. This is the value
+    /// after the final-stage sanitizer, so on sources it repairs (SSAI splices with a restarting
+    /// clock) it differs from a plain rescale of `source`.
+    public let item: CMTime
+
+    /// Absolute index of the segment this frame was muxed into, so a consumer can evict its own table
+    /// alongside the segment bytes.
+    public let segmentIndex: Int
+
+    /// `AV_PKT_FLAG_KEY` on the source packet.
+    public let isKeyframe: Bool
+
+    /// Producer epoch. Increments on every producer (re)start; a restart re-muxes segments from its
+    /// start index forward under a fresh shift, so entries from an older epoch describe bytes AVPlayer
+    /// may no longer be able to reach. Drop a table's older epochs when this changes.
+    public let epoch: UInt64
+
+    public init(source: CMTime, item: CMTime, segmentIndex: Int, isKeyframe: Bool, epoch: UInt64) {
+        self.source = source
+        self.item = item
+        self.segmentIndex = segmentIndex
+        self.isKeyframe = isKeyframe
+        self.epoch = epoch
+    }
+}
+
+/// Called on the producer's pump thread, once per muxed video frame. Must not block: the pump also
+/// fetches and muxes, so time spent here is time the segment is not being produced.
+public typealias NativeVideoFrameTimeObserver = @Sendable (NativeVideoFrameTime) -> Void

--- a/Sources/AetherEngine/PresentationAxisMap.swift
+++ b/Sources/AetherEngine/PresentationAxisMap.swift
@@ -1,0 +1,103 @@
+import Foundation
+
+/// Piecewise-constant map between the two time axes the native path runs on (#260).
+///
+/// - **source axis**: the PTS libavformat demuxes out of the file. Subtitle cues, chapter marks,
+///   A/53 captions and `AetherEngine.sourceTime` all live here.
+/// - **item axis**: what the producer muxes into the fMP4 segments, and therefore what
+///   `AVPlayerItem.currentTime()` and its timebase read.
+///
+/// The two differ by the producer's shift (`videoShiftPts` = `firstActualVideoDts -
+/// desiredFirstVideoTfdtPts`): `source = item + shift`. The shift is constant inside one producer
+/// epoch and changes at an epoch edge (a VOD restart lands wherever the source seek lands, a live
+/// program boundary rebases mid-producer), so the relation is a step function of item time, not one
+/// scalar. A single scalar is only correct until the next edge, because AVPlayer keeps presenting
+/// frames muxed under the previous shift for as long as its buffer holds them.
+///
+/// Seams are ordered ascending by `itemSeconds`; the newest seam at or before a position wins. The
+/// oldest seam is anchored at `-.infinity` so every position at or above the map's origin resolves.
+/// Positions below it (only reachable once the history cap has trimmed the anchor away, which the
+/// builder prevents) and an empty map return nil: no axis has been established, and guessing a shift
+/// of 0 is exactly the convention-instead-of-a-value mistake that #259 cost.
+public struct PresentationAxisMap: Sendable, Equatable {
+
+    /// One epoch edge: from `itemSeconds` onward (item axis), `source = item + shiftSeconds`.
+    public struct Seam: Sendable, Equatable {
+        /// Item-axis position from which this shift applies. `-.infinity` for the anchor.
+        public let itemSeconds: Double
+        /// `source - item` for every frame muxed in this epoch.
+        public let shiftSeconds: Double
+
+        public init(itemSeconds: Double, shiftSeconds: Double) {
+            self.itemSeconds = itemSeconds
+            self.shiftSeconds = shiftSeconds
+        }
+    }
+
+    /// Ascending by `itemSeconds`.
+    public private(set) var seams: [Seam]
+
+    /// Bounded history. Losing the oldest entries only costs fidelity for positions many epoch edges
+    /// back; the trim re-anchors the new oldest at `-.infinity` so lookups never fall off the bottom.
+    public static let maxSeams = 64
+
+    public init(seams: [Seam] = []) {
+        self.seams = seams
+    }
+
+    public var isEmpty: Bool { seams.isEmpty }
+
+    /// `source - item` in effect at an item-axis position. nil when no epoch covers it.
+    public func shiftSeconds(atItemSeconds seconds: Double) -> Double? {
+        seams.last(where: { seconds >= $0.itemSeconds })?.shiftSeconds
+    }
+
+    /// Source PTS of an item-axis position (an `AVPlayerItem` clock reading, a timebase sample).
+    public func sourceSeconds(forItemSeconds seconds: Double) -> Double? {
+        shiftSeconds(atItemSeconds: seconds).map { seconds + $0 }
+    }
+
+    /// Item-axis position of a source PTS (a subtitle cue time, a chapter mark). Resolves the epoch
+    /// by testing each seam against the value it would produce, so the answer stays on the same side
+    /// of an edge as `sourceSeconds(forItemSeconds:)`.
+    public func itemSeconds(forSourceSeconds seconds: Double) -> Double? {
+        seams.last(where: { seconds - $0.shiftSeconds >= $0.itemSeconds })
+            .map { seconds - $0.shiftSeconds }
+    }
+
+    // MARK: - Building
+
+    /// Drop the whole history and start over from one shift that covers everything. The correct move
+    /// when nothing muxed under an older shift can still be on screen: a fresh load, or a live retune
+    /// whose old program AVPlayer will never show again.
+    public static func anchored(shiftSeconds: Double) -> PresentationAxisMap {
+        PresentationAxisMap(seams: [Seam(itemSeconds: -.infinity, shiftSeconds: shiftSeconds)])
+    }
+
+    /// Record an epoch edge: from `itemSeconds` on, the muxed bytes carry `shiftSeconds`.
+    ///
+    /// Seams at or after the edge are dropped, because a producer that starts writing at
+    /// `itemSeconds` rewrites everything from there forward (a backward seek makes the old future
+    /// unreachable, and its recorded shift wrong). Everything before the edge is kept: those bytes
+    /// are already in AVPlayer's buffer on the old axis and stay valid until they are evicted.
+    public mutating func appendSeam(shiftSeconds: Double, activatingAtItemSeconds itemSeconds: Double) {
+        seams.removeAll(where: { $0.itemSeconds >= itemSeconds })
+        seams.append(
+            Seam(itemSeconds: seams.isEmpty ? -.infinity : itemSeconds, shiftSeconds: shiftSeconds)
+        )
+        if seams.count > Self.maxSeams {
+            seams.removeFirst(seams.count - Self.maxSeams)
+            seams[0] = Seam(itemSeconds: -.infinity, shiftSeconds: seams[0].shiftSeconds)
+        }
+    }
+}
+
+/// Thread-safe mirror so an off-main consumer (a host rendering subtitles on its own thread, the
+/// producer pump) can read the axis map the engine maintains on the main actor.
+final class AtomicPresentationAxisMap: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: PresentationAxisMap
+    init(_ initial: PresentationAxisMap = PresentationAxisMap()) { value = initial }
+    func get() -> PresentationAxisMap { lock.lock(); defer { lock.unlock() }; return value }
+    func set(_ newValue: PresentationAxisMap) { lock.lock(); value = newValue; lock.unlock() }
+}

--- a/Sources/AetherEngine/Video/HLSSegmentProducer.swift
+++ b/Sources/AetherEngine/Video/HLSSegmentProducer.swift
@@ -1,3 +1,4 @@
+import CoreMedia
 import Foundation
 import Libavformat
 import Libavcodec
@@ -545,8 +546,20 @@ final class HLSSegmentProducer: @unchecked Sendable {
     /// Fires once per producer when HDR10+ T.35 SEI prefix (B5 00 3C 00 01 04) first appears in a video packet.
     var onFirstHDR10PlusDetected: (@Sendable () -> Void)?
 
+    /// #260: resolves the host's per-frame time observer at emission rather than holding it, so a host that
+    /// installs one mid-session reaches the running producer without a data race on a stored closure. Set
+    /// before `start()`; nil leaves the emission out entirely.
+    var nativeVideoFrameTimeObserverProvider: (@Sendable () -> NativeVideoFrameTimeObserver?)?
+
+    /// Monotonic producer generation, reported with every frame time so a consumer can drop entries from an
+    /// epoch whose segments a restart has since rewritten (#260).
+    let epoch: UInt64
+
     /// Fires at video gate-open with videoShiftPts (source video TB); re-fires on restart (matroska seek imprecision can shift).
-    var onVideoShiftKnown: (@Sendable (Int64) -> Void)?
+    /// `firstItemTfdtPts` is this producer's planned first tfdt, i.e. the item-axis position (same TB) from which
+    /// its shift applies. Everything below it on the item axis was muxed by an earlier producer under an earlier
+    /// shift and may still be in AVPlayer's buffer, so a consumer needs the pair, not the shift alone (#260).
+    var onVideoShiftKnown: (@Sendable (_ shiftPts: Int64, _ firstItemTfdtPts: Int64) -> Void)?
 
     /// Fires at live program boundary with updated videoShiftPts and seamOutputSeconds (AVPlayer clock position of the seam).
     /// Distinct from onVideoShiftKnown: the new shift is at the producer edge, AVPlayer renders it buffer+holdback later.
@@ -711,8 +724,10 @@ final class HLSSegmentProducer: @unchecked Sendable {
         packedSideAudioFallbackDurationPts: Int64 = 0,
         bufferAheadSegments: Int = 10,
         prefetchDiskBudgetBytes: Int = 0,
-        audioMoovPrimeFrame: [UInt8]? = nil
+        audioMoovPrimeFrame: [UInt8]? = nil,
+        epoch: UInt64 = 0
     ) throws {
+        self.epoch = epoch
         self.audioMoovPrimeFrame = audioMoovPrimeFrame
         self.bufferAheadSegments = bufferAheadSegments
         self.prefetchDiskBudgetBytes = prefetchDiskBudgetBytes
@@ -2281,7 +2296,7 @@ final class HLSSegmentProducer: @unchecked Sendable {
                             + "videoPID=\(videoStreamIndex) reconstructed=\(pendingJoinVideoConfig != nil)",
                             category: .session
                         )
-                        onVideoShiftKnown?(videoShiftPts)
+                        onVideoShiftKnown?(videoShiftPts, desiredFirstVideoTfdtPts)
                         // #133 follow-up: the gating IDR's in-band SPS/PPS back this epoch's muxer avcC. Establish
                         // the baseline so a later same-PID parameter-set change (encoder restart / regional splice)
                         // is detected against it. joinConfig is non-nil only in the liveH264AnnexBJoin scope.
@@ -2870,11 +2885,42 @@ final class HLSSegmentProducer: @unchecked Sendable {
             }
         }
 
+        // #260: capture the source axis BEFORE the rescale (after it the packet carries muxer TB) and the
+        // keyframe flag while the packet is still ours. The item axis comes back out of writePacket: the write
+        // blanks the packet, so it cannot be read off it afterwards, and the sanitizer can move it.
+        let frameObserver = nativeVideoFrameTimeObserverProvider?()
+        let frameSourcePts = frameObserver == nil
+            ? Int64.min
+            : Self.foldingShiftBack(packet.pointee.pts, shift: videoShiftPts)
+        let frameIsKeyframe = (packet.pointee.flags & AV_PKT_FLAG_KEY) != 0
+        let frameSegmentIndex = currentMuxerSegmentIndex
+
         av_packet_rescale_ts(packet, sourceVideoTimeBase, muxer.muxerVideoTimeBase)
-        _ = muxer.writePacket(packet)
+        let written = muxer.writePacket(packet).written
+
+        if let frameObserver,
+           let source = Self.cmTime(ticks: frameSourcePts, timeBase: sourceVideoTimeBase),
+           let item = Self.cmTime(ticks: written.pts, timeBase: muxer.muxerVideoTimeBase) {
+            frameObserver(
+                NativeVideoFrameTime(
+                    source: source,
+                    item: item,
+                    segmentIndex: frameSegmentIndex,
+                    isKeyframe: frameIsKeyframe,
+                    epoch: epoch
+                )
+            )
+        }
 
         var pkt: UnsafeMutablePointer<AVPacket>? = packet
         trackedPacketFree(&pkt)
+    }
+
+    /// Ticks in `timeBase` as a `CMTime`. nil for NOPTS or a degenerate time base, so a consumer never
+    /// receives a timestamp the engine could not actually resolve (#260).
+    static func cmTime(ticks: Int64, timeBase: AVRational) -> CMTime? {
+        guard ticks != Int64.min, timeBase.num > 0, timeBase.den > 0 else { return nil }
+        return CMTime(value: CMTimeValue(ticks &* Int64(timeBase.num)), timescale: CMTimeScale(timeBase.den))
     }
 
     /// Strip 7/9-byte ADTS header in-place (advances data pointer, shrinks size; buf untouched for unref safety).

--- a/Sources/AetherEngine/Video/HLSVideoEngine+LiveReopen.swift
+++ b/Sources/AetherEngine/Video/HLSVideoEngine+LiveReopen.swift
@@ -596,7 +596,7 @@ extension HLSVideoEngine {
             )
             // Fresh connection joins the broadcast at "now"; source clock jumps, so the seam carries #EXT-X-DISCONTINUITY. Shift handoff deferred to seam to avoid jumping the host clock while pre-loss content is on screen.
             newProd.firstSegmentDiscontinuous = true
-            newProd.onVideoShiftKnown = { [weak self] shiftPts in
+            newProd.onVideoShiftKnown = { [weak self] shiftPts, _ in
                 self?.handleLiveTimelineRebase(shiftPts, seamOutputSeconds: outputEnd)
             }
             producer = newProd

--- a/Sources/AetherEngine/Video/HLSVideoEngine.swift
+++ b/Sources/AetherEngine/Video/HLSVideoEngine.swift
@@ -141,6 +141,34 @@ public final class HLSVideoEngine: @unchecked Sendable {
     /// Set before start() when the source has no demuxable CC stream.
     var a53CaptionObserverForSession: (@Sendable ([CCDataParser.CCTriplet], Int64, Int64, AVRational) -> Void)?
 
+    /// #260: per-frame presentation times on both axes. Lock-guarded because the pump reads it once per muxed
+    /// frame while the host can install or clear it from any thread at any time (a subtitle track switched
+    /// mid-title must not have to wait for the next producer).
+    private let frameTimeObserverLock = NSLock()
+    private var _nativeVideoFrameTimeObserver: NativeVideoFrameTimeObserver?
+
+    func setNativeVideoFrameTimeObserver(_ observer: NativeVideoFrameTimeObserver?) {
+        frameTimeObserverLock.lock()
+        _nativeVideoFrameTimeObserver = observer
+        frameTimeObserverLock.unlock()
+    }
+
+    private func nativeVideoFrameTimeObserverSnapshot() -> NativeVideoFrameTimeObserver? {
+        frameTimeObserverLock.lock(); defer { frameTimeObserverLock.unlock() }
+        return _nativeVideoFrameTimeObserver
+    }
+
+    /// Monotonic producer generation handed to each producer (#260). Own lock: `makeProducer` runs both
+    /// under `restartLock` (live reopen) and outside it (initial bring-up).
+    private let producerEpochLock = NSLock()
+    private var producerEpochCounter: UInt64 = 0
+
+    private func nextProducerEpoch() -> UInt64 {
+        producerEpochLock.lock(); defer { producerEpochLock.unlock() }
+        producerEpochCounter &+= 1
+        return producerEpochCounter
+    }
+
     /// Sodalite#32: ordinal-aligned source stream indices for the native subtitle cue stores (nil entry =
     /// no demuxable stream, e.g. a sidecar). Drives the producer's subtitle tap: the pump keeps these
     /// streams and hands their packets to the session tap, which decodes into the ordinal's store. Set
@@ -341,7 +369,10 @@ public final class HLSVideoEngine: @unchecked Sendable {
 
     /// Fires on each gate open (initial + restart) so AetherEngine keeps its shift in step
     /// for subtitle cue lookup.
-    var onPlaylistShiftChanged: (@Sendable (Double) -> Void)?
+    /// `(shiftSeconds, seamItemSeconds)`: the new shift, and the item-axis position from which it applies
+    /// (this producer's planned first tfdt). Content below that position was muxed under the previous shift
+    /// and can still be in AVPlayer's buffer, so the host records a seam rather than replacing the scalar (#260).
+    var onPlaylistShiftChanged: (@Sendable (Double, Double) -> Void)?
 
     /// #240: link arbitration shared with the engine's subtitle side readers. Set by `AetherEngine`
     /// before `start()`; nil when the session is driven without one (`aetherctl`, tests), which
@@ -1824,7 +1855,8 @@ public final class HLSVideoEngine: @unchecked Sendable {
             prefetchDiskBudgetBytes: retentionBudgetBytes,
             // AE#222: nil until a pump proved this source cuts its first segment before any audio packet
             // arrives; from then on every producer of the session muxes moov from this frame.
-            audioMoovPrimeFrame: sessionAudioMoovPrimeFrame
+            audioMoovPrimeFrame: sessionAudioMoovPrimeFrame,
+            epoch: nextProducerEpoch()
         )
         // #240: threaded onto every producer (initial + restart), like the wedge-detector providers
         // below. The side readers read one gate for the whole session, so a restart must not leave
@@ -1833,8 +1865,8 @@ public final class HLSVideoEngine: @unchecked Sendable {
         prod.onFirstHDR10PlusDetected = { [weak self] in
             self?.notifyHDR10PlusOnce()
         }
-        prod.onVideoShiftKnown = { [weak self] shiftPts in
-            self?.handleVideoShiftKnown(shiftPts)
+        prod.onVideoShiftKnown = { [weak self] shiftPts, firstItemTfdtPts in
+            self?.handleVideoShiftKnown(shiftPts, firstItemTfdtPts: firstItemTfdtPts)
         }
         prod.onLiveTimelineRebase = { [weak self] shiftPts, seamOutputSeconds in
             self?.handleLiveTimelineRebase(shiftPts, seamOutputSeconds: seamOutputSeconds)
@@ -1855,6 +1887,10 @@ public final class HLSVideoEngine: @unchecked Sendable {
         prod.hasStartedRenderingProvider = hasStartedRenderingProvider
         prod.closedCaptionObserver = closedCaptionObserverForSession   // #77
         prod.a53CaptionObserver = a53CaptionObserverForSession   // #131
+        // #260: resolved per frame, so installing an observer mid-session reaches this producer too.
+        prod.nativeVideoFrameTimeObserverProvider = { [weak self] in
+            self?.nativeVideoFrameTimeObserverSnapshot()
+        }
         // Sodalite#32: build the tap routes lazily on the first producer that has stores + stream
         // indices (the host sets both before start()), then wire the tap onto every producer.
         subtitleTapLock.lock()
@@ -1880,8 +1916,9 @@ public final class HLSVideoEngine: @unchecked Sendable {
     var lastReopenSegmentCount = -1
     static let maxBarrenReopenCycles = 3
 
-    private func handleVideoShiftKnown(_ shiftPts: Int64) {
+    private func handleVideoShiftKnown(_ shiftPts: Int64, firstItemTfdtPts: Int64) {
         let seconds = shiftPts == Int64.min ? 0 : Double(shiftPts) * sourceVideoTbSeconds
+        let seamItemSeconds = Double(firstItemTfdtPts) * sourceVideoTbSeconds
         setPlaylistShiftSeconds(seconds)
         // Refresh every native subtitle store's shift so cuesInWindow stays on the correct AVPlayer
         // axis after a restart (matroska seek can land past the planned keyframe, #55). Snapshot under
@@ -1891,7 +1928,7 @@ public final class HLSVideoEngine: @unchecked Sendable {
         let stores = nativeSubtitleCueStoresForSession
         restartLock.unlock()
         stores.forEach { $0.setShiftSeconds(seconds) }
-        onPlaylistShiftChanged?(seconds)
+        onPlaylistShiftChanged?(seconds, seamItemSeconds)
     }
 
     /// Live program-boundary rebase. Unlike `handleVideoShiftKnown`, does NOT fire `onPlaylistShiftChanged`:

--- a/Sources/AetherEngine/Video/MP4SegmentMuxer.swift
+++ b/Sources/AetherEngine/Video/MP4SegmentMuxer.swift
@@ -442,10 +442,20 @@ final class MP4SegmentMuxer {
 
     // MARK: - Pump-side API
 
+    /// Timestamps exactly as handed to the muxer, in muxer time base (#260). Returned rather than read back
+    /// off the packet, because `av_interleaved_write_frame` takes ownership: "The returned packet will be
+    /// blank (as if returned from av_packet_alloc()), even on error", so afterwards `pts`/`dts` are NOPTS.
+    /// `pts` is what lands in the segment and therefore what `AVPlayerItem`'s timebase reads.
+    struct WrittenTimestamps {
+        let pts: Int64
+        let dts: Int64
+        static let none = WrittenTimestamps(pts: Int64.min, dts: Int64.min)
+    }
+
     /// Write one packet via av_interleaved_write_frame (caller must rescale pts/dts to muxerVideoTimeBase / muxerAudioTimeBase).
     @discardableResult
-    func writePacket(_ packet: UnsafeMutablePointer<AVPacket>) -> Int32 {
-        guard let ctx = formatContext else { return -1 }
+    func writePacket(_ packet: UnsafeMutablePointer<AVPacket>) -> (rc: Int32, written: WrittenTimestamps) {
+        guard let ctx = formatContext else { return (-1, .none) }
         let clean = timestampSanitizer.sanitize(
             streamIndex: packet.pointee.stream_index,
             pts: packet.pointee.pts,
@@ -504,7 +514,7 @@ final class MP4SegmentMuxer {
             }
         }
 
-        return rc
+        return (rc, WrittenTimestamps(pts: clean.pts, dts: clean.dts))
     }
 
     /// Emit a moof+mdat for everything buffered into the CURRENT staging file, without rotating the fd or

--- a/Tests/AetherEngineTests/Issue260FrameTimeAxisTests.swift
+++ b/Tests/AetherEngineTests/Issue260FrameTimeAxisTests.swift
@@ -1,0 +1,170 @@
+import CoreMedia
+import Foundation
+import Testing
+@testable import AetherEngine
+
+// MARK: - Fixtures
+
+/// Fixtures/ is local-only by design (gitignored; Scripts/fetch-fixtures.sh regenerates the
+/// synthetic clips). The tests skip via `.enabled(if:)` when a clip is absent, e.g. on CI.
+private func fixtureURL(_ name: String) -> URL {
+    URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .appendingPathComponent("Fixtures")
+        .appendingPathComponent(name)
+}
+
+private func fixtureExists(_ name: String) -> Bool {
+    FileManager.default.fileExists(atPath: fixtureURL(name).path)
+}
+
+/// The observer fires on the pump thread; the test reads from its own.
+private final class FrameTimeCollector: @unchecked Sendable {
+    private let lock = NSLock()
+    private var frames: [NativeVideoFrameTime] = []
+
+    func record(_ frame: NativeVideoFrameTime) {
+        lock.lock(); frames.append(frame); lock.unlock()
+    }
+
+    func snapshot() -> [NativeVideoFrameTime] {
+        lock.lock(); defer { lock.unlock() }; return frames
+    }
+}
+
+// MARK: - Tests
+
+/// AE#260: per-frame presentation times on both axes. The witness clip is H.264 with `-bf 3`, so its
+/// first muxed frame sits two frames off the item axis (`playlistShiftSeconds` = -0.083333 s at 24 fps),
+/// which is exactly what makes the two axes distinguishable here.
+@Suite("Issue 260 native frame time axes", .serialized)
+struct Issue260FrameTimeAxisTests {
+
+    @Test("Every frame reports source and item, separated by the producer shift",
+          .enabled(if: fixtureExists("restart-witness-av.mp4"),
+                   "run Scripts/fetch-fixtures.sh to generate the witness clip"),
+          .timeLimit(.minutes(2)))
+    func framesCarryBothAxes() throws {
+        let collector = FrameTimeCollector()
+        let engine = HLSVideoEngine(url: fixtureURL("restart-witness-av.mp4"), dvModeAvailable: false)
+        engine.setNativeVideoFrameTimeObserver { collector.record($0) }
+        _ = try engine.start()
+        defer { engine.stop() }
+        let prov = try #require(engine.provider)
+
+        #expect(prov.mediaSegment(at: 0) != nil)
+        #expect(prov.mediaSegment(at: 1) != nil)
+
+        let frames = collector.snapshot()
+        try #require(!frames.isEmpty, "no frame times emitted")
+
+        // Vacuum guard: with a zero shift the two axes coincide and the witness proves nothing.
+        let shift = engine.playlistShiftSeconds
+        try #require(abs(shift) > 0.001,
+                     "producer shift is 0 on this clip; the axis witness would be vacuous")
+
+        for frame in frames {
+            let delta = CMTimeGetSeconds(frame.source) - CMTimeGetSeconds(frame.item)
+            #expect(abs(delta - shift) < 0.001,
+                    "frame at source \(CMTimeGetSeconds(frame.source))s: source - item = \(delta)s, expected the producer shift \(shift)s")
+        }
+
+        // The first muxed frame is the gating keyframe, and it does NOT sit at item time 0: the shift
+        // anchors the segment's tfdt on its DTS, while the reported time is the PTS, which under B-frame
+        // reorder leads the DTS by the reorder distance. That distance IS the shift on this clip, so the
+        // first frame lands at exactly -shift. Assuming item 0 here is the mistake this API prevents.
+        #expect(frames[0].isKeyframe, "the first muxed frame is the gating keyframe")
+        let firstItem = CMTimeGetSeconds(frames[0].item)
+        #expect(abs(firstItem - (-shift)) < 0.001,
+                "first muxed frame should sit at item time \(-shift)s (the reorder distance), got \(firstItem)s")
+        #expect(frames.allSatisfy { CMTimeGetSeconds($0.item) >= 0 },
+                "no muxed frame may carry a negative item timestamp")
+    }
+
+    /// Documented contract: delivery is decode order, so `source` is not monotonic under B-frames and a
+    /// consumer that wants a frame-boundary list has to sort. A fixture without reorder would let a
+    /// consumer assume monotonicity and be right by accident.
+    @Test("Delivery is decode order, not presentation order",
+          .enabled(if: fixtureExists("restart-witness-av.mp4"),
+                   "run Scripts/fetch-fixtures.sh to generate the witness clip"),
+          .timeLimit(.minutes(2)))
+    func deliveryIsDecodeOrder() throws {
+        let collector = FrameTimeCollector()
+        let engine = HLSVideoEngine(url: fixtureURL("restart-witness-av.mp4"), dvModeAvailable: false)
+        engine.setNativeVideoFrameTimeObserver { collector.record($0) }
+        _ = try engine.start()
+        defer { engine.stop() }
+        let prov = try #require(engine.provider)
+        #expect(prov.mediaSegment(at: 0) != nil)
+
+        let sources = collector.snapshot().map { CMTimeGetSeconds($0.source) }
+        try #require(sources.count > 4, "not enough frames to judge ordering")
+        let hasReorder = zip(sources, sources.dropFirst()).contains { $0 > $1 }
+        #expect(hasReorder,
+                "expected B-frame reorder in the delivered sequence; got \(sources.prefix(8))")
+    }
+
+    /// A restart re-muxes segments from its start index forward under a fresh shift. The epoch is how a
+    /// consumer tells the rewritten frames from the ones it recorded before.
+    @Test("A restart opens a new epoch and reports the seam it starts at",
+          .enabled(if: fixtureExists("restart-witness-av.mp4"),
+                   "run Scripts/fetch-fixtures.sh to generate the witness clip"),
+          .timeLimit(.minutes(2)))
+    func restartOpensNewEpoch() throws {
+        let collector = FrameTimeCollector()
+        let seams = SeamCollector()
+        let engine = HLSVideoEngine(url: fixtureURL("restart-witness-av.mp4"), dvModeAvailable: false)
+        engine.setNativeVideoFrameTimeObserver { collector.record($0) }
+        engine.onPlaylistShiftChanged = { shift, seamItemSeconds in
+            seams.record(shift: shift, at: seamItemSeconds)
+        }
+        _ = try engine.start()
+        defer { engine.stop() }
+        let prov = try #require(engine.provider)
+
+        #expect(prov.mediaSegment(at: 0) != nil)
+        #expect(prov.mediaSegment(at: 1) != nil)
+        let firstEpoch = try #require(collector.snapshot().last?.epoch)
+
+        engine.requestRestart(at: 1)
+
+        let deadline = Date().addingTimeInterval(30)
+        var restarted: [NativeVideoFrameTime] = []
+        while Date() < deadline {
+            restarted = collector.snapshot().filter { $0.epoch > firstEpoch }
+            if !restarted.isEmpty { break }
+            usleep(50_000)
+        }
+        try #require(!restarted.isEmpty, "restarted producer emitted no frame times within 30s")
+
+        // The restart producer starts at segment 1, so its seam sits at that segment's item-axis start,
+        // not at 0: a seam of 0 would collapse the history exactly like the pre-#260 behaviour.
+        let recorded = seams.snapshot()
+        try #require(recorded.count >= 2, "expected an initial shift plus a restart shift, got \(recorded)")
+        #expect(abs(recorded[0].at) < 0.001, "the first producer anchors at item 0, got \(recorded[0].at)s")
+        #expect(recorded[1].at > 1.0,
+                "restart at segment 1 must report its own item-axis start, got \(recorded[1].at)s")
+
+        // And the restarted frames land at or after that seam on the item axis.
+        let seamAt = recorded[1].at
+        for frame in restarted {
+            #expect(CMTimeGetSeconds(frame.item) >= seamAt - 0.001,
+                    "restarted frame at item \(CMTimeGetSeconds(frame.item))s precedes its seam \(seamAt)s")
+        }
+    }
+}
+
+private final class SeamCollector: @unchecked Sendable {
+    private let lock = NSLock()
+    private var entries: [(shift: Double, at: Double)] = []
+
+    func record(shift: Double, at: Double) {
+        lock.lock(); entries.append((shift, at)); lock.unlock()
+    }
+
+    func snapshot() -> [(shift: Double, at: Double)] {
+        lock.lock(); defer { lock.unlock() }; return entries
+    }
+}

--- a/Tests/AetherEngineTests/PresentationAxisMapTests.swift
+++ b/Tests/AetherEngineTests/PresentationAxisMapTests.swift
@@ -1,0 +1,104 @@
+import Testing
+@testable import AetherEngine
+
+/// #260: the source/item axis relation is a step function of item time, not a scalar. These pin the
+/// step behaviour that a single `playlistShiftSeconds` cannot express.
+@Suite("Presentation axis map")
+struct PresentationAxisMapTests {
+
+    @Test("An empty map states nothing rather than guessing zero")
+    func emptyMapReturnsNil() {
+        let map = PresentationAxisMap()
+        #expect(map.isEmpty)
+        #expect(map.shiftSeconds(atItemSeconds: 0) == nil)
+        #expect(map.sourceSeconds(forItemSeconds: 12.5) == nil)
+        #expect(map.itemSeconds(forSourceSeconds: 12.5) == nil)
+    }
+
+    @Test("An anchored map covers the whole timeline")
+    func anchoredCoversEverything() {
+        let map = PresentationAxisMap.anchored(shiftSeconds: -0.083333)
+        #expect(map.shiftSeconds(atItemSeconds: -1e9) == -0.083333)
+        #expect(map.sourceSeconds(forItemSeconds: 10) == 10 - 0.083333)
+        #expect(map.itemSeconds(forSourceSeconds: 10 - 0.083333) == 10)
+    }
+
+    @Test("The first seam anchors at -infinity regardless of where the producer starts")
+    func firstSeamAnchors() {
+        var map = PresentationAxisMap()
+        map.appendSeam(shiftSeconds: 2, activatingAtItemSeconds: 48)
+        #expect(map.seams.count == 1)
+        #expect(map.seams[0].itemSeconds == -.infinity)
+        #expect(map.shiftSeconds(atItemSeconds: 0) == 2)
+    }
+
+    /// The property the collapse destroyed: content below the seam keeps folding with the shift it was
+    /// muxed under, which is what AVPlayer still has in its buffer.
+    @Test("A forward restart leaves the old epoch on the old shift")
+    func forwardRestartKeepsOldEpoch() {
+        var map = PresentationAxisMap.anchored(shiftSeconds: 0.5)
+        map.appendSeam(shiftSeconds: 3.92, activatingAtItemSeconds: 600)
+
+        #expect(map.shiftSeconds(atItemSeconds: 599.9) == 0.5)
+        #expect(map.shiftSeconds(atItemSeconds: 600) == 3.92)
+        #expect(map.sourceSeconds(forItemSeconds: 599.9) == 599.9 + 0.5)
+        #expect(map.sourceSeconds(forItemSeconds: 600) == 600 + 3.92)
+        // What a collapsed history would have answered for the old-epoch position, i.e. the error a
+        // consumer inherits: 3.42 s on the witness magnitude from AE#105.
+        #expect(map.shiftSeconds(atItemSeconds: 599.9) != 3.92)
+    }
+
+    @Test("A backward restart drops the seams it rewrites")
+    func backwardRestartTruncatesFuture() {
+        var map = PresentationAxisMap.anchored(shiftSeconds: 0.5)
+        map.appendSeam(shiftSeconds: 1.5, activatingAtItemSeconds: 300)
+        map.appendSeam(shiftSeconds: 2.5, activatingAtItemSeconds: 600)
+        #expect(map.seams.count == 3)
+
+        // Seek back to 200: the producer rewrites everything from there forward, so the 300 and 600
+        // seams describe bytes that no longer exist.
+        map.appendSeam(shiftSeconds: 0.75, activatingAtItemSeconds: 200)
+        #expect(map.seams.count == 2)
+        #expect(map.shiftSeconds(atItemSeconds: 199) == 0.5)
+        #expect(map.shiftSeconds(atItemSeconds: 200) == 0.75)
+        #expect(map.shiftSeconds(atItemSeconds: 650) == 0.75)
+    }
+
+    @Test("A seam at an existing position replaces it")
+    func seamReplacesSamePosition() {
+        var map = PresentationAxisMap.anchored(shiftSeconds: 0.5)
+        map.appendSeam(shiftSeconds: 1.5, activatingAtItemSeconds: 300)
+        map.appendSeam(shiftSeconds: 1.75, activatingAtItemSeconds: 300)
+        #expect(map.seams.count == 2)
+        #expect(map.shiftSeconds(atItemSeconds: 300) == 1.75)
+    }
+
+    @Test("Round trip across a seam, in both directions")
+    func roundTripAcrossSeam() throws {
+        var map = PresentationAxisMap.anchored(shiftSeconds: -0.083333)
+        map.appendSeam(shiftSeconds: 1.25, activatingAtItemSeconds: 100)
+
+        for item in [0.0, 50.0, 99.999, 100.0, 250.0] {
+            let source = try #require(map.sourceSeconds(forItemSeconds: item))
+            let back = try #require(map.itemSeconds(forSourceSeconds: source))
+            #expect(abs(back - item) < 1e-9,
+                    "round trip broke at item \(item) (source \(source), back \(back))")
+        }
+    }
+
+    /// Trimming must not leave a hole at the bottom: a lookup below the oldest seam would answer nil
+    /// and the host would lose the axis for content it can still be showing.
+    @Test("The history cap keeps an anchor at the bottom")
+    func capReanchorsOldest() {
+        var map = PresentationAxisMap.anchored(shiftSeconds: 0)
+        for i in 1...(PresentationAxisMap.maxSeams + 10) {
+            map.appendSeam(shiftSeconds: Double(i), activatingAtItemSeconds: Double(i) * 10)
+        }
+        #expect(map.seams.count == PresentationAxisMap.maxSeams)
+        #expect(map.seams[0].itemSeconds == -.infinity)
+        #expect(map.shiftSeconds(atItemSeconds: 0) != nil)
+        #expect(map.shiftSeconds(atItemSeconds: -1e6) != nil)
+        #expect(map.shiftSeconds(atItemSeconds: Double(PresentationAxisMap.maxSeams + 10) * 10)
+                == Double(PresentationAxisMap.maxSeams + 10))
+    }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -143,6 +143,10 @@ Sources/AetherEngine/
 ├── AetherEngine+AudioTap.swift              Opt-in decoded PCM audio tap (#95): installAudioTap() vends the AsyncStream, dispatches native-loopback vs remote-HLS vs SW-mirror
 ├── AetherEngine+BackgroundAudioTestHooks.swift DEBUG-only hooks letting aetherctl bgaudio toggle the SW background-audio keepalive without a UIApplication lifecycle (never shipped)
 ├── PlaybackClock.swift                      engine.clock: the ~10 Hz ticking values (currentTime, sourceTime, bufferedPosition, progress, live-edge fields) as a separate ObservableObject
+├── PresentationAxis.swift                   Display-axis fold for disc titles (source PTS <-> 0-based published axis, AE#105)
+├── PresentationAxisMap.swift                Source axis <-> item axis (#260): the seam history of producer shifts as a piecewise-constant map, plus its off-main mirror. Written by the shift-changed / rebased handlers, read by the clock fold, the live thumbnail path and hosts
+├── NativeVideoFrameTime.swift               Per-muxed-frame presentation times on both axes (#260): the value type + observer typealias; emitted from HLSSegmentProducer.finalizeAndWriteVideo
+├── AetherEngine+FrameTimes.swift            Public installer for the per-frame time observer, re-armed on each native session
 ├── PlayerState.swift                        PlaybackState, PlaybackPhase, VideoFormat, PlaybackBackend, LoadOptions, SourceProbe, TrackInfo, FontAttachment, MediaMetadata, SubtitleCue, SubtitleImage
 ├── LiveReloadPolicy.swift                   Pure decision functions for live reloads: rejoin at the live edge (no stale resume position), skip the pre-readiness zero seek
 ├── TransportControllable.swift              Common transport surface of the four playback hosts (single active-host dispatch)


### PR DESCRIPTION
Closes the API gap in #260.

## What a host could not do before

Cue times, chapters and `sourceTime` are source PTS. `AVPlayerItem.currentTime()` and its timebase read what the producer muxes into the segments. The two differ by the producer shift, and nothing published closed that gap exactly:

| Surface | Why it falls short |
| --- | --- |
| `playlistShiftSeconds` | A scalar. Correct only until the next producer epoch |
| `clock.sourceTime` | ~10 Hz, and a clock reading is not a frame boundary |
| `Segment.startPts` / `startSeconds` | A genuine pair, about six seconds granular |
| `a53CaptionObserver` | Per frame, but one axis |

## Two pieces

**`PresentationAxisMap`** models the relation as what it actually is, a step function of item time, and replaces the seam array the live path already carried. `sourceSeconds(forItemSeconds:)` and `itemSeconds(forSourceSeconds:)` convert at any position; the map is readable off the main actor.

A VOD restart now records a seam at the item-axis position the new producer starts writing from, instead of collapsing the history to one entry. Content below that position was muxed under the previous shift and can still be in AVPlayer's buffer, so it has to keep folding with that shift. A backward restart drops only the seams it rewrites. Live program boundaries are unchanged. (The #65 shift-fold hypotheses were refuted by measurement at the time; that burst ran with an invariant shift, so this is not a retroactive explanation for it.)

**`setNativeVideoFrameTimeObserver`** reports `NativeVideoFrameTime` per muxed frame: both axes, segment index, keyframe flag, and a producer epoch so a consumer can drop entries a restart has rewritten.

## Two things the issue's proposed shape would have hit

- Emitting after `writePacket` reads a blank packet. `av_interleaved_write_frame` takes ownership and the packet comes back "as if returned from `av_packet_alloc()`, even on error", so `pts` is `AV_NOPTS_VALUE` there. The written value now comes back out of `writePacket`. It also matters that it is that value and not a rescale of the source one: the final-stage sanitizer moves timestamps on SSAI splices.
- Delivery is decode order, so `source` is not monotonic under B-frames. Documented rather than sorted, since sorting would mean buffering inside the pump.

Both surfaces return nil when no axis has been established, rather than defaulting the shift to zero: at the call site a defaulted shift is indistinguishable from a measured one, which is what #259 cost.

`currentAVPlayerItem` publishes alongside, since items are swapped in place and a host holding a timebase gets no signal from `currentAVPlayer` alone.

## Verification

- 1340 tests green, including the new `PresentationAxisMapTests` (step behaviour, backward-restart truncation, history-cap re-anchoring) and `Issue260FrameTimeAxisTests` against `Fixtures/restart-witness-av.mp4`.
- The frame-time test requires a non-zero shift before asserting anything, so a clip where the axes coincide fails the witness instead of passing vacuously. On that fixture the axes are two frames apart (0.083333 s at 24 fps), which is also why the first muxed frame sits at item time +0.083333 rather than 0: the tfdt anchors on the DTS while the reported time is the PTS.
- Clean `-strict-concurrency=complete` build, tvOS Simulator build clean.

Requested by @edde746, who measured the axis gap and offered a PR; the shape here differs in the two points above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HX5zV3Fcf7Nzq4DYGdXvQE