### PR TITLE
fix(subtitles): read an ASS PlayRes declaration through CRLF line endings (#261)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ the public-API contract.
 
 ## [Unreleased]
 
-_Nothing yet._
+### Fixed
+
+- **An ASS track that declares its play resolution with CRLF line endings is no longer read as declaring none.** The header arrives as codec extradata byte for byte as the muxer stored it, and muxed ASS is conventionally CRLF, so the line is `PlayResX: 718\r`. The trim used `CharacterSet.whitespaces`, which is space and tab but not CR, so the CR survived and `Double("718\r")` returned nil. Both lookups failed, the header was reported as declaring nothing, and every `\pos` on the track normalized against libavcodec's 384x288 default instead of the declared space. On a 718x480 script `{\an1\pos(298,432)}` reached the host at (0.776, 1.500) rather than (0.415, 0.900), which is off-picture and indistinguishable from a cue that never arrived. Header lines now split on any newline (CRLF, LF or lone CR) and trim newline-inclusive. Tracks that declare no play resolution are unaffected, since 384x288 is then the correct basis. Reported by rrgomes, traced to the line. (#261)
 
 ## [6.2.0] - 2026-07-30
 

--- a/Sources/AetherEngine/PlayerState.swift
+++ b/Sources/AetherEngine/PlayerState.swift
@@ -669,8 +669,11 @@ public struct SubtitleTextRun: Sendable, Equatable {
 public struct SubtitleTextPlacement: Sendable, Equatable {
     /// ASS numpad alignment from `\an`: 1 bottom-left through 9 top-right, 5 centred.
     public let alignment: Int?
-    /// Anchor from `\pos`, normalized to [0, 1] against the source video frame the same way
-    /// `SubtitleImage.position` is, with y measured from the top.
+    /// Anchor from `\pos`, normalized against the script's declared play resolution the same way
+    /// `SubtitleImage.position` is, with y measured from the top. Usually in [0, 1], but not
+    /// guaranteed: a script may anchor outside the frame on purpose, so a host that cannot draw
+    /// off-picture should decide for itself what to do with such a cue rather than assume the
+    /// range (#261).
     public let position: CGPoint?
 
     public init(alignment: Int?, position: CGPoint?) {

--- a/Sources/AetherEngine/Subtitles/SubtitleRectText.swift
+++ b/Sources/AetherEngine/Subtitles/SubtitleRectText.swift
@@ -73,12 +73,18 @@ enum SubtitleRectText {
     static let defaultASSPlayRes = CGSize(width: 384, height: 288)
 
     /// Play resolution declared by an ASS `[Script Info]` header, or nil when it declares none.
+    ///
+    /// The header arrives as codec extradata byte for byte as the muxer stored it, and muxed ASS
+    /// is conventionally CRLF, so the line endings are not ours to assume (#261). Splitting on
+    /// `isNewline` covers CRLF, LF and lone CR, and the trims are newline-inclusive so a stray CR
+    /// cannot reach `Double(_:)`, which returns nil for `"718\r"` and silently costs the whole
+    /// declaration.
     static func playRes(fromASSHeader header: String) -> CGSize? {
         func value(_ key: String) -> Double? {
-            for line in header.split(separator: "\n", omittingEmptySubsequences: false) {
-                let l = line.trimmingCharacters(in: .whitespaces)
+            for line in header.split(whereSeparator: \.isNewline) {
+                let l = line.trimmingCharacters(in: .whitespacesAndNewlines)
                 guard l.lowercased().hasPrefix(key.lowercased() + ":") else { continue }
-                return Double(l.dropFirst(key.count + 1).trimmingCharacters(in: .whitespaces))
+                return Double(l.dropFirst(key.count + 1).trimmingCharacters(in: .whitespacesAndNewlines))
             }
             return nil
         }

--- a/Tests/AetherEngineTests/Issue261ASSHeaderLineEndingsTests.swift
+++ b/Tests/AetherEngineTests/Issue261ASSHeaderLineEndingsTests.swift
@@ -1,0 +1,60 @@
+import Testing
+import Foundation
+import CoreGraphics
+@testable import AetherEngine
+
+/// #261: an ASS header's declared play resolution is the only frame of reference `\pos` has, and
+/// the header reaches us as codec extradata exactly as the muxer stored it. Muxed ASS is
+/// conventionally CRLF, so the line is `"PlayResX: 718\r"`. `CharacterSet.whitespaces` is space
+/// and tab, not CR, so the trailing CR survived both trims and `Double("718\r")` returned nil.
+/// Both lookups failed, the parser reported "declares none", and every `\pos` on the track
+/// normalized against libavcodec's 384x288 default instead.
+///
+/// On the reporter's 718x480 script `{\an1\pos(298,432)}` arrived at the host as
+/// (0.7760, 1.5000) rather than (0.4151, 0.9000): off-picture, which is indistinguishable from a
+/// cue that never arrived. Every fixture in the suite was a Swift multi-line literal, so LF only,
+/// and the whole class of failure was invisible to the tests. These fixtures carry their line
+/// endings explicitly for that reason.
+struct Issue261ASSHeaderLineEndingsTests {
+
+    /// The reporter's CodecPrivate, line endings included.
+    private let crlfHeader = "[Script Info]\r\nScriptType: v4.00+\r\nPlayResX: 718\r\nPlayResY: 480\r\nTimer: 100.0000\r\n"
+    private let lfHeader = "[Script Info]\nScriptType: v4.00+\nPlayResX: 718\nPlayResY: 480\nTimer: 100.0000\n"
+    private let crHeader = "[Script Info]\rScriptType: v4.00+\rPlayResX: 718\rPlayResY: 480\rTimer: 100.0000\r"
+
+    @Test("a CRLF header declares its play resolution just as an LF one does")
+    func crlfHeaderIsRead() {
+        #expect(SubtitleRectText.playRes(fromASSHeader: crlfHeader) == CGSize(width: 718, height: 480))
+    }
+
+    @Test("line endings do not change what a header declares")
+    func lineEndingsAgree() {
+        let crlf = SubtitleRectText.playRes(fromASSHeader: crlfHeader)
+        #expect(crlf == SubtitleRectText.playRes(fromASSHeader: lfHeader))
+        #expect(crlf == SubtitleRectText.playRes(fromASSHeader: crHeader))
+    }
+
+    @Test("trailing spaces before the line ending are still trimmed")
+    func trailingSpacesTolerated() {
+        let header = "[Script Info]\r\nPlayResX: 1920 \r\nPlayResY:\t1080\t\r\n"
+        #expect(SubtitleRectText.playRes(fromASSHeader: header) == CGSize(width: 1920, height: 1080))
+    }
+
+    @Test("a header that declares no play resolution still reports none")
+    func undeclaredStaysNil() {
+        #expect(SubtitleRectText.playRes(fromASSHeader: "[Script Info]\r\nScriptType: v4.00+\r\n") == nil)
+    }
+
+    /// The reporter's cue, end to end: 432 of a declared 480 is 90% down the frame, and that is
+    /// on the picture. Against the 384x288 default it was 1.5, which is not.
+    @Test("the reporter's cue lands on the picture once the header is read")
+    func reporterCueLandsOnPicture() {
+        let playRes = SubtitleRectText.playRes(fromASSHeader: crlfHeader) ?? SubtitleRectText.defaultASSPlayRes
+        let placement = SubtitleRectText.styledRuns(
+            fromASSEventLine: #"0,0,Default,,0,0,0,,{\an1\pos(298,432)}bottom left"#,
+            playRes: playRes)?.placement
+        #expect(placement?.alignment == 1)
+        #expect(abs((placement?.position?.x ?? 0) - 298.0 / 718.0) < 0.0001)
+        #expect(abs((placement?.position?.y ?? 0) - 0.9) < 0.0001)
+    }
+}


### PR DESCRIPTION
Fixes the parse in `SubtitleRectText.playRes(fromASSHeader:)` reported in #261.

The ASS header reaches the engine as codec extradata byte for byte as the muxer stored it, and muxed ASS is conventionally CRLF, so the line is `PlayResX: 718\r`. The trim used `CharacterSet.whitespaces`, which is space and tab but not CR, so the CR survived and `Double("718\r")` returned nil. Both lookups failed, the header was reported as declaring nothing, and every `\pos` on the track normalized against libavcodec's 384x288 default instead of the declared space.

On the reporter's 718x480 script `{\an1\pos(298,432)}` reached the host at (0.776, 1.500) rather than (0.415, 0.900). Off-picture, which is indistinguishable from a cue that never arrived rather than a misplaced one.

## Changes

- `playRes(fromASSHeader:)` splits header lines on any newline (`isNewline` covers CRLF, LF and lone CR) and both trims are newline-inclusive. Lone CR was broken too, not just CRLF: splitting on `"\n"` collapsed such a header into a single line.
- `SubtitleTextPlacement.position` no longer documents a [0, 1] range. A script may anchor outside the frame on purpose, so that is a range the engine cannot guarantee, and a host reading it as one has no reason to guard the case.
- New `Issue261ASSHeaderLineEndingsTests`, with line endings written explicitly. Every existing PlayRes fixture is a Swift multi-line literal, so LF only, and the whole class of failure was invisible to the suite.

## Verification

Red before the fix (both reporter numbers reproduced: y off by 0.6, i.e. 1.5 instead of 0.9), green after. Full suite: 1345 tests in 206 suites passed.

Reported by rrgomes, traced to the line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HX5zV3Fcf7Nzq4DYGdXvQE