### PR TITLE
fix(io): let custom readers skip disc probing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,15 @@ the public-API contract.
 
 ## [Unreleased]
 
-_Nothing yet._
+### Fixed
+
+- **Ordinary remote custom readers can skip ISO/UDF disc-image recognition.**
+  `IOReader.discImageProbeEnabled` defaults to `true`, preserving automatic DVD
+  and Blu-ray image support. Readers that already know they expose a regular
+  media file can return `false`, avoiding the sparse remote seeks used only for
+  ISO9660 and UDF signature checks. The policy travels with independent readers,
+  so subtitle side demuxers, reloads, and frame extraction do not repeat those
+  unnecessary network reads.
 
 ## [6.6.3] - 2026-08-04
 

--- a/README.md
+++ b/README.md
@@ -242,9 +242,13 @@ final class MyArchiveReader: IOReader {
     func seek(offset: Int64, whence: Int32) -> Int64 { /* ... */ }  // AVSEEK_SIZE (65536) returns total size
     func close() { /* ... */ }
 
-    // Optional (both have defaults). Override to unlock extra features:
+    // Optional requirements have defaults. Override to unlock extra features:
     func cancel() { /* unblock a blocked read at teardown, do NOT invalidate the reader */ }
     func makeIndependentReader() -> IOReader? { /* a fresh cursor over the same source, or nil */ }
+
+    // Optional, defaults to true. Return false when this is known to be an
+    // ordinary media file rather than a raw ISO/UDF disc image.
+    var discImageProbeEnabled: Bool { false }
 }
 
 let probe = try await engine.load(source: .custom(MyArchiveReader(), formatHint: "mp4"))
@@ -265,7 +269,10 @@ let smb = try await SMBConnection.connect(
     server: URL(string: "smb://nas.local")!, share: "media",
     path: "Movies/film.mkv", user: "alice", password: "s3cret"
 )
-try await engine.load(source: .custom(SMBIOReader(source: smb), formatHint: "matroska"))
+try await engine.load(source: .custom(
+    SMBIOReader(source: smb, discImageProbeEnabled: false),
+    formatHint: "matroska"
+))
 ```
 
 Read-only, NTLMv2 / guest auth (no Kerberos). On tvOS the host must declare `NSLocalNetworkUsageDescription` + the local-network entitlement to reach a LAN share. See [`aetherctl smbtest`](docs/cli.md#smbtest) to validate a share from macOS.

--- a/README.md
+++ b/README.md
@@ -270,10 +270,14 @@ let smb = try await SMBConnection.connect(
     path: "Movies/film.mkv", user: "alice", password: "s3cret"
 )
 try await engine.load(source: .custom(
-    SMBIOReader(source: smb, discImageProbeEnabled: false),
+    SMBIOReader(source: smb),
     formatHint: "matroska"
 ))
 ```
