### PR TITLE
fix(swplayback): name a software session that decodes into nothing (#298)

### DIFF
--- a/Sources/AetherEngine/Native/SoftwarePlaybackHost.swift
+++ b/Sources/AetherEngine/Native/SoftwarePlaybackHost.swift
@@ -255,6 +255,67 @@ final class SoftwarePlaybackHost {
 
     private var timeTimer: AnyCancellable?
 
+    // MARK: - Surface visibility (#298)
+
+    /// Where a software session's frames end up on screen, or why they cannot.
+    enum SurfaceVisibility: Equatable {
+        case onScreen
+        /// The display layer is in no view hierarchy: the host never bound a render surface.
+        case notInViewHierarchy
+        /// Attached, but the bound view never got a layout, so nothing can be visible.
+        case zeroSized(width: Int, height: Int)
+    }
+
+    /// #298: a software session renders into `renderer.displayLayer`, which only reaches the screen
+    /// once the host binds a surface (`AetherEngine.bind(view:)` / `AetherPlayerSurface`). A host that
+    /// presents an AVPlayerViewController instead gets audio, a completely healthy engine log, and no
+    /// picture, because this path has no AVPlayerItem for AVKit to show (its own spinner then sits
+    /// there forever). Neither condition left a trace before, so the report reads as a renderer stall.
+    /// "Never bound" wins over the size: an unbound layer is usually zero-sized as well, and the bind
+    /// is the actionable half.
+    nonisolated static func assessSurface(hasSuperlayer: Bool, size: CGSize) -> SurfaceVisibility {
+        guard hasSuperlayer else { return .notInViewHierarchy }
+        guard size.width > 0, size.height > 0 else {
+            return .zeroSized(width: Int(size.width), height: Int(size.height))
+        }
+        return .onScreen
+    }
+
+    /// Ticks (0.25 s each) the surface check waits after the first enqueued frame. A host binding its
+    /// view during load, and the first layout pass after that, both land well inside this.
+    private static let surfaceCheckTicks = 8
+
+    private var surfaceCheckTicksSeen = 0
+    private var surfaceChecked = false
+
+    /// Runs once per session, ~2 s after frames start flowing. Reads CALayer state, so main actor only.
+    private func checkSurfaceVisibilityIfDue() {
+        guard !surfaceChecked, !backgroundAudioOnly, framesEnqueued > 0 else { return }
+        surfaceCheckTicksSeen += 1
+        guard surfaceCheckTicksSeen >= Self.surfaceCheckTicks else { return }
+        surfaceChecked = true
+
+        let layer = renderer.displayLayer
+        switch Self.assessSurface(hasSuperlayer: layer.superlayer != nil, size: layer.bounds.size) {
+        case .onScreen:
+            return
+        case .notInViewHierarchy:
+            EngineLog.emit(
+                "[SWHost] \(framesEnqueued) frames decoded into a display layer that is in no view "
+                + "hierarchy: the host never bound a render surface (AetherEngine.bind(view:) / "
+                + "AetherPlayerSurface). The software path renders into that layer, not through "
+                + "AVPlayerViewController, so audio plays and no picture can appear",
+                category: .swPlayback
+            )
+        case .zeroSized(let width, let height):
+            EngineLog.emit(
+                "[SWHost] display layer is bound but sized \(width)x\(height) after "
+                + "\(framesEnqueued) frames: the bound view has no layout, so no frame can be visible",
+                category: .swPlayback
+            )
+        }
+    }
+
     /// Caching the chosen rate so resume() restores the right speed after a pause without the
     /// host needing to know its history. Lock-guarded: the demux/feeder threads read it at clock
     /// arming so a host rate change between load and arm is not lost (#107).
@@ -1733,7 +1794,10 @@ final class SoftwarePlaybackHost {
         timeTimer = Timer.publish(every: 0.25, on: .main, in: .common)
             .autoconnect()
             .sink { [weak self] _ in
-                guard let self, let aOut = self.audioOutput else { return }
+                guard let self else { return }
+                // Independent of the clock below: a seek in flight must not defer the one check.
+                self.checkSurfaceVisibilityIfDue()
+                guard let aOut = self.audioOutput else { return }
                 // #254: a reposition in flight holds `currentTime` at its target; the synchronizer is
                 // still on the pre-seek anchor and would drag the published position backwards.
                 guard !self.seekInFlight else { return }

--- a/Sources/AetherEngine/Renderer/SampleBufferRenderer.swift
+++ b/Sources/AetherEngine/Renderer/SampleBufferRenderer.swift
@@ -61,8 +61,17 @@ final class SampleBufferRenderer: @unchecked Sendable {
 
     private var loggedLayerFailed = false
     private var loggedNotReady = false
-    private var enqueueCount = 0
+    /// Internal (not private) for #298 tests: the gate's job is that untimed frames never get here.
+    private(set) var enqueueCount = 0
     private var hdr10PlusAttachedCount = 0
+
+    /// #298: frames refused at the enqueue gate for carrying an unschedulable PTS. Guarded by `reorderLock`.
+    private var _untimedFramesDropped = 0
+    var untimedFramesDropped: Int {
+        reorderLock.lock()
+        defer { reorderLock.unlock() }
+        return _untimedFramesDropped
+    }
 
     init() {
         displayLayer = Self.makeDisplayLayer(isHDR: false)
@@ -136,9 +145,32 @@ final class SampleBufferRenderer: @unchecked Sendable {
         reorderLock.unlock()
     }
 
+    /// #298: whether a frame's presentation timestamp can be scheduled at all. AV_NOPTS_VALUE reaches
+    /// the decoder callback as `CMTime.invalid`, and CoreMedia builds a sample buffer from it without
+    /// complaint (`CMSampleBufferCreateReadyWithImageBuffer` returns noErr, the sample's PTS reads back
+    /// as NaN seconds), so the display queue is the first place it can do damage: the render
+    /// synchronizer cannot pace an untimed sample. The deinterlace path already drops its untimestamped
+    /// output for exactly this reason (see `SoftwareVideoDecoder.drainDecodedFrames`); this is the same
+    /// rule one layer lower, so no producer can put an unschedulable sample in the queue.
+    static func isSchedulable(_ pts: CMTime) -> Bool { pts.isNumeric }
+
     /// Enqueue a decoded frame through the B-frame reorder buffer. `hdr10PlusData` carries per-frame ST 2094-40 metadata serialised to T.35 SEI format for kCMSampleAttachmentKey_HDR10PlusPerFrameData.
     func enqueue(pixelBuffer: CVPixelBuffer, pts: CMTime, hdr10PlusData: Data? = nil) {
         reorderLock.lock()
+
+        // Refused before the reorder buffer, not at flush: `CMTimeGetSeconds(.invalid)` is NaN and
+        // every comparison against NaN is false, so an untimed frame lands past frames it should
+        // precede and reorders its neighbours on the way out.
+        guard Self.isSchedulable(pts) else {
+            _untimedFramesDropped += 1
+            let dropped = _untimedFramesDropped
+            reorderLock.unlock()
+            if dropped == 1 || dropped % 250 == 0 {
+                EngineLog.emit("[Renderer] dropped \(dropped) frame(s) with no usable timestamp (unschedulable)",
+                               category: .swPlayback)
+            }
+            return
+        }
 
         if let threshold = skipUntilPTS {
             if CMTimeCompare(pts, threshold) < 0 {

--- a/Tests/AetherEngineTests/Issue298SoftwareSurfaceTests.swift
+++ b/Tests/AetherEngineTests/Issue298SoftwareSurfaceTests.swift
@@ -1,0 +1,138 @@
+import Testing
+import Foundation
+import CoreMedia
+import CoreVideo
+import QuartzCore
+@testable import AetherEngine
+
+/// #298 (akacores): an AVI whose video track is packed-bitstream XviD played its audio to
+/// completion while the picture never appeared, with `[Renderer] enqueue #30 ... ready=false` read
+/// as "the renderer stopped accepting frames". That log line is what a HEALTHY software session
+/// prints: `isReadyForMoreMediaData` is the demux loop's back-pressure gate, so a full queue right
+/// after an enqueue is the gate working, and the counter reaching #100 at t+4.7 s on a 23.976 fps
+/// source is real-time pacing. A queue that had truly stopped draining would have parked the one
+/// demux loop that also feeds audio within a queue depth, and the audio would have stopped with it.
+///
+/// What the session cannot say today is where the frames went. Two silent host-side conditions
+/// produce exactly this report, and neither leaves a trace:
+///
+/// - the display layer is in no view hierarchy at all (`AetherEngine.bind(view:)` / `AetherPlayerSurface`
+///   never called; the software path does not render through AVPlayerViewController, which has no
+///   AVPlayerItem here and shows its own spinner forever),
+/// - the layer is attached to a view that never got a layout, so it is sized 0x0.
+///
+/// Plus one hardening: a frame whose PTS is not numeric cannot be scheduled by the render
+/// synchronizer. The deinterlace path already drops its untimestamped output for that reason; the
+/// direct path passed `CMTime.invalid` straight through to the display queue, and a NaN also
+/// silently breaks the reorder buffer's PTS ordering (every comparison against NaN is false).
+@Suite("Software-path surface visibility + unschedulable frame gate (#298)")
+struct Issue298SoftwareSurfaceTests {
+
+    // MARK: - Unschedulable frames
+
+    @Test("a numeric PTS is schedulable")
+    func numericPTSSchedulable() {
+        #expect(SampleBufferRenderer.isSchedulable(CMTimeMake(value: 42, timescale: 1000)))
+        #expect(SampleBufferRenderer.isSchedulable(.zero))
+    }
+
+    /// AV_NOPTS_VALUE reaches the decoder callback as `CMTime.invalid`; CoreMedia happily builds a
+    /// sample buffer from it (measured: `CMSampleBufferCreateReadyWithImageBuffer` returns noErr and
+    /// the sample's PTS reads back as NaN seconds), so nothing downstream rejects it either.
+    @Test("an invalid, indefinite or infinite PTS is not schedulable")
+    func nonNumericPTSRejected() {
+        #expect(!SampleBufferRenderer.isSchedulable(.invalid))
+        #expect(!SampleBufferRenderer.isSchedulable(.indefinite))
+        #expect(!SampleBufferRenderer.isSchedulable(.positiveInfinity))
+        #expect(!SampleBufferRenderer.isSchedulable(.negativeInfinity))
+    }
+
+    @Test("untimed frames never reach the display queue and are counted")
+    func untimedFramesDropped() throws {
+        let renderer = SampleBufferRenderer()
+        let pixelBuffer = try Self.makePixelBuffer()
+
+        for _ in 0..<6 {
+            renderer.enqueue(pixelBuffer: pixelBuffer, pts: .invalid)
+        }
+        renderer.drainReorderBuffer()
+
+        #expect(renderer.untimedFramesDropped == 6)
+        #expect(renderer.enqueueCount == 0)
+    }
+
+    @Test("timed frames still reach the display queue")
+    func timedFramesPass() throws {
+        let renderer = SampleBufferRenderer()
+        let pixelBuffer = try Self.makePixelBuffer()
+
+        for i in 0..<5 {
+            renderer.enqueue(pixelBuffer: pixelBuffer,
+                             pts: CMTimeMake(value: Int64(i) * 42, timescale: 1000))
+        }
+        renderer.drainReorderBuffer()
+
+        #expect(renderer.untimedFramesDropped == 0)
+        #expect(renderer.enqueueCount == 5)
+    }
+
+    /// The gate also protects the reorder buffer: `CMTimeGetSeconds(.invalid)` is NaN and every
+    /// comparison against NaN is false, so an untimed frame used to be appended past frames it
+    /// should have preceded, reordering its neighbours as well.
+    @Test("ordering of timed frames survives untimed ones in the same run")
+    func orderingSurvivesUntimedFrames() throws {
+        let renderer = SampleBufferRenderer()
+        let pixelBuffer = try Self.makePixelBuffer()
+
+        for (i, pts) in [30, -1, 10, -1, 20].enumerated() {
+            _ = i
+            renderer.enqueue(pixelBuffer: pixelBuffer,
+                             pts: pts < 0 ? .invalid : CMTimeMake(value: Int64(pts), timescale: 1000))
+        }
+        renderer.drainReorderBuffer()
+
+        #expect(renderer.untimedFramesDropped == 2)
+        #expect(renderer.enqueueCount == 3)
+    }
+
+    // MARK: - Surface visibility
+
+    @Test("a layer in a view hierarchy with a real size is on screen")
+    func boundSurfaceIsOnScreen() {
+        #expect(SoftwarePlaybackHost.assessSurface(
+            hasSuperlayer: true, size: CGSize(width: 1920, height: 1080)) == .onScreen)
+    }
+
+    /// The reported configuration: a host that presents AVPlayerViewController and never binds a
+    /// render surface. Audio plays, the log is clean, no frame can ever be visible.
+    @Test("a layer with no superlayer is named as unbound")
+    func unboundSurfaceIsNamed() {
+        #expect(SoftwarePlaybackHost.assessSurface(
+            hasSuperlayer: false, size: CGSize(width: 1920, height: 1080)) == .notInViewHierarchy)
+        // An unbound layer is usually zero-sized too; "never bound" is the more useful of the two.
+        #expect(SoftwarePlaybackHost.assessSurface(
+            hasSuperlayer: false, size: .zero) == .notInViewHierarchy)
+    }
+
+    @Test("a bound but unlaid-out surface is named by its size")
+    func zeroSizedSurfaceIsNamed() {
+        #expect(SoftwarePlaybackHost.assessSurface(
+            hasSuperlayer: true, size: .zero) == .zeroSized(width: 0, height: 0))
+        #expect(SoftwarePlaybackHost.assessSurface(
+            hasSuperlayer: true, size: CGSize(width: 320, height: 0)) == .zeroSized(width: 320, height: 0))
+    }
+
+    // MARK: - Helpers
+
+    private static func makePixelBuffer() throws -> CVPixelBuffer {
+        var pb: CVPixelBuffer?
+        let status = CVPixelBufferCreate(
+            kCFAllocatorDefault, 128, 96,
+            kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange,
+            [kCVPixelBufferIOSurfacePropertiesKey: [:] as CFDictionary] as CFDictionary,
+            &pb
+        )
+        #expect(status == kCVReturnSuccess)
+        return try #require(pb)
+    }
+}


