### PR TITLE
fix(hls): remux finite HEVC MPEG-TS VOD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,15 @@ the public-API contract.
 
 ## [Unreleased]
 
-_Nothing yet._
+### Fixed
+
+- **Finite HEVC-in-MPEG-TS HLS VOD no longer reaches AVPlayer's audio-only,
+  black native path.** A bounded content probe now confirms the playlist is
+  finite, its segments are MPEG-TS, and its PMT declares HEVC before selecting
+  a seekable TS-to-fMP4 ingest. Direct media playlists and master playlists are
+  both covered; URL, HTTP headers, duration, resume position, and forward or
+  backward seek semantics are preserved. H.264, fMP4, live, audio-only, and
+  inconclusive HLS inputs keep their existing route. (#268)
 
 ## [6.3.0] - 2026-07-31
 

--- a/Sources/AetherEngine/AetherEngine.swift
+++ b/Sources/AetherEngine/AetherEngine.swift
@@ -2397,6 +2397,26 @@ public final class AetherEngine: ObservableObject {
         // (audio-tap reader selection, seek paths) sees a genuine remote-HLS session.
         if RemoteHLSMediaSelection.shouldReroute(failure: probeFailure, isCustomSource: isCustomSource),
            case .url(let hlsURL) = source {
+            if let reader = try await HLSVODIngestReader.makeIfHEVCMPEGTS(
+                playlistURL: hlsURL,
+                httpHeaders: loadedOptions.httpHeaders
+            ) {
+                try checkLoadCurrent(gen)
+                EngineLog.emit(
+                    "[AetherEngine] AE#268: finite HEVC-in-MPEG-TS HLS; "
+                        + "routing through seekable TS -> fMP4 ingest",
+                    category: .engine
+                )
+                var remuxOptions = loadedOptions
+                remuxOptions.nativeRemoteHLS = false
+                return try await load(
+                    source: .custom(reader, formatHint: "mpegts"),
+                    startPosition: startPosition,
+                    options: remuxOptions,
+                    audioSourceStreamIndex: audioSourceStreamIndex,
+                    discTitleID: discTitleID
+                )
+            }
             EngineLog.emit("[AetherEngine] AE#154: HLS playlist on the VOD loopback path; rerouting to the native remote-HLS bypass", category: .engine)
             loadedOptions.nativeRemoteHLS = true
             do {
@@ -2924,6 +2944,26 @@ public final class AetherEngine: ObservableObject {
             if RemoteHLSMediaSelection.shouldReroute(failure: error, isCustomSource: isCustomSource),
                case .url(let hlsURL) = source,
                loadGeneration == gen {
+                if let reader = try await HLSVODIngestReader.makeIfHEVCMPEGTS(
+                    playlistURL: hlsURL,
+                    httpHeaders: loadedOptions.httpHeaders
+                ) {
+                    try checkLoadCurrent(gen)
+                    EngineLog.emit(
+                        "[AetherEngine] AE#268: second open confirmed finite HEVC-in-MPEG-TS HLS; "
+                            + "restarting through seekable TS -> fMP4 ingest",
+                        category: .engine
+                    )
+                    var remuxOptions = loadedOptions
+                    remuxOptions.nativeRemoteHLS = false
+                    return try await load(
+                        source: .custom(reader, formatHint: "mpegts"),
+                        startPosition: startPosition,
+                        options: remuxOptions,
+                        audioSourceStreamIndex: audioSourceStreamIndex,
+                        discTitleID: discTitleID
+                    )
+                }
                 EngineLog.emit(
                     "[AetherEngine] AE#246: the loopback session's own open classified the source as HLS; "
                     + "taking the AE#154 reroute onto the native remote-HLS bypass",

--- a/Sources/AetherEngine/Demuxer/CustomIOReaderBridge.swift
+++ b/Sources/AetherEngine/Demuxer/CustomIOReaderBridge.swift
@@ -15,6 +15,10 @@ final class CustomIOReaderBridge: AVIOProvider, @unchecked Sendable {
     private var isFullyClosed = false
     private(set) var isSeekable: Bool = true
 
+    var timeSeekableReader: TimeSeekableIOReader? {
+        reader as? TimeSeekableIOReader
+    }
+
     var cumulativeBytesFetched: Int64 { 0 }  // custom readers don't track network bytes
 
     /// #112 round 9: same demux-thread-only contract as AVIOReader's deadline. Armed by
@@ -68,7 +72,8 @@ final class CustomIOReaderBridge: AVIOProvider, @unchecked Sendable {
         context = ctx
 
         // SEEK_SET to 0 is a no-op for seekable, refused by forward-only (returns negative).
-        isSeekable = reader.seek(offset: 0, whence: 0) >= 0
+        isSeekable = timeSeekableReader != nil
+            || reader.seek(offset: 0, whence: 0) >= 0
     }
 
     func markClosed() {

--- a/Sources/AetherEngine/Demuxer/Demuxer.swift
+++ b/Sources/AetherEngine/Demuxer/Demuxer.swift
@@ -549,6 +549,11 @@ public final class Demuxer: @unchecked Sendable {
     }
 
     var duration: Double {
+        if let duration = (avioProvider as? CustomIOReaderBridge)?
+            .timeSeekableReader?.mediaDuration,
+           duration > 0 {
+            return duration
+        }
         let container: Double = {
             guard let ctx = formatContext else { return 0 }
             let dur = ctx.pointee.duration
@@ -1071,6 +1076,11 @@ public final class Demuxer: @unchecked Sendable {
         accessLock.lock()
         defer { accessLock.unlock() }
         guard let ctx = formatContext else { return }
+        if let reader = (avioProvider as? CustomIOReaderBridge)?.timeSeekableReader {
+            guard reader.seek(to: seconds) else { return }
+            resetAfterTimeSeek(ctx)
+            return
+        }
         let timestamp = Int64(seconds * Double(AV_TIME_BASE))
         let ret = avformat_seek_file(ctx, -1, Int64.min, timestamp, Int64.max, 0)
         if ret < 0 {
@@ -1090,6 +1100,16 @@ public final class Demuxer: @unchecked Sendable {
         guard let ctx = formatContext,
               streamIndex >= 0,
               streamIndex < Int32(ctx.pointee.nb_streams) else { return false }
+        if let reader = (avioProvider as? CustomIOReaderBridge)?.timeSeekableReader,
+           let stream = ctx.pointee.streams[Int(streamIndex)] {
+            let timeBase = stream.pointee.time_base
+            guard timeBase.num > 0, timeBase.den > 0 else { return false }
+            let seconds = Double(timestamp) * Double(timeBase.num)
+                / Double(timeBase.den)
+            guard reader.seek(to: max(0, seconds)) else { return false }
+            resetAfterTimeSeek(ctx)
+            return true
+        }
         let ret = avformat_seek_file(
             ctx,
             streamIndex,
@@ -1107,6 +1127,16 @@ public final class Demuxer: @unchecked Sendable {
         avformat_flush(ctx)
         lastReadClipIdx = -1
         return ret >= 0
+    }
+
+    private func resetAfterTimeSeek(_ ctx: UnsafeMutablePointer<AVFormatContext>) {
+        if let pb = ctx.pointee.pb {
+            avio_flush(pb)
+            pb.pointee.eof_reached = 0
+            pb.pointee.error = 0
+        }
+        avformat_flush(ctx)
+        lastReadClipIdx = -1
     }
 
     /// #112 round 10: latched by the side reader once a timestamp positioning seek timed out or failed on this

--- a/Sources/AetherEngine/IO/HLSIngest/HLSVODIngestReader.swift
+++ b/Sources/AetherEngine/IO/HLSIngest/HLSVODIngestReader.swift
@@ -1,0 +1,604 @@
+import CommonCrypto
+import Foundation
+
+/// The reader resolves one immutable ENDLIST playlist and exposes its segments
+/// as a blocking MPEG-TS stream. Unlike `HLSLiveIngestReader`, seeks restart the
+/// same source at the segment preceding the requested playlist time. Demuxer
+/// packet gating then discards frames before the exact target.
+final class HLSVODIngestReader: TimeSeekableIOReader, @unchecked Sendable {
+    private struct ResolvedMedia {
+        let url: URL
+        let segments: [HLSMediaSegment]
+        let starts: [Double]
+        let duration: Double
+    }
+
+    private static let maximumBufferedBytes = 32 * 1024 * 1024
+    private static let maximumPlaylistBytes = 2 * 1024 * 1024
+    private static let maximumCarriageProbeBytes = 512 * 1024
+    private static let maxConcurrentSegmentFetches = 4
+
+    private let playlistURL: URL
+    private let httpHeaders: [String: String]
+    private let session: URLSession
+    private let ownsSession: Bool
+    private let condition = NSCondition()
+    private let keyCacheLock = NSLock()
+    private var keyCache: [String: Data] = [:]
+
+    private var resolved: ResolvedMedia?
+    private var queue: [Data] = []
+    private var headOffset = 0
+    private var bufferedBytes = 0
+    private var bytePosition: Int64 = 0
+    private var generation: UInt64 = 0
+    private var started = false
+    private var finished = false
+    private var failed = false
+    private var closed = false
+    private var producer: Task<Void, Never>?
+
+    init(
+        playlistURL: URL,
+        httpHeaders: [String: String],
+        session: URLSession? = nil
+    ) {
+        self.playlistURL = playlistURL
+        self.httpHeaders = httpHeaders
+        if let session {
+            self.session = session
+            ownsSession = false
+        } else {
+            let configuration = URLSessionConfiguration.ephemeral
+            configuration.timeoutIntervalForRequest = 15
+            configuration.timeoutIntervalForResource = 45
+            configuration.requestCachePolicy = .reloadIgnoringLocalAndRemoteCacheData
+            configuration.urlCache = nil
+            self.session = URLSession(configuration: configuration)
+            ownsSession = true
+        }
+    }
+
+    /// Returns a pre-resolved reader only when the finite playlist has positive
+    /// content evidence for HEVC in MPEG-TS. Unknown, live, fMP4, H.264 and
+    /// demuxed-audio shapes stay on the existing native remote-HLS route.
+    static func makeIfHEVCMPEGTS(
+        playlistURL: URL,
+        httpHeaders: [String: String],
+        session: URLSession? = nil
+    ) async throws -> HLSVODIngestReader? {
+        let reader = HLSVODIngestReader(
+            playlistURL: playlistURL,
+            httpHeaders: httpHeaders,
+            session: session
+        )
+        var accepted = false
+        defer {
+            if !accepted { reader.close() }
+        }
+        do {
+            let media = try await reader.resolveMedia()
+            guard let first = media.segments.first,
+                  first.crypt == nil,
+                  let segmentURL = HLSPlaylistParser.resolve(
+                    uri: first.uri,
+                    against: media.url
+                  ) else {
+                return nil
+            }
+            let prefix = try await reader.fetchCarriageProbe(segmentURL)
+            guard LiveSegmentFormat.classify(prefix) == .mpegts,
+                  MPEGTransportStreamCodecProbe.containsHEVC(prefix) else {
+                return nil
+            }
+            reader.condition.withLock {
+                reader.resolved = media
+            }
+            accepted = true
+            return reader
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            if Task.isCancelled { throw CancellationError() }
+            EngineLog.emit(
+                "[HLSVODIngest] carriage probe inconclusive: \(error)",
+                category: .engine
+            )
+            return nil
+        }
+    }
+
+    var mediaDuration: Double {
+        condition.withLock { resolved?.duration ?? 0 }
+    }
+
+    func read(_ buffer: UnsafeMutablePointer<UInt8>?, size: Int32) -> Int32 {
+        guard let buffer, size > 0 else { return -1 }
+        startIfNeeded()
+        condition.lock()
+        defer { condition.unlock() }
+        while queue.isEmpty, !finished, !failed, !closed {
+            condition.wait()
+        }
+        guard !failed, !closed else { return -1 }
+        guard !queue.isEmpty else { return 0 }
+
+        let available = queue[0].count - headOffset
+        let count = min(available, Int(size))
+        queue[0].withUnsafeBytes { bytes in
+            guard let base = bytes.baseAddress else { return }
+            buffer.update(
+                from: base.assumingMemoryBound(to: UInt8.self)
+                    .advanced(by: headOffset),
+                count: count
+            )
+        }
+        headOffset += count
+        bufferedBytes -= count
+        bytePosition += Int64(count)
+        if headOffset == queue[0].count {
+            queue.removeFirst()
+            headOffset = 0
+        }
+        condition.broadcast()
+        return Int32(count)
+    }
+
+    /// Byte seeks are deliberately unsupported. SEEK_SET(0) is the capability
+    /// handshake used by `CustomIOReaderBridge`; real positioning crosses the
+    /// `TimeSeekableIOReader` seam in `Demuxer`.
+    func seek(offset: Int64, whence: Int32) -> Int64 {
+        if whence == SEEK_SET, offset == 0 { return 0 }
+        if whence == SEEK_CUR, offset == 0 {
+            return condition.withLock { bytePosition }
+        }
+        return -1
+    }
+
+    func seek(to seconds: Double) -> Bool {
+        guard seconds.isFinite, seconds >= 0 else { return false }
+        startIfNeeded()
+
+        condition.lock()
+        while resolved == nil, !failed, !closed {
+            condition.wait()
+        }
+        guard let resolved, !failed, !closed else {
+            condition.unlock()
+            return false
+        }
+        let containing = resolved.starts.lastIndex(where: { $0 <= seconds }) ?? 0
+        // A playlist need not declare independent segments. Starting one GOP
+        // earlier supplies the decoder with a random-access point; the engine's
+        // existing target gate drops frames before the requested time.
+        let startIndex = max(0, containing - 1)
+        let previous = producer
+        generation &+= 1
+        let currentGeneration = generation
+        queue.removeAll(keepingCapacity: true)
+        headOffset = 0
+        bufferedBytes = 0
+        bytePosition = 0
+        finished = false
+        failed = false
+        producer = Task.detached(priority: .userInitiated) { [self] in
+            await produce(
+                resolved: resolved,
+                startIndex: startIndex,
+                generation: currentGeneration
+            )
+        }
+        condition.broadcast()
+        condition.unlock()
+        previous?.cancel()
+
+        let targetText = String(format: "%.2f", seconds)
+        let originText = String(format: "%.2f", resolved.starts[startIndex])
+        EngineLog.emit(
+            "[HLSVODIngest] seek target=\(targetText)s "
+                + "segment=\(startIndex) origin=\(originText)s",
+            category: .engine
+        )
+        return true
+    }
+
+    func cancel() {
+        condition.lock()
+        failed = true
+        let task = producer
+        producer = nil
+        condition.broadcast()
+        condition.unlock()
+        task?.cancel()
+    }
+
+    func close() {
+        condition.lock()
+        guard !closed else {
+            condition.unlock()
+            return
+        }
+        closed = true
+        let task = producer
+        producer = nil
+        queue.removeAll()
+        bufferedBytes = 0
+        condition.broadcast()
+        condition.unlock()
+        task?.cancel()
+        if ownsSession {
+            session.invalidateAndCancel()
+        }
+    }
+
+    func makeIndependentReader() -> IOReader? {
+        HLSVODIngestReader(playlistURL: playlistURL, httpHeaders: httpHeaders)
+    }
+
+    private func startIfNeeded() {
+        condition.lock()
+        guard !started, !closed else {
+            condition.unlock()
+            return
+        }
+        started = true
+        generation &+= 1
+        let currentGeneration = generation
+        let preResolved = resolved
+        producer = Task.detached(priority: .userInitiated) { [self] in
+            do {
+                let media: ResolvedMedia
+                if let preResolved {
+                    media = preResolved
+                } else {
+                    media = try await resolveMedia()
+                }
+                let accepted = condition.withLock { () -> Bool in
+                    guard generation == currentGeneration, !closed else {
+                        return false
+                    }
+                    resolved = media
+                    condition.broadcast()
+                    return true
+                }
+                guard accepted else {
+                    return
+                }
+                let durationText = String(format: "%.2f", media.duration)
+                EngineLog.emit(
+                    "[HLSVODIngest] resolved finite MPEG-TS VOD segments=\(media.segments.count) "
+                        + "duration=\(durationText)s",
+                    category: .engine
+                )
+                await produce(
+                    resolved: media,
+                    startIndex: 0,
+                    generation: currentGeneration
+                )
+            } catch is CancellationError {
+            } catch {
+                fail(error, generation: currentGeneration)
+            }
+        }
+        condition.unlock()
+    }
+
+    private func produce(
+        resolved: ResolvedMedia,
+        startIndex: Int,
+        generation: UInt64
+    ) async {
+        do {
+            let remaining = Array(resolved.segments[startIndex...])
+            try await ingestSegmentBatch(
+                remaining,
+                mediaURL: resolved.url,
+                generation: generation
+            )
+            condition.withLock {
+                if self.generation == generation, !closed {
+                    finished = true
+                    producer = nil
+                    condition.broadcast()
+                }
+            }
+        } catch is CancellationError {
+        } catch {
+            fail(error, generation: generation)
+        }
+    }
+
+    private func ingestSegmentBatch(
+        _ segments: [HLSMediaSegment],
+        mediaURL: URL,
+        generation: UInt64
+    ) async throws {
+        let resolvedSegments: [(HLSMediaSegment, URL)] = try segments.map { segment in
+            guard let url = HLSPlaylistParser.resolve(uri: segment.uri, against: mediaURL) else {
+                throw HLSIngestError.playlistInvalid(reason: "unresolvable segment URI")
+            }
+            return (segment, url)
+        }
+
+        try await withThrowingTaskGroup(of: (Int, Data).self) { group in
+            var nextToSpawn = 0
+            var nextToCommit = 0
+            var ready: [Int: Data] = [:]
+
+            func spawn(_ index: Int) {
+                let item = resolvedSegments[index]
+                group.addTask {
+                    let bytes = try await self.fetch(item.1)
+                    guard let crypt = item.0.crypt else { return (index, bytes) }
+                    return (
+                        index,
+                        try await self.decrypt(bytes, crypt: crypt, baseURL: mediaURL)
+                    )
+                }
+            }
+
+            while nextToSpawn < resolvedSegments.count,
+                  nextToSpawn < Self.maxConcurrentSegmentFetches {
+                spawn(nextToSpawn)
+                nextToSpawn += 1
+            }
+            while nextToCommit < resolvedSegments.count {
+                try Task.checkCancellation()
+                guard let (index, bytes) = try await group.next() else { break }
+                ready[index] = bytes
+                while let head = ready.removeValue(forKey: nextToCommit) {
+                    if nextToCommit == 0,
+                       LiveSegmentFormat.classify(head) != .mpegts {
+                        throw HLSIngestError.unsupportedSegmentFormat
+                    }
+                    nextToCommit += 1
+                    guard append(head, generation: generation) else {
+                        group.cancelAll()
+                        return
+                    }
+                    while nextToSpawn < resolvedSegments.count,
+                          nextToSpawn < nextToCommit + Self.maxConcurrentSegmentFetches {
+                        spawn(nextToSpawn)
+                        nextToSpawn += 1
+                    }
+                }
+            }
+        }
+    }
+
+    private func append(_ data: Data, generation: UInt64) -> Bool {
+        condition.lock()
+        defer { condition.unlock() }
+        while self.generation == generation,
+              !closed,
+              bufferedBytes >= Self.maximumBufferedBytes {
+            condition.wait()
+        }
+        guard self.generation == generation, !closed else { return false }
+        queue.append(data)
+        bufferedBytes += data.count
+        condition.broadcast()
+        return true
+    }
+
+    private func fail(_ error: Error, generation: UInt64) {
+        condition.lock()
+        guard self.generation == generation, !closed else {
+            condition.unlock()
+            return
+        }
+        failed = true
+        producer = nil
+        condition.broadcast()
+        condition.unlock()
+        EngineLog.emit("[HLSVODIngest] terminal: \(error)", category: .engine)
+    }
+
+    private func resolveMedia() async throws -> ResolvedMedia {
+        let (root, rootURL) = try await fetchPlaylist(playlistURL)
+        let media: HLSMediaPlaylist
+        let mediaURL: URL
+        switch root {
+        case .media(let value):
+            media = value
+            mediaURL = rootURL
+        case .master(let master):
+            guard let best = master.variants.max(by: { $0.bandwidth < $1.bandwidth }),
+                  best.audioGroupID == nil,
+                  let url = HLSPlaylistParser.resolve(uri: best.uri, against: rootURL) else {
+                throw HLSIngestError.demuxedAudioNotSupported
+            }
+            let (selected, selectedURL) = try await fetchPlaylist(url)
+            guard case .media(let value) = selected else {
+                throw HLSIngestError.playlistInvalid(reason: "selected variant is not a media playlist")
+            }
+            media = value
+            mediaURL = selectedURL
+        }
+
+        guard media.hasEndList else {
+            throw HLSIngestError.playlistInvalid(reason: "finite VOD requires EXT-X-ENDLIST")
+        }
+        guard !media.hasMap else { throw HLSIngestError.unsupportedSegmentFormat }
+        guard !media.hasUnsupportedEncryption else {
+            throw HLSIngestError.encryptedNotSupported
+        }
+        var starts: [Double] = []
+        starts.reserveCapacity(media.segments.count)
+        var duration = 0.0
+        for segment in media.segments {
+            guard segment.duration.isFinite, segment.duration > 0 else {
+                throw HLSIngestError.playlistInvalid(reason: "segment duration must be positive")
+            }
+            starts.append(duration)
+            duration += segment.duration
+        }
+        return ResolvedMedia(
+            url: mediaURL,
+            segments: media.segments,
+            starts: starts,
+            duration: duration
+        )
+    }
+
+    private func makeRequest(_ url: URL) -> URLRequest {
+        var request = URLRequest(url: url)
+        for (field, value) in httpHeaders {
+            request.setValue(value, forHTTPHeaderField: field)
+        }
+        return request
+    }
+
+    private func fetchPlaylist(_ url: URL) async throws -> (HLSPlaylist, URL) {
+        let (data, response) = try await session.data(for: makeRequest(url))
+        let status = (response as? HTTPURLResponse)?.statusCode ?? -1
+        guard (200..<300).contains(status) else {
+            throw HLSIngestError.playlistUnreachable(status: status)
+        }
+        guard data.count <= Self.maximumPlaylistBytes,
+              let text = String(data: data, encoding: .utf8) else {
+            throw HLSIngestError.playlistInvalid(reason: "playlist is not bounded UTF-8")
+        }
+        return (try HLSPlaylistParser.parse(text), response.url ?? url)
+    }
+
+    private func fetch(_ url: URL) async throws -> Data {
+        let (data, response) = try await session.data(for: makeRequest(url))
+        let status = (response as? HTTPURLResponse)?.statusCode ?? -1
+        guard (200..<300).contains(status), !data.isEmpty else {
+            throw HLSIngestError.playlistUnreachable(status: status)
+        }
+        return data
+    }
+
+    private func fetchCarriageProbe(_ url: URL) async throws -> Data {
+        var request = makeRequest(url)
+        request.setValue(
+            "bytes=0-\(Self.maximumCarriageProbeBytes - 1)",
+            forHTTPHeaderField: "Range"
+        )
+        let (bytes, response) = try await session.bytes(for: request)
+        defer { bytes.task.cancel() }
+        let status = (response as? HTTPURLResponse)?.statusCode ?? -1
+        guard status == 200 || status == 206 else {
+            throw HLSIngestError.playlistUnreachable(status: status)
+        }
+        var data = Data()
+        data.reserveCapacity(Self.maximumCarriageProbeBytes)
+        for try await byte in bytes {
+            data.append(byte)
+            if data.count == Self.maximumCarriageProbeBytes { break }
+        }
+        guard !data.isEmpty else {
+            throw HLSIngestError.unsupportedSegmentFormat
+        }
+        return data
+    }
+
+    private func decrypt(
+        _ ciphertext: Data,
+        crypt: HLSSegmentCrypt,
+        baseURL: URL
+    ) async throws -> Data {
+        guard let keyURL = HLSPlaylistParser.resolve(uri: crypt.keyURI, against: baseURL) else {
+            throw HLSIngestError.segmentDecryptFailed(reason: "unresolvable key URI")
+        }
+        let key: Data
+        if let cached = keyCacheLock.withLock({ keyCache[keyURL.absoluteString] }) {
+            key = cached
+        } else {
+            let fetched = try await fetch(keyURL)
+            guard fetched.count == kCCKeySizeAES128 else {
+                throw HLSIngestError.segmentDecryptFailed(reason: "key length is not 16 bytes")
+            }
+            keyCacheLock.withLock { keyCache[keyURL.absoluteString] = fetched }
+            key = fetched
+        }
+        guard let plaintext = HLSSegmentDecryptor.decryptAES128CBC(
+            ciphertext,
+            key: key,
+            iv: crypt.iv
+        ) else {
+            throw HLSIngestError.segmentDecryptFailed(reason: "AES-128-CBC failed")
+        }
+        return plaintext
+    }
+}
+
+/// Bounded MPEG-TS PMT inspection. HEVC is stream_type 0x24; no URL suffix or
+/// response MIME type is treated as codec evidence.
+enum MPEGTransportStreamCodecProbe {
+    private static let packetSize = 188
+
+    static func containsHEVC(_ data: Data) -> Bool {
+        let bytes = [UInt8](data)
+        guard let syncOffset = (0..<min(packetSize, bytes.count)).first(
+            where: { offset in
+                offset + packetSize * 2 < bytes.count
+                    && bytes[offset] == 0x47
+                    && bytes[offset + packetSize] == 0x47
+                    && bytes[offset + packetSize * 2] == 0x47
+            }
+        ) else {
+            return false
+        }
+
+        var packetStart = syncOffset
+        while packetStart + packetSize <= bytes.count {
+            if packetContainsHEVC(bytes, packetStart: packetStart) {
+                return true
+            }
+            packetStart += packetSize
+        }
+        return false
+    }
+
+    private static func packetContainsHEVC(
+        _ bytes: [UInt8],
+        packetStart: Int
+    ) -> Bool {
+        guard bytes[packetStart] == 0x47,
+              bytes[packetStart + 1] & 0x40 != 0 else {
+            return false
+        }
+        let adaptationControl = (bytes[packetStart + 3] >> 4) & 0x03
+        guard adaptationControl == 1 || adaptationControl == 3 else {
+            return false
+        }
+        var payload = packetStart + 4
+        if adaptationControl == 3 {
+            payload += 1 + Int(bytes[payload])
+        }
+        let packetEnd = packetStart + packetSize
+        guard payload < packetEnd else { return false }
+        payload += 1 + Int(bytes[payload])
+        guard payload + 12 <= packetEnd, bytes[payload] == 0x02 else {
+            return false
+        }
+
+        let sectionLength =
+            (Int(bytes[payload + 1] & 0x0F) << 8)
+                | Int(bytes[payload + 2])
+        let sectionEnd = min(packetEnd, payload + 3 + sectionLength - 4)
+        let programInfoLength =
+            (Int(bytes[payload + 10] & 0x0F) << 8)
+                | Int(bytes[payload + 11])
+        var stream = payload + 12 + programInfoLength
+        while stream + 5 <= sectionEnd {
+            if bytes[stream] == 0x24 { return true }
+            let infoLength =
+                (Int(bytes[stream + 3] & 0x0F) << 8)
+                    | Int(bytes[stream + 4])
+            stream += 5 + infoLength
+        }
+        return false
+    }
+}
+
+private extension NSCondition {
+    func withLock<T>(_ body: () -> T) -> T {
+        lock()
+        defer { unlock() }
+        return body()
+    }
+}

--- a/Sources/AetherEngine/IO/IOReader.swift
+++ b/Sources/AetherEngine/IO/IOReader.swift
@@ -17,6 +17,13 @@ public protocol IOReader: AnyObject, Sendable {
     func makeIndependentReader() -> IOReader?
 }
 
+/// Internal seam for finite segmented sources whose natural seek axis is time,
+/// not a synthetic concatenated byte offset.
+protocol TimeSeekableIOReader: IOReader {
+    var mediaDuration: Double { get }
+    func seek(to seconds: Double) -> Bool
+}
+
 public extension IOReader {
     func cancel() {}
     func makeIndependentReader() -> IOReader? { nil }

--- a/Sources/AetherEngine/Native/RemoteHLSIngestFallback.swift
+++ b/Sources/AetherEngine/Native/RemoteHLSIngestFallback.swift
@@ -52,9 +52,9 @@ enum RemoteHLSIngestFallback {
         return variantHasVideoAttributes.contains(true)
     }
 
-    /// The watchdog runs only for live bypass sessions with the fallback enabled: VOD remote HLS is the
-    /// AE#154 reroute target (ingesting it back would ping-pong), and hosts can opt out via
-    /// `LoadOptions.nativeRemoteHLSIngestFallback`.
+    /// The watchdog runs only for live bypass sessions with the fallback enabled. Finite
+    /// HEVC-in-MPEG-TS VOD uses the content-gated, seekable #268 ingest before a native mount, and hosts
+    /// can opt out of this live recovery via `LoadOptions.nativeRemoteHLSIngestFallback`.
     static func shouldArm(isLive: Bool, fallbackEnabled: Bool) -> Bool {
         isLive && fallbackEnabled
     }

--- a/Sources/AetherEngine/PlayerState.swift
+++ b/Sources/AetherEngine/PlayerState.swift
@@ -200,8 +200,9 @@ public struct LoadOptions: Sendable, Equatable {
     /// readyToPlay but never builds a video track for a master that advertises one. That signature means
     /// the master delivers HEVC in MPEG-TS segments, which AVFoundation's HLS demuxer does not support
     /// (the HLS Authoring Spec sanctions HEVC only in fMP4); the ingest path remuxes TS to fMP4 and plays
-    /// the same stream. Live-only (VOD remote HLS is the AE#154 reroute target). `httpHeaders` ride along
-    /// onto the ingest fetches. Default `true` (AetherEngine#168).
+    /// the same stream. Live-only; finite HEVC-in-MPEG-TS VOD is classified before the native mount and
+    /// uses the seekable #268 ingest instead. `httpHeaders` ride along onto the ingest fetches. Default
+    /// `true` (AetherEngine#168).
     public var nativeRemoteHLSIngestFallback: Bool
 
     /// Emit raw ASS event lines (`ReadOrder,Layer,Style,...,Text` including override tags) instead of plain-text extraction. Opt-in for hosts that render ASS styling themselves; pair with `TrackInfo.assHeader`. Only affects ASS / SSA codecs. Default `false` (AetherEngine#30).

--- a/Tests/AetherEngineTests/Issue268HLSVODIngestTests.swift
+++ b/Tests/AetherEngineTests/Issue268HLSVODIngestTests.swift
@@ -1,0 +1,210 @@
+import Foundation
+import XCTest
+@testable import AetherEngine
+
+/// #268: HEVC carried in finite MPEG-TS HLS must be identified from the
+/// playlist and PMT, then exposed through the seekable VOD ingest rather than
+/// handed to AVPlayer's black native path.
+final class Issue268HLSVODIngestTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        Issue268URLProtocol.reset()
+    }
+
+    func testDirectMediaPlaylistBuildsSeekableHEVCReader() async throws {
+        let root = try XCTUnwrap(URL(string: "https://vod.test/media.m3u8"))
+        let segment = try XCTUnwrap(URL(string: "https://vod.test/segment.ts"))
+        Issue268URLProtocol.bodyByURL[root.absoluteString] = mediaPlaylist("segment.ts")
+        Issue268URLProtocol.bodyByURL[segment.absoluteString] = transportStream(streamType: 0x24)
+
+        let session = makeSession()
+        defer { session.invalidateAndCancel() }
+        let reader = try await HLSVODIngestReader.makeIfHEVCMPEGTS(
+            playlistURL: root,
+            httpHeaders: ["X-Fixture": "allowed"],
+            session: session
+        )
+        let admitted = try XCTUnwrap(reader)
+        defer { admitted.close() }
+
+        XCTAssertEqual(admitted.mediaDuration, 6, accuracy: 0.001)
+        XCTAssertTrue(admitted.seek(to: 5))
+        var bytes = [UInt8](repeating: 0, count: 188)
+        let count = bytes.withUnsafeMutableBufferPointer {
+            admitted.read($0.baseAddress, size: Int32($0.count))
+        }
+        XCTAssertEqual(count, 188)
+        XCTAssertEqual(bytes[0], 0x47)
+        XCTAssertEqual(
+            Issue268URLProtocol.headersByURL[root.absoluteString]?["X-Fixture"],
+            "allowed"
+        )
+        XCTAssertEqual(
+            Issue268URLProtocol.headersByURL[segment.absoluteString]?["X-Fixture"],
+            "allowed"
+        )
+    }
+
+    func testMasterPlaylistUsesHighestBandwidthHEVCVariant() async throws {
+        let root = try XCTUnwrap(URL(string: "https://vod.test/master.m3u8"))
+        let low = try XCTUnwrap(URL(string: "https://vod.test/low.m3u8"))
+        let high = try XCTUnwrap(URL(string: "https://vod.test/high.m3u8"))
+        let lowSegment = try XCTUnwrap(URL(string: "https://vod.test/low.ts"))
+        let highSegment = try XCTUnwrap(URL(string: "https://vod.test/high.ts"))
+        Issue268URLProtocol.bodyByURL[root.absoluteString] = Data("""
+        #EXTM3U
+        #EXT-X-STREAM-INF:BANDWIDTH=800000
+        low.m3u8
+        #EXT-X-STREAM-INF:BANDWIDTH=4000000
+        high.m3u8
+        """.utf8)
+        Issue268URLProtocol.bodyByURL[low.absoluteString] = mediaPlaylist("low.ts")
+        Issue268URLProtocol.bodyByURL[high.absoluteString] = mediaPlaylist("high.ts")
+        Issue268URLProtocol.bodyByURL[lowSegment.absoluteString] = transportStream(streamType: 0x1B)
+        Issue268URLProtocol.bodyByURL[highSegment.absoluteString] = transportStream(streamType: 0x24)
+
+        let session = makeSession()
+        defer { session.invalidateAndCancel() }
+        let reader = try await HLSVODIngestReader.makeIfHEVCMPEGTS(
+            playlistURL: root,
+            httpHeaders: [:],
+            session: session
+        )
+        XCTAssertNotNil(reader)
+        reader?.close()
+        XCTAssertNil(Issue268URLProtocol.headersByURL[low.absoluteString])
+        XCTAssertNotNil(Issue268URLProtocol.headersByURL[high.absoluteString])
+        XCTAssertNil(Issue268URLProtocol.headersByURL[lowSegment.absoluteString])
+        XCTAssertNotNil(Issue268URLProtocol.headersByURL[highSegment.absoluteString])
+    }
+
+    func testH264MPEGTSRemainsOnNativeHLSRoute() async throws {
+        let root = try XCTUnwrap(URL(string: "https://vod.test/h264.m3u8"))
+        let segment = try XCTUnwrap(URL(string: "https://vod.test/h264.ts"))
+        Issue268URLProtocol.bodyByURL[root.absoluteString] = mediaPlaylist("h264.ts")
+        Issue268URLProtocol.bodyByURL[segment.absoluteString] = transportStream(streamType: 0x1B)
+
+        let session = makeSession()
+        defer { session.invalidateAndCancel() }
+        let reader = try await HLSVODIngestReader.makeIfHEVCMPEGTS(
+            playlistURL: root,
+            httpHeaders: [:],
+            session: session
+        )
+        XCTAssertNil(reader)
+    }
+
+    func testFMP4AndLivePlaylistsRemainOnExistingRoutes() async throws {
+        let fmp4 = try XCTUnwrap(URL(string: "https://vod.test/fmp4.m3u8"))
+        let live = try XCTUnwrap(URL(string: "https://vod.test/live.m3u8"))
+        Issue268URLProtocol.bodyByURL[fmp4.absoluteString] = Data("""
+        #EXTM3U
+        #EXT-X-TARGETDURATION:6
+        #EXT-X-MAP:URI="init.mp4"
+        #EXTINF:6,
+        segment.m4s
+        #EXT-X-ENDLIST
+        """.utf8)
+        Issue268URLProtocol.bodyByURL[live.absoluteString] = Data("""
+        #EXTM3U
+        #EXT-X-TARGETDURATION:6
+        #EXTINF:6,
+        segment.ts
+        """.utf8)
+
+        let session = makeSession()
+        defer { session.invalidateAndCancel() }
+        let fmp4Reader = try await HLSVODIngestReader.makeIfHEVCMPEGTS(
+            playlistURL: fmp4,
+            httpHeaders: [:],
+            session: session
+        )
+        let liveReader = try await HLSVODIngestReader.makeIfHEVCMPEGTS(
+            playlistURL: live,
+            httpHeaders: [:],
+            session: session
+        )
+        XCTAssertNil(fmp4Reader)
+        XCTAssertNil(liveReader)
+    }
+
+    private func makeSession() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [Issue268URLProtocol.self]
+        return URLSession(configuration: configuration)
+    }
+
+    private func mediaPlaylist(_ segment: String) -> Data {
+        Data("""
+        #EXTM3U
+        #EXT-X-TARGETDURATION:6
+        #EXTINF:6,
+        \(segment)
+        #EXT-X-ENDLIST
+        """.utf8)
+    }
+
+    private func transportStream(streamType: UInt8) -> Data {
+        var bytes = [UInt8](repeating: 0xFF, count: 188 * 3)
+        for packet in 0..<3 {
+            bytes[packet * 188] = 0x47
+            bytes[packet * 188 + 3] = 0x10
+        }
+        bytes[1] = 0x40
+        bytes[2] = 0x64
+        bytes[4] = 0
+        bytes[5] = 0x02
+        bytes[6] = 0xB0
+        bytes[7] = 18
+        bytes[8] = 0
+        bytes[9] = 1
+        bytes[10] = 0xC1
+        bytes[11] = 0
+        bytes[12] = 0
+        bytes[13] = 0xE1
+        bytes[14] = 0
+        bytes[15] = 0xF0
+        bytes[16] = 0
+        bytes[17] = streamType
+        bytes[18] = 0xE1
+        bytes[19] = 1
+        bytes[20] = 0xF0
+        bytes[21] = 0
+        return Data(bytes)
+    }
+}
+
+final class Issue268URLProtocol: URLProtocol, @unchecked Sendable {
+    nonisolated(unsafe) static var bodyByURL: [String: Data] = [:]
+    nonisolated(unsafe) static var headersByURL: [String: [String: String]] = [:]
+
+    static func reset() {
+        bodyByURL = [:]
+        headersByURL = [:]
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+    override func stopLoading() {}
+
+    override func startLoading() {
+        guard let url = request.url else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badURL))
+            return
+        }
+        Self.headersByURL[url.absoluteString] = request.allHTTPHeaderFields ?? [:]
+        guard let data = Self.bodyByURL[url.absoluteString] else {
+            client?.urlProtocol(self, didFailWithError: URLError(.fileDoesNotExist))
+            return
+        }
+        let response = HTTPURLResponse(
+            url: url,
+            statusCode: request.value(forHTTPHeaderField: "Range") == nil ? 200 : 206,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Length": String(data.count)]
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: data)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+}


### PR DESCRIPTION
Fixes #268.

## Problem

AVPlayer can mount finite HEVC-in-MPEG-TS HLS as audio-only / black video. This is a long-standing HEVC HLS playback-path problem, not a device-generation-specific issue.

The existing HLS reroute sends VOD back to native remote HLS. That is correct for ordinary HLS, but preserves the black-screen path for this carriage. Reusing the live ingest is also not suitable because its rolling-window contract breaks VOD seek semantics.

## Change

- classify the source from playlist and segment content before choosing the native route
- require `#EXT-X-ENDLIST`, MPEG-TS carriage, and PMT stream type `0x24` (HEVC)
- accept direct media playlists and the highest-bandwidth muxed master variant
- feed confirmed inputs through a bounded, ordered TS ingest
- expose duration and restart the finite playlist at the segment preceding a time seek
- preserve HTTP headers, resume position, forward/backward seek, and the existing demux/decoder/remux path
- leave H.264, fMP4, live, audio-only, encrypted/inconclusive, and unsupported playlist shapes on their existing route

This is content-gated; it does not infer codecs from the `.m3u8` suffix or retry from an AVPlayer error string.

## Validation

- `swift test --filter Issue268HLSVODIngestTests` — 4 passed
- `swift build -Xswiftc -strict-concurrency=complete` — passed
- `xcodebuild -scheme AetherEngine -destination 'generic/platform=tvOS' build CODE_SIGNING_ALLOWED=NO` — passed
- `swift test --skip-build --skip Issue220SoftwareDecoderDrainTests` — 1361 tests in 206 suites passed

A full unfiltered run has one failure in `Issue220SoftwareDecoderDrainTests` (expected drain counter >= 24, observed 17). The same failure reproduces in a clean worktree at upstream `83dca0b`, so it is not introduced by this branch.

The same reader/demux seam was physically validated in a downstream integration with finite duration, forward seek, post-seek progress, and 2x playback. This PR reconstructs that workaround against current upstream `main`; direct physical-device acceptance of this exact branch remains pending, hence the draft status.
