### PR TITLE
fix(hls): break the live backpressure/blocking-reload deadlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,24 @@ the public-API contract.
   to an unobservable DV panel: it reads the same attribution the settle branch
   got in #274, so an engine rate-only write that never reports an end says so
   rather than claiming DV. Measured from the logs on Sodalite#49.
+- **Live sessions no longer freeze 6-8 s at a time when the producer's
+  backpressure park meets an LL-HLS blocking reload.** The advance park
+  released only on a client segment GET, while the client's held
+  `?_HLS_msn=` reload was only satisfiable by a producer cut — and the held
+  reload occupies the serialized keep-alive connection, starving the very
+  segment GET that would release the park. The 18 s hold then expired into
+  `503 unsatisfiable` long after AVPlayer's ~4 s forward buffer had drained
+  into `playbackStalled`. Live production is source-paced now: the advance
+  and versioned-init parks are VOD-only, replaced on live by a logged
+  resident-segment runaway guard that releases on window eviction instead of
+  consumer fetches. Three aggravators fixed alongside: the sliding window is
+  sized by the observed segment cadence instead of the cut target (fastZap's
+  0.5 s target vs ~2 s GOPs inflated the window 4x, pinning MEDIA-SEQUENCE
+  at 0 and deferring `evictBelow` for minutes), the stall-recovery item
+  reload now honors `LiveReloadPolicy` (live rejoin: no stale-clock resume,
+  no zero-tolerance initial seek), and the blocking-reload hold is bounded
+  by `3 x` the sealed TARGETDURATION (= the advertised HOLD-BACK) instead of
+  a hardcoded 18 s. VOD paths are byte-identical.
 
 ## [6.4.4] - 2026-08-02
 

