### PR TITLE
feat(swplayback): report the software path's read-ahead and display outcome (#303)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,24 @@ the public-API contract.
 
 ## [Unreleased]
 
-_Nothing yet._
+### Added
+
+- **The software path reports its read-ahead, and what the display did with it.** A software
+  session left a trace with no cushion figure in it: `frameAhead` is the native producer-shift
+  fold and reads 0 here whatever the buffer holds, `bufferedSessionTime` is fed only on live
+  sessions so a VOD software session published its own playhead back as its frontier, and the
+  `isReadyForMoreMediaData=false` line is latched to one per session. The memprobe now carries
+  `swAhead=` (seconds of decoded video queued ahead of the clock), plus `swDropped=` and
+  `swDelay=` from the renderer's own accounting, which counts frames dropped for missing their
+  display deadline rather than only the ones we refuse ourselves. On a native session the fields
+  are absent rather than zero.
+
+### Changed
+
+- **`bufferedPosition` on a VOD software session reports the decoded cushion instead of the
+  playhead.** The AetherEngine#54 contract is unchanged (it never trails the playhead) and the live
+  frontier still wins where it is larger; what changes is that the VOD software case stops
+  publishing a frontier that was only ever a placeholder.
 
 ## [6.6.4] - 2026-08-04
 

--- a/Sources/AetherEngine/AetherEngine+Diagnostics.swift
+++ b/Sources/AetherEngine/AetherEngine+Diagnostics.swift
@@ -146,6 +146,14 @@ extension AetherEngine {
                         ?? self.nativeVideoSession?.demuxerBytesFetched,
                     prefetchFetchedBytes: self.subtitleForwardPrefetchDemuxer?.avioBytesFetched)
 
+                // #303: the software path's own read-ahead, and what the display did with it.
+                // `avBufAhead` covers the AVPlayer path only, and `frameAhead` is the native
+                // producer-shift fold that reads 0 here whatever the buffer is doing, so a software
+                // session used to leave a trace with no cushion figure in it at all.
+                let swStr = Self.softwareReadAheadFragment(
+                    cushionSeconds: self.softwareHost?.displayCushionSeconds,
+                    metrics: await self.softwareHost?.loadRenderMetrics())
+
                 let line = "[AetherEngine] memprobe t=\(elapsed)s "
                     + "rss=\(rssMB)MB "
                     + vmStr
@@ -175,6 +183,7 @@ extension AetherEngine {
                     // separates "reads fast while building its lead" from "the lead never settles".
                     + SubtitlePrefetchTelemetry.probeFragment(playhead: self.sourceTime)
                     + "swFrames=\(self.softwareHostFramesEnqueued) "
+                    + swStr
                     + "audioTracks=\(self.audioTracks.count) "
                     + "subTracks=\(self.subtitleTracks.count) "
                     + "subActive=\(self.isSubtitleActive) "
@@ -290,6 +299,26 @@ extension AetherEngine {
         }
         return fragment("pump", pump, pumpFetchedBytes)
             + fragment("pref", prefetch, prefetchFetchedBytes)
+    }
+
+    /// #303: the software path's read-ahead, and the display's own account of what it did with it.
+    /// Empty on a native session, so the line does not carry three fields that can only read zero
+    /// there. Each half is independently optional: the cushion exists as soon as a frame has been
+    /// enqueued, while the metrics need an OS and a queue target that can answer for them.
+    nonisolated static func softwareReadAheadFragment(
+        cushionSeconds: Double?,
+        metrics: SampleBufferRenderer.RenderMetrics?
+    ) -> String {
+        var out = ""
+        if let cushionSeconds {
+            out += "swAhead=\(String(format: "%.2f", cushionSeconds))s "
+        }
+        if let metrics {
+            out += "swDropped=\(metrics.dropped)/\(metrics.total) "
+            if metrics.corrupted > 0 { out += "swCorrupt=\(metrics.corrupted) " }
+            out += "swDelay=\(String(format: "%.2f", metrics.accumulatedDelay))s "
+        }
+        return out
     }
 
     // MARK: - Live telemetry bridge

