### PR TITLE
subtitle-resolution: state the retained contiguous determination span (#276)

### DIFF
--- a/Sources/AetherEngine/AetherEngine+SubtitleResolution.swift
+++ b/Sources/AetherEngine/AetherEngine+SubtitleResolution.swift
@@ -46,17 +46,28 @@ extension AetherEngine {
             decodedThrough: cursor?.lastDecodedPts ?? .nan,
             prefetchFrontier: SubtitlePrefetchTelemetry.resolutionFrontier(matching: fence),
             prefetchAtEndOfFile: SubtitlePrefetchTelemetry.reachedEndOfFile(matching: fence),
+            // #276: the retained run's floor. Read straight off the cursor, which the drain tick
+            // has already folded for this tick; nothing is recomputed here.
+            retainedFrom: cursor?.retained?.from,
             reason: reason)
+    }
+
+    /// Emit an already-built statement. The drain tick builds one per tick either way, because
+    /// #276 banks its `resolvedThrough` into the retained run's high-water whether or not the line
+    /// is worth printing, and rebuilding it for the print would read the telemetry twice.
+    func emitSubtitleResolutionStatement(_ statement: SubtitleResolutionStatement.Statement,
+                                         channel: SubtitleChannel) {
+        subtitleResolutionLastFrontier[channel] = statement.via
+        EngineLog.emit(SubtitleResolutionStatement.format(statement), category: .engine)
     }
 
     func emitSubtitleResolutionStatement(
         channel: SubtitleChannel, streamIndex: Int32,
         reason: SubtitleResolutionStatement.Reason
     ) {
-        let statement = subtitleResolutionStatement(channel: channel, streamIndex: streamIndex,
-                                                    reason: reason)
-        subtitleResolutionLastFrontier[channel] = statement.via
-        EngineLog.emit(SubtitleResolutionStatement.format(statement), category: .engine)
+        emitSubtitleResolutionStatement(
+            subtitleResolutionStatement(channel: channel, streamIndex: streamIndex, reason: reason),
+            channel: channel)
     }
 
     /// A change of frontier source is a step change in what the engine can claim, so it is worth a