--- a/Sources/AetherEngine/AetherEngine.swift
+++ b/Sources/AetherEngine/AetherEngine.swift
@@ -1679,14 +1679,20 @@ public final class AetherEngine: ObservableObject {
         stallRecoveryWindowUntil = Date().addingTimeInterval(Self.stallRecoveryWindowSeconds)
         EngineLog.emit(
             "[AetherEngine] #65 nudge did not revive the consumer; reloading item at "
-            + "\(String(format: "%.2f", anchor))s"
+            + (isLive ? "the live edge (rejoin)" : "\(String(format: "%.2f", anchor))s")
             + Self.recoveryAnchorLogSuffix(
                 anchor: anchor, position: position,
                 pendingSeekTarget: pendingRecoverySeekClockTarget)
             + " (same URL, same host)",
             category: .engine
         )
-        host.load(url: url, startPosition: anchor, inPlaceSwap: true)
+        // Live reload = live REJOIN: no stale-clock resume, no explicit start seek — the
+        // zero-tolerance seek into a possibly-slid window wedges the fresh item in waitingToPlay.
+        // Same contract as the #98 media fallback above; see LiveReloadPolicy.
+        host.load(url: url,
+                  startPosition: isLive ? nil : anchor,
+                  skipInitialSeek: LiveReloadPolicy.skipInitialSeek(isLive: isLive, isRejoin: true),
+                  inPlaceSwap: true)
         host.play()
         if let ordinal = nativeSubtitleReapplyOrdinal {
             EngineLog.emit(

--- a/Sources/AetherEngine/Network/HLSLocalServer.swift
+++ b/Sources/AetherEngine/Network/HLSLocalServer.swift
@@ -86,6 +86,12 @@ protocol HLSSegmentProvider: AnyObject {
 
     /// LL-HLS blocking reload: block until segment at absolute index exists. Holds AVPlayer's ?_HLS_msn= reload open so it receives the new segment the instant it is cut, not a poll-interval late.
     func waitForLiveSegment(index: Int, timeout: TimeInterval) -> Bool
+
+    /// Upper bound on how long a blocking reload may hold before the 503. Production providers derive
+    /// it from the sealed TARGETDURATION (3 x TD, the HOLD-BACK depth) so a fastZap session (TD=2)
+    /// times out in 6 s instead of 18 s — a hold that outlives AVPlayer's forward buffer guarantees
+    /// the stall it was meant to prevent.
+    var liveBlockingReloadHoldSeconds: TimeInterval { get }
 }
 
 extension HLSSegmentProvider {
@@ -120,6 +126,7 @@ extension HLSSegmentProvider {
     }
     func waitForFirstLiveSegment(timeout: TimeInterval) -> Bool { true }
     func waitForLiveSegment(index: Int, timeout: TimeInterval) -> Bool { true }
+    var liveBlockingReloadHoldSeconds: TimeInterval { 18.0 }
     func notePlaylistBuild() -> (visibleCount: Int, firstVisible: Int, refreshCounter: Int, endlistAdded: Bool, discontinuitySequence: Int) {
         return (visibleCount: segmentCount, firstVisible: 0, refreshCounter: 0, endlistAdded: false, discontinuitySequence: 0)
     }
@@ -675,7 +682,7 @@ final class HLSLocalServer: @unchecked Sendable {
                         // unchanged playlist. A 200 without the requested MSN after a hold is "Invalid
                         // server blocking reload behavior" (-15410) to AVPlayer (#167 follow-up;
                         // RFC 8216bis requires the 503 here).
-                        if !p.waitForLiveSegment(index: msn, timeout: 18.0) {
+                        if !p.waitForLiveSegment(index: msn, timeout: p.liveBlockingReloadHoldSeconds) {
                             return send503(fd: fd, path: normalizedPath,
                                            reason: "blocking reload msn=\(msn) unsatisfiable")
                         }

--- a/Sources/AetherEngine/Video/HLSSegmentProducer.swift
+++ b/Sources/AetherEngine/Video/HLSSegmentProducer.swift
@@ -464,6 +464,13 @@ final class HLSSegmentProducer: @unchecked Sendable {
     /// safe (see BackpressureWedgeDetector.fastBreakThresholdSeconds).
     private static let backpressureWedgeFastBreakThresholdSeconds = 5
 
+    /// Live disk runaway cap for awaitLiveWindowHeadroom. In healthy play resident count tracks the
+    /// sliding window (~windowSegmentCount plus a few in flight) because every playlist build slides
+    /// evictBelow. It can only approach this cap when the consumer stopped polling entirely (dead
+    /// item), at which point the engine's stall watchdogs reload the item within ~12 s — so a park
+    /// here is diagnostic, never steady state. ~6 min of 2 s GOP segments.
+    private static let liveResidentSegmentCap = 180
+
     private let pumpQueue = DispatchQueue(
         label: "AetherEngine.HLSSegmentProducer.pump",
         qos: .userInitiated
@@ -1086,6 +1093,41 @@ final class HLSSegmentProducer: @unchecked Sendable {
         return false
     }
 
+    /// Live replacement for the advance-path backpressure park (#65). Live production is source-paced,
+    /// so overproduction is bounded by the origin's real-time delivery; the only unbounded case is a
+    /// consumer that stopped polling entirely, which this cap catches. Unlike the old park it releases
+    /// on eviction (window slide), not on a consumer fetch, so it cannot deadlock against a held
+    /// blocking reload. Logs from the first cycle — the old live park was silent below 12 s, which is
+    /// why consumer-facing 6-8 s freezes never showed a producer-side line. Returns true on release,
+    /// false when stop was requested.
+    private func awaitLiveWindowHeadroom(head: Int) -> Bool {
+        if cache.count < Self.liveResidentSegmentCap { return true }
+        // #240: a parked pump is not using the link.
+        sideReaderLinkGate?.videoFetchEnded()
+        defer { sideReaderLinkGate?.videoFetchBegan() }
+        var parked = 0
+        while !checkShouldStop() {
+            if cache.count < Self.liveResidentSegmentCap {
+                EngineLog.emit(
+                    "[HLSSegmentProducer] live headroom released head=\(head) after=\(parked)s "
+                    + "resident=\(cache.count)",
+                    category: .session
+                )
+                return true
+            }
+            if parked % 10 == 0 {
+                EngineLog.emit(
+                    "[HLSSegmentProducer] live headroom PARK head=\(head) resident=\(cache.count) "
+                    + "cap=\(Self.liveResidentSegmentCap) parked=\(parked)s (playlist polls stopped?)",
+                    category: .session
+                )
+            }
+            Thread.sleep(forTimeInterval: 1.0)
+            parked += 1
+        }
+        return false
+    }
+
     /// #207 disk park. The segment window is a sanity bound; the real bound on an opt-in whole-source
     /// prefetch is the session retention budget, which `pruneOutsideWindow` cannot enforce because it
     /// never evicts the hard window. Parks the pump while the race-ahead has filled that budget AND the
@@ -1162,7 +1204,9 @@ final class HLSSegmentProducer: @unchecked Sendable {
         // base segment is never overproduction: the consumer requested it (fetch-triggered restart)
         // or is about to (anchored start). seg0 sessions are unaffected (their target is negative
         // and releases immediately).
-        if initialSegmentIndex != baseIndex {
+        // Live never parks on the fetch high-water (see awaitLiveWindowHeadroom); an SSAI
+        // versioned-init re-alloc mid-live must not re-enter the park either.
+        if initialSegmentIndex != baseIndex, !isLive {
             let backpressureTarget = initialSegmentIndex - bufferAheadSegments
             if !awaitBackpressureRelease(target: backpressureTarget, head: initialSegmentIndex, context: "alloc") { return nil }
         }
@@ -1390,9 +1434,19 @@ final class HLSSegmentProducer: @unchecked Sendable {
             return nil
         }
         currentMuxerSegmentIndex = newIdx
-        let backpressureTarget = newIdx - bufferAheadSegments
-        if !awaitBackpressureRelease(target: backpressureTarget, head: newIdx, context: "advance") { return nil }
-        if !awaitPrefetchDiskBudgetRelease(head: newIdx, context: "advance") { return nil }
+        if isLive {
+            // Live is source-paced: the pump only runs ahead of real time while draining the join
+            // backlog, and the sliding window (notePlaylistBuild -> evictBelow) bounds resident
+            // segments. Parking on the consumer's fetch high-water here deadlocked against a held
+            // LL-HLS blocking reload (the hold starves the segment GET that would release the park)
+            // and pushed TCP backpressure onto the single-connection origin whenever the join
+            // backlog exceeded bufferAheadSegments.
+            if !awaitLiveWindowHeadroom(head: newIdx) { return nil }
+        } else {
+            let backpressureTarget = newIdx - bufferAheadSegments
+            if !awaitBackpressureRelease(target: backpressureTarget, head: newIdx, context: "advance") { return nil }
+            if !awaitPrefetchDiskBudgetRelease(head: newIdx, context: "advance") { return nil }
+        }
         if checkShouldStop() { return nil }
 
         return muxer

--- a/Sources/AetherEngine/Video/VideoSegmentProvider.swift
+++ b/Sources/AetherEngine/Video/VideoSegmentProvider.swift
@@ -30,11 +30,21 @@ struct LiveWindowSizing {
 
     /// Number of segments the playlist keeps visible (and the cache keeps
     /// resident). Clamped up to `minSafeSegments`.
-    var windowSegmentCount: Int {
+    ///
+    /// `targetSegmentDurationSeconds` is the CUT TARGET — a lower bound on the real GOP-quantized
+    /// segment duration (fastZap: 0.5 s target vs ~2 s GOPs). Dividing the window seconds by it
+    /// alone inflated the window 4x (120 segments ≈ 240 s), pinning MEDIA-SEQUENCE at 0 for minutes
+    /// and deferring evictBelow — the "sliding" window never slid. Callers that know the observed
+    /// cadence (mean EXTINF of recent finalized segments) pass it so the window really holds
+    /// `effectiveWindowSeconds` of content.
+    func windowSegmentCount(observedSegmentDurationSeconds: Double?) -> Int {
         let effective = dvrWindowSeconds ?? Self.liveOnlyFloorSeconds
-        let raw = Int(ceil(effective / max(0.5, targetSegmentDurationSeconds)))
+        let divisor = max(max(0.5, targetSegmentDurationSeconds), observedSegmentDurationSeconds ?? 0)
+        let raw = Int(ceil(effective / divisor))
         return max(Self.minSafeSegments, raw)
     }
+
+    var windowSegmentCount: Int { windowSegmentCount(observedSegmentDurationSeconds: nil) }
 }
 
 // MARK: - Live-edge holdback policy
@@ -251,6 +261,11 @@ final class VideoSegmentProvider: HLSSegmentProvider, @unchecked Sendable {
     private var _liveFirstVisible: Int = 0
     /// EXT-X-DISCONTINUITY-SEQUENCE: incremented for each discontinuous segment that slides out.
     private var _discontinuitySequence: Int = 0
+    /// Rolling EXTINF of the most recent finalized live segments; feeds the observed-cadence
+    /// divisor of `LiveWindowSizing.windowSegmentCount(observedSegmentDurationSeconds:)`.
+    /// Guarded by stateLock.
+    private var _liveRecentDurations: [Double] = []
+    private static let liveRecentDurationSampleCount = 20
 
     init(
         cache: SegmentCache,
@@ -341,6 +356,10 @@ final class VideoSegmentProvider: HLSSegmentProvider, @unchecked Sendable {
             durationSeconds: durationSeconds,
             discontinuous: discontinuous
         ))
+        _liveRecentDurations.append(durationSeconds)
+        if _liveRecentDurations.count > Self.liveRecentDurationSampleCount {
+            _liveRecentDurations.removeFirst(_liveRecentDurations.count - Self.liveRecentDurationSampleCount)
+        }
         stateLock.unlock()
         firstSegmentCondition.lock()
         firstSegmentCondition.broadcast()
@@ -357,7 +376,9 @@ final class VideoSegmentProvider: HLSSegmentProvider, @unchecked Sendable {
         refreshCounter += 1
         if isLive {
             let total = segments.count
-            let window = liveWindowSizing.windowSegmentCount
+            let observedMean = _liveRecentDurations.isEmpty
+                ? nil : _liveRecentDurations.reduce(0, +) / Double(_liveRecentDurations.count)
+            let window = liveWindowSizing.windowSegmentCount(observedSegmentDurationSeconds: observedMean)
             // highWater is the last produced index (total - 1). Keep the
             // last `window` segments visible: firstVisible = highWater -
             // window + 1 = total - window. Until at least `window`
@@ -817,6 +838,18 @@ final class VideoSegmentProvider: HLSSegmentProvider, @unchecked Sendable {
         Self.resolveLiveBlockingReload(halted: liveProductionHalted,
                                        override: blockingReloadOverride,
                                        policy: liveCadencePolicy)
+    }
+
+    /// Blocking-reload hold bound: 3 x sealed TARGETDURATION (= the advertised HOLD-BACK depth).
+    /// The old hardcoded 18 s was 9 x TD under fastZap — a hold that outlives AVPlayer's ~4 s
+    /// forward buffer guarantees the stall it exists to prevent. The seal is always resolved before
+    /// the first playlist that can advertise CAN-BLOCK-RELOAD is served (every serve path runs
+    /// waitForFirstLiveSegment first), so the TD=6 fallback (3 x 6 = legacy 18 s) only covers tests.
+    var liveBlockingReloadHoldSeconds: TimeInterval {
+        stateLock.lock()
+        let sealed = liveTargetDurationSeal.value
+        stateLock.unlock()
+        return Double(3 * (sealed ?? 6))
     }
 
     var liveProductionHalted: Bool {

--- a/Tests/AetherEngineTests/LiveWindowObservedCadenceTests.swift
+++ b/Tests/AetherEngineTests/LiveWindowObservedCadenceTests.swift
@@ -1,0 +1,92 @@
+// Tests/AetherEngineTests/LiveWindowObservedCadenceTests.swift
+// Live backpressure/blocking-reload deadlock follow-up: the sliding window must be sized by the
+// OBSERVED segment cadence, not the cut target. Under .fastZap the cut target is 0.5s but real
+// GOP-quantized segments run ~2s, so dividing 60s by 0.5 inflated the window to 120 segments
+// (~240s) — MEDIA-SEQUENCE stayed pinned at 0 and evictBelow never fired in short sessions.
+// Also pins the blocking-reload hold bound: 3 x sealed TARGETDURATION instead of hardcoded 18s.
+import XCTest
+@testable import AetherEngine
+
+final class LiveWindowObservedCadenceTests: XCTestCase {
+
+    // MARK: - LiveWindowSizing
+
+    func testWindowUsesObservedCadenceOverCutTarget() {
+        let sizing = LiveWindowSizing(targetSegmentDurationSeconds: 0.5, dvrWindowSeconds: nil)
+        // Legacy path (no observation yet): 60 / 0.5 = 120.
+        XCTAssertEqual(sizing.windowSegmentCount, 120)
+        XCTAssertEqual(sizing.windowSegmentCount(observedSegmentDurationSeconds: nil), 120)
+        // Real fastZap cadence (2s GOPs): 60 / 2 = 30.
+        XCTAssertEqual(sizing.windowSegmentCount(observedSegmentDurationSeconds: 2.0), 30)
+    }
+
+    func testObservedCadenceBelowCutTargetCannotWidenTheWindow() {
+        // The divisor is max(cutTarget, observed): a burst of sub-target segments (scene-cut
+        // keyframes) must not inflate the window past what the cut target already allows.
+        let sizing = LiveWindowSizing(targetSegmentDurationSeconds: 4.0, dvrWindowSeconds: nil)
+        XCTAssertEqual(sizing.windowSegmentCount(observedSegmentDurationSeconds: 0.7), 15)
+    }
+
+    func testMinSafeSegmentsFloorSurvivesLongObservedSegments() {
+        let sizing = LiveWindowSizing(targetSegmentDurationSeconds: 4.0, dvrWindowSeconds: nil)
+        // 60 / 10 = 6 < minSafeSegments(8).
+        XCTAssertEqual(sizing.windowSegmentCount(observedSegmentDurationSeconds: 10.0), 8)
+    }
+
+    // MARK: - Provider window slide
+
+    func testPlaylistSlidesAtObservedCadenceNotCutTarget() {
+        let provider = makeFastZapProvider()
+        // 35 finalized 2s segments: observed mean = 2.0 -> window 30 -> firstVisible = 35 - 30 = 5.
+        // Pre-fix the window was 120 and firstVisible stayed 0 for four minutes of content.
+        for i in 0..<35 {
+            provider.appendLiveSegment(index: i, startSeconds: Double(i) * 2.0, durationSeconds: 2.0)
+        }
+        let build = provider.notePlaylistBuild()
+        XCTAssertEqual(build.visibleCount, 35)
+        XCTAssertEqual(build.firstVisible, 5)
+    }
+
+    func testPlaylistDoesNotSlideBeforeWindowFills() {
+        let provider = makeFastZapProvider()
+        for i in 0..<10 {
+            provider.appendLiveSegment(index: i, startSeconds: Double(i) * 2.0, durationSeconds: 2.0)
+        }
+        XCTAssertEqual(provider.notePlaylistBuild().firstVisible, 0)
+    }
+
+    // MARK: - Blocking-reload hold bound
+
+    func testBlockingReloadHoldIsThreeSealedTargetDurations() {
+        let provider = makeFastZapProvider()
+        // Unsealed: legacy 18s (3 x fallback TD 6) so non-live/test conformers keep today's bound.
+        XCTAssertEqual(provider.liveBlockingReloadHoldSeconds, 18.0, accuracy: 0.001)
+        // Seal at fastZap cadence: max segment 1.92s -> TD=2 -> hold 6s.
+        XCTAssertEqual(provider.liveTargetDurationSeconds(maxSegmentDuration: 1.92), 2)
+        XCTAssertEqual(provider.liveBlockingReloadHoldSeconds, 6.0, accuracy: 0.001)
+        // Seal is session-stable: a later, longer segment cannot stretch the hold.
+        _ = provider.liveTargetDurationSeconds(maxSegmentDuration: 5.76)
+        XCTAssertEqual(provider.liveBlockingReloadHoldSeconds, 6.0, accuracy: 0.001)
+    }
+
+    // MARK: - Helpers
+
+    private func makeFastZapProvider() -> VideoSegmentProvider {
+        VideoSegmentProvider(
+            cache: SegmentCache(forwardWindow: 10, backwardWindow: 10),
+            segments: [],
+            codecsString: "avc1.640029,mp4a.40.2",
+            supplementalCodecs: nil,
+            resolution: (1920, 1080),
+            videoRange: .sdr,
+            frameRate: 25,
+            hdcpLevel: nil,
+            sourceBitrate: 8_000_000,
+            isLive: true,
+            liveWindowSizing: LiveWindowSizing(
+                targetSegmentDurationSeconds: 0.5,
+                dvrWindowSeconds: nil
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Live sessions freeze for 6-8 s at a time (picture + audio) on a repeating cadence. Root cause is a three-legged mutual wait between the segment producer's backpressure park and the LL-HLS blocking reload served by the loopback server:

1. `HLSSegmentProducer.advanceMuxer` parks once `head - bufferAheadSegments` exceeds the consumer's fetch high-water. The park releases **only** on a client segment GET (`declareTarget` from the serve paths).
2. Meanwhile AVPlayer's blocking reload asks for `_HLS_msn = head` — a segment only a producer cut can satisfy. `waitForLiveSegment` waits passively on `firstSegmentCondition`; there is no demand path back to the parked producer.
3. The held reload occupies the serialized HTTP/1.1 keep-alive connection (`handleConnection` loop), so AVPlayer's next segment GET — the one that would release the park — queues behind the hold.

The 18 s hold expires into `503 blocking reload msn=N unsatisfiable` long after AVPlayer's ~4 s forward buffer (`preferredForwardBufferDuration` default on the loopback path) has drained into `playbackStalled`. Recovery is then the generic stall watchdog (nudge at +6 s, item reload at +12 s) — the visible multi-second freeze. The live pump watchdogs cannot fire during the park because the pump is blocked inside `advanceMuxer`, below the top of `readLoop`, and the VOD wedge breaker is `!isLive`-gated.

Log signature (Apple TV 4K, tvOS 26, Xtream MPEG-TS 1080i/p25 H.264):

```
[LagDiag] ... fwd=5.2 ... fwd=1.2 (5 s without a single segment fetch)
[NativeAVPlayerHost] #1 playbackStalled
[HLSLocalServer] -> 503 /media.m3u8 reason=blocking reload msn=24 unsatisfiable
[HLSSegmentProducer] #65 backpressure released (advance) head=24 target=14 after=18s
[AetherEngine] #65 re-engaging stalled AVPlayer (stall + 6s without fetches): nudge seek ...
```

## Changes

- **Live is source-paced: the advance and versioned-init parks are now VOD-only.** Overproduction on live is bounded by the origin's real-time delivery; the only unbounded case is a consumer that stopped polling entirely, which a new logged runaway guard (`awaitLiveWindowHeadroom`, 180 resident segments) catches. Unlike the park it releases on window eviction, not consumer fetches, so it cannot deadlock against a held reload. It also logs from the first cycle — the old live park was silent below 12 s, which is why the consumer-facing freezes never showed a producer-side line.
- **`LiveWindowSizing.windowSegmentCount` is sized by the observed segment cadence** (rolling mean EXTINF of the last 20 finalized segments), not the cut target alone. Under `.fastZap` the 0.5 s cut target vs ~2 s GOPs inflated the "60 s" window to 120 segments (~240 s): `EXT-X-MEDIA-SEQUENCE` stayed pinned at 0 and `evictBelow` never fired in short sessions. The divisor is `max(cutTarget, observed)`, so sub-target keyframe bursts cannot widen the window; `minSafeSegments` still floors it.
- **`reloadStalledConsumerItem` honors `LiveReloadPolicy`** — live rejoin with `startPosition: nil` + `skipInitialSeek`, same contract as the #98 media fallback and the reload paths in `AetherEngine+Loading`. Previously it issued the zero-tolerance seek into a possibly-slid window that `LiveReloadPolicy`'s doc comment forbids for live rejoins.
- **The blocking-reload hold is bounded by `3 x` the sealed TARGETDURATION** (= the advertised HOLD-BACK) via a new `liveBlockingReloadHoldSeconds` protocol member (default extension keeps 18.0 for other conformers). `.standard` stays exactly 18 s; `.fastZap` (TD=2) drops to 6 s — a hold that outlives the consumer's forward buffer guarantees the stall it exists to prevent.

VOD paths are byte-identical: both parks, the wedge breaker, and the VOD window math are untouched.

## Test plan

- **Device:** Apple TV 4K (3rd gen, A15), tvOS 26.6, live MPEG-TS over Xtream (H.264 1080p25/1080i25, AAC + MP2 audio, ~2 s GOPs, `.fastZap` join profile, `max_connections=1` origin). Pre-fix the freeze reproduced roughly every 2 minutes; post-fix, initial sessions play clean — no `503 ... unsatisfiable`, no `backpressure released (advance)`, no `playbackStalled` in the logs, and `EXT-X-MEDIA-SEQUENCE` starts sliding after ~60 s. A longer soak is still running; I will report back on this PR if anything surfaces.
- **Unit:** full suite green on this branch rebased onto current `main` (1411 tests), including 6 new tests (`LiveWindowObservedCadenceTests`) pinning the observed-cadence window math, the slide behavior, and the hold bound (unsealed fallback 18 s, sealed TD=2 -> 6 s, seal stability).
- `CHANGELOG.md` updated under `[Unreleased]`.

## Notes

- The new runaway-guard cap (180 resident segments) is intentionally far above the steady-state window; if it ever logs `live headroom PARK`, the consumer has stopped polling and the engine's existing 12 s watchdogs are already the real recovery. Happy to rename/tune per your conventions.
- Host apps that want the old behavior back can keep forcing `LoadOptions.liveBlockingReload = false`; with this fix the blocking-reload contract is actually satisfiable again, so we left the engine default untouched.
