### PR TITLE
fix(display): size the play-gate start grace by what can still switch (#274)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,28 @@ the public-API contract.
 
 ## [Unreleased]
 
-_Nothing yet._
+### Fixed
+
+- **The post-load play-gate only pays the Dolby Vision cold-start budget when a
+  dynamic-range switch can still reach the session.** The gate blind-polls up to
+  1000 ms for a panel switch to *start*, a budget sized for the one case that
+  needs it: a sole-writer host (`LoadOptions.suppressDisplayCriteria`) whose
+  criteria write lands during the load, from AVKit's auto path. Every other
+  session paid the same wait for a switch that could not arrive. Sessions where
+  the engine wrote the criteria itself (synchronously, before the item loads, and
+  already settled in the pre-flight for an HDR write) and sessions on SDR content,
+  which no dynamic-range write can follow, now take a 200 ms budget instead, the
+  value that was in place before the AVKit-sole-writer architecture raised it. A
+  switch that has genuinely started still settles in Stage 2 unchanged, and a
+  failed probe keeps the full budget because the source range is then unknown.
+  Reported and measured by @digilearn-dev (#274).
+
+- **A panel switch the engine did not initiate is no longer logged as a failed
+  HDR handshake.** When a sole-writer host's own criteria write settled with EDR
+  headroom at 1.0, the settle classification read `didApply == false` as the HDR
+  branch and emitted `WARN ... panel stayed SDR despite HDR criteria` for what
+  was a correct SDR rate-only switch. The engine has no target range to compare
+  against for a write it never made, and now says so (#274).
 
 ## [6.4.2] - 2026-08-02
 

--- a/Sources/AetherEngine/AetherEngine+Loading.swift
+++ b/Sources/AetherEngine/AetherEngine+Loading.swift
@@ -1575,7 +1575,15 @@ extension AetherEngine {
                 activeAudioDecoder = nativeVideoSession?.audioPipelineDescription
                 presentCurrentLayer()
                 // Wait for pending AVKit display-criteria handshake before resuming (first frame must not hit a mid-transition panel).
-                await displayCriteria.waitForSwitch()
+                // #274: this reload preserved the criteria (resetDisplayCriteria: false) and re-applies none,
+                // so only a sole-writer host's re-write on the swapped item can still switch anything; the
+                // published (panel-clamped) format decides whether that can be a dynamic-range switch.
+                await displayCriteria.waitForSwitch(startGrace: Self.playGateGrace(
+                    criteriaUnchanged: false,
+                    engineIsCriteriaWriter: !loadedOptions.suppressDisplayCriteria,
+                    formatKnown: true,
+                    effectiveFormat: videoFormat
+                ))
                 try checkLoadCurrent(gen)
                 nativeHost?.play()
             }

--- a/Sources/AetherEngine/AetherEngine+Probe.swift
+++ b/Sources/AetherEngine/AetherEngine+Probe.swift
@@ -357,6 +357,36 @@ extension AetherEngine {
         (suppressDisplayCriteria || audioOnlyPath) ? .clearStale : .applyFresh
     }
 
+    /// #274: how long the post-load play-gate blind-polls for a panel switch to start.
+    ///
+    /// The gate exists for one case: a sole-writer host (`suppressDisplayCriteria`) whose criteria write
+    /// lands during the load, from AVKit's auto path reading dvcC off the live AVPlayerItem. DV P5 has no
+    /// HDR10 base layer, so its first frame must not hit a panel that is still SDR, and 1000 ms is the
+    /// budget that made that land (5d60dbb2). Every other session paid the same 1000 ms for a switch that
+    /// could not arrive, which is dead startup time, not safety:
+    ///
+    /// - Engine-writer sessions wrote their criteria synchronously *before* `loadNative`. Whatever switch
+    ///   that write triggers has started long before the gate runs (and `.willSwitch` already settled it in
+    ///   the pre-flight), so a second full blind poll buys nothing.
+    /// - SDR content reaches no dynamic-range switch at all. The only write anyone can still make is
+    ///   rate-only, and the engine already declines to gate its own rate-only writes (`apply()` returns
+    ///   `.applied` with no pre-flight wait) because those switches are sub-second.
+    ///
+    /// `formatKnown` is false when the open-time probe failed: the real range is then unknown and a DV write
+    /// may still be inbound, so a suppressed host keeps the full budget.
+    nonisolated static func playGateGrace(
+        criteriaUnchanged: Bool,
+        engineIsCriteriaWriter: Bool,
+        formatKnown: Bool,
+        effectiveFormat: VideoFormat
+    ) -> DisplayCriteriaController.StartGrace {
+        // #133: the criteria were already active, nothing was written, nothing can settle.
+        if criteriaUnchanged { return .skip }
+        if engineIsCriteriaWriter { return .brief }
+        guard formatKnown else { return .full }
+        return effectiveFormat == .sdr ? .brief : .full
+    }
+
     /// Whitelist (not blacklist) of AVPlayer-native audio codecs: AAC, MP3, MP2, ALAC, AC-3/E-AC-3, LPCM, FLAC (native since iOS/tvOS 11). Anything else falls back to `AudioPlaybackHost` (FFmpeg).
     nonisolated static func avPlayerCanDecodeAudio(_ codecID: AVCodecID) -> Bool {
         switch codecID {

--- a/Sources/AetherEngine/AetherEngine.swift
+++ b/Sources/AetherEngine/AetherEngine.swift
@@ -2952,9 +2952,15 @@ public final class AetherEngine: ObservableObject {
                 // #133: unchanged criteria (same-format zap) mean the panel is already in the target mode and
                 // neither the engine nor AVKit will switch it, so there is nothing to settle here. Skipping
                 // avoids Stage 1's blind 1s (and, on unobservable-DV panels, the full ~3s cap) on every zap.
-                if !criteriaUnchanged {
-                    await displayCriteria.waitForSwitch()
-                }
+                // #274: the 1000ms Stage 1 budget is the DV-cold-start bet on a sole-writer host's inbound
+                // write. Sessions no dynamic-range switch can reach (engine-writer, or SDR content) take the
+                // 200ms budget instead of paying it on every load.
+                await displayCriteria.waitForSwitch(startGrace: Self.playGateGrace(
+                    criteriaUnchanged: criteriaUnchanged,
+                    engineIsCriteriaWriter: !options.suppressDisplayCriteria,
+                    formatKnown: probeOpened,
+                    effectiveFormat: effectiveFormat
+                ))
                 try checkLoadCurrent(gen)
                 // automaticallyWaitsToMinimizeStalling=true (default) handles play-before-ready.
                 // #35: on a real SDR->HDR switch while serving a VOD master, drive the bounded

--- a/Sources/AetherEngine/Display/DisplayCriteriaController.swift
+++ b/Sources/AetherEngine/Display/DisplayCriteriaController.swift
@@ -54,6 +54,48 @@ final class DisplayCriteriaController {
         return target.isHDR ? .willSwitch : .applied
     }
 
+    /// How long `waitForSwitch` blind-polls for a switch to *start* before giving up (Stage 1). The wait is
+    /// blind by construction: nothing reports "a criteria write is inbound", so the budget is a bet on the
+    /// writer's latency and every millisecond of it is startup time when the bet is wrong (#274).
+    enum StartGrace: Equatable {
+        /// Nothing can be pending; return before touching the display manager.
+        case skip
+        /// 200 ms: only a rate-only switch could still start (the pre-#274 budget, sized for a synchronous
+        /// engine write). Rate switches are sub-second and the engine already declines to gate its own.
+        case brief
+        /// 1000 ms: a dynamic-range switch may still be inbound from a writer whose timing we don't control
+        /// (AVKit's auto-criteria path fires from the AVPlayerItem formatDescription). DV P5 cold start
+        /// depends on this budget.
+        case full
+
+        var ticks: Int {
+            switch self {
+            case .skip:  0
+            case .brief: 20
+            case .full:  100
+            }
+        }
+    }
+
+    /// What a mode switch that ended with EDR headroom still at 1.0 means. Only the engine's own HDR write
+    /// makes that a failure; a switch the engine never initiated carries no target range it could check
+    /// against, so attributing one produced a false "panel stayed SDR despite HDR criteria" WARN on
+    /// sole-writer hosts (#274).
+    enum SwitchEndOutcome: Equatable {
+        /// Engine wrote SDR rate-only criteria: the panel staying SDR is the expected end state.
+        case rateOnlySettled
+        /// Engine wrote HDR criteria and the panel ended SDR: a real dynamic-range handshake failure.
+        case hdrHandshakeFailed
+        /// Engine never wrote this session (sole-writer host): the switch was somebody else's, its target
+        /// range is not knowable here.
+        case hostDrivenUnattributable
+    }
+
+    nonisolated static func switchEndOutcome(didApply: Bool, lastCriteriaWasHDR: Bool) -> SwitchEndOutcome {
+        guard didApply else { return .hostDrivenUnattributable }
+        return lastCriteriaWasHDR ? .hdrHandshakeFailed : .rateOnlySettled
+    }
+
     init() {}
 
     /// Program AVDisplayCriteria before the session starts. `.sdr` programs a rate-only criteria so Match Frame Rate still engages. `codecTag` nil derives from format (`'dvh1'` for DV, `'hvc1'` otherwise). `omitColorExtensions` skips BT.2020 extensions for diagnostic builds. Returns `.willSwitch` when a dynamic-range switch is expected (caller should call waitForSwitch), `.applied` for an SDR rate-only write, or `.unchanged` when the criteria are already active and nothing was written (#133).
@@ -168,8 +210,9 @@ final class DisplayCriteriaController {
     /// unobservable switch can't stall the first frame.
     ///
     /// Callers: the engine pre-flight gates this on `apply()`'s isHDR return; the
-    /// play-gate call after the host loads runs unconditionally, so SDR rate-only
-    /// switches still settle here via the in-progress flag as before.
+    /// play-gate call after the host loads sizes `startGrace` by what can still be
+    /// inbound (`AetherEngine.playGateGrace`), so a session that no dynamic-range
+    /// switch can reach doesn't pay the DV cold-start budget (#274).
     ///
     /// `preferredDisplayCriteria` is a *hint*: when Match Content is enabled the TV
     /// performs the switch over HDMI and reports progress via the AVDisplayManager
@@ -182,8 +225,9 @@ final class DisplayCriteriaController {
     /// timeout. Presenting slightly early on that fallback is at worst cosmetic:
     /// the panel is mid re-sync (black) during the handshake and shows the correct
     /// frame once it locks. The decode/color-correctness guard is Stage 1 below.
-    func waitForSwitch() async {
+    func waitForSwitch(startGrace: StartGrace = .full) async {
         #if os(tvOS)
+        guard startGrace != .skip else { return }
         guard let window = resolveWindow() else { return }
         let displayManager = window.avDisplayManager
         let screen = window.screen
@@ -214,13 +258,13 @@ final class DisplayCriteriaController {
             NotificationCenter.default.removeObserver(endToken)
         }
 
-        // Stage 1: up to 1000ms for the switch to actually start. The handshake
+        // Stage 1: `startGrace` for the switch to actually start. The handshake
         // initiates asynchronously after the criteria write (and AVKit's sole-writer
         // path fires it later than the engine pre-flight), so give it headroom
         // before the DV asset loads; starting the decode mid-write races an
         // AVPlayer error on DV Profile 8.1.
         var sawSwitchStart = false
-        for _ in 0..<100 {
+        for _ in 0..<startGrace.ticks {
             if switchEnded.fired || screen.currentEDRHeadroom > 1.001 {
                 EngineLog.emit("[DisplayCriteria] settled during start phase (EDR headroom \(String(format: "%.2f", screen.currentEDRHeadroom)))", category: .engine)
                 return
@@ -231,10 +275,11 @@ final class DisplayCriteriaController {
             }
             try? await Task.sleep(for: .milliseconds(10))
         }
+        let startBudgetMs = startGrace.ticks * 10
         if !sawSwitchStart {
-            // No switch started within 1000ms: panel already satisfies the criteria
+            // No switch started within the grace: panel already satisfies the criteria
             // or the setter was a no-op. Don't block; AVPlayer tonemaps or errors for real.
-            EngineLog.emit("[DisplayCriteria] no switch started (EDR headroom \(String(format: "%.2f", screen.currentEDRHeadroom)) after 1000ms); proceeding", category: .engine)
+            EngineLog.emit("[DisplayCriteria] no switch started (EDR headroom \(String(format: "%.2f", screen.currentEDRHeadroom)) after \(startBudgetMs)ms); proceeding", category: .engine)
             return
         }
 
@@ -246,7 +291,7 @@ final class DisplayCriteriaController {
         let capTicks = 40  // 40 x 50ms = 2000ms
         for tick in 0..<capTicks {
             try? await Task.sleep(for: .milliseconds(50))
-            let elapsed = (tick + 1) * 50 + 1000
+            let elapsed = (tick + 1) * 50 + startBudgetMs
             if switchEnded.fired {
                 EngineLog.emit("[DisplayCriteria] switch settled via modeSwitchEnd (~\(elapsed)ms)", category: .engine)
                 return
@@ -257,17 +302,23 @@ final class DisplayCriteriaController {
             }
             if !displayManager.isDisplayModeSwitchInProgress {
                 // Headroom is still 1.0 here (the EDR check above runs first each tick).
-                if didApply && !lastCriteriaWasHDR {
+                switch Self.switchEndOutcome(didApply: didApply, lastCriteriaWasHDR: lastCriteriaWasHDR) {
+                case .rateOnlySettled:
                     // SDR rate-only criteria: refresh-rate switch settled, panel correctly stayed SDR.
                     EngineLog.emit("[DisplayCriteria] rate-only switch settled (~\(elapsed)ms, SDR, EDR headroom 1.0 as expected)", category: .engine)
-                } else {
+                case .hdrHandshakeFailed:
                     // HDR was requested but panel ended in SDR: real dynamic-range handshake failure.
                     EngineLog.emit("[DisplayCriteria] WARN switch ended (~\(elapsed)ms) but EDR headroom still 1.0 (panel stayed SDR despite HDR criteria)", category: .engine)
+                case .hostDrivenUnattributable:
+                    // #274: sole-writer host. The engine wrote nothing, so it has no target range to compare
+                    // the SDR end state against; a host SDR rate write ending SDR is correct and used to be
+                    // logged as an HDR handshake failure.
+                    EngineLog.emit("[DisplayCriteria] host switch ended (~\(elapsed)ms, EDR headroom 1.0; engine wrote no criteria this session, target range unknown)", category: .engine)
                 }
                 return
             }
         }
-        EngineLog.emit("[DisplayCriteria] proceed after ~\(capTicks * 50 + 1000)ms cap (switch not observable, likely DV; EDR headroom \(String(format: "%.2f", screen.currentEDRHeadroom)))", category: .engine)
+        EngineLog.emit("[DisplayCriteria] proceed after ~\(capTicks * 50 + startBudgetMs)ms cap (switch not observable, likely DV; EDR headroom \(String(format: "%.2f", screen.currentEDRHeadroom)))", category: .engine)
         #endif
     }
 

--- a/Tests/AetherEngineTests/DisplayCriteriaPlayGateTests.swift
+++ b/Tests/AetherEngineTests/DisplayCriteriaPlayGateTests.swift
@@ -1,0 +1,89 @@
+import Testing
+@testable import AetherEngine
+
+// #274: the post-load play-gate called waitForSwitch() with the same 1000 ms Stage 1 budget on every load.
+// That budget exists for one case, a sole-writer host whose criteria write lands during the load (AVKit's
+// auto path, DV P5 cold start). Sessions no dynamic-range switch can reach paid it as dead startup time,
+// and the Stage 2 classification attributed a host-driven switch that ended SDR to a failed HDR handshake.
+// Both are pure decisions; this suite covers them.
+@Suite("DisplayCriteria play-gate grace and switch-end attribution")
+struct DisplayCriteriaPlayGateTests {
+
+    // MARK: - Stage 1 budget
+
+    @Test("Unchanged criteria skip the gate entirely (#133 behaviour preserved)")
+    func unchangedCriteriaSkip() {
+        #expect(AetherEngine.playGateGrace(
+            criteriaUnchanged: true, engineIsCriteriaWriter: true,
+            formatKnown: true, effectiveFormat: .dolbyVision) == .skip)
+        #expect(AetherEngine.playGateGrace(
+            criteriaUnchanged: true, engineIsCriteriaWriter: false,
+            formatKnown: false, effectiveFormat: .sdr) == .skip)
+    }
+
+    @Test("Engine-writer sessions take the brief budget: their write already happened, pre-load and synchronously")
+    func engineWriterIsBrief() {
+        for format: VideoFormat in [.sdr, .hdr10, .hdr10Plus, .hlg, .dolbyVision] {
+            #expect(AetherEngine.playGateGrace(
+                criteriaUnchanged: false, engineIsCriteriaWriter: true,
+                formatKnown: true, effectiveFormat: format) == .brief)
+        }
+    }
+
+    @Test("Sole-writer host with HDR/DV content keeps the full budget (the DV P5 cold-start case the gate exists for)")
+    func suppressedHostHDRIsFull() {
+        for format: VideoFormat in [.hdr10, .hdr10Plus, .hlg, .dolbyVision] {
+            #expect(AetherEngine.playGateGrace(
+                criteriaUnchanged: false, engineIsCriteriaWriter: false,
+                formatKnown: true, effectiveFormat: format) == .full)
+        }
+    }
+
+    @Test("Sole-writer host with SDR content takes the brief budget: only a rate-only write can still arrive")
+    func suppressedHostSDRIsBrief() {
+        #expect(AetherEngine.playGateGrace(
+            criteriaUnchanged: false, engineIsCriteriaWriter: false,
+            formatKnown: true, effectiveFormat: .sdr) == .brief)
+    }
+
+    @Test("Sole-writer host keeps the full budget when the probe failed and the range is unknown")
+    func suppressedHostUnknownFormatIsFull() {
+        // effectiveFormat defaults to .sdr on a failed probe, so the format alone must not decide here.
+        #expect(AetherEngine.playGateGrace(
+            criteriaUnchanged: false, engineIsCriteriaWriter: false,
+            formatKnown: false, effectiveFormat: .sdr) == .full)
+    }
+
+    @Test("Budgets are the documented millisecond values")
+    func graceTicks() {
+        #expect(DisplayCriteriaController.StartGrace.skip.ticks == 0)
+        #expect(DisplayCriteriaController.StartGrace.brief.ticks == 20)   // 20 x 10ms = 200ms
+        #expect(DisplayCriteriaController.StartGrace.full.ticks == 100)   // 100 x 10ms = 1000ms
+    }
+
+    // MARK: - Stage 2 attribution
+
+    @Test("Engine HDR criteria ending with headroom 1.0 stays a real handshake failure")
+    func engineHDRFailureStillWarns() {
+        #expect(DisplayCriteriaController.switchEndOutcome(
+            didApply: true, lastCriteriaWasHDR: true) == .hdrHandshakeFailed)
+    }
+
+    @Test("Engine SDR rate-only criteria ending SDR is the expected outcome")
+    func engineRateOnlySettles() {
+        #expect(DisplayCriteriaController.switchEndOutcome(
+            didApply: true, lastCriteriaWasHDR: false) == .rateOnlySettled)
+    }
+
+    @Test("A switch the engine never wrote is unattributable, not an HDR failure")
+    func hostDrivenSwitchIsUnattributable() {
+        // The reporter's symptom: a host SDR rate write, mid-load, logged as
+        // "panel stayed SDR despite HDR criteria" because didApply was false.
+        #expect(DisplayCriteriaController.switchEndOutcome(
+            didApply: false, lastCriteriaWasHDR: false) == .hostDrivenUnattributable)
+        // lastCriteriaWasHDR is stale state from a previous session once didApply is false; it must not
+        // resurrect the HDR verdict.
+        #expect(DisplayCriteriaController.switchEndOutcome(
+            didApply: false, lastCriteriaWasHDR: true) == .hostDrivenUnattributable)
+    }
+}