--- a/Sources/AetherEngine/AetherEngine+Subtitles.swift
+++ b/Sources/AetherEngine/AetherEngine+Subtitles.swift
@@ -272,16 +272,25 @@ extension AetherEngine {
             // #250: a reset starts a fresh contiguous decoded run; a steady tick extends the one
             // already running.
             var coverageStart = subtitleDrainCursors[channel]?.coverageStart
+            // #276: the run retained across seeks. Folded here, banked after the decode.
+            var retained = subtitleDrainCursors[channel]?.retained
+            let isReset: Bool
             switch plan {
             case .idle:
                 subtitleDrainCursors[channel]?.lastPlayhead = playhead
+                // #276: an idle tick decoded nothing, so it banks nothing into the retained run.
+                // The frontier may well have moved under it; folding that in would claim
+                // determination the drainer never performed.
                 emitSubtitleResolutionStatementIfFrontierChanged(channel: channel,
                                                                  streamIndex: streamIndex)
                 continue
             case .decode(let from, let through):
+                isReset = false
                 window = (from, through)
             case .resetAndDecode(let from, let through):
+                isReset = true
                 coverageStart = from
+                retained = SubtitleResolutionStatement.fold(retained, windowFrom: from)
                 subtitleDrainDecoders[channel] = nil
                 // Fresh selection or seek: the backscan decodes compositions BEHIND the
                 // playhead. Run them through the gate's reconstruction admission so the
@@ -330,10 +339,13 @@ extension AetherEngine {
                 // steady ticks rescan it without re-triggering the discontinuity path.
                 lastDecoded = window.from
             }
+            // #276: floor now, ceiling after the statement below states it.
+            let runRetained = retained ?? .init(from: coverageStart ?? window.from, through: nil)
             subtitleDrainCursors[channel] = SubtitleDrainCursor(
                 lastDecodedPts: lastDecoded ?? window.from,
                 lastPlayhead: playhead,
-                coverageStart: coverageStart ?? window.from)
+                coverageStart: coverageStart ?? window.from,
+                retained: runRetained)
             // #143/#204: a renderable composition at/after the playhead ends reconstruction while
             // decoding above. If the pass remains active with a candidate after the whole window,
             // finalize it. Raw packet presence cannot answer this: the landing line's own zero-object
@@ -362,12 +374,18 @@ extension AetherEngine {
             }
             if didMutate { publishRetainedSubtitleCues(cues, for: channel) }
             // #250: the post-seek window has decoded, so state how far determination reaches.
-            if case .resetAndDecode = plan {
-                emitSubtitleResolutionStatement(channel: channel, streamIndex: streamIndex,
-                                                reason: .reconstruction)
-            } else {
-                emitSubtitleResolutionStatementIfFrontierChanged(channel: channel,
-                                                                 streamIndex: streamIndex)
+            // #276: one statement value per decoding tick, built whether or not it is printed. Its
+            // `resolvedThrough` is this run's determined end under the fence that is live RIGHT
+            // NOW, and banking it here is the only place it can be had: by the next reset tick the
+            // seek generation has moved on and the outgoing run's frontier no longer passes its
+            // own fence.
+            let statement = subtitleResolutionStatement(
+                channel: channel, streamIndex: streamIndex,
+                reason: isReset ? .reconstruction : .frontier)
+            subtitleDrainCursors[channel]?.retained = SubtitleResolutionStatement.extend(
+                runRetained, with: statement.resolvedThrough)
+            if isReset || subtitleResolutionLastFrontier[channel] != statement.via {
+                emitSubtitleResolutionStatement(statement, channel: channel)
             }
         }
         // #151: a jump (seek / producer re-anchor) moves the drain window out from under the

--- a/Sources/AetherEngine/Diagnostics/SubtitleResolutionStatement.swift
+++ b/Sources/AetherEngine/Diagnostics/SubtitleResolutionStatement.swift
@@ -65,6 +65,31 @@ enum SubtitleResolutionStatement {
         }
     }
 