--- a/Sources/AetherEngine/AetherEngine+Loading.swift
+++ b/Sources/AetherEngine/AetherEngine+Loading.swift
@@ -1179,7 +1179,13 @@ extension AetherEngine {
                 guard let self = self else { return }
                 self.clock.currentTime = value
                 // bufferedPosition = newest demuxed source PTS, clamped to never trail the playhead (#54).
-                self.clock.bufferedPosition = max(value, host.bufferedSessionTime)
+                // #303: `bufferedSessionTime` is fed from `noteEdge`, which only runs on live
+                // sessions, so a VOD software session used to publish the playhead back as its own
+                // frontier. The decoded cushion is what it has instead.
+                self.clock.bufferedPosition = SoftwareBufferFrontier.bufferedPosition(
+                    currentTime: value,
+                    liveFrontier: host.bufferedSessionTime,
+                    cushion: host.displayCushionSeconds)
             }
             .store(in: &softwareCancellables)
         // #107: sourceTime rides the RAW synchronizer clock (source axis) so subtitle cues

--- a/Sources/AetherEngine/Native/SoftwareBufferFrontier.swift
+++ b/Sources/AetherEngine/Native/SoftwareBufferFrontier.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// #303: how far ahead of the clock the software path is actually holding decoded video, and how
+/// that folds into the `bufferedPosition` a host reads.
+///
+/// The two inputs come from different places (the renderer knows what it has queued, the host knows
+/// where the synchronizer is), and the arithmetic between them is the part worth pinning, so it
+/// lives here as plain functions rather than inside either of them.
+enum SoftwareBufferFrontier {
+
+    /// Seconds of decoded video queued ahead of the source clock, or nil when nothing has been
+    /// enqueued yet. Both arguments are on the source axis, so this needs no session anchor and
+    /// reads the same on VOD and live.
+    ///
+    /// Clamped at zero on purpose: the synchronizer keeps running while the queue starves, which is
+    /// exactly when this number is interesting, and a clock past the newest held frame means an
+    /// empty cushion rather than a negative one.
+    static func cushionSeconds(newestEnqueuedPts: Double?, sourceClock: Double) -> Double? {
+        guard let newestEnqueuedPts, newestEnqueuedPts.isFinite, sourceClock.isFinite else { return nil }
+        return max(0, newestEnqueuedPts - sourceClock)
+    }
+
+    /// `clock.bufferedPosition` for a software session. `liveFrontier` is the newest demuxed source
+    /// PTS in session time, which only live sessions feed (`noteEdge` is gated on `isLive`); on VOD
+    /// it is 0 and the cushion is the only thing that can carry a frontier. AetherEngine#54: the
+    /// result never trails the playhead.
+    static func bufferedPosition(currentTime: Double, liveFrontier: Double, cushion: Double?) -> Double {
+        max(currentTime, liveFrontier, currentTime + (cushion ?? 0))
+    }
+}

