### PR TITLE
fix(io): keep the window across a bounded-range continuation (#295)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,20 @@ the public-API contract.
 
 ## [Unreleased]
 
-_Nothing yet._
+### Fixed
+
+- **A bounded-range boundary no longer re-fetches bytes the origin already
+  delivered.** The #220 frontier refill opens the next range while data is still
+  resident ahead of the read position, so a range boundary is not a stall.
+  Starting that connection reset the window start to the frontier and dropped
+  the window with it, up to 8 MB of delivered but undrained bytes, and the next
+  read then sat below the window start, took the backward branch, and pulled
+  those same bytes back over the network in 4 MB detour blocks on the demux read
+  thread. A continuation now keeps its window. Visible on any paced consumer
+  (playback reads at media rate, so the transfer always wins the race), worst on
+  a high-bitrate source where the boundary comes around often, and worst of all
+  on the software path, which carries no read-ahead and turns a blocked read
+  straight into a picture stutter.
 
 ## [6.6.3] - 2026-08-04
 

--- a/Sources/AetherEngine/Demuxer/AVIOReader.swift
+++ b/Sources/AetherEngine/Demuxer/AVIOReader.swift
@@ -351,6 +351,12 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
     /// `connEndedByBackpressure`; cleared by `startPersistentConnection`.
     private var connEndedAtRangeEnd = false
 
+    /// First byte the live connection was asked for. Distinct from `winStart` since #295: a
+    /// continuation keeps the resident window, so the window no longer begins where the request
+    /// did, and the checks that need the REQUESTED offset (a 200 that ignored Range, the size
+    /// derived from a from-zero response) must not read the window's start instead. winCond-guarded.
+    private var connRequestedOffset: Int64 = 0
+
     /// #220: winCond-guarded snapshot of the sliding window for the periodic memprobe.
     /// `ahead` is the undrained forward extent, the quantity `appendPersistentData` gates
     /// the suspend on, so a window sitting far above winHighWater with `suspended=false` is
@@ -1811,8 +1817,24 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
             if fileSize > offset { return min(Self.persistentRangeBytes, fileSize - offset) }
             return fileSize <= 0 ? Self.persistentRangeBytes : nil
         }()
-        winStart = offset
-        window = Data()
+        // #295: a request that begins inside the resident window, or exactly at its end, is a
+        // CONTINUATION rather than a reposition. Resetting `winStart` to it dropped every byte
+        // below it, which for the #220 frontier refill is up to `winLowWater` of already delivered,
+        // still undrained data: the very next read then sat below `winStart`, took the backward
+        // branch, and pulled those same bytes back over the network 4 MB at a time on the demux
+        // read thread. Keeping them costs nothing (the new range covers only what follows) and the
+        // window stays bounded by `trimWindowLocked` and `winHardCap` exactly as before.
+        // The truncating case is the narrow race where the old connection appended past the
+        // frontier the read loop computed before it unlocked; those bytes are re-delivered by the
+        // new range, which is correct if slightly wasteful, and never leaves a hole.
+        if offset >= winStart, offset <= winStart + Int64(window.count) {
+            let keep = Int(offset - winStart)
+            if keep < window.count { window = window.subdata(in: 0..<keep) }
+        } else {
+            winStart = offset
+            window = Data()
+        }
+        connRequestedOffset = offset
         connEnded = false
         connEndedByBackpressure = false
         connEndedAtRangeEnd = false
@@ -2004,7 +2026,7 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
         // VOD: 200 at offset > 0 means server ignored Range and sent the full body
         // from byte 0 (silent corruption). Reject it. Live is exempt: transcode
         // reconnect legitimately answers 200 with "from now".
-        let requestedOffset = (generation == connGeneration) ? winStart : 0
+        let requestedOffset = (generation == connGeneration) ? connRequestedOffset : 0
         // Issue #70: the first from-0 data connection doubles as the size probe, so the
         // playback open skips probeFileSize() entirely. Derive the total from this
         // response (206 Content-Range, or Content-Length on a from-0 2xx). Write-once

