### PR TITLE
A VOD outlives the end AVPlayer calls while its own seekable range runs on (#287)

### DIFF
--- a/Sources/AetherEngine/AetherEngine+Loading.swift
+++ b/Sources/AetherEngine/AetherEngine+Loading.swift
@@ -288,7 +288,8 @@ extension AetherEngine {
                   // #168 follow-up: live-only (VOD remote HLS is the AE#154 reroute target; ingesting it
                   // back would ping-pong), and hosts can opt out via LoadOptions.
                   armVideoCarriageWatchdog: RemoteHLSIngestFallback.shouldArm(
-                      isLive: options.isLive, fallbackEnabled: options.nativeRemoteHLSIngestFallback))
+                      isLive: options.isLive, fallbackEnabled: options.nativeRemoteHLSIngestFallback),
+                  isLive: options.isLive)
 
         // AE#154: surface the item's legible AVMediaSelectionGroup as `subtitleTracks` so hosts with
         // their own picker see the external WebVTT renditions AVPlayer renders on this bypass.
@@ -1051,7 +1052,8 @@ extension AetherEngine {
                   perFrameHDR: true,
                   skipInitialSeek: LiveReloadPolicy.skipInitialSeek(
                       isLive: isLive, isRejoin: liveRejoin),
-                  inPlaceSwap: inPlaceHandover)
+                  inPlaceSwap: inPlaceHandover,
+                  isLive: isLive)
         forceNativeLegibleDeselectedUntilHostSelects()
     }
 

--- a/Sources/AetherEngine/AetherEngine.swift
+++ b/Sources/AetherEngine/AetherEngine.swift
@@ -1861,6 +1861,71 @@ public final class AetherEngine: ObservableObject {
         frozenTicks >= endOfMediaParkGraceTicks
     }
 
+    /// How far short of `duration` an end-of-item event must land before it counts as premature
+    /// (AetherEngine#287). Deliberately above `endOfMediaEpsilonSeconds` so the #169 tail park owns the
+    /// last half second and the two can never contend for the same event.
+    nonisolated static let prematureEndShortfallSeconds: Double = 1.0
+
+    /// How far past the playhead AVPlayer's own seekable range must reach before its end-of-item event
+    /// counts as self-contradicted (AetherEngine#287).
+    nonisolated static let prematureEndSeekableLeadSeconds: Double = 1.0
+
+    /// Cap on premature-end recoveries per item (AetherEngine#287). A source whose video track has
+    /// several holes gets a recovery at each of them; a pathological one cannot spin.
+    nonisolated static let prematureEndRecoveryMaxAttempts: Int = 3
+
+    /// A recovery must have moved the playhead by at least this much before another one is allowed
+    /// (AetherEngine#287). Re-seeking a position that already failed to resume would loop forever.
+    nonisolated static let prematureEndRecoveryMinProgressSeconds: Double = 0.5
+
+    /// True when AVPlayer's `didPlayToEndTime` is contradicted by AVPlayer's own seekable range, i.e. it
+    /// ended the item tens of seconds inside a presentation it still reports as seekable
+    /// (AetherEngine#287).
+    ///
+    /// A VOD whose selected audio track outruns its video track (the reporter's dual-audio BDRip: video
+    /// ends 1431.971 s, the selected English AAC 1484.935 s, container 1484.936 s) makes AVPlayer end the
+    /// item the moment the video renderer runs dry, ~53 s short of the advertised duration. Reproduced
+    /// on a synthesized 60 s-video / 113 s-audio MKV: the end fires at 60.03 s of a 113.02 s
+    /// presentation whose final segment had already been fetched whole, and identically for a 2 s, an
+    /// 8 s and a 53 s tail, so the trigger is the video exhaustion rather than the length of the tail.
+    /// The playlist is not the culprit either: its EXTINF sum equals the container duration to the
+    /// millisecond (measured 14 x 4.004 + 56.967 = 113.023).
+    ///
+    /// The engine cannot talk AVPlayer out of that call, but it must not forward it as an organic
+    /// finish. `.ended` is terminal (#63/#164), so seek and play become no-ops and the tail is
+    /// unreachable for the rest of the session; the host sees a hard stop tens of seconds early. Seeking
+    /// back to the SAME position and resuming re-arms the renderers and plays the tail out to an organic
+    /// end at the real duration with no audio dropped (measured; `play()` without the seek leaves the
+    /// clock frozen at the boundary indefinitely).
+    ///
+    /// The witness is the SEEKABLE range, not the loaded one that carries #169. Measured at the instant
+    /// the premature end fires: `loadedTimeRanges` has already been trimmed back to the exhaustion point
+    /// ([22.34, 60.01] with the playhead at 60.03), so the loaded range agrees with AVPlayer's mistake
+    /// and cannot refute it, while `seekableTimeRanges` still reports the whole presentation
+    /// ([0, 113.02]). A live session fails this guard on its own, its seekable end being the live edge.
+    ///
+    /// A real serve failure does not reach here: a segment that never arrives fails the item with
+    /// `failedToPlayToEndTime` / -12889, a different notification with its own recovery. And a recovery
+    /// that cannot work costs one re-seek before the same end is accepted, so the worst case is today's
+    /// behaviour one seek later.
+    nonisolated static func prematureEndRecoveryQualifies(
+        isLive: Bool,
+        duration: Double,
+        playhead: Double,
+        seekableEnd: Double?,
+        attemptsUsed: Int,
+        lastAttemptPlayhead: Double?
+    ) -> Bool {
+        guard !isLive, duration > 0, playhead.isFinite else { return false }
+        guard attemptsUsed < prematureEndRecoveryMaxAttempts else { return false }
+        guard duration - playhead > prematureEndShortfallSeconds else { return false }
+        guard let seekableEnd, seekableEnd.isFinite,
+              seekableEnd - playhead >= prematureEndSeekableLeadSeconds else { return false }
+        if let lastAttemptPlayhead,
+           playhead - lastAttemptPlayhead < prematureEndRecoveryMinProgressSeconds { return false }
+        return true
+    }
+
     /// Complete a native VOD that parked a hair short of its advertised duration because the final
     /// segment's video is exhausted (AetherEngine#169): the final segment's EXTINF, derived from the
     /// container duration, overshoots the last real video sample, so AVPlayer sits in

