### PR TITLE
fix(live): the carriage probe spends playlists against the mount, and a segment only after it

### DIFF
--- a/Sources/AetherEngine/IO/HLSIngest/HLSCarriageProbe.swift
+++ b/Sources/AetherEngine/IO/HLSIngest/HLSCarriageProbe.swift
@@ -5,6 +5,10 @@ import Foundation
 /// after it. Same evidence chain #268 uses for finite VOD, minus the VOD-only requirements (no
 /// EXT-X-ENDLIST, no duration axis), so a rolling live window can be judged as well.
 ///
+/// AE#296: two stages, because they cost different things. The playlist stage is free of a per-token
+/// connection cap and settles every source whose playlists already carry the answer; only what is left
+/// reaches a segment, and the caller spends that read once a lost connection can no longer cost the mount.
+///
 /// Never throws: a caller acts on positive evidence only, so every failure collapses to `inconclusive`
 /// and leaves the source on the route it is already taking.
 enum HLSCarriageProbe {
@@ -25,34 +29,82 @@ enum HLSCarriageProbe {
         return URLSession(configuration: configuration)
     }()
 
-    private enum PlaylistOutcome {
-        case segment(URL)
+    /// AE#296: what the playlist chain established, and whether a media byte is still needed to settle it.
+    /// The two stages are separated because they have different costs: playlists are free of a per-token
+    /// connection cap, a segment fetch is not.
+    enum PlaylistEvidence: Equatable {
+        /// Answered from the playlists alone; no segment was fetched.
         case settled(MPEGTransportStreamCodecProbe.Verdict)
+        /// Only this segment's PMT separates the carriages here.
+        case needsSegmentHead(URL)
     }
 
-    /// Classifies the carriage behind a master or media playlist URL. Costs one playlist fetch for a
-    /// media playlist, two for a master, plus a bounded ranged read of one segment head. An `EXT-X-MAP`
-    /// settles it as fMP4 before any segment byte is fetched.
-    static func classifyLiveCarriage(
+    /// AE#296: the playlist stage. Costs one playlist fetch for a media playlist, two for a master, and
+    /// never a media byte, so it can run against the native mount on a connection-capped origin.
+    ///
+    /// It settles the case outright when the playlists already carry the answer: an `EXT-X-MAP` is fMP4
+    /// carriage, and an fMP4-only advertised codec (`advertisesFragmentedMP4OnlyVideo`, from the master
+    /// `CODECS` AVFoundation has already parsed) *without* an `EXT-X-MAP` is that codec in MPEG-TS, since
+    /// an fMP4 media segment requires an EXT-X-MAP (RFC 8216 4.3.2.5). Everything else hands back the
+    /// segment whose PMT decides it, for the caller to spend when a lost connection can no longer cost
+    /// the mount.
+    static func classifyFromPlaylists(
         playlistURL: URL,
+        httpHeaders: [String: String],
+        advertisesFragmentedMP4OnlyVideo: Bool,
+        session: URLSession? = nil
+    ) async -> PlaylistEvidence {
+        do {
+            return try await resolveFirstSegment(
+                playlistURL: playlistURL,
+                httpHeaders: httpHeaders,
+                advertisesFragmentedMP4OnlyVideo: advertisesFragmentedMP4OnlyVideo,
+                session: session ?? sharedSession
+            )
+        } catch {
+            EngineLog.emit("[HLSCarriageProbe] carriage probe inconclusive: \(error)", category: .engine)
+            return .settled(.inconclusive)
+        }
+    }
+
+    /// AE#296: the segment stage, run apart from the playlist stage so the one media byte the probe ever
+    /// spends is spent where losing it costs the verdict rather than the mount. Never throws: an origin
+    /// that refuses this read leaves the source on the route it is already taking.
+    static func classifyDeferredSegmentHead(
+        url: URL,
         httpHeaders: [String: String],
         session: URLSession? = nil
     ) async -> MPEGTransportStreamCodecProbe.Verdict {
-        let session = session ?? sharedSession
         do {
-            switch try await resolveFirstSegment(
-                playlistURL: playlistURL, httpHeaders: httpHeaders, session: session
-            ) {
-            case .settled(let verdict):
-                return verdict
-            case .segment(let segmentURL):
-                return try await classifySegmentHead(
-                    url: segmentURL, httpHeaders: httpHeaders, session: session
-                )
-            }
+            return try await classifySegmentHead(
+                url: url, httpHeaders: httpHeaders, session: session ?? sharedSession
+            )
         } catch {
             EngineLog.emit("[HLSCarriageProbe] carriage probe inconclusive: \(error)", category: .engine)
             return .inconclusive
+        }
+    }
+
+    /// Both stages back to back. The host runs them at different times (AE#296); this is the composed
+    /// chain for harnesses and tests that want one verdict.
+    static func classifyLiveCarriage(
+        playlistURL: URL,
+        httpHeaders: [String: String],
+        advertisesFragmentedMP4OnlyVideo: Bool = false,
+        session: URLSession? = nil
+    ) async -> MPEGTransportStreamCodecProbe.Verdict {
+        switch await classifyFromPlaylists(
+            playlistURL: playlistURL,
+            httpHeaders: httpHeaders,
+            advertisesFragmentedMP4OnlyVideo: advertisesFragmentedMP4OnlyVideo,
+            session: session
+        ) {
+        case .settled(let verdict):
+            return verdict
+        case .needsSegmentHead(let segmentURL):
+            return await classifyDeferredSegmentHead(
+                url: segmentURL, httpHeaders: httpHeaders, session: session
+            )
         }
     }
 
@@ -96,8 +148,9 @@ enum HLSCarriageProbe {
     private static func resolveFirstSegment(
         playlistURL: URL,
         httpHeaders: [String: String],
+        advertisesFragmentedMP4OnlyVideo: Bool,
         session: URLSession
-    ) async throws -> PlaylistOutcome {
+    ) async throws -> PlaylistEvidence {
         let (root, rootURL) = try await fetchPlaylist(playlistURL, httpHeaders: httpHeaders, session: session)
         let media: HLSMediaPlaylist
         let mediaURL: URL
@@ -119,6 +172,13 @@ enum HLSCarriageProbe {
         }
         // fMP4 carriage is what AVFoundation wants; the playlist says so before a segment is touched.
         guard !media.hasMap else { return .settled(.otherCarriage) }
+        // AE#296: an fMP4 media segment requires an EXT-X-MAP, so an fMP4-only codec advertised over a
+        // window that has none is that codec in MPEG-TS, settled without a media connection. Encryption
+        // does not block this branch the way it blocks the PMT read (nothing is being decrypted here),
+        // except where the ingest could not serve the carriage anyway.
+        if advertisesFragmentedMP4OnlyVideo, !media.hasUnsupportedEncryption, !media.segments.isEmpty {
+            return .settled(.hevcInMPEGTS)
+        }
         // An encrypted segment hides its PMT, and an absence of evidence never reroutes.
         guard let first = media.segments.first,
               first.crypt == nil,
@@ -126,7 +186,7 @@ enum HLSCarriageProbe {
               let segmentURL = HLSPlaylistParser.resolve(uri: first.uri, against: mediaURL) else {
             return .settled(.inconclusive)
         }
-        return .segment(segmentURL)
+        return .needsSegmentHead(segmentURL)
     }
 
     private static func fetchPlaylist(

--- a/Sources/AetherEngine/Native/NativeAVPlayerHost.swift
+++ b/Sources/AetherEngine/Native/NativeAVPlayerHost.swift
@@ -87,6 +87,10 @@ final class NativeAVPlayerHost {
     /// and the reroute no longer waits out a grace whose conclusion is known.
     private var carriageProbeEvidence: RemoteHLSIngestFallback.CarriageEvidence = .pending
     private var carriageProbeTask: Task<Void, Never>?
+    /// #296: cadence and ceiling of the wait that holds the probe's deferred segment-head read until
+    /// readyToPlay. 20 s is well past the point where a mount that has not become ready is going to.
+    static let carriageProbeReadinessTickSeconds = 0.05
+    static let carriageProbeReadinessTicks = 400
 
     /// #35 (Sodalite) cold-DV-master startup-readiness gate. While the engine drives the bounded
     /// retry loop this is true, so a startup failure (`.failed` with any code, including a
@@ -1242,11 +1246,16 @@ final class NativeAVPlayerHost {
         }
     }
 
-    /// AE#293: read the carriage off the source itself (playlist plus the first segment's PMT) while the
-    /// native mount runs, so the #168 verdict does not cost a mount plus the watchdog grace on every
-    /// first open. Gated on AVFoundation's own master parse, which is already fetched and therefore free:
-    /// only a codec the HLS Authoring Spec sanctions in fMP4 alone, or a source with no master evidence
-    /// at all, reaches the network here. The verdict feeds the same watchdog; it never fires on its own.
+    /// AE#293: read the carriage off the source itself (playlist plus, where the playlists cannot settle
+    /// it, the first segment's PMT) while the native mount runs, so the #168 verdict does not cost a mount
+    /// plus the watchdog grace on every first open. Gated on AVFoundation's own master parse, which is
+    /// already fetched and therefore free: only a codec the HLS Authoring Spec sanctions in fMP4 alone, or
+    /// a source with no master evidence at all, reaches the network here. The verdict feeds the same
+    /// watchdog; it never fires on its own.
+    ///
+    /// AE#296: the two stages run at different times, because they cost different things. Playlists are
+    /// not what a per-token connection cap counts, so the playlist stage runs against the mount; a segment
+    /// fetch is, so it waits for readyToPlay (see `awaitReadyForDeferredProbe`).
     @MainActor
     private func startCarriageProbe(asset: AVURLAsset, url: URL, httpHeaders: [String: String]) {
         let sid = sessionID
@@ -1258,15 +1267,60 @@ final class NativeAVPlayerHost {
             let codecs = variants.compactMap { $0.videoAttributes }.flatMap { $0.codecTypes }
             guard RemoteHLSIngestFallback.shouldProbeCarriage(
                 advertisesVideo: advertises, advertisedVideoCodecs: codecs) else { return }
-            let verdict = await HLSCarriageProbe.classifyLiveCarriage(
-                playlistURL: url, httpHeaders: httpHeaders)
-            guard let self, !Task.isCancelled, self.sessionID == sid else { return }
-            self.carriageProbeEvidence = verdict == .hevcInMPEGTS ? .transportStreamHEVC : .nativeCapable
-            EngineLog.emit(
-                "[NativeAVPlayerHost] #\(sid) carriage probe: \(verdict) (#293)",
-                category: .engine
+            let evidence = await HLSCarriageProbe.classifyFromPlaylists(
+                playlistURL: url,
+                httpHeaders: httpHeaders,
+                advertisesFragmentedMP4OnlyVideo:
+                    RemoteHLSIngestFallback.advertisesFragmentedMP4OnlyVideo(codecs)
             )
+            guard let self, !Task.isCancelled, self.sessionID == sid else { return }
+            switch evidence {
+            case .settled(let verdict):
+                self.publishCarriageProbeVerdict(verdict, sid: sid, from: "playlist")
+            case .needsSegmentHead(let segmentURL):
+                EngineLog.emit(
+                    "[NativeAVPlayerHost] #\(sid) carriage probe: the playlists cannot settle this one, "
+                    + "so the segment head waits for readyToPlay rather than compete with the mount (#296)",
+                    category: .engine
+                )
+                guard await self.awaitReadyForDeferredProbe(sid: sid) else { return }
+                let verdict = await HLSCarriageProbe.classifyDeferredSegmentHead(
+                    url: segmentURL, httpHeaders: httpHeaders)
+                guard !Task.isCancelled, self.sessionID == sid else { return }
+                self.publishCarriageProbeVerdict(verdict, sid: sid, from: "segment PMT")
+            }
         }
+    }
+
+    @MainActor
+    private func publishCarriageProbeVerdict(
+        _ verdict: MPEGTransportStreamCodecProbe.Verdict, sid: Int, from source: String
+    ) {
+        carriageProbeEvidence = verdict == .hevcInMPEGTS ? .transportStreamHEVC : .nativeCapable
+        EngineLog.emit(
+            "[NativeAVPlayerHost] #\(sid) carriage probe: \(verdict) from \(source) evidence (#293)",
+            category: .engine
+        )
+    }
+
+    /// AE#296: hold the deferred segment-head read until the item is ready. The verdict cannot be acted on
+    /// before then anyway (the watchdog arms at readyToPlay), so waiting costs nothing and removes the one
+    /// window where the read is expensive: a connection lost while the mount is establishing its own can
+    /// cost the mount, one lost here can only cost the verdict, on a session that is already black. A
+    /// session that never reaches readyToPlay, or whose watchdog disarms first, spends no media byte at
+    /// all. Returns false when the wait was overtaken by cancellation, a new session or the ceiling.
+    @MainActor
+    private func awaitReadyForDeferredProbe(sid: Int) async -> Bool {
+        var ticksWaited = 0
+        while !isReady {
+            guard !Task.isCancelled,
+                  sessionID == sid,
+                  ticksWaited < Self.carriageProbeReadinessTicks else { return false }
+            ticksWaited += 1
+            try? await Task.sleep(
+                nanoseconds: UInt64(Self.carriageProbeReadinessTickSeconds * 1_000_000_000))
+        }
+        return !Task.isCancelled && sessionID == sid
     }
 
     /// AetherEngine#168 follow-up: after readyToPlay, poll `item.tracks` at the tick cadence against the

--- a/Sources/AetherEngine/Native/RemoteHLSIngestFallback.swift
+++ b/Sources/AetherEngine/Native/RemoteHLSIngestFallback.swift
@@ -110,7 +110,15 @@ enum RemoteHLSIngestFallback {
         if advertisesVideo == false { return false }
         guard advertisesVideo == true else { return true }
         guard !advertisedVideoCodecs.isEmpty else { return true }
-        return advertisedVideoCodecs.contains { fragmentedMP4OnlyVideoCodecs.contains($0) }
+        return advertisesFragmentedMP4OnlyVideo(advertisedVideoCodecs)
+    }
+
+    /// #296: whether the master's own `CODECS` names a sample type the HLS Authoring Spec sanctions in
+    /// fMP4 alone. Combined with a media playlist that carries no `EXT-X-MAP` (an fMP4 media segment
+    /// requires one), this settles the carriage from the playlists, so the probe spends no segment fetch
+    /// on the shape that produced #293 in the first place.
+    static func advertisesFragmentedMP4OnlyVideo(_ advertisedVideoCodecs: [FourCharCode]) -> Bool {
+        advertisedVideoCodecs.contains { fragmentedMP4OnlyVideoCodecs.contains($0) }
     }
 
     /// #199: a load whose master already fired the carriage verdict (`RerouteVerdictMemory`) routes

--- a/Tests/AetherEngineTests/Issue296CarriageProbeConnectionBudgetTests.swift
+++ b/Tests/AetherEngineTests/Issue296CarriageProbeConnectionBudgetTests.swift
@@ -1,0 +1,399 @@
+import Foundation
+import XCTest
+@testable import AetherEngine
+
+/// AE#296: the #293 carriage probe reads a segment head to classify the PMT, and it reads it while the
+/// native mount is establishing its own connection to the same origin. On a per-token connection cap
+/// (the IPTV norm) that is a second media connection competing with the mount, on exactly the channels
+/// the probe's gate admits. Two defects, neither of which is "the probe reads a segment": it reads one
+/// where the playlists already answer, and it reads it at the one moment where losing the race costs the
+/// mount rather than the verdict. These tests pin the playlist stage's evidence rules and the point at
+/// which a media byte is spent at all.
+final class Issue296CarriageProbeConnectionBudgetTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        Issue296URLProtocol.reset()
+    }
+
+    // MARK: - Advertisement classification
+
+    func testFragmentedMP4OnlyCodecsAreRecognized() {
+        // The HLS Authoring Spec sanctions these in fMP4 carriage alone, so MPEG-TS segments behind such
+        // an advertisement are the #168 case without a PMT read.
+        for codec in [Self.hvc1, Self.hev1, Self.dvh1, Self.dvhe, Self.av01] {
+            XCTAssertTrue(RemoteHLSIngestFallback.advertisesFragmentedMP4OnlyVideo([codec]))
+        }
+        XCTAssertTrue(RemoteHLSIngestFallback.advertisesFragmentedMP4OnlyVideo([Self.avc1, Self.hvc1]))
+    }
+
+    func testH264AndAbsentAdvertisementAreNotFragmentedMP4Only() {
+        XCTAssertFalse(RemoteHLSIngestFallback.advertisesFragmentedMP4OnlyVideo([Self.avc1]))
+        XCTAssertFalse(
+            RemoteHLSIngestFallback.advertisesFragmentedMP4OnlyVideo([]),
+            "no CODECS attribute is an absence of evidence, and only the PMT can settle that source"
+        )
+    }
+
+    // MARK: - Playlist stage: settled without a media byte
+
+    func testAdvertisedHEVCWithoutMapSettlesWithoutFetchingASegment() async throws {
+        let master = try XCTUnwrap(URL(string: "https://cap.test/master.m3u8"))
+        let high = try XCTUnwrap(URL(string: "https://cap.test/high.m3u8"))
+        Issue296URLProtocol.bodyByURL[master.absoluteString] = Data("""
+        #EXTM3U
+        #EXT-X-STREAM-INF:BANDWIDTH=6000000,CODECS="hvc1.2.4.L150.B0"
+        high.m3u8
+        """.utf8)
+        Issue296URLProtocol.bodyByURL[high.absoluteString] = liveMediaPlaylist("high0.ts")
+        Issue296URLProtocol.bodyByURL["https://cap.test/high0.ts"] = transportStream(streamType: 0x24)
+
+        let session = makeSession()
+        defer { session.invalidateAndCancel() }
+        let evidence = await HLSCarriageProbe.classifyFromPlaylists(
+            playlistURL: master,
+            httpHeaders: [:],
+            advertisesFragmentedMP4OnlyVideo: true,
+            session: session
+        )
+
+        XCTAssertEqual(
+            evidence,
+            .settled(.hevcInMPEGTS),
+            "an fMP4 media segment requires an EXT-X-MAP, so an fMP4-only codec without one is MPEG-TS"
+        )
+        XCTAssertNil(
+            Issue296URLProtocol.headersByURL["https://cap.test/high0.ts"],
+            "the playlists answered; a capped origin must not see a second media connection for this"
+        )
+    }
+
+    func testAdvertisedHEVCWithMapStaysOtherCarriage() async throws {
+        let media = try XCTUnwrap(URL(string: "https://cap.test/fmp4.m3u8"))
+        Issue296URLProtocol.bodyByURL[media.absoluteString] = Data("""
+        #EXTM3U
+        #EXT-X-TARGETDURATION:6
+        #EXT-X-MAP:URI="init.mp4"
+        #EXTINF:6,
+        fmp40.m4s
+        """.utf8)
+
+        let session = makeSession()
+        defer { session.invalidateAndCancel() }
+        let evidence = await HLSCarriageProbe.classifyFromPlaylists(
+            playlistURL: media,
+            httpHeaders: [:],
+            advertisesFragmentedMP4OnlyVideo: true,
+            session: session
+        )
+
+        XCTAssertEqual(evidence, .settled(.otherCarriage), "fMP4 is the carriage AVPlayer builds itself")
+    }
+
+    func testAES128DoesNotBlockPlaylistEvidence() async throws {
+        // The PMT behind AES-128 is unreadable, which is why the segment stage gives up on it. Playlist
+        // evidence does not read the PMT, and the ingest decrypts this carriage, so the verdict lands
+        // early instead of costing the full grace before the watchdog concludes the same thing.
+        let media = try XCTUnwrap(URL(string: "https://cap.test/aes.m3u8"))
+        Issue296URLProtocol.bodyByURL[media.absoluteString] = Data("""
+        #EXTM3U
+        #EXT-X-TARGETDURATION:6
+        #EXT-X-MEDIA-SEQUENCE:99
+        #EXT-X-KEY:METHOD=AES-128,URI="key.bin"
+        #EXTINF:6,
+        aes0.ts
+        """.utf8)
+
+        let session = makeSession()
+        defer { session.invalidateAndCancel() }
+        let evidence = await HLSCarriageProbe.classifyFromPlaylists(
+            playlistURL: media,
+            httpHeaders: [:],
+            advertisesFragmentedMP4OnlyVideo: true,
+            session: session
+        )
+
+        XCTAssertEqual(evidence, .settled(.hevcInMPEGTS))
+        XCTAssertNil(Issue296URLProtocol.headersByURL["https://cap.test/aes0.ts"])
+        XCTAssertNil(
+            Issue296URLProtocol.headersByURL["https://cap.test/key.bin"],
+            "the key is the ingest's business, not the probe's"
+        )
+    }
+
+    func testSampleAESStaysInconclusiveOnPlaylistEvidence() async throws {
+        // SAMPLE-AES is not carriage the ingest can serve, so positive evidence must not be claimed for it.
+        let media = try XCTUnwrap(URL(string: "https://cap.test/sample-aes.m3u8"))
+        Issue296URLProtocol.bodyByURL[media.absoluteString] = Data("""
+        #EXTM3U
+        #EXT-X-TARGETDURATION:6
+        #EXT-X-KEY:METHOD=SAMPLE-AES,URI="key.bin"
+        #EXTINF:6,
+        sae0.ts
+        """.utf8)
+
+        let session = makeSession()
+        defer { session.invalidateAndCancel() }
+        let evidence = await HLSCarriageProbe.classifyFromPlaylists(
+            playlistURL: media,
+            httpHeaders: [:],
+            advertisesFragmentedMP4OnlyVideo: true,
+            session: session
+        )
+
+        XCTAssertEqual(evidence, .settled(.inconclusive))
+    }
+
+    func testEmptyPlaylistStaysInconclusive() async throws {
+        // A window with no segments states nothing about its carriage, and an absence never reroutes.
+        let media = try XCTUnwrap(URL(string: "https://cap.test/empty.m3u8"))
+        Issue296URLProtocol.bodyByURL[media.absoluteString] = Data("""
+        #EXTM3U
+        #EXT-X-TARGETDURATION:6
+        #EXT-X-MEDIA-SEQUENCE:4
+        """.utf8)
+
+        let session = makeSession()
+        defer { session.invalidateAndCancel() }
+        let evidence = await HLSCarriageProbe.classifyFromPlaylists(
+            playlistURL: media,
+            httpHeaders: [:],
+            advertisesFragmentedMP4OnlyVideo: true,
+            session: session
+        )
+
+        XCTAssertEqual(evidence, .settled(.inconclusive))
+    }
+
+    // MARK: - Playlist stage: what still needs the PMT
+
+    func testDirectMediaPlaylistDefersTheSegmentHead() async throws {
+        // No master, so no CODECS: only the PMT separates HEVC in MPEG-TS from H.264 in MPEG-TS here, and
+        // dropping that distinction would pull working H.264 channels off the native path. The playlist
+        // stage must hand the segment back rather than fetch it, so the host can spend it after
+        // readyToPlay instead of against the mount.
+        let media = try XCTUnwrap(URL(string: "https://cap.test/direct.m3u8"))
+        Issue296URLProtocol.bodyByURL[media.absoluteString] = liveMediaPlaylist("direct0.ts")
+        Issue296URLProtocol.bodyByURL["https://cap.test/direct0.ts"] = transportStream(streamType: 0x24)
+
+        let session = makeSession()
+        defer { session.invalidateAndCancel() }
+        let evidence = await HLSCarriageProbe.classifyFromPlaylists(
+            playlistURL: media,
+            httpHeaders: [:],
+            advertisesFragmentedMP4OnlyVideo: false,
+            session: session
+        )
+
+        XCTAssertEqual(
+            evidence,
+            .needsSegmentHead(try XCTUnwrap(URL(string: "https://cap.test/direct0.ts")))
+        )
+        XCTAssertNil(
+            Issue296URLProtocol.headersByURL["https://cap.test/direct0.ts"],
+            "the playlist stage runs against the mount, so it spends playlists only"
+        )
+    }
+
+    func testMasterWithoutCodecEvidenceDefersTheSegmentHead() async throws {
+        let master = try XCTUnwrap(URL(string: "https://cap.test/nocodecs.m3u8"))
+        let variant = try XCTUnwrap(URL(string: "https://cap.test/v1.m3u8"))
+        Issue296URLProtocol.bodyByURL[master.absoluteString] = Data("""
+        #EXTM3U
+        #EXT-X-STREAM-INF:BANDWIDTH=3000000,RESOLUTION=1920x1080
+        v1.m3u8
+        """.utf8)
+        Issue296URLProtocol.bodyByURL[variant.absoluteString] = liveMediaPlaylist("v10.ts")
+
+        let session = makeSession()
+        defer { session.invalidateAndCancel() }
+        let evidence = await HLSCarriageProbe.classifyFromPlaylists(
+            playlistURL: master,
+            httpHeaders: [:],
+            advertisesFragmentedMP4OnlyVideo: false,
+            session: session
+        )
+
+        XCTAssertEqual(
+            evidence,
+            .needsSegmentHead(try XCTUnwrap(URL(string: "https://cap.test/v10.ts")))
+        )
+    }
+
+    func testEncryptedSegmentWithoutCodecEvidenceStaysInconclusive() async throws {
+        let media = try XCTUnwrap(URL(string: "https://cap.test/aes-nocodecs.m3u8"))
+        Issue296URLProtocol.bodyByURL[media.absoluteString] = Data("""
+        #EXTM3U
+        #EXT-X-TARGETDURATION:6
+        #EXT-X-KEY:METHOD=AES-128,URI="key.bin"
+        #EXTINF:6,
+        aes0.ts
+        """.utf8)
+
+        let session = makeSession()
+        defer { session.invalidateAndCancel() }
+        let evidence = await HLSCarriageProbe.classifyFromPlaylists(
+            playlistURL: media,
+            httpHeaders: [:],
+            advertisesFragmentedMP4OnlyVideo: false,
+            session: session
+        )
+
+        XCTAssertEqual(evidence, .settled(.inconclusive), "an unreadable PMT is not evidence of anything")
+    }
+
+    func testUnreachablePlaylistSettlesInconclusive() async throws {
+        let media = try XCTUnwrap(URL(string: "https://cap.test/dead.m3u8"))
+
+        let session = makeSession()
+        defer { session.invalidateAndCancel() }
+        let evidence = await HLSCarriageProbe.classifyFromPlaylists(
+            playlistURL: media,
+            httpHeaders: [:],
+            advertisesFragmentedMP4OnlyVideo: true,
+            session: session
+        )
+
+        XCTAssertEqual(evidence, .settled(.inconclusive))
+    }
+
+    // MARK: - Deferred segment stage
+
+    func testDeferredSegmentHeadClassifiesTheCarriage() async throws {
+        Issue296URLProtocol.bodyByURL["https://cap.test/direct0.ts"] = transportStream(streamType: 0x24)
+        let session = makeSession()
+        defer { session.invalidateAndCancel() }
+
+        let verdict = await HLSCarriageProbe.classifyDeferredSegmentHead(
+            url: try XCTUnwrap(URL(string: "https://cap.test/direct0.ts")),
+            httpHeaders: ["X-Fixture": "allowed"],
+            session: session
+        )
+
+        XCTAssertEqual(verdict, .hevcInMPEGTS)
+        XCTAssertEqual(
+            Issue296URLProtocol.headersByURL["https://cap.test/direct0.ts"]?["X-Fixture"],
+            "allowed",
+            "header-enforcing origins must see the session's headers on the deferred fetch too"
+        )
+    }
+
+    func testDeferredSegmentHeadCollapsesFailureToInconclusive() async throws {
+        let session = makeSession()
+        defer { session.invalidateAndCancel() }
+
+        let verdict = await HLSCarriageProbe.classifyDeferredSegmentHead(
+            url: try XCTUnwrap(URL(string: "https://cap.test/gone.ts")),
+            httpHeaders: [:],
+            session: session
+        )
+
+        XCTAssertEqual(verdict, .inconclusive, "a refused connection is not a reason to reroute")
+    }
+
+    // MARK: - Composed chain (the #293 behaviour that must not regress)
+
+    func testComposedChainStillClassifiesADirectMediaPlaylist() async throws {
+        let media = try XCTUnwrap(URL(string: "https://cap.test/direct.m3u8"))
+        Issue296URLProtocol.bodyByURL[media.absoluteString] = liveMediaPlaylist("direct0.ts")
+        Issue296URLProtocol.bodyByURL["https://cap.test/direct0.ts"] = transportStream(streamType: 0x24)
+
+        let session = makeSession()
+        defer { session.invalidateAndCancel() }
+        let verdict = await HLSCarriageProbe.classifyLiveCarriage(
+            playlistURL: media,
+            httpHeaders: [:],
+            session: session
+        )
+
+        XCTAssertEqual(verdict, .hevcInMPEGTS)
+    }
+
+    // MARK: - Fixtures
+
+    private static let avc1: FourCharCode = 0x61766331
+    private static let hvc1: FourCharCode = 0x68766331
+    private static let hev1: FourCharCode = 0x68657631
+    private static let dvh1: FourCharCode = 0x64766831
+    private static let dvhe: FourCharCode = 0x64766865
+    private static let av01: FourCharCode = 0x61763031
+
+    private func makeSession() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [Issue296URLProtocol.self]
+        return URLSession(configuration: configuration)
+    }
+
+    private func liveMediaPlaylist(_ segment: String) -> Data {
+        Data("""
+        #EXTM3U
+        #EXT-X-TARGETDURATION:6
+        #EXT-X-MEDIA-SEQUENCE:812
+        #EXTINF:6,
+        \(segment)
+        """.utf8)
+    }
+
+    private func transportStream(streamType: UInt8) -> Data {
+        var bytes = [UInt8](repeating: 0xFF, count: 188 * 3)
+        for packet in 0..<3 {
+            bytes[packet * 188] = 0x47
+            bytes[packet * 188 + 3] = 0x10
+        }
+        bytes[1] = 0x40
+        bytes[2] = 0x64
+        bytes[4] = 0
+        bytes[5] = 0x02
+        bytes[6] = 0xB0
+        bytes[7] = 18
+        bytes[8] = 0
+        bytes[9] = 1
+        bytes[10] = 0xC1
+        bytes[11] = 0
+        bytes[12] = 0
+        bytes[13] = 0xE1
+        bytes[14] = 0
+        bytes[15] = 0xF0
+        bytes[16] = 0
+        bytes[17] = streamType
+        bytes[18] = 0xE1
+        bytes[19] = 1
+        bytes[20] = 0xF0
+        bytes[21] = 0
+        return Data(bytes)
+    }
+}
+
+final class Issue296URLProtocol: URLProtocol, @unchecked Sendable {
+    nonisolated(unsafe) static var bodyByURL: [String: Data] = [:]
+    nonisolated(unsafe) static var headersByURL: [String: [String: String]] = [:]
+
+    static func reset() {
+        bodyByURL = [:]
+        headersByURL = [:]
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+    override func stopLoading() {}
+
+    override func startLoading() {
+        guard let url = request.url else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badURL))
+            return
+        }
+        Self.headersByURL[url.absoluteString] = request.allHTTPHeaderFields ?? [:]
+        guard let data = Self.bodyByURL[url.absoluteString] else {
+            client?.urlProtocol(self, didFailWithError: URLError(.fileDoesNotExist))
+            return
+        }
+        let response = HTTPURLResponse(
+            url: url,
+            statusCode: request.value(forHTTPHeaderField: "Range") == nil ? 200 : 206,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Length": String(data.count)]
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: data)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+}


### PR DESCRIPTION
Part of #296. The issue stays open for the device leg on a real connection-capped origin.

The #293 probe classifies a live source's carriage from its playlist and the head of its first segment. That segment read starts in `NativeAVPlayerHost.load`, concurrently with the native mount, and on an origin that caps concurrent connections per token (the IPTV norm, one or two) it is a second **media** connection competing with the mount. Playlist fetches are generally not what such caps count. The shapes the gate admits, an fMP4-only advertised codec or no master evidence at all, are precisely the channels where the cap bites, so this could land as an intermittent failure to start on the channels the probe exists to speed up, and it would read as a flaky origin rather than as the probe.

Two defects, neither of which is "the probe reads a segment".

**It reads one where the playlists already answer.** An fMP4 media segment requires an `EXT-X-MAP` (RFC 8216 4.3.2.5). A master advertising `hvc1`/`hev1`/`dvh1`/`dvhe`/`av01` over a window with no `EXT-X-MAP` is therefore that codec in MPEG-TS, settled from a `CODECS` attribute AVFoundation has already parsed plus one playlist fetch. `HLSCarriageProbe.classifyFromPlaylists` settles that outright now. AES-128 no longer blocks the branch either: the PMT is not what is being read there, the ingest decrypts that carriage, and the alternative for those channels was the full grace ending in the same reroute.

**It reads it at the one moment where losing the race is expensive.** The verdict cannot be acted on before `readyToPlay` regardless, since it feeds the watchdog and the watchdog arms there. Running the read against the mount buys nothing but a head start on the probe's own latency. What survives the playlist stage, a direct media playlist or a master without `CODECS`, is where the PMT is the only evidence separating HEVC in MPEG-TS from H.264 in MPEG-TS: dropping it would either pull working H.264 channels off the native path or return that case to indefinite black. So the read stays, and waits for `readyToPlay`, where a lost connection can only cost the verdict on a session that is already showing black. A session whose watchdog disarms first, or which never becomes ready, now spends no media byte at all.

Media connections per channel shape:

| shape | before | after |
|---|---|---|
| master advertising HEVC/DV/AV1, no `EXT-X-MAP` | 1, against the mount | **0** |
| master advertising HEVC/DV/AV1, AES-128 | 0, inconclusive, full grace | **0**, settled early |
| direct media playlist, no `CODECS` | 1, against the mount | 1, after `readyToPlay` |
| H.264 master | 0 | 0 |

The saving stays about 3.5 s of the 4 s grace: the deferred verdict lands inside the first tick or two.

## Verification

`Issue296CarriageProbeConnectionBudgetTests`, 14 tests, all watched failing first. They pin the playlist evidence rules (advertised fMP4-only codec, `EXT-X-MAP`, AES-128 vs SAMPLE-AES, an empty window, no `CODECS`) and assert on the origin's request log that no segment is fetched where the playlists settle it. Full suite green: 463 XCTest (1 skipped) plus 1479 swift-testing. tvOS Simulator build clean.

Raised by @kskchaitanya1993 on #293 after the device leg, as a design concern against connection-capped origins rather than a reproduction.