--- a/Tests/AetherEngineTests/Issue295RangeBoundaryRefetchTests.swift
+++ b/Tests/AetherEngineTests/Issue295RangeBoundaryRefetchTests.swift
@@ -1,0 +1,67 @@
+import Testing
+import Foundation
+@testable import AetherEngine
+
+/// #295: a linear read that crosses a bounded-range boundary must not re-fetch what the origin
+/// already delivered. The #220 frontier refill exists so the boundary is not a stall: it opens the
+/// next range while bytes are still resident ahead of the read position. `startPersistentConnection`
+/// then resets `winStart` to that frontier and drops the window, so the very next read sits BELOW
+/// the new window start, takes the backward branch, and pulls the bytes it just discarded back over
+/// the network one 4 MB detour block at a time, on the demux read thread.
+///
+/// The shape only appears when the consumer is SLOWER than the transfer, which is playback: the
+/// range completes long before the window drains, so the refill fires with up to `winLowWater`
+/// bytes still resident ahead of the read position. A test that reads flat out drains the window
+/// as fast as it arrives, reaches the boundary with nothing undrained, and sees nothing.
+@Suite("Range-boundary refetch (#295)")
+struct Issue295RangeBoundaryRefetchTests {
+
+    /// Every byte the data connection asks for, minus the #281 speculative tail probe (which sits
+    /// at the very end of the file and is deliberately not range-sized).
+    private func dataRanges(_ server: ThrottledOriginServer, fileSize: Int64) -> [(start: Int64, end: Int64?)] {
+        server.requestedRanges.filter { $0.start < fileSize - 1 * 1024 * 1024 }
+    }
+
+    @Test("a linear read across a range boundary never re-requests a delivered byte")
+    func linearReadDoesNotRefetchAcrossBoundary() async throws {
+        let total: Int64 = 128 * 1024 * 1024
+        let boundary: Int64 = 20 * 1024 * 1024
+        // Fast origin, paced consumer: the transfer has to win the race for the refill to fire with
+        // bytes still undrained, which is the field shape (media-rate consumption off a LAN source).
+        let server = try #require(ThrottledOriginServer(totalSize: total, throttleUs: 1000))
+        defer { server.stop() }
+        // The boundary sits well past `headSpanMaxBytes`, so the retained file head cannot serve a
+        // backward read for free and hide the defect.
+        let reader = AVIOReader(url: URL(string: "http://127.0.0.1:\(server.port)/movie.bin")!,
+                                boundedInitialFetch: boundary)
+        defer { reader.markClosed(); reader.close() }
+        try reader.open()
+
+        let chunk = 256 * 1024
+        let buf = UnsafeMutablePointer<UInt8>.allocate(capacity: chunk)
+        defer { buf.deallocate() }
+
+        var read: Int64 = 0
+        while read < boundary + 6 * 1024 * 1024 {
+            let n = reader.read(into: buf, size: Int32(chunk))
+            #expect(n > 0, "read failed at offset \(read)")
+            if n <= 0 { break }
+            read += Int64(n)
+            try? await Task.sleep(nanoseconds: 6_000_000)
+        }
+        try? await Task.sleep(nanoseconds: 200_000_000)
+
+        let ranges = dataRanges(server, fileSize: total)
+        var overlaps: [String] = []
+        var covered: [(Int64, Int64)] = []
+        for r in ranges {
+            let end = r.end ?? total - 1
+            for c in covered where r.start <= c.1 && end >= c.0 {
+                overlaps.append("[\(r.start)-\(end)] overlaps [\(c.0)-\(c.1)]")
+            }
+            covered.append((r.start, end))
+        }
+        #expect(overlaps.isEmpty,
+                "delivered bytes were fetched again: \(overlaps.joined(separator: ", ")); all ranges: \(ranges)")
+    }
+}


### PR DESCRIPTION
Closes nothing yet: leaving #295 open for the reporter's retest.

## The defect

The #220 frontier refill opens the next bounded range while bytes are still resident ahead of the read position, precisely so a range boundary does not become a stall. `startPersistentConnection` then reset `winStart` to that offset and dropped the window with it, which for the refill is up to `winLowWater` (8 MB) of delivered but undrained data. The very next read sat below `winStart`, took the backward branch, and re-fetched those same bytes 4 MB at a time through the detour cache, blocking on the demux read thread.

## Why it surfaced now, and on this content

It needs a consumer slower than the transfer, which is what playback is: the range completes long before the window drains, so the refill fires with the full low-water amount still resident. A test that reads flat out drains the window as fast as it arrives, reaches the boundary with nothing undrained, and sees nothing, which is why the existing #220 coverage stayed green.

The reporter's asset is a 6.7 Mbps SD MPEG-2 source, so a 32 MB range comes around every 40 s. Their correlation run put every visible stutter within reaction time of an `[AVIOReader] detour fill` line, at 40.2 s +/- 0.2 s spacing. The software path carries no read-ahead (`frameAhead=0.00s`), so a blocked read longer than a frame interval is a picture stutter rather than an invisible hiccup. A 1 Mbps source rotates every several minutes and is rarely caught in the act.

## The fix

A request that begins inside the resident window, or exactly at its end, is a continuation rather than a reposition, so the bytes below it are kept. The narrow race where the old connection appends past the frontier the read loop computed truncates instead; the new range re-covers that span, so it never leaves a hole.

`connRequestedOffset` carries the offset that was actually asked for, since `winStart` is no longer that offset once a continuation keeps its window. The 200-ignored-Range rejection and the from-zero size derivation read it.

Peak footprint goes down rather than up: the discarded window used to come back as up to 32 MB of detour blocks on top of the new range.

## Witness

`Issue295RangeBoundaryRefetchTests` drives a real HTTP origin with a paced consumer across a bounded-range boundary and asserts that no requested range overlaps another. Before the fix the origin logs

```
bytes=0-20971519          initial range
bytes=20971520-54525951   #220 frontier refill
bytes=12582912-16777215   re-fetch
bytes=16777216-20971519   re-fetch
```

exactly `winLowWater` of re-fetched bytes, in two blocking detour fetches per boundary.

Full suite green (1492 tests, 222 suites, plus the XCTest targets).