--- a/Sources/AetherEngine/Native/NativeAVPlayerHost.swift
+++ b/Sources/AetherEngine/Native/NativeAVPlayerHost.swift
@@ -27,6 +27,17 @@ final class NativeAVPlayerHost {
     /// #50: latched on first .playing; discriminates startup failures (never played) from mid-playback transients. .failed and timeControlStatus KVOs are unsynchronized, so instantaneous status is unreliable. Reset with the item on a reused host.
     private var hasEverPlayed = false
     @Published private(set) var didReachEnd: Bool = false
+
+    /// Set per load; gates the AE#287 premature-end recovery, which only makes sense for a fixed-length
+    /// presentation. A live session has no advertised end to fall short of.
+    private var isLiveSession: Bool = false
+    /// AE#287 bookkeeping, cleared with the item in `unloadCurrentItem`.
+    private var prematureEndRecoveryAttempts: Int = 0
+    private var lastPrematureEndRecoveryPlayhead: Double?
+    /// True across the re-seek of a premature-end recovery. AVPlayer drops to `.paused` for its
+    /// duration, and publishing that transient would bounce the engine through `.paused` and back for
+    /// what the viewer must not even notice; the real status is republished when the recovery settles.
+    private var prematureEndRecoveryInFlight = false
     /// Mirrors avPlayer.timeControlStatus so the engine can reconcile when AVKit's transport bar, Control Center, or hardware buttons toggle the player externally (without this, engine state goes stale and play/pause presses are swallowed).
     @Published private(set) var timeControlStatus: AVPlayer.TimeControlStatus = .paused
     /// Monotonic count of AVPlayerItem playbackStalled notifications (#93 residual): the engine
@@ -227,11 +238,12 @@ final class NativeAVPlayerHost {
     /// after an in-PiP recovery reload) and the pause bounces transport for nothing. The swap
     /// keeps transport intent, clocks and the old item alive until replaceCurrentItem hands
     /// AVPlayer the fresh one.
-    func load(url: URL, startPosition: Double?, perFrameHDR: Bool = true, skipInitialSeek: Bool = false, forwardBufferDuration: Double = 4.0, surfaceEndFailures: Bool = false, inPlaceSwap: Bool = false, httpHeaders: [String: String] = [:], armVideoCarriageWatchdog: Bool = false) {
+    func load(url: URL, startPosition: Double?, perFrameHDR: Bool = true, skipInitialSeek: Bool = false, forwardBufferDuration: Double = 4.0, surfaceEndFailures: Bool = false, inPlaceSwap: Bool = false, httpHeaders: [String: String] = [:], armVideoCarriageWatchdog: Bool = false, isLive: Bool = false) {
         unloadCurrentItem(inPlaceSwap: inPlaceSwap)
 
         self.surfaceEndFailures = surfaceEndFailures
         self.carriageWatchdogArmed = armVideoCarriageWatchdog
+        self.isLiveSession = isLive
         Self.nextSessionID += 1
         sessionID = Self.nextSessionID
         let sid = sessionID
@@ -406,6 +418,8 @@ final class NativeAVPlayerHost {
             EngineLog.emit("[NativeAVPlayerHost] #\(sid) timeControlStatus=\(statusStr) reason=\(reason) t+\(String(format: "%.2f", elapsed))s", category: .engine)
             Task { @MainActor in
                 guard let self = self else { return }
+                // AE#287: swallow the pause AVPlayer takes while a premature-end recovery re-seeks.
+                if status == .paused, self.prematureEndRecoveryInFlight { return }
                 self.timeControlStatus = status
                 // First .playing: re-sample route after 2.5s settle -- AVKit only negotiates HDMI format on playback start (issue #24).
                 if status == .playing { self.hasEverPlayed = true }
@@ -520,7 +534,11 @@ final class NativeAVPlayerHost {
         ) { [weak self] _ in
             EngineLog.emit("[NativeAVPlayerHost] #\(sid) didPlayToEndTime", category: .engine)
             Task { @MainActor in
-                self?.didReachEnd = true
+                guard let self else { return }
+                // AE#287: AVPlayer ends a VOD the moment its video renderer runs dry, even with the
+                // audio-only tail still ahead. Recover before `.ended` latches; it is terminal.
+                if await self.recoverFromPrematureEnd() { return }
+                self.didReachEnd = true
             }
         }
         notificationObservers.append(didEndObs)
@@ -845,6 +863,75 @@ final class NativeAVPlayerHost {
         didReachEnd = true
     }
 
+    /// The mirror of `markEndOfMediaReached` (AetherEngine#287): suppress an end-of-item event that
+    /// AVPlayer's own seekable range contradicts, and resume instead of completing.
+    ///
+    /// A VOD whose selected audio track outruns its video track makes AVPlayer fire didPlayToEndTime
+    /// the moment the video renderer runs dry, tens of seconds short of the advertised duration and
+    /// well inside the range it still reports as seekable. Forwarding that as `didReachEnd` latches the terminal
+    /// `.ended` (#63/#164), after which the tail is unreachable for the rest of the session. Re-seeking
+    /// to the SAME position re-arms the renderers and the tail plays out to an organic end at the real
+    /// duration, dropping nothing (measured; `play()` alone leaves the clock frozen at the boundary).
+    ///
+    /// Returns true when the end was suppressed and playback resumed, false when the caller should
+    /// complete the item as usual. Both the attempt cap and the forward-progress rule live in
+    /// `AetherEngine.prematureEndRecoveryQualifies`, so a recovery that cannot work costs one re-seek
+    /// and then completes exactly as it does today.
+    private func recoverFromPrematureEnd() async -> Bool {
+        // Only resume what the viewer was playing: an item that ends while the transport is parked
+        // must stay parked.
+        guard playIntent, !didReachEnd else { return false }
+        let playhead = avPlayer.currentTime().seconds
+        let seekEnd = seekableRangeEndSeconds
+        guard AetherEngine.prematureEndRecoveryQualifies(
+            isLive: isLiveSession,
+            duration: duration,
+            playhead: playhead,
+            seekableEnd: seekEnd,
+            attemptsUsed: prematureEndRecoveryAttempts,
+            lastAttemptPlayhead: lastPrematureEndRecoveryPlayhead
+        ) else { return false }
+
+        prematureEndRecoveryAttempts += 1
+        lastPrematureEndRecoveryPlayhead = playhead
+        prematureEndRecoveryInFlight = true
+        EngineLog.emit(
+            "[NativeAVPlayerHost] #\(sessionID) AE#287 premature end: playhead="
+            + "\(String(format: "%.3f", playhead))s duration=\(String(format: "%.3f", duration))s "
+            + "seekableEnd=\(String(format: "%.3f", seekEnd ?? -1))s "
+            + "loadedEnd=\(String(format: "%.3f", loadedRangeEndSeconds ?? -1))s; "
+            + "\(String(format: "%.1f", duration - playhead))s of the presentation lies past the end "
+            + "AVPlayer reported, re-seeking in place (attempt \(prematureEndRecoveryAttempts))",
+            category: .engine)
+        await seek(to: playhead)
+        avPlayer.play()
+        prematureEndRecoveryInFlight = false
+        timeControlStatus = avPlayer.timeControlStatus
+        EngineLog.emit(
+            "[NativeAVPlayerHost] #\(sessionID) AE#287 resumed: rate=\(avPlayer.rate) "
+            + "t=\(String(format: "%.3f", avPlayer.currentTime().seconds))s",
+            category: .engine)
+        return true
+    }
+
+    /// End of AVPlayer's last seekable time range, in item seconds: the extent of the presentation it
+    /// parsed from the playlist. Read from the item rather than the `seekableEnd` KVO mirror, which
+    /// exists to keep the LIVE edge off a tick-cadence read (#134); this is one read at a rare event.
+    private var seekableRangeEndSeconds: Double? {
+        guard let last = playerItem?.seekableTimeRanges.last?.timeRangeValue else { return nil }
+        let end = CMTimeGetSeconds(CMTimeAdd(last.start, last.duration))
+        return end.isFinite ? end : nil
+    }
+
+    /// Raw end of AVPlayer's last loaded time range, in item seconds; diagnostics only. It is NOT the
+    /// #287 witness: measured at a premature end, AVPlayer has already trimmed this range back to the
+    /// exhaustion point, so it corroborates the mistake instead of refuting it.
+    private var loadedRangeEndSeconds: Double? {
+        guard let last = playerItem?.loadedTimeRanges.last?.timeRangeValue else { return nil }
+        let end = CMTimeGetSeconds(CMTimeAdd(last.start, last.duration))
+        return end.isFinite ? end : nil
+    }
+
     /// Resolve only when the seek physically lands (loopback source lands seeks seconds after the call; issue #37).
     /// seekInFlight suppresses the periodic observer across the wait; only the latest seekGeneration clears it.
     func seek(to seconds: Double) async {
@@ -1032,6 +1119,10 @@ final class NativeAVPlayerHost {
         // Clear terminal flags: keepNativeHost reload reuses the host and @Published replays on subscribe; stale failureMessage/didReachEnd corrupt the new session (issue #15).
         failureMessage = nil
         didReachEnd = false
+        // AE#287: the recovery budget is per item, not per host.
+        prematureEndRecoveryAttempts = 0
+        lastPrematureEndRecoveryPlayhead = nil
+        prematureEndRecoveryInFlight = false
         didSampleSettledRoute = false
         // #168: a reused host must not report the prior session's dynamic range before the new item resolves.
         detectedVideoFormat = nil

--- a/Sources/aetherctl/PlaybackCmd.swift
+++ b/Sources/aetherctl/PlaybackCmd.swift
@@ -9,7 +9,7 @@ import AetherEngine
 /// and optionally activate an embedded subtitle track (`--subs <codec-or-lang>`)
 /// and log every overlay cue that arrives. Repro harness for "loads but never
 /// plays" reports and for live teletext end-to-end validation (#107).
-func runPlay(url: URL, seconds: Double, live: Bool, dvrWindow: Double?, subsPick: String?, hostCalls: [String], audioStats: Bool = false, seekEvery: Double? = nil, seekPattern: [Double] = [], mallocCensus: Bool = false, forceSoftware: Bool = false,
+func runPlay(url: URL, seconds: Double, live: Bool, dvrWindow: Double?, subsPick: String?, hostCalls: [String], audioStats: Bool = false, seekEvery: Double? = nil, seekPattern: [Double] = [], startPosition: Double? = nil, mallocCensus: Bool = false, forceSoftware: Bool = false,
                     censusThresholdMB: Int? = nil, censusHz: Double? = nil) -> Int32 {
     EngineLog.handler = { print($0) }
     if mallocCensus {
@@ -19,12 +19,12 @@ func runPlay(url: URL, seconds: Double, live: Bool, dvrWindow: Double?, subsPick
             triggerPollHz: censusHz ?? 8)
     }
     if forceSoftware { AetherEngine.setForceSoftwarePathForTesting(true) }
-    print("aetherctl play: \(url.absoluteString) (seconds=\(seconds) live=\(live) dvrWindow=\(dvrWindow.map { String($0) } ?? "nil") subs=\(subsPick ?? "off") hostCalls=\(hostCalls.isEmpty ? "none" : hostCalls.joined(separator: "+")) audioStats=\(audioStats) seekEvery=\(seekEvery.map { String($0) } ?? "off") seekPattern=\(seekPattern.isEmpty ? "off" : seekPattern.map { String($0) }.joined(separator: "/")))")
+    print("aetherctl play: \(url.absoluteString) (seconds=\(seconds) live=\(live) dvrWindow=\(dvrWindow.map { String($0) } ?? "nil") subs=\(subsPick ?? "off") hostCalls=\(hostCalls.isEmpty ? "none" : hostCalls.joined(separator: "+")) audioStats=\(audioStats) seekEvery=\(seekEvery.map { String($0) } ?? "off") seekPattern=\(seekPattern.isEmpty ? "off" : seekPattern.map { String($0) }.joined(separator: "/")) startPosition=\(startPosition.map { String($0) } ?? "0"))")
     print("")
     // CFRunLoopRun, not a blocking semaphore: AetherEngine is @MainActor, so parking the main thread would deadlock the executor.
     let box = UncheckedBox<Int32?>(nil)
     Task { @MainActor in
-        box.value = await playSmokeTest(url: url, seconds: seconds, live: live, dvrWindow: dvrWindow, subsPick: subsPick, hostCalls: hostCalls, audioStats: audioStats, seekEvery: seekEvery, seekPattern: seekPattern)
+        box.value = await playSmokeTest(url: url, seconds: seconds, live: live, dvrWindow: dvrWindow, subsPick: subsPick, hostCalls: hostCalls, audioStats: audioStats, seekEvery: seekEvery, seekPattern: seekPattern, startPosition: startPosition)
         CFRunLoopStop(CFRunLoopGetMain())
     }
     CFRunLoopRun()
@@ -70,7 +70,7 @@ private final class AudioContinuityMonitor {
 }
 
 @MainActor
-private func playSmokeTest(url: URL, seconds: Double, live: Bool, dvrWindow: Double?, subsPick: String?, hostCalls: [String], audioStats: Bool, seekEvery: Double? = nil, seekPattern: [Double] = []) async -> Int32 {
+private func playSmokeTest(url: URL, seconds: Double, live: Bool, dvrWindow: Double?, subsPick: String?, hostCalls: [String], audioStats: Bool, seekEvery: Double? = nil, seekPattern: [Double] = [], startPosition: Double? = nil) async -> Int32 {
     let engine: AetherEngine
     do {
         engine = try AetherEngine()
@@ -112,7 +112,7 @@ private func playSmokeTest(url: URL, seconds: Double, live: Bool, dvrWindow: Dou
         dvrWindowSeconds: dvrWindow
     )
     do {
-        let probe = try await engine.load(url: url, options: options)
+        let probe = try await engine.load(url: url, startPosition: startPosition, options: options)
         // Mirror AetherPlayer's Open URL flow: a probe-flagged live source is reloaded
         // back-to-back on the live path (same engine instance, stopInternal in between).
         if hostCalls.contains("reloadlive"), let probe, probe.isLive, !engine.isLive {

--- a/Sources/aetherctl/main.swift
+++ b/Sources/aetherctl/main.swift
@@ -71,6 +71,7 @@ func printUsage() {
       aetherctl validate [--no-dv] <url>
       aetherctl swdecode [--frames N] <url>
       aetherctl play [--seconds N] [--live] [--dvr-window N] [--subs <codec-or-lang>]
+                 [--start-position S]
                      [--audio-stats] [--host-calls play,extractor,setrate,reloadlive,seekback] <url>
                      (full load+play session smoke test; --subs activates the first
                       matching embedded subtitle track and logs overlay cues;
@@ -464,6 +465,9 @@ if first == "play" {
     // Slow-CDN simulation, same hook as `serve` / `seektest`: a local file lets the producer race
     // minutes ahead, which is the one regime where producer scheduling cannot matter (AE#286).
     let playThrottleKbps = takeIntFlag("--throttle-kbps", from: &rest)
+    // Resume anchor, the same one load(startPosition:) takes. AE#287 needs it: the reporter's hard
+    // park only reproduces when a rebuilt session opens exactly at the video-exhaustion boundary.
+    let playStartPosition = takeDoubleFlag("--start-position", from: &rest)
     rejectStrayFlags(rest, subcommand: "play")
     if let playThrottleKbps {
         AetherEngine.setSourceThrottleKbpsForTesting(playThrottleKbps)
@@ -475,7 +479,7 @@ if first == "play" {
         printUsage()
         exit(64)
     }
-    exit(runPlay(url: parseSourceURL(urlArg), seconds: seconds, live: live, dvrWindow: dvrWindow, subsPick: subsPick, hostCalls: hostCalls, audioStats: audioStats, seekEvery: seekEvery, seekPattern: seekPattern, mallocCensus: mallocCensus, forceSoftware: playForceSW,
+    exit(runPlay(url: parseSourceURL(urlArg), seconds: seconds, live: live, dvrWindow: dvrWindow, subsPick: subsPick, hostCalls: hostCalls, audioStats: audioStats, seekEvery: seekEvery, seekPattern: seekPattern, startPosition: playStartPosition, mallocCensus: mallocCensus, forceSoftware: playForceSW,
                  censusThresholdMB: censusThresholdMB, censusHz: censusHz))
 }
 

--- a/Tests/AetherEngineTests/PrematureEndOfItemTests.swift
+++ b/Tests/AetherEngineTests/PrematureEndOfItemTests.swift
@@ -1,0 +1,155 @@
+// Premature end-of-item recovery (AetherEngine#287).
+//
+// When a VOD's selected audio track outruns its video track, AVPlayer ends the item the moment the
+// video renderer runs dry, tens of seconds short of the advertised duration. Measured on the
+// reporter's shape (video 60.0 s, audio 113.0 s, one loopback fMP4 rendition): `didPlayToEndTime` at
+// 60.03 s of a 113.02 s presentation, reproducing identically for a 2 s, an 8 s and a 53 s tail, so
+// it is the video exhaustion that triggers it and not the length of the tail. The playlist is not
+// the culprit either: its EXTINF sum equals the container duration to the millisecond.
+//
+// `.ended` is terminal (#63/#164), so forwarding that event as an organic finish makes the tail
+// unreachable for the rest of the session. The discriminator is AVPlayer contradicting itself: it
+// ended the item well inside a presentation it still reports as SEEKABLE. The loaded range cannot
+// serve here (unlike #169): at that instant AVPlayer has already trimmed it back to the exhaustion
+// point, so it agrees with the mistake.
+//
+// These pure cases pin that discriminator and the bounds that keep a futile retry from looping.
+import Foundation
+import Testing
+@testable import AetherEngine
+
+@Suite("Premature end-of-item recovery (#287)")
+struct PrematureEndOfItemTests {
+
+    // The reporter's exact shape: video ends 1431.971 s, selected AAC ends 1484.935 s, container
+    // duration 1484.936 s, end fired at 1432.000 s.
+    let duration = 1484.936
+    let boundary = 1432.0
+    let seekableToEnd = 1484.936
+
+    @Test("An end fired at video exhaustion inside the seekable range is contradicted")
+    func qualifiesInsideSeekableRange() {
+        #expect(AetherEngine.prematureEndRecoveryQualifies(
+            isLive: false,
+            duration: duration,
+            playhead: boundary,
+            seekableEnd: seekableToEnd,
+            attemptsUsed: 0,
+            lastAttemptPlayhead: nil))
+    }
+
+    @Test("An end at the edge of the seekable range is a real finish, not a contradiction")
+    func rejectsEndAtSeekableEdge() {
+        #expect(!AetherEngine.prematureEndRecoveryQualifies(
+            isLive: false,
+            duration: duration,
+            playhead: boundary,
+            seekableEnd: boundary,
+            attemptsUsed: 0,
+            lastAttemptPlayhead: nil))
+    }
+
+    @Test("A missing seekable range is never a contradiction")
+    func rejectsMissingSeekableRange() {
+        #expect(!AetherEngine.prematureEndRecoveryQualifies(
+            isLive: false,
+            duration: duration,
+            playhead: boundary,
+            seekableEnd: nil,
+            attemptsUsed: 0,
+            lastAttemptPlayhead: nil))
+    }
+
+    @Test("A genuine finish at the advertised duration is forwarded unchanged")
+    func rejectsOrganicEnd() {
+        #expect(!AetherEngine.prematureEndRecoveryQualifies(
+            isLive: false,
+            duration: duration,
+            playhead: duration - 0.05,
+            seekableEnd: seekableToEnd,
+            attemptsUsed: 0,
+            lastAttemptPlayhead: nil))
+    }
+
+    // The #169 tail park completes within `endOfMediaEpsilonSeconds` of duration; this recovery must
+    // not reach into that window, or the two would fight over the same last half second.
+    @Test("The #169 tail-park window is disjoint from this recovery")
+    func disjointFromTailParkWindow() {
+        #expect(AetherEngine.prematureEndShortfallSeconds > AetherEngine.endOfMediaEpsilonSeconds)
+        #expect(!AetherEngine.prematureEndRecoveryQualifies(
+            isLive: false,
+            duration: duration,
+            playhead: duration - AetherEngine.endOfMediaEpsilonSeconds,
+            seekableEnd: seekableToEnd,
+            attemptsUsed: 0,
+            lastAttemptPlayhead: nil))
+    }
+
+    @Test("A live source never qualifies (no fixed end to fall short of)")
+    func rejectsLive() {
+        #expect(!AetherEngine.prematureEndRecoveryQualifies(
+            isLive: true,
+            duration: duration,
+            playhead: boundary,
+            seekableEnd: seekableToEnd,
+            attemptsUsed: 0,
+            lastAttemptPlayhead: nil))
+    }
+
+    @Test("An unknown duration never qualifies")
+    func rejectsUnknownDuration() {
+        #expect(!AetherEngine.prematureEndRecoveryQualifies(
+            isLive: false,
+            duration: 0,
+            playhead: boundary,
+            seekableEnd: seekableToEnd,
+            attemptsUsed: 0,
+            lastAttemptPlayhead: nil))
+    }
+
+    @Test("A non-finite playhead never qualifies")
+    func rejectsNonFinitePlayhead() {
+        #expect(!AetherEngine.prematureEndRecoveryQualifies(
+            isLive: false,
+            duration: duration,
+            playhead: .nan,
+            seekableEnd: seekableToEnd,
+            attemptsUsed: 0,
+            lastAttemptPlayhead: nil))
+    }
+
+    // A recovery that did not move the playhead is a recovery that cannot work on this item. Accept
+    // the end rather than re-seek the same position forever.
+    @Test("A repeat end at the same position after a recovery is accepted")
+    func rejectsStalledRetry() {
+        #expect(!AetherEngine.prematureEndRecoveryQualifies(
+            isLive: false,
+            duration: duration,
+            playhead: boundary + 0.01,
+            seekableEnd: seekableToEnd,
+            attemptsUsed: 1,
+            lastAttemptPlayhead: boundary))
+    }
+
+    @Test("A repeat end further along the item still qualifies")
+    func acceptsRetryAfterProgress() {
+        #expect(AetherEngine.prematureEndRecoveryQualifies(
+            isLive: false,
+            duration: duration,
+            playhead: boundary + 40,
+            seekableEnd: seekableToEnd,
+            attemptsUsed: 1,
+            lastAttemptPlayhead: boundary))
+    }
+
+    @Test("Attempts are bounded")
+    func boundsAttempts() {
+        #expect(!AetherEngine.prematureEndRecoveryQualifies(
+            isLive: false,
+            duration: duration,
+            playhead: boundary,
+            seekableEnd: seekableToEnd,
+            attemptsUsed: AetherEngine.prematureEndRecoveryMaxAttempts,
+            lastAttemptPlayhead: nil))
+    }
+}