--- a/Sources/AetherEngine/Native/SoftwarePlaybackHost.swift
+++ b/Sources/AetherEngine/Native/SoftwarePlaybackHost.swift
@@ -139,6 +139,22 @@ final class SoftwarePlaybackHost {
     /// thread writing while the main-actor time tick reads them.
     private let liveEdgeLock = NSLock()
 
+    /// #303: seconds of decoded video queued ahead of the clock, nil before the first frame. This is
+    /// the cushion an IO hiccup eats into, and the reason a blocked read reaches the picture here
+    /// while the native path swallows the same event. Distinct from `bufferedSessionTime`, which is
+    /// the DEMUXED frontier and is only fed on live sessions.
+    var displayCushionSeconds: Double? {
+        SoftwareBufferFrontier.cushionSeconds(newestEnqueuedPts: renderer.newestEnqueuedPtsSeconds,
+                                              sourceClock: sourceClockSeconds)
+    }
+
+    /// #303: the renderer's own view of what reached the display. Async because the AVFoundation
+    /// accessor is; the memprobe already runs in an async context, so it is read there rather than
+    /// cached, and the line never carries a stale snapshot.
+    func loadRenderMetrics() async -> SampleBufferRenderer.RenderMetrics? {
+        await renderer.loadRenderMetrics()
+    }
+
     /// SW path's buffered frontier (AetherEngine#54): newest demuxed source PTS in session time. Published as clock.bufferedPosition.
     nonisolated var bufferedSessionTime: Double {
         liveEdgeLock.lock()

--- a/Sources/AetherEngine/Renderer/SampleBufferRenderer.swift
+++ b/Sources/AetherEngine/Renderer/SampleBufferRenderer.swift
@@ -73,8 +73,41 @@ final class SampleBufferRenderer: @unchecked Sendable {
         return _untimedFramesDropped
     }
 
+    /// #303: newest presentation timestamp this renderer has admitted, in seconds on the source
+    /// axis, nil before the first frame. Recorded at admission into the reorder buffer, so it is
+    /// past the unschedulable-PTS gate and the post-seek skip: everything counted here is decoded
+    /// and will be displayed. Its lead over the synchronizer is the cushion an IO hiccup eats into.
+    /// Guarded by `reorderLock`.
+    private var _newestEnqueuedPtsSeconds: Double?
+    var newestEnqueuedPtsSeconds: Double? {
+        reorderLock.lock()
+        defer { reorderLock.unlock() }
+        return _newestEnqueuedPtsSeconds
+    }
+
     init() {
         displayLayer = Self.makeDisplayLayer(isHDR: false)
+    }
+
+    /// #303: what the display did with the frames, as the renderer itself counts them. Our own
+    /// counters can only see what we refuse; `numberOfDroppedFrames` also covers frames dropped for
+    /// missing their display deadline, which is the class that shows up as a stutter.
+    struct RenderMetrics: Sendable {
+        let total: Int
+        let dropped: Int
+        let corrupted: Int
+        let accumulatedDelay: TimeInterval
+    }
+
+    /// nil where the metrics cannot be asked for: an OS predating the API, or the pre-tvOS-18 path
+    /// where the queue target is the display layer itself rather than an `AVSampleBufferVideoRenderer`.
+    func loadRenderMetrics() async -> RenderMetrics? {
+        guard #available(tvOS 18.0, iOS 18.0, macOS 15.0, *) else { return nil }
+        guard let m = await displayLayer.sampleBufferRenderer.videoPerformanceMetrics else { return nil }
+        return RenderMetrics(total: m.totalNumberOfFrames,
+                             dropped: m.numberOfDroppedFrames,
+                             corrupted: m.numberOfCorruptedFrames,
+                             accumulatedDelay: m.totalAccumulatedFrameDelay)
     }
 
     // MARK: - Queue rendering target
@@ -181,6 +214,12 @@ final class SampleBufferRenderer: @unchecked Sendable {
         }
 
         let ptsSeconds = CMTimeGetSeconds(pts)
+        // #303: the frontier is the newest timestamp HELD, not the newest handed over. A B-frame run
+        // arrives out of order, so taking the last call's timestamp would report a cushion that
+        // shrinks and grows with the coding pattern rather than with the buffer.
+        if ptsSeconds > (_newestEnqueuedPtsSeconds ?? -.greatestFiniteMagnitude) {
+            _newestEnqueuedPtsSeconds = ptsSeconds
+        }
         let insertIdx = reorderBuffer.firstIndex(where: {
             CMTimeGetSeconds($0.1) > ptsSeconds
         }) ?? reorderBuffer.endIndex
@@ -202,6 +241,10 @@ final class SampleBufferRenderer: @unchecked Sendable {
     func flush(removingDisplayedImage: Bool = true) {
         reorderLock.lock()
         reorderBuffer.removeAll()
+        // #303: nothing is held any more, so the frontier is not a frontier. Left standing, a
+        // backward seek would keep reporting the pre-seek timestamp and read as a cushion of
+        // however far the seek travelled.
+        _newestEnqueuedPtsSeconds = nil
         // Invalidate the format description cache; the next load() may open a stream with different colorimetry at the same resolution.
         cachedFormatDesc = nil
         cachedFormatKey = nil

--- a/Tests/AetherEngineTests/Issue303SoftwareReadAheadTests.swift
+++ b/Tests/AetherEngineTests/Issue303SoftwareReadAheadTests.swift
@@ -1,0 +1,117 @@
+import Testing
+import Foundation
+import CoreMedia
+@testable import AetherEngine
+
+/// #303: the software path's read-ahead is whatever `AVSampleBufferVideoRenderer` accepts, and
+/// until now nothing reported the depth it actually had. `frameAhead` is the native producer-shift
+/// fold and reads 0 here by construction; `bufferedSessionTime` is fed only on live sessions, so a
+/// VOD software session published a `bufferedPosition` that just mirrored the playhead.
+@Suite("Software read-ahead telemetry (#303)")
+struct Issue303SoftwareReadAheadTests {
+
+    // MARK: - Frontier
+
+    @Test("the enqueued frontier follows the newest presentation timestamp, not the newest call")
+    func frontierTracksMaximum() {
+        let renderer = SampleBufferRenderer()
+        #expect(renderer.newestEnqueuedPtsSeconds == nil)
+
+        // B-frame order: the decoder hands out 0.0, 0.12, 0.04, 0.08. The frontier is the newest
+        // timestamp held, which the reorder buffer will present last, not the last one handed over.
+        for seconds in [0.0, 0.12, 0.04, 0.08] {
+            renderer.enqueue(pixelBuffer: Self.makePixelBuffer(),
+                             pts: CMTime(seconds: seconds, preferredTimescale: 600))
+        }
+        let frontier = try? #require(renderer.newestEnqueuedPtsSeconds)
+        #expect(frontier == 0.12)
+    }
+
+    @Test("a frame refused at the unschedulable-PTS gate does not advance the frontier")
+    func untimedFrameDoesNotAdvanceFrontier() {
+        let renderer = SampleBufferRenderer()
+        renderer.enqueue(pixelBuffer: Self.makePixelBuffer(),
+                         pts: CMTime(seconds: 1.0, preferredTimescale: 600))
+        renderer.enqueue(pixelBuffer: Self.makePixelBuffer(), pts: .invalid)
+
+        #expect(renderer.newestEnqueuedPtsSeconds == 1.0)
+        #expect(renderer.untimedFramesDropped == 1)
+    }
+
+    // MARK: - Cushion
+
+    @Test("the cushion is the frontier's lead over the source clock")
+    func cushionIsLeadOverSourceClock() {
+        #expect(SoftwareBufferFrontier.cushionSeconds(newestEnqueuedPts: 12.5, sourceClock: 11.0) == 1.5)
+    }
+
+    @Test("nothing enqueued yet is no cushion, not a cushion of zero")
+    func cushionIsNilBeforeFirstFrame() {
+        #expect(SoftwareBufferFrontier.cushionSeconds(newestEnqueuedPts: nil, sourceClock: 11.0) == nil)
+    }
+
+    /// The synchronizer can read past the newest frame held (it keeps running while the queue
+    /// starves, which is exactly the moment this number is interesting). A negative lead is not a
+    /// negative cushion, it is an empty one.
+    @Test("a clock past the frontier reports an empty cushion, never a negative one")
+    func cushionClampsAtZero() {
+        #expect(SoftwareBufferFrontier.cushionSeconds(newestEnqueuedPts: 10.0, sourceClock: 10.4) == 0)
+    }
+
+    // MARK: - bufferedPosition composition
+
+    @Test("a VOD software session reports the cushion instead of mirroring the playhead")
+    func bufferedPositionCarriesTheCushionOnVOD() {
+        // Live frontier is 0 on VOD: `noteEdge` only runs on live sessions.
+        let pos = SoftwareBufferFrontier.bufferedPosition(currentTime: 30.0, liveFrontier: 0, cushion: 1.25)
+        #expect(pos == 31.25)
+    }
+
+    @Test("the live frontier still wins where it is the larger of the two")
+    func liveFrontierIsPreserved() {
+        let pos = SoftwareBufferFrontier.bufferedPosition(currentTime: 30.0, liveFrontier: 44.0, cushion: 1.25)
+        #expect(pos == 44.0)
+    }
+
+    /// #54: `bufferedPosition` never trails the playhead, whatever the inputs say.
+    @Test("bufferedPosition never trails the playhead")
+    func bufferedPositionNeverTrailsPlayhead() {
+        #expect(SoftwareBufferFrontier.bufferedPosition(currentTime: 30.0, liveFrontier: 0, cushion: nil) == 30.0)
+        #expect(SoftwareBufferFrontier.bufferedPosition(currentTime: 30.0, liveFrontier: 12.0, cushion: nil) == 30.0)
+    }
+
+    // MARK: - memprobe fragment
+
+    @Test("a native session adds nothing to the line")
+    func fragmentIsEmptyWithoutASoftwareSession() {
+        #expect(AetherEngine.softwareReadAheadFragment(cushionSeconds: nil, metrics: nil).isEmpty)
+    }
+
+    @Test("the cushion is reported before the display metrics can answer")
+    func fragmentCarriesCushionAlone() {
+        let s = AetherEngine.softwareReadAheadFragment(cushionSeconds: 1.417, metrics: nil)
+        #expect(s == "swAhead=1.42s ")
+    }
+
+    @Test("a clean run does not print a corruption count")
+    func fragmentOmitsCorruptWhenZero() {
+        let m = SampleBufferRenderer.RenderMetrics(total: 1520, dropped: 3, corrupted: 0, accumulatedDelay: 0.08)
+        let s = AetherEngine.softwareReadAheadFragment(cushionSeconds: 1.42, metrics: m)
+        #expect(s == "swAhead=1.42s swDropped=3/1520 swDelay=0.08s ")
+    }
+
+    @Test("corrupted frames are named when there are any")
+    func fragmentNamesCorruption() {
+        let m = SampleBufferRenderer.RenderMetrics(total: 900, dropped: 0, corrupted: 2, accumulatedDelay: 0)
+        let s = AetherEngine.softwareReadAheadFragment(cushionSeconds: nil, metrics: m)
+        #expect(s == "swDropped=0/900 swCorrupt=2 swDelay=0.00s ")
+    }
+
+    // MARK: -
+
+    private static func makePixelBuffer() -> CVPixelBuffer {
+        var pb: CVPixelBuffer?
+        CVPixelBufferCreate(kCFAllocatorDefault, 16, 16, kCVPixelFormatType_32BGRA, nil, &pb)
+        return pb!
+    }
+}


### PR DESCRIPTION
Closes #303.

## Why

A software session left a field trace with no cushion figure in it, which is what made #295 hard to place: a ~100 ms blocked read reached the picture and no number said whether the buffer had 40 ms or 2 s.

Three signals look like they answer it and do not:

- `frameAhead` is `activeProducerShiftSeconds - playlistShiftSeconds`, the #49 producer-shift fold on the native path, hardcoded to 0 on software and audio. It was read in #295 as evidence of no read-ahead. It cannot carry that claim in either direction.
- `bufferedSessionTime` is fed from `noteEdge`, whose two call sites are both gated on `isLive`. On VOD it returns 0, so `bufferedPosition` fell back to `max(currentTime, 0)` and published the playhead back as its own frontier.
- `[Renderer] isReadyForMoreMediaData=false at enqueue #N` is latched to one line per session. It marks the first fill, which is healthy, not a sustained one.

## What

`SampleBufferRenderer` records the newest timestamp it has admitted, at admission into the reorder buffer so it sits past the #298 unschedulable gate and the post-seek skip, and clears it on `flush` so a backward seek cannot report the distance travelled as cushion. The frontier is the newest timestamp HELD, not the newest handed over, or a B-frame run would make the number breathe with the coding pattern.

`SoftwareBufferFrontier` holds the arithmetic as plain functions. The two inputs come from different objects (the renderer knows what it queued, the host knows where the synchronizer is) and the composition is the part worth pinning down.

`clock.bufferedPosition` on a VOD software session now carries the cushion. The #54 contract holds and the live frontier still wins where it is larger. This is a behaviour change on a public surface, in the direction of that surface`&apos;`s documented meaning.

The memprobe gains `swAhead=`, `swDropped=` and `swDelay=`. The latter two come from `AVSampleBufferVideoRenderer.videoPerformanceMetrics`, which counts frames dropped for missing their display deadline: exactly the class our own counters cannot see. Absent rather than zero on a native session.

## Scope

Measurement only. No floor, no target depth, no change to the demux loop`&apos;`s back-pressure. Whether this path holds too little is unproven, and with the #295 mechanism removed it is unknown whether anything is left. Measure first, decide after.

## Verification

`aetherctl play --sw` over a 70 s fixture:

```
swFrames=753 swAhead=0.26s swDropped=187/749 swDelay=0.00s ... frameAhead=0.00s
```

and the same run without `--sw` leaves the line as it was. Worth stating plainly: that drop count is an artefact of a headless layer in no view hierarchy (the #298 warning fires in the same run), not a statement about on-device cushion.

12 new tests, full suite green (1504 tests, 223 suites, plus the XCTest targets). The tests cover the frontier, the gate interaction, the cushion arithmetic and the log fragment. What they do not cover, and I am not claiming otherwise: `AVVideoPerformanceMetrics` needs a real renderer, so only the aetherctl run exercises it.