### PR TITLE
Record how the test process left when it dies without failing a test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,47 @@ jobs:
       - name: swift build
         run: swift build
 
+      # The test process has twice died mid-run without failing a test: no ✘, no backtrace, no
+      # swift-testing summary, just exit 1 while the three tests that drive a local HTTP origin were
+      # running (#255 head probe, two Issue240 side-reader tests). A time limit would not catch that,
+      # since nothing hangs. Record how the process actually left, and keep whatever macOS wrote about
+      # it, so the next occurrence names its own cause instead of leaving us between two hypotheses.
       - name: swift test
-        run: swift test
+        id: swift_test
+        run: |
+          set +e
+          date -u +"test start %H:%M:%SZ"
+          swift test
+          status=$?
+          date -u +"test end %H:%M:%SZ"
+          echo "swift test exited with $status"
+          # 128+N means a signal (137 = SIGKILL, typically the memory pressure killer).
+          if [ "$status" -gt 128 ]; then
+            echo "::warning::test process died on signal $((status - 128))"
+          fi
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+          exit $status
+
+      - name: Collect crash evidence
+        if: failure() && steps.swift_test.outcome == 'failure'
+        run: |
+          mkdir -p /tmp/test-death
+          cp ~/Library/Logs/DiagnosticReports/*.ips /tmp/test-death/ 2>/dev/null || true
+          sudo cp /Library/Logs/DiagnosticReports/*.ips /tmp/test-death/ 2>/dev/null || true
+          # A memory-pressure kill leaves no .ips, only a jetsam entry in the system log.
+          log show --last 10m --predicate 'eventMessage CONTAINS "jetsam" OR eventMessage CONTAINS "AetherEnginePackageTests"' \
+            > /tmp/test-death/system-log.txt 2>&1 || true
+          vm_stat > /tmp/test-death/vm_stat.txt 2>&1 || true
+          ls -la /tmp/test-death/
+
+      - name: Upload crash evidence
+        if: failure() && steps.swift_test.outcome == 'failure'
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-death-evidence
+          path: /tmp/test-death/
+          if-no-files-found: warn
+          retention-days: 14
 
   build-tvos:
     name: xcodebuild (tvOS Simulator)


### PR DESCRIPTION
`swift test (macOS)` has now gone red twice in 24 hours without a single failed test: no `✘`, no backtrace, no swift-testing summary, just `exit 1` partway through the run. Both times a rerun with no change was green.

## What the logs actually say

- 1331 tests started, the summary never printed.
- The three tests still running at the end are the only ones in the suite that drive a local HTTP origin concurrently: `#255 headProbeReservesNothingEndToEnd`, and the two `Issue240SideReaderLinkPriorityTests` side-reader cases.
- The runner was about 15x slower than local both times, measured on unrelated suites (the OCR suite took 70.3 s against ~5 s locally).

That rules out the readings that would explain themselves: a failing test writes a `✘`, a `fatalError` or `try!` writes a trace, and a hang would sit until the 30 minute job timeout rather than exiting after three minutes. What is left is a kill from outside (memory pressure on a 7 GB runner with 200+ suites in parallel and those three buffering over loopback) or an `exit()` out of library code, and the log cannot distinguish them.

## Why not a time limit on those suites

That was the previously noted hardening, and it would not have caught this. Nothing hangs here; the process is terminated, and a deadline that fires inside a dead process fires never.

## What this does instead

Log the exit status, name the signal when the status encodes one (128+N, so 137 is SIGKILL), and on failure keep what macOS wrote about it: `DiagnosticReports/*.ips` plus a jetsam-filtered `log show` window, since a memory-pressure kill leaves no crash report at all. Uploaded as an artifact with 14 day retention.

No test code changes. Nothing runs on a green build. The next occurrence names its own cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HX5zV3Fcf7Nzq4DYGdXvQE