### PR DESCRIPTION
Fixes the ~53 s early stop reported in #287.

## What happens

An MKV whose selected audio track outruns its video track ends tens of seconds early. AVPlayer fires `didPlayToEndTime` the moment its video renderer runs dry, and the engine forwards that as organic completion. `.ended` is terminal (#63/#164), so the audio-only tail is unreachable for the rest of the session, and a host that rebuilds the session at the boundary gets the same instant end again.

## Measured, not inferred

Reproduced deterministically on macOS with `aetherctl play` on a synthesized MKV (60 s HEVC video, 113 s AAC audio):

| | measured |
|---|---|
| container duration | 113.023 s |
| video ends | 59.93 s |
| playlist EXTINF sum | **113.023 s** (14 x 4.004 + 56.967) |
| `didPlayToEndTime` | 60.03 s, final segment already fetched whole |
| 53 s / 8 s / 2 s tail | all three end at 60.03 s |

Two things this rules out. The playlist is **not** video-anchored: its EXTINF sum equals the container duration to the millisecond, so the presentation the engine advertises is self-consistent. And the tail length is irrelevant, so the trigger is the video exhaustion itself.

## The fix

The engine cannot talk AVPlayer out of that call, so it stops repeating it. An end that lands more than a second inside the range AVPlayer itself still reports as **seekable** is refused; the item is re-seeked to the SAME position and resumed. That re-arms the renderers, and the tail plays out to an organic end at the real duration with nothing dropped.

The witness is the seekable range, not the loaded one that carries #169. At the instant of the premature end AVPlayer has already trimmed `loadedTimeRanges` back to the exhaustion point (`[22.34, 60.01]` against a playhead of 60.03), so the loaded range corroborates the mistake instead of refuting it, while `seekableTimeRanges` still reports `[0, 113.02]`. `play()` without the seek was measured too: it leaves the clock frozen at the boundary indefinitely.

Bounds: recoveries are capped at 3 per item and each must have moved the playhead, so a source that genuinely cannot continue costs one re-seek and then completes exactly as it does today. A live session fails the guard twice over (explicit flag, and its seekable end is the live edge). A real serve failure never reaches this path, failing the item with `failedToPlayToEndTime` / -12889 instead.

The transient pause AVPlayer takes across the re-seek is swallowed, so the engine never bounces through `.paused` for something the viewer must not notice.

## Verification

| fixture | before | after |
|---|---|---|
| 53 s tail (dur 113.02) | ended 60.03 | **112.97, organic** |
| 8 s tail (dur 68.02) | ended 60.03 | **67.98, organic** |
| 2 s tail (dur 62.02) | ended 60.03 | **61.98, organic** |
| equal-length A/V (dur 60.02) | ended 59.97 | 59.97, recovery never armed |
| resume at the boundary (60.03) | - | plays to 112.97 |

Each recovering fixture takes exactly one attempt.

- 1462 tests in 217 suites green (11 new in `PrematureEndOfItemTests`, written red first)
- strict Swift concurrency clean
- tvOS and iOS device builds green

`aetherctl play` gains `--start-position`, the resume anchor the reporter's hard-park arm needs to be reproducible at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HX5zV3Fcf7Nzq4DYGdXvQE