### PR TITLE
fix(hls): plan VOD segments on the source's declared boundaries (#268)

### DIFF
--- a/Scripts/fetch-fixtures.sh
+++ b/Scripts/fetch-fixtures.sh
@@ -267,9 +267,10 @@ open(path, 'wb').write(bytes(data))
 PY
 
 # AetherEngine#268: finite HEVC-in-MPEG-TS HLS VOD, the carriage AVFoundation refuses to build a
-# video track for. Two shapes, because the seek axis only shows up in the second one:
-#   hls-hevc-vod/       PTS origin at ffmpeg's default 1.4 s
-#   hls-hevc-vod-offset/ PTS origin at ~1001 s, what broadcast-derived VOD carries
+# video track for. Three shapes, because each one only shows its own defect:
+#   hls-hevc-vod/        PTS origin at ffmpeg's default 1.4 s, 6 s segments, 2 s GOP
+#   hls-hevc-vod-offset/ PTS origin at ~1001 s, what broadcast-derived VOD carries (seek axis)
+#   hls-hevc-vod-longgop/ 20 min, 10 s segments, ONE I-frame per segment (segment plan)
 # plus an H.264 control that has to STAY on the native AVPlayer route. Serve the parent directory
 # over HTTP (any static, range-capable origin) and drive it with
 # `aetherctl play --seek-every 6 --seek-pattern 500,120 http://127.0.0.1:PORT/hls-hevc-vod/media.m3u8`.
@@ -287,6 +288,25 @@ hls_vod_fixture() {  # <dir> <encoder> <extra-out-args...>
 }
 hls_vod_fixture hls-hevc-vod libx265 -x265-params "keyint=50:min-keyint=50:scenecut=0:log-level=none"
 hls_vod_fixture hls-h264-vod libx264 -g 50 -keyint_min 50 -sc_threshold 0
+
+# The GOP is the point: one I-frame per 10 s segment, the reporter's shape. A 2 s GOP (above) hides
+# the #268 round 2 defect entirely, because every plan boundary then still catches a keyframe. It
+# also has to be long enough that a seek lands outside what the ingest has already produced, so
+# 20 min rather than 120 s. Drive it with a target that is NOT a multiple of 20 s, e.g.
+# `aetherctl play --seek-every 14 --seek-pattern 1055.79,333.3,777.7 http://127.0.0.1:PORT/hls-hevc-vod-longgop/media.m3u8`
+# and watch `video gate open`: `anchorPts - target` must stay at the plan's boundary backoff.
+LONGGOP_TS="$FIXTURES_DIR/user/hevc-longgop.ts"
+LONGGOP_DIR="$FIXTURES_DIR/user/hls-hevc-vod-longgop"
+rm -rf "$LONGGOP_DIR" && mkdir -p "$LONGGOP_DIR"
+ffmpeg -hide_banner -loglevel error -y \
+    -f lavfi -i "testsrc2=size=320x180:rate=25" \
+    -f lavfi -i "sine=frequency=440:sample_rate=48000" -t 1200 \
+    -c:v libx265 -preset ultrafast \
+    -x265-params "keyint=250:min-keyint=250:scenecut=0:log-level=none" \
+    -pix_fmt yuv420p -c:a aac -b:a 64k -f mpegts "$LONGGOP_TS"
+ffmpeg -hide_banner -loglevel error -y -i "$LONGGOP_TS" -c copy \
+    -f hls -hls_time 10 -hls_list_size 0 -hls_playlist_type vod \
+    -hls_segment_filename "$LONGGOP_DIR/seg%03d.ts" "$LONGGOP_DIR/media.m3u8"
 
 # Broadcast-style PTS origin: mux once with the offset, then segment with -copyts so the segments
 # keep it. A reader that mistakes an absolute source PTS for playlist time seeks to the wrong end of

--- a/Sources/AetherEngine/IO/HLSIngest/HLSVODIngestReader.swift
+++ b/Sources/AetherEngine/IO/HLSIngest/HLSVODIngestReader.swift
@@ -126,6 +126,13 @@ final class HLSVODIngestReader: TimeSeekableIOReader, @unchecked Sendable {
         condition.withLock { resolved?.duration ?? 0 }
     }
 