+    /// #276: the RETAINED contiguous decoded run, folded across seeks.
+    ///
+    /// `coveredFrom` is the current run's window start and resets on every discontinuity, so after
+    /// a far seek it can neither affirm nor refute that determination still reaches back to track
+    /// start. That is the one truth class the statement could not express: "empty because nothing
+    /// was ever authored before this point" needs coverage back to the earliest point that could
+    /// change the answer, and on a PGS track a composition established minutes earlier is still
+    /// the displayed state.
+    ///
+    /// The engine does retain that determination: `reanchorSubtitleOverlays` deliberately leaves a
+    /// drained channel's cues in place across a seek and only rebuilds the decoder and the stale
+    /// arrival gate. What was missing is the bookkeeping, not the state. This is it.
+    struct Retention: Equatable, Sendable {
+        /// Earliest source time from which the retained decoded display state is contiguous. Like
+        /// `coveredFrom` it is an upper bound on where determination begins and is deliberately
+        /// unclamped: on a container with `start_time != 0` a clamp to zero would claim coverage
+        /// below the first PTS, the exact over-claim this whole line exists to avoid.
+        var from: Double
+        /// High-water of the retained run's determined end. nil until a run states one. Advanced
+        /// only by ticks that actually decoded, so an idle tick's unobserved frontier growth is
+        /// never folded in: a high-water that lags reads as a gap at the next reset, which
+        /// restarts the run and under-claims. That is the safe direction.
+        var through: Double?
+    }
+
     struct Statement: Equatable, Sendable {
         var fence: Fence
         var streamIndex: Int32
@@ -75,7 +100,44 @@ enum SubtitleResolutionStatement {
         /// The last packet actually handed to the overlay decoder. Kept alongside
         /// `resolvedThrough` so a sparse stretch stays distinguishable from a starved one.
         var decodedThrough: Double
+        /// #276: `Retention.from`, or nil when nothing is retained yet. Never later than
+        /// `coveredFrom`; the two are separate claims and neither substitutes for the other.
+        var retainedFrom: Double?
         var reason: Reason
+    }
+
+    /// #276: fold a fresh decode run's window start into the retained run.
+    ///
+    /// The runs join only when the new window starts INSIDE the retained span. Two rejections
+    /// matter and both would otherwise be silent over-claims:
+    ///
+    /// - `windowFrom > through`: a forward seek past everything the old run determined leaves a
+    ///   hole nobody decoded, and the 15 s backscan does not reach back over it.
+    /// - `windowFrom < from`: a backward seek starting below the retained floor. The union is two
+    ///   disjoint intervals until the new run's determination climbs up to the old floor, so the
+    ///   retained span restarts on the new window rather than spanning the hole. The old run's
+    ///   ceiling is dropped with it, which under-claims the top of a region nobody is asking
+    ///   about: questions are asked at the playhead, which just moved below it.
+    static func fold(_ retained: Retention?, windowFrom: Double) -> Retention {
+        guard let retained, let through = retained.through,
+              windowFrom >= retained.from, windowFrom <= through else {
+            return Retention(from: windowFrom, through: nil)
+        }
+        return retained
+    }
+
+    /// #276: bank a tick's determined end into the retained run's high-water.
+    ///
+    /// Called on the tick that produced the value, never reconstructed later: at a reset tick the
+    /// engine's `seekGeneration` has already advanced, so the outgoing run's frontier no longer
+    /// passes its own fence and asking for it then would be exactly the cross-generation
+    /// combination the fence forbids. Stamping it while it is live is not that: the engine is
+    /// recording its own history at the moment it was valid.
+    static func extend(_ retained: Retention, with determinedThrough: Double?) -> Retention {
+        guard let determinedThrough, determinedThrough.isFinite else { return retained }
+        var next = retained
+        next.through = max(retained.through ?? determinedThrough, determinedThrough)
+        return next
     }
 
     /// Which frontier bounds the claim. Split out because the drain tick needs it every tick to
@@ -101,6 +163,11 @@ enum SubtitleResolutionStatement {
     ///   - prefetchFrontier: the side reader's banked read position, or nil when it is unusable.
     ///     The caller is responsible for the fence check; an unfenced position is worse than none.
     ///   - prefetchAtEndOfFile: the fenced session ended at EOF.
+    ///   - retainedFrom: `Retention.from` for the channel, or nil when nothing is retained. The
+    ///     only field on the line that deliberately outlives a seek generation, because it is the
+    ///     engine's own reconciliation of runs it fenced itself. It dies with the drain cursor,
+    ///     which is cleared by every track switch and every session teardown, so it is still
+    ///     load-fenced.
     static func make(
         fence: Fence,
         streamIndex: Int32,
@@ -109,6 +176,7 @@ enum SubtitleResolutionStatement {
         decodedThrough: Double,
         prefetchFrontier: Double?,
         prefetchAtEndOfFile: Bool,
+        retainedFrom: Double?,
         reason: Reason
     ) -> Statement {
         let via = self.via(prefetchFrontier: prefetchFrontier,
@@ -125,16 +193,18 @@ enum SubtitleResolutionStatement {
         }
         return Statement(fence: fence, streamIndex: streamIndex, coveredFrom: coveredFrom,
                          resolvedThrough: resolved, via: via, decodedThrough: decodedThrough,
-                         reason: reason)
+                         retainedFrom: retainedFrom, reason: reason)
     }
 
     static func format(_ s: Statement) -> String {
         let resolved = s.resolvedThrough.map { String(format: "%.2f", $0) } ?? "none"
         let decoded = s.decodedThrough.isFinite ? String(format: "%.2f", s.decodedThrough) : "none"
+        let retained = s.retainedFrom.map { String(format: "%.2f", $0) } ?? "none"
         return "[AetherEngine] #250 subtitle-resolution "
             + "loadGen=\(s.fence.loadGeneration) seekGen=\(s.fence.seekGeneration) "
             + "stream=\(s.streamIndex) "
             + "coveredFrom=\(String(format: "%.2f", s.coveredFrom)) "
+            + "retainedFrom=\(retained) "
             + "resolvedThrough=\(resolved) "
             + "via=\(s.via.rawValue) "
             + "decodedThrough=\(decoded) "

--- a/Sources/AetherEngine/Subtitles/SubtitleOverlayDrainer.swift
+++ b/Sources/AetherEngine/Subtitles/SubtitleOverlayDrainer.swift
@@ -15,6 +15,11 @@ struct SubtitleDrainCursor: Sendable {
     /// `.resetAndDecode`. Steady ticks decode forward from the cursor, so the tick's own window
     /// start says nothing about how far back determination reaches. nil until the first reset.
     var coverageStart: Double? = nil
+    /// #276: the retained run, i.e. the same span folded ACROSS seeks for as long as the runs keep
+    /// touching. Lives on the cursor because the cursor's lifetime is exactly the claim's: both are
+    /// cleared by `stopSubtitleDrainer` and by every track switch, and those are the same points
+    /// that empty the channel's cue array.
+    var retained: SubtitleResolutionStatement.Retention? = nil
 }
 
 enum SubtitleDrainPlan: Equatable, Sendable {

--- a/Tests/AetherEngineTests/Issue250SubtitleResolutionTests.swift
+++ b/Tests/AetherEngineTests/Issue250SubtitleResolutionTests.swift
@@ -22,6 +22,7 @@ struct Issue250SubtitleResolutionTests {
         decodedThrough: Double = 1204,
         prefetchFrontier: Double? = nil,
         prefetchAtEndOfFile: Bool = false,
+        retainedFrom: Double? = 1185,
         reason: SubtitleResolutionStatement.Reason = .reconstruction
     ) -> SubtitleResolutionStatement.Statement {
         SubtitleResolutionStatement.make(
@@ -29,6 +30,7 @@ struct Issue250SubtitleResolutionTests {
             coveredFrom: coveredFrom, windowThrough: windowThrough,
             decodedThrough: decodedThrough,
             prefetchFrontier: prefetchFrontier, prefetchAtEndOfFile: prefetchAtEndOfFile,
+            retainedFrom: retainedFrom,
             reason: reason)
     }
 
@@ -199,6 +201,7 @@ struct Issue250SubtitleResolutionTests {
         #expect(line.contains("loadGen=3 seekGen=7 "))
         #expect(line.contains("stream=4 "))
         #expect(line.contains("coveredFrom=1185.00 "))
+        #expect(line.contains("retainedFrom=1185.00 "))   // #276
         #expect(line.contains("resolvedThrough=1218.00 "))
         #expect(line.contains("via=prefetch "))
         #expect(line.contains("decodedThrough=1204.00 "))

--- a/Tests/AetherEngineTests/Issue276RetainedCoverageTests.swift
+++ b/Tests/AetherEngineTests/Issue276RetainedCoverageTests.swift
@@ -1,0 +1,171 @@
+import Foundation
+import Testing
+@testable import AetherEngine
+
+/// #276 (cmcpherson274): the #250 statement could express every truth class its harness needed
+/// except one, "empty because nothing was ever authored before this point". Adjudicating that as
+/// determined emptiness rather than a dead pipeline needs coverage back to track start, and
+/// `coveredFrom` resets to `target - backscan` on every discontinuity. The pre-seek line does carry
+/// the bound, but under the previous `seekGen`, and combining across the fence is exactly what the
+/// fence forbids. So the engine has to do the reconciling and state the result: `retainedFrom`.
+///
+/// The claim is real rather than optimistic bookkeeping: `reanchorSubtitleOverlays` leaves a
+/// drained channel's cues in place across a seek by design and rebuilds only the decoder and the
+/// stale-arrival gate. What was missing was the record of it.
+///
+/// Every case here is one way the field could lie. A diagnostic that over-claims is worse than no
+/// diagnostic, because the harness adjudicates on it.
+struct Issue276RetainedCoverageTests {
+
+    private typealias Retention = SubtitleResolutionStatement.Retention
+
+    // MARK: - Folding a fresh run into the retained one
+
+    /// The reporter's case. A load run covered from before track start and determined through 40;
+    /// a far seek to 30 opens its window at 15, inside that span. The runs touch, so the floor
+    /// survives the seek and the line can still state coverage back past zero.
+    @Test("a seek landing inside the retained span keeps the floor")
+    func contiguousSeekKeepsTheFloor() {
+        let folded = SubtitleResolutionStatement.fold(Retention(from: -15, through: 40),
+                                                      windowFrom: 15)
+        #expect(folded.from == -15)
+        #expect(folded.through == 40)
+    }
+
+    /// Abutting is touching. A window that opens exactly at the determined end leaves no undecoded
+    /// second between the runs, so there is nothing to over-claim.
+    @Test("a window opening exactly at the determined end still joins")
+    func abuttingRunsJoin() {
+        #expect(SubtitleResolutionStatement.fold(Retention(from: -15, through: 40),
+                                                 windowFrom: 40).from == -15)
+    }
+
+    /// The over-claim the fold exists to prevent. A seek far enough forward that the 15 s backscan
+    /// does not reach back over the hole leaves a span nobody decoded, and a floor spanning it
+    /// would state determination over content the engine never saw.
+    @Test("a forward seek past the determined end starts a new run")
+    func forwardSeekPastTheEndStartsOver() {
+        let folded = SubtitleResolutionStatement.fold(Retention(from: -15, through: 40),
+                                                      windowFrom: 285)
+        #expect(folded.from == 285)
+        #expect(folded.through == nil, "the old run's ceiling does not carry over a hole")
+    }
+
+    /// The mirror image, and the subtler one: a backward seek whose window opens BELOW the retained
+    /// floor. `windowFrom <= through` holds, but the union is two disjoint intervals until the new
+    /// run's determination climbs back up to the old floor, so the retained span restarts on the
+    /// new window. The old ceiling goes with it, which under-claims a region above a playhead that
+    /// just moved below it.
+    @Test("a backward seek below the retained floor starts a new run")
+    func backwardSeekBelowTheFloorStartsOver() {
+        let folded = SubtitleResolutionStatement.fold(Retention(from: 100, through: 160),
+                                                      windowFrom: -5)
+        #expect(folded.from == -5)
+        #expect(folded.through == nil)
+    }
+
+    /// A run that never stated a determined end vouches for nothing, so nothing can be folded into
+    /// it. This is the state right after a reset whose reader had not banked a position yet.
+    @Test("a run with no determined end cannot be extended into")
+    func runWithoutACeilingCannotBeJoined() {
+        let folded = SubtitleResolutionStatement.fold(Retention(from: 15, through: nil),
+                                                      windowFrom: 20)
+        #expect(folded.from == 20)
+    }
+
+    /// The first run of a session seeds the floor from its own window, unclamped: a container with
+    /// `start_time != 0` must not have coverage claimed below its first PTS.
+    @Test("the first run seeds the floor from its window, unclamped")
+    func firstRunSeedsTheFloor() {
+        let seeded = SubtitleResolutionStatement.fold(nil, windowFrom: -15)
+        #expect(seeded.from == -15)
+        #expect(seeded.through == nil)
+    }
+
+    // MARK: - Banking the determined end
+
+    /// The high-water only ever moves forward. A tick whose frontier sits behind the retained
+    /// ceiling (a backward seek leaves the reader ahead of the new window, so its early ticks
+    /// resolve short) must not pull the ceiling down and manufacture a hole at the next seek.
+    @Test("the determined end is a high-water mark")
+    func determinedEndIsAHighWater() {
+        var run = SubtitleResolutionStatement.extend(Retention(from: -15, through: nil), with: 40)
+        #expect(run.through == 40)
+        run = SubtitleResolutionStatement.extend(run, with: 25)
+        #expect(run.through == 40)
+        run = SubtitleResolutionStatement.extend(run, with: 90)
+        #expect(run.through == 90)
+    }
+
+    /// A tick that determined nothing states nothing. `resolvedThrough` is nil whenever the window
+    /// holds no usable frontier, and folding that in as a zero would put the ceiling below the
+    /// floor and read as a hole forever after.
+    @Test("an unresolved tick banks nothing")
+    func unresolvedTickBanksNothing() {
+        let run = Retention(from: -15, through: 40)
+        #expect(SubtitleResolutionStatement.extend(run, with: nil).through == 40)
+        #expect(SubtitleResolutionStatement.extend(run, with: .nan).through == 40)
+        #expect(SubtitleResolutionStatement.extend(Retention(from: -15, through: nil),
+                                                   with: nil).through == nil)
+    }
+
+    // MARK: - The two claims stay separate
+
+    /// `retainedFrom` is never later than `coveredFrom`: a fold either keeps a floor that is at or
+    /// below the new window start, or restarts on that same window start. The harness reads them
+    /// as a pair, and an inversion would mean one of them is not what it says it is.
+    @Test("the retained floor is never later than the reset window")
+    func retainedFloorNeverExceedsCoveredFrom() {
+        for windowFrom in stride(from: -30.0, through: 300.0, by: 7.5) {
+            let folded = SubtitleResolutionStatement.fold(Retention(from: -15, through: 40),
+                                                          windowFrom: windowFrom)
+            #expect(folded.from <= windowFrom)
+        }
+    }
+
+    /// End to end on the reporter's fixture: PGS whose first display set is at 88.380, a load run
+    /// determined through 40, a far seek to 30. The line states a reset window of 15 and a retained
+    /// floor of -15 at the same time, under the CURRENT seek generation, so the harness never has
+    /// to combine two lines to reach track start.
+    @Test("a far seek states the reset window and the retained floor together")
+    func farSeekStatesBothFloors() {
+        let retained = SubtitleResolutionStatement.fold(Retention(from: -15, through: 40),
+                                                        windowFrom: 15)
+        let s = SubtitleResolutionStatement.make(
+            fence: .init(loadGeneration: 3, seekGeneration: 8),
+            streamIndex: 4,
+            coveredFrom: 15, windowThrough: 90, decodedThrough: .nan,
+            prefetchFrontier: 92, prefetchAtEndOfFile: false,
+            retainedFrom: retained.from, reason: .reconstruction)
+        #expect(s.coveredFrom == 15)
+        #expect(s.retainedFrom == -15)
+        #expect(s.resolvedThrough == 90)
+        let line = SubtitleResolutionStatement.format(s)
+        #expect(line.contains("coveredFrom=15.00 "))
+        #expect(line.contains("retainedFrom=-15.00 "))
+    }
+
+    /// The honest negative, and the reason the field is not simply pinned to the load window: seek
+    /// to 30 before the reader ever passed 15 and the span between them is a real hole that the
+    /// backscan does not fill. The floor rises to the new window and the harness correctly fails to
+    /// prove track-start coverage.
+    @Test("a seek before the reader reached the window states no retained coverage")
+    func seekAheadOfTheReaderDropsTheFloor() {
+        let retained = SubtitleResolutionStatement.fold(Retention(from: -15, through: 3),
+                                                        windowFrom: 15)
+        #expect(retained.from == 15)
+    }
+
+    /// Nothing retained is stated as nothing, not as a position. A cursor-less channel has decoded
+    /// no run at all, and "none" has to stay distinguishable from a floor that happens to be 0.
+    @Test("no retained run formats as none")
+    func noRetainedRunFormatsAsNone() {
+        let s = SubtitleResolutionStatement.make(
+            fence: .init(loadGeneration: 1, seekGeneration: 1),
+            streamIndex: 4,
+            coveredFrom: 15, windowThrough: 90, decodedThrough: .nan,
+            prefetchFrontier: nil, prefetchAtEndOfFile: false,
+            retainedFrom: nil, reason: .tick)
+        #expect(SubtitleResolutionStatement.format(s).contains("retainedFrom=none "))
+    }
+}


### PR DESCRIPTION
Closes nothing yet: #276 stays open until the reporter's harness has retested.

## The gap

The #250 statement can express every truth class the reporter's conformance harness needs except one: **"empty because nothing was ever authored before this point"**. On a PGS track whose first display set is at 88.380, a seek to 30 correctly renders nothing, but adjudicating that as *determined* emptiness rather than a dead pipeline needs coverage reaching back to track start, the earliest point that could change the answer.

`coveredFrom` cannot carry that: it is the last reset's window start, so after a far seek it reads `target - 15`. The load-time line does carry `coveredFrom=-15.00`, but under the previous `seekGen`, and combining across the fence is exactly what the fence exists to forbid.

## What was actually missing

Not the state, the record of it. `reanchorSubtitleOverlays` deliberately leaves a drained channel's cues in place across a seek and rebuilds only the decoder and the PGS stale-arrival gate. The determination survives; `SubtitleDrainCursor.coverageStart` just overwrites its own history at every `.resetAndDecode`.

## The change

`SubtitleDrainCursor` gains a `Retention` (a floor plus a high-water of the run's determined end). A reset **folds** the fresh window into it instead of overwriting, and the line states the floor as a new `retainedFrom=` field, placed next to `coveredFrom` because they are read as a pair.

```
[AetherEngine] #250 subtitle-resolution loadGen=3 seekGen=8 stream=4 coveredFrom=15.00 retainedFrom=-15.00 resolvedThrough=90.00 via=prefetch decodedThrough=none reason=reconstruction
```

`coveredFrom` is untouched. The two are separate claims: `coveredFrom` is seek-fenced, `retainedFrom` deliberately outlives a seek generation because it is the engine reconciling runs it fenced itself, and it dies with the drain cursor, which every track switch and every teardown clears. So it is still load-fenced.

## Two things a naive build gets wrong

- **The outgoing run's determined end cannot be fetched at the reset tick.** By then `seekGeneration` has advanced and the prefetch frontier no longer passes its own fence, so asking for it there would be the cross-generation combination the fence forbids. It is banked on the tick that produced it, while it was live. The drain tick therefore builds one statement per decoding tick whether or not the line is printed, and reuses it for the emission.
- **The runs join only when the new window opens INSIDE the retained span.** A forward seek past the determined end leaves a hole the 15 s backscan does not reach back over. A backward seek starting below the retained floor leaves two disjoint intervals until the new run climbs back up. Both restart the run rather than span the gap. An idle tick decoded nothing and banks nothing, so unobserved frontier growth is never folded in; a lagging high-water reads as a gap and under-claims, which is the safe direction.

## Not built, and why

- **The first-successor variant** from the issue does not answer the case on its own: the covered floor is 15 after the seek, so a display set at 5 would not be refuted. With `retainedFrom` it is redundant.
- **Real store harvest coverage** ("the store was filled from 0") would be unfounded. The producer tap has no read-position surface at all, which is why `via=pump` is the weak state in #250.

## Known limit

Seek to 30 before the reader ever passed 15 and `retainedFrom` reads 15. That is correct rather than a miss: the span between them was genuinely never decoded, and the backscan does not fill it.

## Verification

- 1408 tests / 211 suites green (`swift test`), including 12 new in `Issue276RetainedCoverageTests`, one per way the field could lie.
- `xcodebuild -scheme AetherEngine -destination 'generic/platform=tvOS Simulator' build` clean, no new warnings.
- `swift build -Xswiftc -strict-concurrency=complete` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HX5zV3Fcf7Nzq4DYGdXvQE