### PR DESCRIPTION
Closes nothing yet: reporter retest pending.

## What the report found

With `LoadOptions.suppressDisplayCriteria = true` the engine skips its own `apply()` (only `.clearStale` runs), but the post-load play-gate still called `waitForSwitch()` with the same budget as every other session. @digilearn-dev measured a residual startup cost on VOD loads where nothing was in flight for the engine to wait on, plus a mis-attributed `WARN ... panel stayed SDR despite HDR criteria` for a switch their own host had initiated.

## Root cause

Two independent defects, both from the gate not knowing who writes criteria.

**1. Stage 1 budget.** `waitForSwitch` Stage 1 blind-polls for a switch to *start*. It went 200 ms -> 1000 ms in 5d60dbb2 for one architecture: an AVKit-sole-writer host whose criteria write fires from the live `AVPlayerItem.formatDescription` during the load. DV P5 has no HDR10 base layer, so its first frame must not hit an SDR panel, and that budget is what made the cold start land. Every other session paid it for a write that could not arrive:

- **Engine-writer sessions** wrote synchronously *before* `loadNative`. Whatever switch that triggered started long before the gate runs, and a `.willSwitch` was already settled by the pre-flight `waitForSwitch`. A second full blind poll buys nothing.
- **SDR content** reaches no dynamic-range switch at all. The only write still possible is rate-only, and the engine already declines to gate its own rate-only writes (`apply()` returns `.applied` with no pre-flight wait) because those settle sub-second.