+    /// EXTINF sum in front of each segment. A conforming HLS segment opens on a random-access point,
+    /// so these are the only boundaries the segment plan may advertise: a finer synthetic grid puts
+    /// boundaries where no keyframe is, and a restart there overshoots to the next IRAP (AE#268).
+    var segmentStartTimesSeconds: [Double] {
+        condition.withLock { resolved?.starts ?? [] }
+    }
+
     func read(_ buffer: UnsafeMutablePointer<UInt8>?, size: Int32) -> Int32 {
         guard let buffer, size > 0 else { return -1 }
         startIfNeeded()
@@ -228,9 +235,20 @@ final class HLSVODIngestReader: TimeSeekableIOReader, @unchecked Sendable {
     /// contract and the engine's packet gate drops what precedes the exact target. A target past the
     /// end clamps to the last segment rather than failing, which keeps a rounding overshoot at the
     /// final boundary playable.
+    ///
+    /// A target sitting just BELOW a segment start counts as that segment: the plan built on this
+    /// playlist backs each boundary off by `HLSVideoEngine.segmentedPlanBoundaryBackoff` so an IRAP can
+    /// never fall below its own boundary (AE#268), and without the same tolerance here every such seek
+    /// would fetch one more segment than it needs. The tolerance uses that same formula, so it can
+    /// never reach past the previous segment start.
     static func restartSegmentIndex(forElapsed elapsed: Double, starts: [Double]) -> Int {
         guard !starts.isEmpty else { return 0 }
-        let containing = starts.lastIndex(where: { $0 <= elapsed }) ?? 0
+        var shortest = Double.greatestFiniteMagnitude
+        for i in 1..<max(1, starts.count) where starts[i] > starts[i - 1] {
+            shortest = min(shortest, starts[i] - starts[i - 1])
+        }
+        let tolerance = shortest.isFinite ? min(0.5, shortest / 2) : 0
+        let containing = starts.lastIndex(where: { $0 <= elapsed + tolerance }) ?? 0
         return max(0, containing - 1)
     }
 

--- a/Sources/AetherEngine/IO/IOReader.swift
+++ b/Sources/AetherEngine/IO/IOReader.swift
@@ -28,6 +28,16 @@ protocol TimeSeekableIOReader: IOReader {
     /// (`Demuxer.repositionTimeSeekable`). Landing at or before the requested time is the contract;
     /// the demuxer's packet gate drops what precedes the exact target.
     func seek(to seconds: Double) -> Bool
+
+    /// Elapsed media time in front of each of the source's own segments, ascending, starting at 0.
+    /// These are the source's declared random-access points: the segment plan is built on them so
+    /// every advertised boundary is one the producer's keyframe gate can actually open (AE#268).
+    /// Empty when the reader has no segment structure to report.
+    var segmentStartTimesSeconds: [Double] { get }
+}
+
+extension TimeSeekableIOReader {
+    var segmentStartTimesSeconds: [Double] { [] }
 }
 
 public extension IOReader {

--- a/Sources/AetherEngine/Video/HLSSegmentProducer.swift
+++ b/Sources/AetherEngine/Video/HLSSegmentProducer.swift
@@ -153,6 +153,12 @@ final class HLSSegmentProducer: @unchecked Sendable {
     /// Start PTS (source video TB) for each segment at baseIndex+i; used to detect segment crossings.
     private let segmentBoundaries: [Int64]
 
+    /// Source PTS of plan time 0 (the plan's `firstKeyframePts`). The item axis every consumer sees is
+    /// `sourcePts - planAnchorVideoPts`, so this is what maps an item-axis timestamp back onto a plan
+    /// boundary. Deliberately NOT `videoShiftPts`: the shift additionally carries whatever this
+    /// producer's gate overshot its restart target by (AE#268).
+    private let planAnchorVideoPts: Int64
+
     /// Live mode: cuts at keyframes past targetSegmentDurationSeconds; ignores segmentBoundaries.
     private let isLive: Bool
 
@@ -719,6 +725,7 @@ final class HLSSegmentProducer: @unchecked Sendable {
         desiredFirstVideoTfdtPts: Int64,
         desiredFirstAudioTfdtPts: Int64 = 0,
         segmentBoundaries: [Int64],
+        planAnchorVideoPts: Int64 = 0,
         isLive: Bool = false,
         packedSideAudioStartPts: Int64? = nil,
         packedSideAudioFallbackDurationPts: Int64 = 0,
@@ -765,7 +772,12 @@ final class HLSSegmentProducer: @unchecked Sendable {
         self.sourceVideoTimeBase = video.timeBase
         self.targetSegmentDurationSeconds = targetSegmentDurationSeconds
         self.segmentBoundaries = segmentBoundaries
-        self.vodCutter = VODSegmentCutter(boundaries: segmentBoundaries, baseIndex: baseIndex)
+        self.planAnchorVideoPts = planAnchorVideoPts
+        self.vodCutter = VODSegmentCutter(
+            sourceBoundaries: segmentBoundaries,
+            planAnchorPts: planAnchorVideoPts,
+            baseIndex: baseIndex
+        )
         self.isLive = isLive
         self.liveCurrentSegmentIndex = baseIndex
         self.videoFallbackDurationPts = videoFallbackDurationPts
@@ -866,10 +878,19 @@ final class HLSSegmentProducer: @unchecked Sendable {
         return Double(sourceVideoTimeBase.num) / Double(sourceVideoTimeBase.den)
     }
 
-    /// Map post-shift pts to absolute segment index. Folds shift back before comparing against source-axis boundaries.
+    /// Map post-shift (item-axis) pts to absolute segment index.
+    ///
+    /// AE#268: folds back the PLAN ANCHOR, not `videoShiftPts`. The two are equal whenever the gate
+    /// opened on the boundary the restart aimed at, but a restart that landed off a random-access
+    /// point carries the whole overshoot in the shift, and folding that back routed audio into a
+    /// segment index the video cutter never opened (a 10 s GOP under a 4 s plan skewed them by up to
+    /// two segments). The anchor is what the plan's item axis is defined against, so it is what maps
+    /// an item-axis timestamp onto a plan boundary.
     private func segmentIndex(forSourcePts pts: Int64) -> Int {
-        let absolute = videoShiftPts == Int64.min ? pts : pts &+ videoShiftPts
-        return baseIndex + Self.segmentOffset(forAbsolutePts: absolute, boundaries: segmentBoundaries)
+        return baseIndex + Self.segmentOffset(
+            forAbsolutePts: pts &+ planAnchorVideoPts,
+            boundaries: segmentBoundaries
+        )
     }
 
     /// Source-axis value of a timestamp the pump has already rebased onto the output axis
@@ -1236,7 +1257,9 @@ final class HLSSegmentProducer: @unchecked Sendable {
         }
     }
 
-    /// Returns [start, end) on the AVPlayer axis for subtitle injection. VOD: from segmentBoundaries+videoShiftPts. Live: from liveSegmentStartByIndex.
+    /// Returns [start, end) on the AVPlayer axis for subtitle injection. VOD: from segmentBoundaries
+    /// minus the plan anchor (AE#268: the anchor defines the item axis; the shift carries a restart's
+    /// gate overshoot on top of it and would move the window under the cues). Live: from liveSegmentStartByIndex.
     private func segmentWindowAVPlayerSeconds(
         segIdx: Int,
         nextSegIdx: Int
@@ -1251,8 +1274,8 @@ final class HLSSegmentProducer: @unchecked Sendable {
             let i = segIdx - baseIndex
             let iNext = nextSegIdx - baseIndex
             guard i >= 0, iNext < segmentBoundaries.count else { return nil }
-            let t0 = Double(segmentBoundaries[i] - videoShiftPts) * sourceVideoTbSeconds
-            let t1 = Double(segmentBoundaries[iNext] - videoShiftPts) * sourceVideoTbSeconds
+            let t0 = Double(segmentBoundaries[i] - planAnchorVideoPts) * sourceVideoTbSeconds
+            let t1 = Double(segmentBoundaries[iNext] - planAnchorVideoPts) * sourceVideoTbSeconds
             return (t0, t1)
         }
     }

--- a/Sources/AetherEngine/Video/HLSVideoEngine+SegmentPlanning.swift
+++ b/Sources/AetherEngine/Video/HLSVideoEngine+SegmentPlanning.swift
@@ -100,6 +100,79 @@ extension HLSVideoEngine {
         return plan
     }
 
+    /// Backoff applied to every boundary of a plan built from a source's DECLARED segment starts.
+    ///
+    /// The manifest axis (EXTINF sums) and the container's real PTS are two measurements of the same
+    /// boundary, and they differ by whatever the segmenter rounded. A boundary that lands even a
+    /// millisecond PAST its own IRAP is worse than one that lands early: the producer's scan-forward
+    /// gate takes the first keyframe at-or-after the boundary, so it skips the whole segment and opens
+    /// a GOP late. Pulling each boundary slightly below its segment start keeps the IRAP inside the
+    /// segment it is supposed to open. Capped below half the shortest segment so a backed-off boundary
+    /// can never reach back to the PREVIOUS segment's IRAP.
+    static func segmentedPlanBoundaryBackoff(shortestSegmentSeconds: Double) -> Double {
+        guard shortestSegmentSeconds > 0 else { return 0 }
+        return min(0.5, shortestSegmentSeconds / 2)
+    }
+
+    /// Plan built from a segmented source's own boundaries (AE#268: the HLS VOD ingest's EXTINF sums).
+    ///
+    /// A segmented source declares where its random-access points are, and those are the only
+    /// boundaries the plan may advertise. The uniform fallback ignores that and lays a 4 s grid over a
+    /// source whose GOP can be much longer: on the reporter's 10 s-GOP MPEG-TS VOD only every fifth
+    /// grid boundary coincided with an IRAP, so a restart at any other index opened its gate up to 8 s
+    /// (two whole plan segments) late, and every downstream index mapping skewed by that overshoot
+    /// until AVPlayer starved on a segment that never arrived (CoreMediaErrorDomain -12889). Boundaries
+    /// that ARE the source's own segment starts make the overshoot structurally zero.
+    ///
+    /// `startPts0` anchors the source axis exactly like the other two builders (plan time 0 = the
+    /// content start), so `startSeconds` stays 0-based and every consumer's source <-> item mapping is
+    /// unchanged.
+    static func buildSegmentedSourcePlan(
+        segmentStartsSeconds: [Double],
+        videoTimeBase: AVRational,
+        sourceDurationSeconds: Double,
+        startPts0: Int64
+    ) -> [Segment] {
+        guard segmentStartsSeconds.count >= 2, sourceDurationSeconds > 0,
+              videoTimeBase.num > 0, videoTimeBase.den > 0 else { return [] }
+        let tb = Double(videoTimeBase.num) / Double(videoTimeBase.den)
+        guard tb > 0 else { return [] }
+        let starts = segmentStartsSeconds
+        guard starts[0] == 0 else { return [] }
+
+        var shortest = Double.greatestFiniteMagnitude
+        for i in 1..<starts.count {
+            let span = starts[i] - starts[i - 1]
+            guard span > 0 else { return [] }  // non-monotonic manifest: leave the source on the fallback
+            shortest = Swift.min(shortest, span)
+        }
+        // The manifest's own duration ends the final segment. A duration that does not even reach the
+        // last start is not usable (an estimate on a truncated container), so that case falls back to
+        // one more segment rather than a zero-length tail.
+        let lastStart = starts[starts.count - 1]
+        let end = sourceDurationSeconds > lastStart ? sourceDurationSeconds : lastStart + shortest
+        let backoff = segmentedPlanBoundaryBackoff(shortestSegmentSeconds: shortest)
+
+        // Segment 0 keeps the content start itself: there is nothing below it to back off toward, and
+        // the head-of-stream gate has no restart target anyway.
+        func boundaryPts(_ i: Int) -> Int64 {
+            i == 0 ? startPts0 : startPts0 + Int64((starts[i] - backoff) / tb)
+        }
+
+        var plan: [Segment] = []
+        plan.reserveCapacity(starts.count)
+        for i in 0..<starts.count {
+            let endSeconds = i + 1 < starts.count ? starts[i + 1] : end
+            plan.append(Segment(
+                startPts: boundaryPts(i),
+                endPts: i + 1 < starts.count ? boundaryPts(i + 1) : startPts0 + Int64(end / tb),
+                startSeconds: starts[i],
+                durationSeconds: Swift.max(0.001, endSeconds - starts[i])
+            ))
+        }
+        return plan
+    }
+
     /// Keyframe-aligned plan mirroring libavformat's hls muxer cut algorithm: segment N ends at the first keyframe where `(keyframe_pts - start_pts) >= (N+1) * targetDuration`. Absolute thresholds match the muxer; relative per-segment thresholds diverged on irregular GOPs.
     static func buildKeyframeSegmentPlan(
         keyframes: [Int64],

--- a/Sources/AetherEngine/Video/HLSVideoEngine.swift
+++ b/Sources/AetherEngine/Video/HLSVideoEngine.swift
@@ -879,7 +879,33 @@ public final class HLSVideoEngine: @unchecked Sendable {
                 videoTimeBase: videoTimeBase,
                 sourceDurationSeconds: durationSeconds
             )
-            if keyframes.count >= 2, indexTrustworthy {
+            // AE#268: a segmented source declares its own random-access points. Prefer them over both
+            // builders below: the index is sparse on MPEG-TS, and the uniform grid advertises
+            // boundaries no keyframe sits on (a 4 s grid over a 10 s GOP is producible on one boundary
+            // in five; a restart at any other one opens its gate a GOP late and skews every index
+            // mapping until AVPlayer starves).
+            let declaredSegmentStarts = dem.timeSeekableReader?.segmentStartTimesSeconds ?? []
+            let segmentedAnchorPts: Int64 = keyframes.sorted().first
+                ?? (videoStream.pointee.start_time != Int64.min
+                    ? max(0, videoStream.pointee.start_time) : 0)
+            let segmentedPlan = Self.buildSegmentedSourcePlan(
+                segmentStartsSeconds: declaredSegmentStarts,
+                videoTimeBase: videoTimeBase,
+                sourceDurationSeconds: durationSeconds,
+                startPts0: segmentedAnchorPts
+            )
+            if !segmentedPlan.isEmpty {
+                plan = segmentedPlan
+                self.firstKeyframePts = segmentedAnchorPts
+                self.firstKeyframeSeconds = Double(segmentedAnchorPts)
+                    * Double(videoTimeBase.num) / Double(videoTimeBase.den)
+                EngineLog.emit(
+                    "[HLSVideoEngine] segment plan: source-declared boundaries, "
+                    + "\(plan.count) segments [anchorPts=\(segmentedAnchorPts) "
+                    + "shortestSegment=\(String(format: "%.3f", plan.map { $0.durationSeconds }.min() ?? 0))s]",
+                    category: .session
+                )
+            } else if keyframes.count >= 2, indexTrustworthy {
                 plan = Self.buildKeyframeSegmentPlan(
                     keyframes: keyframes,
                     videoTimeBase: videoTimeBase,
@@ -1827,7 +1853,14 @@ public final class HLSVideoEngine: @unchecked Sendable {
             } ?? 0
         } else if baseIndex > 0, baseIndex < segmentPlan.count {
             videoTarget = segmentPlan[baseIndex].startPts
-            desiredVideoTfdt = segmentPlan[baseIndex].startPts - firstKeyframePts
+            // The produced timeline continues at the segment's ADVERTISED item-axis start, never at
+            // its (possibly backed-off) source boundary: `startPts` is a gate/seek target chosen to sit
+            // at-or-below the segment's IRAP (AE#268), while `startSeconds` is what the playlist told
+            // AVPlayer this segment starts at. Identical for the keyframe and uniform plans, where the
+            // boundary is the item-axis start plus the anchor.
+            desiredVideoTfdt = sourceVideoTbSeconds > 0
+                ? Int64((segmentPlan[baseIndex].startSeconds / sourceVideoTbSeconds).rounded())
+                : segmentPlan[baseIndex].startPts - firstKeyframePts
             // Rescale into source audio TB (not bridge.inputTimeBase=1/48000). The pre-fix bug
             // was FLAC-bridge-only: shift=-152485195 (off by 48x); stream-copy unaffected.
             desiredAudioTfdt = savedAudioConfig.map {
@@ -1865,6 +1898,7 @@ public final class HLSVideoEngine: @unchecked Sendable {
             desiredFirstVideoTfdtPts: desiredVideoTfdt,
             desiredFirstAudioTfdtPts: desiredAudioTfdt,
             segmentBoundaries: segmentBoundaries,
+            planAnchorVideoPts: firstKeyframePts,
             isLive: isLiveSession,
             packedSideAudioStartPts: packedSideAudioStartPts,
             packedSideAudioFallbackDurationPts: packedSideAudioFallbackDurationPts,

--- a/Sources/AetherEngine/Video/VODSegmentCutter.swift
+++ b/Sources/AetherEngine/Video/VODSegmentCutter.swift
@@ -14,21 +14,30 @@ import Foundation
 /// stream. The cut point is the only thing that changes; EXTINF still comes from the plan boundaries.
 struct VODSegmentCutter {
 
-    /// Plan boundaries in source PTS: `boundaries[i]` is the start PTS of segment `baseIndex + i`.
+    /// Plan boundaries on the ITEM axis: `boundaries[i]` is the start of segment `baseIndex + i` as
+    /// AVPlayer sees it, i.e. the plan's source PTS minus the plan anchor (plan time 0 in source PTS).
     /// `boundaries.count` is the segment count + 1 (the last entry is the end of the final segment).
+    ///
+    /// AE#268: packets reach the cutter with the producer's shift already subtracted, so they are on
+    /// the item axis; comparing them against SOURCE-axis boundaries offset every cut by the anchor,
+    /// and by the whole gate overshoot after a restart that landed off a random-access point. Both
+    /// axes now agree, which also lets a plan whose boundaries ARE the source's IRAPs cut on them
+    /// (against source boundaries such a keyframe never reaches its own boundary, so the cutter would
+    /// never advance).
     let boundaries: [Int64]
     let baseIndex: Int
     private(set) var current: Int
 
-    init(boundaries: [Int64], baseIndex: Int) {
-        self.boundaries = boundaries
+    init(sourceBoundaries: [Int64], planAnchorPts: Int64, baseIndex: Int) {
+        self.boundaries = sourceBoundaries.map { $0 &- planAnchorPts }
         self.baseIndex = baseIndex
         self.current = baseIndex
     }
 
-    /// Segment index for a video packet, in decode order. Advances on a keyframe that has reached the
-    /// next boundary; every other packet (and an intra-segment keyframe that has not yet reached the
-    /// next boundary, e.g. when the GOP is shorter than the segment) stays in the current segment.
+    /// Segment index for a video packet, in decode order, from its ITEM-axis presentation time.
+    /// Advances on a keyframe that has reached the next boundary; every other packet (and an
+    /// intra-segment keyframe that has not yet reached the next boundary, e.g. when the GOP is shorter
+    /// than the segment) stays in the current segment.
     mutating func index(pts: Int64, isKeyframe: Bool) -> Int {
         guard isKeyframe, pts != Int64.min else { return current }
         // boundaries[count-1] is the end of the final segment, not a segment start, so the last segment

--- a/Tests/AetherEngineTests/Issue268HLSVODIngestTests.swift
+++ b/Tests/AetherEngineTests/Issue268HLSVODIngestTests.swift
@@ -154,6 +154,19 @@ final class Issue268HLSVODIngestTests: XCTestCase {
         XCTAssertEqual(HLSVODIngestReader.restartSegmentIndex(forElapsed: 6.001, starts: starts), 0)
     }
 
+    /// A target sitting just below a segment start belongs to that segment. The plan built on this
+    /// playlist backs each boundary off so an IRAP can never fall below its own boundary (AE#268);
+    /// without the same tolerance here, every seek to such a boundary would refetch one segment more
+    /// than it needs. The tolerance uses the plan's own formula, so it never reaches the previous start.
+    func testRestartSegmentIndexSnapsATargetJustBelowASegmentStart() {
+        let starts: [Double] = [0, 10, 20, 30, 40]
+        XCTAssertEqual(HLSVODIngestReader.restartSegmentIndex(forElapsed: 29.5, starts: starts), 2)
+        XCTAssertEqual(HLSVODIngestReader.restartSegmentIndex(forElapsed: 28.9, starts: starts), 1)
+        // Short segments cap the tolerance at half a segment, so it cannot skip one.
+        let short: [Double] = [0, 0.4, 0.8, 1.2]
+        XCTAssertEqual(HLSVODIngestReader.restartSegmentIndex(forElapsed: 0.79, starts: short), 1)
+    }
+
     func testRestartSegmentIndexClampsAtBothEnds() {
         let starts: [Double] = [0, 6, 12]
         XCTAssertEqual(HLSVODIngestReader.restartSegmentIndex(forElapsed: 0, starts: starts), 0)
@@ -193,6 +206,30 @@ final class Issue268HLSVODIngestTests: XCTestCase {
         XCTAssertEqual(count, 188)
         XCTAssertEqual(bytes[0], 0x47)
         XCTAssertEqual(bytes[Self.markerOffset], 2, "20s sits in segment 3, so the ingest restarts at 2")
+    }
+
+    /// The reader publishes the playlist's own boundaries so the segment plan can be built on them
+    /// instead of a synthetic grid that lands between the source's IRAPs (AE#268).
+    func testReaderPublishesItsSegmentStarts() async throws {
+        let root = try XCTUnwrap(URL(string: "https://vod.test/starts.m3u8"))
+        let names = (0..<5).map { "starts\($0).ts" }
+        Issue268URLProtocol.bodyByURL[root.absoluteString] = mediaPlaylist(names)
+        for (index, name) in names.enumerated() {
+            Issue268URLProtocol.bodyByURL["https://vod.test/\(name)"] =
+                transportStream(streamType: 0x24, marker: UInt8(index))
+        }
+
+        let session = makeSession()
+        defer { session.invalidateAndCancel() }
+        let made = try await HLSVODIngestReader.makeIfHEVCMPEGTS(
+            playlistURL: root,
+            httpHeaders: [:],
+            session: session
+        )
+        let reader = try XCTUnwrap(made)
+        defer { reader.close() }
+
+        XCTAssertEqual(reader.segmentStartTimesSeconds, [0, 6, 12, 18, 24])
     }
 
     /// Byte seeks stay refused: the concatenated segment stream has no address space, and answering a

--- a/Tests/AetherEngineTests/SegmentPlanDeclaredBoundariesTests.swift
+++ b/Tests/AetherEngineTests/SegmentPlanDeclaredBoundariesTests.swift
@@ -1,0 +1,153 @@
+// Segment plan built from a segmented source's OWN boundaries (AE#268).
+//
+// The reporter's source is a finite HEVC-in-MPEG-TS HLS VOD: 10 s segments, one I-frame per segment,
+// PTS origin 1.48 s. Its keyframe index is sparse (MPEG-TS carries no upfront table), so the plan fell
+// back to the uniform 4 s stride, which advertises boundaries no keyframe sits on: only every fifth
+// grid boundary coincided with an IRAP. A restart at any other index made the producer's scan-forward
+// gate open up to 8 s (two whole plan segments) late, every downstream index mapping skewed by that
+// overshoot, and AVPlayer starved on a segment that never arrived (CoreMediaErrorDomain -12889). The
+// seek that passed on device (122.000 s -> plan index 30 -> 120 s, a multiple of both 4 and 10) was
+// exactly the one-in-five aligned case.
+import Foundation
+import Testing
+import Libavutil
+@testable import AetherEngine
+
+@Suite("Segment plan from source-declared boundaries (AE#268)")
+struct SegmentPlanDeclaredBoundariesTests {
+
+    private let ts90k = AVRational(num: 1, den: 90_000)
+
+    /// 1.48 s PTS origin, the reporter's (and ffmpeg's default) MPEG-TS start.
+    private let anchor: Int64 = Int64(1.48 * 90_000)
+
+    /// 120 x 10 s starts, the fixture that reproduces the report.
+    private var tenSecondStarts: [Double] { (0..<120).map { Double($0) * 10 } }
+
+    /// Every I-frame of a 10 s-GOP source, in source PTS.
+    private func irapsEvery10s(count: Int) -> [Int64] {
+        (0..<count).map { anchor + Int64(Double($0) * 10 * 90_000) }
+    }
+
+    /// The property the whole fix rests on: for every advertised boundary, the first IRAP at-or-after
+    /// it must still fall inside that segment. Where it does not, the producer's gate opens in a LATER
+    /// segment than the one the restart was aimed at.
+    private func firstIRAPStaysInsideItsSegment(plan: [HLSVideoEngine.Segment], iraps: [Int64]) -> Bool {
+        for (i, segment) in plan.enumerated() where i + 1 < plan.count {
+            guard let firstAtOrAfter = iraps.first(where: { $0 >= segment.startPts }) else { continue }
+            if firstAtOrAfter >= plan[i + 1].startPts { return false }
+        }
+        return true
+    }
+
+    @Test("Declared boundaries keep every segment's own IRAP inside it")
+    func declaredBoundariesAreProducible() {
+        let plan = HLSVideoEngine.buildSegmentedSourcePlan(
+            segmentStartsSeconds: tenSecondStarts,
+            videoTimeBase: ts90k,
+            sourceDurationSeconds: 1200,
+            startPts0: anchor
+        )
+        #expect(plan.count == 120)
+        #expect(firstIRAPStaysInsideItsSegment(plan: plan, iraps: irapsEvery10s(count: 120)))
+    }
+
+    @Test("The uniform 4 s grid does not: that is the reported defect")
+    func uniformGridStrandsMostBoundaries() {
+        // Same source, the pre-fix plan. Four boundaries in five have their IRAP in a later segment,
+        // which is what a restart at those indices runs into.
+        let plan = HLSVideoEngine.buildUniformSegmentPlan(
+            videoTimeBase: ts90k,
+            sourceDurationSeconds: 1200,
+            startPts0: anchor
+        )
+        #expect(plan.count == 300)
+        #expect(firstIRAPStaysInsideItsSegment(plan: plan, iraps: irapsEvery10s(count: 120)) == false)
+    }
+
+    @Test("The item axis stays the manifest's own: startSeconds are the EXTINF sums")
+    func itemAxisMatchesTheManifest() {
+        let plan = HLSVideoEngine.buildSegmentedSourcePlan(
+            segmentStartsSeconds: tenSecondStarts,
+            videoTimeBase: ts90k,
+            sourceDurationSeconds: 1200,
+            startPts0: anchor
+        )
+        #expect(plan[0].startSeconds == 0)
+        #expect(plan[63].startSeconds == 630)
+        #expect(plan[63].durationSeconds == 10)
+        #expect(plan.last?.startSeconds == 1190)
+    }
+
+    @Test("Boundaries are backed off below their IRAP, never past the previous one")
+    func boundariesBackOffBelowTheirIRAP() {
+        let plan = HLSVideoEngine.buildSegmentedSourcePlan(
+            segmentStartsSeconds: tenSecondStarts,
+            videoTimeBase: ts90k,
+            sourceDurationSeconds: 1200,
+            startPts0: anchor
+        )
+        let backoff = HLSVideoEngine.segmentedPlanBoundaryBackoff(shortestSegmentSeconds: 10)
+        #expect(backoff == 0.5)
+        // Segment 0 keeps the content start itself; every later boundary sits `backoff` below its IRAP.
+        #expect(plan[0].startPts == anchor)
+        for i in [1, 2, 63, 119] {
+            let irap = anchor + Int64(plan[i].startSeconds * 90_000)
+            #expect(plan[i].startPts == irap - Int64(backoff * 90_000))
+            #expect(plan[i].startPts > anchor + Int64((plan[i].startSeconds - 10) * 90_000))
+        }
+    }
+
+    @Test("Short segments cap the backoff below half a segment")
+    func shortSegmentsCapTheBackoff() {
+        #expect(HLSVideoEngine.segmentedPlanBoundaryBackoff(shortestSegmentSeconds: 0.4) == 0.2)
+        #expect(HLSVideoEngine.segmentedPlanBoundaryBackoff(shortestSegmentSeconds: 0) == 0)
+        let plan = HLSVideoEngine.buildSegmentedSourcePlan(
+            segmentStartsSeconds: [0, 0.4, 0.8, 1.2],
+            videoTimeBase: ts90k,
+            sourceDurationSeconds: 1.6,
+            startPts0: anchor
+        )
+        #expect(plan.count == 4)
+        // A backed-off boundary must stay strictly above the previous segment's start, or a restart
+        // would open on the previous segment's IRAP.
+        for i in 1..<plan.count {
+            #expect(plan[i].startPts > anchor + Int64(plan[i - 1].startSeconds * 90_000))
+        }
+    }
+
+    @Test("A manifest that cannot be trusted leaves the source on the existing builders")
+    func rejectsUnusableManifests() {
+        // Fewer than two starts, a non-zero first start, and a non-monotonic list all return empty so
+        // the caller falls through to the keyframe / uniform plan.
+        #expect(HLSVideoEngine.buildSegmentedSourcePlan(
+            segmentStartsSeconds: [0], videoTimeBase: ts90k,
+            sourceDurationSeconds: 100, startPts0: anchor).isEmpty)
+        #expect(HLSVideoEngine.buildSegmentedSourcePlan(
+            segmentStartsSeconds: [10, 20], videoTimeBase: ts90k,
+            sourceDurationSeconds: 100, startPts0: anchor).isEmpty)
+        #expect(HLSVideoEngine.buildSegmentedSourcePlan(
+            segmentStartsSeconds: [0, 10, 10], videoTimeBase: ts90k,
+            sourceDurationSeconds: 100, startPts0: anchor).isEmpty)
+        #expect(HLSVideoEngine.buildSegmentedSourcePlan(
+            segmentStartsSeconds: [0, 10, 20], videoTimeBase: ts90k,
+            sourceDurationSeconds: 0, startPts0: anchor).isEmpty)
+    }
+
+    @Test("A trailing short segment keeps its own EXTINF, and the plan spans the source")
+    func trailingSegmentIsPreserved() {
+        // The reporter's playlist ends on an 8.76 s segment.
+        var starts = (0..<270).map { Double($0) * 10 }
+        starts[269] = 2690
+        let plan = HLSVideoEngine.buildSegmentedSourcePlan(
+            segmentStartsSeconds: starts,
+            videoTimeBase: ts90k,
+            sourceDurationSeconds: 2698.76,
+            startPts0: anchor
+        )
+        #expect(plan.count == 270)
+        #expect(abs((plan.last?.durationSeconds ?? 0) - 8.76) < 0.001)
+        let spanned = (plan.last?.startSeconds ?? 0) + (plan.last?.durationSeconds ?? 0)
+        #expect(abs(spanned - 2698.76) < 0.001)
+    }
+}

--- a/Tests/AetherEngineTests/VODSegmentCutterTests.swift
+++ b/Tests/AetherEngineTests/VODSegmentCutterTests.swift
@@ -7,19 +7,19 @@ final class VODSegmentCutterTests: XCTestCase {
     private let fourSeg: [Int64] = [0, 4000, 8000, 12000, 16000]
 
     func testFirstKeyframeOpensBaseSegment() {
-        var c = VODSegmentCutter(boundaries: fourSeg, baseIndex: 0)
+        var c = VODSegmentCutter(sourceBoundaries: fourSeg, planAnchorPts: 0, baseIndex: 0)
         XCTAssertEqual(c.index(pts: 0, isKeyframe: true), 0)   // first IRAP stays in seg 0
     }
 
     func testNonKeyframesStayInCurrentSegment() {
-        var c = VODSegmentCutter(boundaries: fourSeg, baseIndex: 0)
+        var c = VODSegmentCutter(sourceBoundaries: fourSeg, planAnchorPts: 0, baseIndex: 0)
         _ = c.index(pts: 0, isKeyframe: true)
         XCTAssertEqual(c.index(pts: 1000, isKeyframe: false), 0)
         XCTAssertEqual(c.index(pts: 2000, isKeyframe: false), 0)
     }
 
     func testBoundaryKeyframeOpensNextSegment() {
-        var c = VODSegmentCutter(boundaries: fourSeg, baseIndex: 0)
+        var c = VODSegmentCutter(sourceBoundaries: fourSeg, planAnchorPts: 0, baseIndex: 0)
         _ = c.index(pts: 0, isKeyframe: true)
         XCTAssertEqual(c.index(pts: 4000, isKeyframe: true), 1)   // IRAP at 4s opens seg 1
         XCTAssertEqual(c.index(pts: 8000, isKeyframe: true), 2)
@@ -29,7 +29,7 @@ final class VODSegmentCutterTests: XCTestCase {
     /// The #92 fix: open-GOP RASL leading pictures arrive in decode order AFTER the CRA but carry a PTS
     /// BEFORE it. They must stay in the CRA's segment, not be re-routed to the previous one.
     func testRaslLeadingPicturesStayWithTheirKeyframe() {
-        var c = VODSegmentCutter(boundaries: fourSeg, baseIndex: 0)
+        var c = VODSegmentCutter(sourceBoundaries: fourSeg, planAnchorPts: 0, baseIndex: 0)
         _ = c.index(pts: 0, isKeyframe: true)
         XCTAssertEqual(c.index(pts: 4000, isKeyframe: true), 1)    // CRA opens seg 1
         XCTAssertEqual(c.index(pts: 3958, isKeyframe: false), 1)   // RASL, pts < CRA -> stays in seg 1
@@ -41,7 +41,7 @@ final class VODSegmentCutterTests: XCTestCase {
     /// must NOT open a new segment.
     func testIntraSegmentKeyframeDoesNotCut() {
         let twoSeg: [Int64] = [0, 8000, 16000]   // 8s segments
-        var c = VODSegmentCutter(boundaries: twoSeg, baseIndex: 0)
+        var c = VODSegmentCutter(sourceBoundaries: twoSeg, planAnchorPts: 0, baseIndex: 0)
         _ = c.index(pts: 0, isKeyframe: true)
         XCTAssertEqual(c.index(pts: 4000, isKeyframe: true), 0)   // mid-segment IRAP stays in seg 0
         XCTAssertEqual(c.index(pts: 8000, isKeyframe: true), 1)   // boundary IRAP opens seg 1
@@ -49,20 +49,20 @@ final class VODSegmentCutterTests: XCTestCase {
 
     func testBaseIndexOffsetForRestart() {
         let b: [Int64] = [264_000, 268_000, 272_000, 276_000]   // 3 segments: 264, 265, 266
-        var c = VODSegmentCutter(boundaries: b, baseIndex: 264)
+        var c = VODSegmentCutter(sourceBoundaries: b, planAnchorPts: 0, baseIndex: 264)
         XCTAssertEqual(c.index(pts: 264_000, isKeyframe: true), 264)
         XCTAssertEqual(c.index(pts: 268_000, isKeyframe: true), 265)
         XCTAssertEqual(c.index(pts: 272_000, isKeyframe: true), 266)
     }
 
     func testSparseKeyframeJumpAdvancesMultiple() {
-        var c = VODSegmentCutter(boundaries: fourSeg, baseIndex: 0)
+        var c = VODSegmentCutter(sourceBoundaries: fourSeg, planAnchorPts: 0, baseIndex: 0)
         _ = c.index(pts: 0, isKeyframe: true)
         XCTAssertEqual(c.index(pts: 12000, isKeyframe: true), 3)   // skips 1,2 in one step
     }
 
     func testNeverAdvancesPastLastSegment() {
-        var c = VODSegmentCutter(boundaries: fourSeg, baseIndex: 0)
+        var c = VODSegmentCutter(sourceBoundaries: fourSeg, planAnchorPts: 0, baseIndex: 0)
         _ = c.index(pts: 0, isKeyframe: true)
         // Keyframes well past the final boundary clamp at the last segment (count-1 boundaries => seg 3).
         XCTAssertEqual(c.index(pts: 99_000, isKeyframe: true), 3)
@@ -70,8 +70,33 @@ final class VODSegmentCutterTests: XCTestCase {
     }
 
     func testNoptsKeyframeStaysPut() {
-        var c = VODSegmentCutter(boundaries: fourSeg, baseIndex: 0)
+        var c = VODSegmentCutter(sourceBoundaries: fourSeg, planAnchorPts: 0, baseIndex: 0)
         _ = c.index(pts: 0, isKeyframe: true)
         XCTAssertEqual(c.index(pts: Int64.min, isKeyframe: true), 0)
+    }
+
+    /// AE#268: packets arrive with the producer's shift already subtracted, so they are on the item
+    /// axis while the plan's boundaries are source PTS. On a source whose content starts at 1.48 s
+    /// (every MPEG-TS), comparing the two directly put each cut a whole anchor late; on a plan whose
+    /// boundaries ARE the source's IRAPs it never cut at all, because such a keyframe's item-axis pts
+    /// is exactly one anchor below its own boundary.
+    func testNonZeroPlanAnchorCutsOnTheItemAxis() {
+        let anchor: Int64 = 1480
+        let boundaries: [Int64] = [1480, 11480, 21480, 31480]   // IRAPs of a 10 s-segmented source
+        var c = VODSegmentCutter(sourceBoundaries: boundaries, planAnchorPts: anchor, baseIndex: 0)
+        XCTAssertEqual(c.index(pts: 0, isKeyframe: true), 0)
+        XCTAssertEqual(c.index(pts: 9999, isKeyframe: false), 0)
+        XCTAssertEqual(c.index(pts: 10_000, isKeyframe: true), 1)   // the source's own second IRAP
+        XCTAssertEqual(c.index(pts: 20_000, isKeyframe: true), 2)
+    }
+
+    /// A restart whose gate overshot its target still opens at `baseIndex`: the producer rebases the
+    /// gating keyframe onto the segment's advertised start, and the cutter sees exactly that.
+    func testRestartGateOvershootStillOpensBaseIndex() {
+        let anchor: Int64 = 1480
+        let boundaries: [Int64] = [641_480, 651_480, 661_480, 671_480]
+        var c = VODSegmentCutter(sourceBoundaries: boundaries, planAnchorPts: anchor, baseIndex: 64)
+        XCTAssertEqual(c.index(pts: 640_000, isKeyframe: true), 64)   // rebased onto seg 64's start
+        XCTAssertEqual(c.index(pts: 650_000, isKeyframe: true), 65)
     }
 }


### PR DESCRIPTION
Round 2 of #268, from the reporter's hardware retest against the original source on 6.4.0: route selection, finite-playlist resolution and a 122 s control seek are confirmed, while a 1055.79 s seek never recovers and dies with `CoreMediaErrorDomain -12889`.

## Root cause

The ingest route resolves the playlist, but the SEGMENT PLAN behind it does not use it. MPEG-TS has no upfront keyframe table, so `keyframeIndexIsTrustworthy` rejects the sparse index and the plan falls back to the uniform 4 s stride. The reporter's source carries one I-frame per 10 s segment, so only every fifth grid boundary is a random-access point:

- a restart at any other index makes the producer's scan-forward gate wait for the first IRAP at-or-after the boundary, up to 8 s (two whole plan segments) late;
- that overshoot rides in `videoShiftPts`, which the video cutter and the audio index mapping then fold back on two different axes, so they disagree by the overshoot;
- AVPlayer ends up waiting on a segment that never arrives, which is the engine's own `-12889` signature.

The control seek passed because 120 s is a multiple of both 4 and 10, the one alignment in five where a grid boundary is a real IRAP. Producer index 263 (1052 s) is not.

## Fix

- `TimeSeekableIOReader` publishes its segment starts; the HLS VOD ingest reports the playlist's EXTINF sums.
- The plan is built on those boundaries whenever a source declares them, so every advertised boundary is one the gate can open. Each boundary is backed off half a segment (0.5 s cap) so manifest-vs-PTS rounding cannot put a boundary past its own IRAP; the reader's restart index snaps with the same tolerance instead of refetching a segment more.
- `VODSegmentCutter` compares on the item axis rather than mixing shift-rebased packet timestamps with source-axis boundaries. That mismatch cut a whole PTS origin late on every non-zero-origin source, and against boundaries that ARE the IRAPs it would never have cut at all.
- The audio index mapping folds back the plan anchor, not `videoShiftPts`.
- A restart's first tfdt is the segment's advertised item-axis start.

## Verification

New fixture (`fetch-fixtures.sh`): 20 min, 10 s segments, one I-frame each, served from a static local origin. The existing 2 s-GOP fixture cannot reproduce this, because every plan boundary there still catches a keyframe.

Same five scattered seek targets, including the reporter's 1055.79 s:

| | gate overshoot per restart |
|---|---|
| before | 0 / 4 / 0 / 2 / 6 s |
| after | 0.5 s on every restart (the plan's own boundary backoff) |

Before, the misaligned restarts also produced the reporter's other signature: repeated identical re-anchors at one index plus a stalled consumer. After, seven seeks land in 77-114 ms with no wedge, no re-anchor and no stall.

Regression: full suite green (1387 tests), tvOS Simulator build green, `-strict-concurrency=complete` clean. Smoke-checked on the keyframe-aligned MP4 path (drift stays 0.000 s), the 2 s-GOP #268 fixture, a plain long-GOP local MPEG-TS on the uniform plan, and the H.264 HLS control that must stay on the native route.

Residual, out of scope here: a plain long-GOP MPEG-TS with no manifest still gets the 4 s uniform grid, so a seek there can still land up to a GOP ahead of the clock. It recovers, unlike the #268 route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HX5zV3Fcf7Nzq4DYGdXvQE