+
+When the SMB path is known to be an ordinary media file, construct the reader with
+`discImageProbeEnabled: false` to skip ISO/UDF signature reads. Keep the default for raw disc
+images so DVD/Blu-ray recognition remains available.
 
 Read-only, NTLMv2 / guest auth (no Kerberos). On tvOS the host must declare `NSLocalNetworkUsageDescription` + the local-network entitlement to reach a LAN share. See [`aetherctl smbtest`](docs/cli.md#smbtest) to validate a share from macOS.
 

--- a/Sources/AetherEngine/Demuxer/Demuxer.swift
+++ b/Sources/AetherEngine/Demuxer/Demuxer.swift
@@ -348,10 +348,12 @@ public final class Demuxer: @unchecked Sendable {
     /// Open a custom `IOReader` source. `formatHint` disambiguates probing when
     /// no filename is available. `isLive` suppresses SEEK_END that latches EOF
     /// on forward-only readers (38ad60b). AetherEngine#36: DiscReader adapts
-    /// DVD/BD ISOs to VOB/MPEGTS concat streams.
+    /// DVD/BD ISOs to VOB/MPEGTS concat streams unless the reader opts out via
+    /// `discImageProbeEnabled`.
     func open(reader: IOReader, formatHint: String? = nil, profile: DemuxerOpenProfile = .playback, isLive: Bool = false, selectTitleID: Int? = nil, discCacheKey: String? = nil) throws {
         self.openProfile = profile
-        if let discInfo = try DiscReader.wrap(reader, selectTitleID: selectTitleID, cacheKey: discCacheKey) {
+        if reader.discImageProbeEnabled,
+           let discInfo = try DiscReader.wrap(reader, selectTitleID: selectTitleID, cacheKey: discCacheKey) {
             adoptDiscInfo(discInfo)
             let bridge = CustomIOReaderBridge(reader: discInfo.reader)
             let inputFormat = av_find_input_format(discInfo.formatHint)

--- a/Sources/AetherEngine/IO/IOReader.swift
+++ b/Sources/AetherEngine/IO/IOReader.swift
@@ -15,6 +15,13 @@ public protocol IOReader: AnyObject, Sendable {
 
     /// Return an independent reader with its own cursor over the same source for concurrent access (side demuxer, scrub previews). Return nil for one-shot streams; the engine skips that feature. The returned reader is owned and closed by the engine.
     func makeIndependentReader() -> IOReader?
+
+    /// Whether the engine should inspect this custom byte source for an ISO/UDF disc image before
+    /// opening it as an ordinary media container. Keep the default for raw disc images. Remote
+    /// readers that already know they represent a regular media file can return `false` to avoid
+    /// the sparse signature reads performed by disc recognition. Independent readers should
+    /// preserve the same value.
+    var discImageProbeEnabled: Bool { get }
 }
 
 /// Internal seam for finite segmented sources whose natural seek axis is time,
@@ -43,6 +50,7 @@ extension TimeSeekableIOReader {
 public extension IOReader {
     func cancel() {}
     func makeIndependentReader() -> IOReader? { nil }
+    var discImageProbeEnabled: Bool { true }
 }
 
 /// The source AetherEngine loads media from.

--- a/Sources/AetherEngineSMB/SMBIOReader.swift
+++ b/Sources/AetherEngineSMB/SMBIOReader.swift
@@ -13,6 +13,7 @@ private final class ReadOutcome: @unchecked Sendable {
 public final class SMBIOReader: IOReader, @unchecked Sendable {
     private let source: ByteRangeSource
     private let ownsSource: Bool
+    public let discImageProbeEnabled: Bool
     // `position` and `didClose` are only accessed on the demux/teardown thread
     // per the IOReader contract; no lock needed.
     private var position: Int64 = 0
@@ -37,9 +38,17 @@ public final class SMBIOReader: IOReader, @unchecked Sendable {
     /// `AVSEEK_SIZE` from FFmpeg: return total size, do not move.
     private let avseekSize: Int32 = 65536
 
-    public init(source: ByteRangeSource, ownsSource: Bool = true) {
+    /// - Parameter discImageProbeEnabled: Keep enabled for an SMB path that is a raw ISO/UDF disc
+    ///   image. Set to `false` for an ordinary media file to avoid sparse signature reads before
+    ///   container probing.
+    public init(
+        source: ByteRangeSource,
+        ownsSource: Bool = true,
+        discImageProbeEnabled: Bool = true
+    ) {
         self.source = source
         self.ownsSource = ownsSource
+        self.discImageProbeEnabled = discImageProbeEnabled
     }
 
     public func read(_ buffer: UnsafeMutablePointer<UInt8>?, size: Int32) -> Int32 {
@@ -114,7 +123,11 @@ public final class SMBIOReader: IOReader, @unchecked Sendable {
     public func makeIndependentReader() -> IOReader? {
         // Range reads are serialised per connection by SMBClient, so the
         // independent reader shares the connection but never owns its teardown.
-        SMBIOReader(source: source, ownsSource: false)
+        SMBIOReader(
+            source: source,
+            ownsSource: false,
+            discImageProbeEnabled: discImageProbeEnabled
+        )
     }
 
     public func close() {

--- a/Tests/AetherEngineSMBTests/SMBIOReaderTests.swift
+++ b/Tests/AetherEngineSMBTests/SMBIOReaderTests.swift
@@ -80,6 +80,19 @@ final class SMBIOReaderTests: XCTestCase {
         XCTAssertEqual(src.closeCount, 1)
     }
 
+    func testDiscImageProbeDefaultsOnAndIndependentReaderPreservesOptOut() throws {
+        let defaultReader = SMBIOReader(source: FakeByteRangeSource(payload))
+        XCTAssertTrue(defaultReader.discImageProbeEnabled)
+
+        let ordinaryMediaReader = SMBIOReader(
+            source: FakeByteRangeSource(payload),
+            discImageProbeEnabled: false
+        )
+        XCTAssertFalse(ordinaryMediaReader.discImageProbeEnabled)
+        let independent = try XCTUnwrap(ordinaryMediaReader.makeIndependentReader())
+        XCTAssertFalse(independent.discImageProbeEnabled)
+    }
+
     func testNegativeSeekDoesNotCorruptCursor() {
         let r = SMBIOReader(source: FakeByteRangeSource(payload))
         XCTAssertEqual(r.seek(offset: 10, whence: SEEK_SET), 10)

--- a/Tests/AetherEngineTests/CustomDiscProbePolicyTests.swift
+++ b/Tests/AetherEngineTests/CustomDiscProbePolicyTests.swift
@@ -1,0 +1,67 @@
+import Foundation
+import Testing
+@testable import AetherEngine
+
+struct CustomDiscProbePolicyTests {
+    @Test("an opted-out custom reader skips ISO and UDF signature offsets")
+    func disabledDiscProbeSkipsSignatureReads() {
+        let reader = TrackingIOReader(discImageProbeEnabled: false)
+        let demuxer = Demuxer()
+
+        #expect(throws: (any Error).self) {
+            try demuxer.open(reader: reader, formatHint: "matroska")
+        }
+
+        #expect(!reader.seekOffsets.contains(0x8001))
+        #expect(!reader.seekOffsets.contains(256 * 2048))
+    }
+
+    @Test("custom readers probe disc signatures by default")
+    func defaultDiscProbeChecksSignatureOffsets() {
+        let reader = TrackingIOReader()
+        let demuxer = Demuxer()
+
+        #expect(throws: (any Error).self) {
+            try demuxer.open(reader: reader, formatHint: "matroska")
+        }
+
+        #expect(reader.seekOffsets.contains(0x8001))
+        #expect(reader.seekOffsets.contains(256 * 2048))
+    }
+}
+
+private final class TrackingIOReader: IOReader, @unchecked Sendable {
+    let discImageProbeEnabled: Bool
+
+    private let lock = NSLock()
+    private var offset: Int64 = 0
+    private var recordedSeekOffsets: [Int64] = []
+
+    init(discImageProbeEnabled: Bool = true) {
+        self.discImageProbeEnabled = discImageProbeEnabled
+    }
+
+    var seekOffsets: [Int64] {
+        lock.withLock { recordedSeekOffsets }
+    }
+
+    func read(_ buffer: UnsafeMutablePointer<UInt8>?, size: Int32) -> Int32 {
+        guard let buffer, size > 0 else { return 0 }
+        let count = min(Int(size), 4096)
+        buffer.initialize(repeating: 0, count: count)
+        lock.withLock { offset += Int64(count) }
+        return Int32(count)
+    }
+
+    func seek(offset requestedOffset: Int64, whence: Int32) -> Int64 {
+        lock.withLock {
+            if whence & 0x10000 != 0 { return 4096 }
+            guard whence & ~0x20000 == SEEK_SET else { return -1 }
+            offset = requestedOffset
+            recordedSeekOffsets.append(requestedOffset)
+            return requestedOffset
+        }
+    }
+
+    func close() {}
+}


### PR DESCRIPTION
## Summary

- add `IOReader.discImageProbeEnabled`, defaulting to `true`
- skip `DiscReader.wrap` when a custom reader declares that it represents ordinary media
- expose the same opt-out on `SMBIOReader` and preserve it across independent-reader clones
- document the behavior and cover both the opt-out and compatibility default with regression tests

## Why

Every custom `IOReader` currently enters disc recognition before its supplied container hint is applied. For an ordinary remote media file, that performs sparse reads at the ISO9660 and UDF signature offsets even though the caller already knows the source is not a disc image. Those reads are network round trips, and the cost can recur when playback creates independent readers for subtitles or frame extraction.

URL sources already gate remote disc recognition by file extension. Custom readers have no equivalent way to communicate that source fact.

## Compatibility

The new property defaults to `true`, so existing readers and raw ISO/UDF sources keep automatic DVD/Blu-ray recognition. The public `MediaSource.custom` case remains unchanged, avoiding a source break for callers that pattern-match its associated values.

## Validation

- `swift test`
- 1493 tests passed, 0 failures
- regression coverage verifies that opting out avoids seeks to `0x8001` and `256 * 2048`
- SMB coverage verifies that the default remains enabled and independent readers preserve an explicit opt-out