**2. Settle attribution.** Stage 2's classification was `didApply && !lastCriteriaWasHDR -> rate-only, else -> WARN HDR failure`. On a sole-writer host `didApply` is false, so a host SDR rate write that correctly ended SDR fell into the HDR-failure branch. The engine cannot attribute a switch it did not initiate.

## The fix

`waitForSwitch(startGrace:)` takes `.skip` / `.brief` (200 ms) / `.full` (1000 ms). `AetherEngine.playGateGrace` is the pure decision:

| session | grace |
|---|---|
| criteria unchanged (#133 same-format zap) | skip |
| engine is the criteria writer | brief |
| sole-writer host, probe failed (range unknown) | full |
| sole-writer host, SDR content | brief |
| sole-writer host, HDR/DV content | full |

A switch that genuinely started still settles in Stage 2 unchanged, and the entry fast-exit on EDR headroom is untouched, so an already-HDR panel still returns instantly. The audio-switch reload gate routes through the same rule: it preserves the criteria (`resetDisplayCriteria: false`) and re-applies none, so only a host re-write on the swapped item can switch anything there.

`switchEndOutcome(didApply:lastCriteriaWasHDR:)` adds the third case and logs it neutrally instead of warning.

## What deliberately did not change

The report proposed skipping `waitForSwitch` entirely when `suppressDisplayCriteria == true`. That is the one case the gate was built for (5d60dbb2, validated on DrHurt's Build 173 DV P8.4 testing), so skipping there would trade this startup cost for a DV P5 cold-start regression on AVKit-auto hosts. The budget is now sized by whether a dynamic-range switch can reach the session, which covers the reporter's SDR loads without touching that guarantee.

## Verification

- `swift test`: 1396 tests in 210 suites pass, including the new `DisplayCriteriaPlayGateTests` (both decisions are pure).
- `xcodebuild -scheme AetherEngine -destination 'generic/platform=tvOS Simulator' build`: clean.
- Device verification of the startup timing is the reporter's retest; their host already logs `applyTiming` / `isHDRCriteria`, and the new `no switch started ... after 200ms` line names the budget that was used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HX5zV3Fcf7Nzq4DYGdXvQE