### PR DESCRIPTION
## What #298 reported

A packed-bitstream XviD AVI: audio plays to completion, the picture never appears, and the session log reads

```
[Renderer] enqueue #1:   status=rendering ready=true  error=nil
[Renderer] enqueue #30:  status=rendering ready=false error=nil   (t+1.37s)
[Renderer] enqueue #100: status=rendering ready=false error=nil   (t+4.74s)
```

which was read as "the renderer stopped accepting frames".

## What the measurement says

`isReadyForMoreMediaData` is the demux loop's back-pressure gate (`SoftwarePlaybackHost` parks on it before feeding a video packet), so a full queue immediately after an enqueue is the gate working. The counter reaching #100 at t+4.74s on a 23.976 fps source is real-time pacing, and a queue that had genuinely stopped draining would have parked the one loop that also feeds audio within a queue depth, taking the audio with it.

Reproduced locally on `ffmpeg -f lavfi -i testsrc -c:v mpeg4 -vtag XVID -bf 2 ... .avi` through `aetherctl play --sw`: the same three lines, the same `pts=0.042s` first frame, `VERDICT: OK`, clock advancing. aetherctl binds no view at all, so it also shows nothing.

That is the actual gap. A software session renders into `SampleBufferRenderer.displayLayer`, which reaches the screen only once the host binds a surface (`AetherEngine.bind(view:)` / `AetherPlayerSurface`). A host presenting `AVPlayerViewController` instead gets audio, a completely healthy engine log, and no picture, because this path has no `AVPlayerItem` for AVKit to show (the reporter's log has `playerItem.status=0, loading=YES` and `_becomeNowPlaying denied: no player item` throughout). Nothing named that condition.

## Changes

**1. Surface visibility, `SoftwarePlaybackHost`.** Once per session, 8 ticks (~2 s) after frames start flowing, on the main actor:

```
[SWHost] 50 frames decoded into a display layer that is in no view hierarchy: the host never
bound a render surface (AetherEngine.bind(view:) / AetherPlayerSurface). The software path
renders into that layer, not through AVPlayerViewController, so audio plays and no picture
can appear
```

and the sibling case, a layer bound to a view that never got a layout:

```
[SWHost] display layer is bound but sized 0x0 after 50 frames: the bound view has no layout,
so no frame can be visible
```

The delay covers a host that binds during load plus the first layout pass. `assessSurface(hasSuperlayer:size:)` is a pure function so both verdicts are pinned without a live layer.

**2. Unschedulable frames, `SampleBufferRenderer`.** `AV_NOPTS_VALUE` reaches the decoder callback as `CMTime.invalid` and CoreMedia builds a sample buffer from it without complaint (measured: `CMSampleBufferCreateReadyWithImageBuffer` returns noErr and the sample's PTS reads back as NaN seconds), so the display queue was the first place it could do damage. The deinterlace path already drops its untimestamped output for that reason; this is the same rule one layer lower, before the reorder buffer, where a NaN also silently breaks ordering for its neighbours (every comparison against NaN is false). Drops are counted and named.

This is hardening, not the cause: the demuxer runs `fflags +genpts`, so AVI's missing anchor-frame timestamps are regenerated (`pktdump` on the fixture: `NOPTS_pts=0`, presentation order `I(1) B(2) B(3) P(4)`). It closes the mechanism the report hypothesised and makes a source that genuinely produces untimed frames say so.

## Not changed

No stall watchdog / `.error` transition. Nothing is stalled here, and a watchdog on "ready has been false for a while" would fire on healthy back-pressure, which is the exact reading this issue is about. Engine logging already goes through `os_log` (subsystem `de.superuser404.AetherEngine`, category `sw.playback`), which is how the reporter captured these lines.

## Verification

- 1491 tests green (8 new in `Issue298SoftwareSurfaceTests`), `swift build -Xswiftc -strict-concurrency=complete` clean, tvOS Simulator `BUILD SUCCEEDED`.
- `aetherctl play --sw` on the AVI fixture emits the new line at t≈1.9s, in the same position the reporter's log would have shown it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HX5zV3Fcf7Nzq4DYGdXvQE
