### PR TITLE
fix(avio): bound reconnects for error-ended zero-byte connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,24 @@ the public-API contract.
 
 ## [Unreleased]
 
-_Nothing yet._
+### Fixed
+
+- **An origin refusing every range refill no longer spins the reader in an unbounded
+  reconnect spiral.** A connection that ended in error without delivering a byte of its
+  generation was treated as a benign reposition: `seekReconnect` cleared the unproductive
+  streak and applied no backoff, so a connection-capped origin answering 500 at a 32 MiB
+  range boundary produced ~15 reconnects/s (925 in 60 s observed) until the segment
+  provider tore the demuxer down from outside. Such connections now take the failure
+  ladder: status accounting, Retry-After, exponential backoff, a `.reconnecting` network
+  phase, and a bounded give-up. The previously silent non-200/206 response rejection is
+  now logged with its status and offset.
+- **A pinned post-redirect URL is dropped on hard 5xx answers and on repeated zero-byte
+  failures.** Redirect targets that expire per connection (Xtream-style aggregators)
+  answered every later range with 500 from the pinned URL; only auth-expiry statuses
+  (401/403/404/410) invalidated the pin. The reader now falls back to the source URL for
+  a fresh redirect (503 keeps the pin — that is rate limiting, #71).
+- **A VOD session whose readError revive cap is exhausted surfaces `onVODSourceFailed`**
+  instead of dying silently with AVPlayer parked in `waitingToPlay` forever (#169).
 
 ## [6.7.0] - 2026-08-04
 

--- a/Sources/AetherEngine/AetherEngine+Loading.swift
+++ b/Sources/AetherEngine/AetherEngine+Loading.swift
@@ -578,8 +578,9 @@ extension AetherEngine {
                 self.liveSourceReset.send()
             }
         }
-        // #126: zero-progress VOD pump death (readError before any packet/segment). Without this
-        // the host sees isPlayable=true, tracks=0, waitingToPlay until its own first-frame timeout.
+        // #126: zero-progress VOD pump death (readError before any packet/segment), and #169:
+        // mid-session readError after the revive cap. Without this the host sees
+        // isPlayable=true / a stalled item and waits until its own timeout.
         session.onVODSourceFailed = { [weak self, weak session] code in
             Task { @MainActor in
                 guard let self, let session, self.nativeVideoSession === session else {
@@ -589,7 +590,7 @@ extension AetherEngine {
                     )
                     return
                 }
-                self.state = .error("Source read failed before any media was produced (code \(code))")
+                self.state = .error("Source read failed (code \(code))")
             }
         }
         // prepareNativeSubtitles + non-bitmap text tracks: builds the native subtitle table; must be set before start().

--- a/Sources/AetherEngine/AetherEngine.swift
+++ b/Sources/AetherEngine/AetherEngine.swift
@@ -884,6 +884,11 @@ public final class AetherEngine: ObservableObject {
         sourceThrottleKbpsForTesting = max(0, kbps)
     }
 
+    /// TEST-ONLY: scales the reader's reconnect backoff (1.0 = real timing). Read once by each
+    /// `AVIOReader` at init, so set it before `load`/`start`. Lets a bounded give-up that spans
+    /// ~13 exponential backoffs finish in test time instead of a minute of real sleeping.
+    nonisolated(unsafe) static var reconnectBackoffScaleForTesting = 1.0
+
     /// Reads `AVPlayer.eligibleForHDRPlayback` and `AVPlayer.availableHDRModes` at call time.
     /// Eligibility is display-configuration aware on all platforms (its change notification fires
     /// on display connection/disconnection), so per-load reads pick up monitor changes; the value

--- a/Sources/AetherEngine/Demuxer/AVIOReader.swift
+++ b/Sources/AetherEngine/Demuxer/AVIOReader.swift
@@ -93,19 +93,27 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
         }
     }
 
-    private func invalidateResolvedURL() {
+    private func invalidateResolvedURL(reason: String = "expiry status") {
         resolvedURLLock.lock()
         defer { resolvedURLLock.unlock() }
         if _resolvedURL != nil {
             _resolvedURL = nil
             #if DEBUG
-            EngineLog.emit("[AVIOReader] Dropped resolved URL cache (expiry status)", category: .demux)
+            EngineLog.emit("[AVIOReader] Dropped resolved URL cache (\(reason))", category: .demux)
             #endif
         }
     }
 
     private static func isResolvedExpiryStatus(_ status: Int) -> Bool {
         return status == 401 || status == 403 || status == 404 || status == 410
+    }
+
+    /// Hard server errors answered by a pinned post-redirect URL: the redirect target
+    /// may be dead or expired while the source URL would mint a fresh one. 503 is
+    /// excluded — it is rate limiting (#71), carries Retry-After, and the pin is not
+    /// the problem there.
+    static func isResolvedHardServerError(_ status: Int) -> Bool {
+        return status >= 500 && status != 503
     }
 
     // Cumulative bytes fetched since open; memory probe compares against RSS growth.
@@ -466,6 +474,8 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
 
     /// TEST-ONLY slow-CDN throttle (kbit/s, 0 = unlimited), captured once from the static hook at init.
     private let throttleKbps: Int
+    /// TEST-ONLY reconnect-backoff scale (1.0 = real timing), captured once from the static hook at init.
+    private let backoffScale: Double
     private var throttleVClockNs: UInt64 = 0
     private let throttleLock = NSLock()
 
@@ -484,6 +494,7 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
         self.chunkMaxRetries = max(1, chunkMaxRetries)
         self.boundedInitialFetch = boundedInitialFetch.map { max(1, $0) }
         self.throttleKbps = AetherEngine.sourceThrottleKbpsForTesting
+        self.backoffScale = AetherEngine.reconnectBackoffScaleForTesting
     }
 
     /// Slow-CDN simulation: hold delivered bytes to `throttleKbps` by sleeping the demux thread before the
@@ -1198,7 +1209,19 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
             // connections and 1506918 delivered bytes, 1.97x what was read. Serving what is in
             // hand first also lets the #220 frontier refill below run, which it could not while
             // this branch preempted it on every completed range.
-            if activeTask == nil, !connEndedByBackpressure, !windowCanServe {
+            //
+            // A connection that ended in ERROR without delivering a single byte of its
+            // generation is excluded too: this branch reconnects via seekReconnect, which
+            // clears the unproductive streak and applies no backoff, so an origin refusing
+            // every request (e.g. a connection-capped panel answering 500) turned into an
+            // unbounded reconnect spiral at ~15 connections/s. Falling through reaches the
+            // ended-connection ladder below: status accounting, Retry-After, backoff,
+            // `.reconnecting`, bounded give-up. Planned ends stay here — a completed range
+            // (connEndedAtRangeEnd) and a hard-cap end delivered their bytes, and any
+            // generation that delivered at least one byte keeps the fast path.
+            let endedInError = connEnded && !connEndedAtRangeEnd && !connEndedByBackpressure
+                && !connFirstDataSeen
+            if activeTask == nil, !connEndedByBackpressure, !windowCanServe, !endedInError {
                 let target = position
                 winCond.unlock()
                 timedReconnect(seek: true, at: target)
@@ -1427,6 +1450,13 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
             EngineLog.emit("[AVIOReader] \(label) conn ended at offset \(frontier) status=\(status), reconnecting (streak=\(backoffStreak) retryAfter=\(retryAfter)s)", category: .demux)
             lastUnplannedReconnectAt = Date()
             emitNetworkPhase(.reconnecting)   // unplanned reconnect now in flight (#85)
+            // Two consecutive zero-progress failures through the pinned URL point at
+            // the pin itself (an expired redirect target answers every offset alike),
+            // not a transient: drop it so the retry re-resolves through the source URL
+            // for a fresh redirect. No-op when nothing is pinned.
+            if unproductiveReconnects >= 2 || rateLimitStreak >= 2 {
+                invalidateResolvedURL(reason: "unproductive reconnect streak")
+            }
             let backoffStart = DispatchTime.now()
             backoffBeforeReconnect(streak: backoffStreak, retryAfter: retryAfter)
             diag.recordBackoff(ms: msSince(backoffStart))
@@ -1491,13 +1521,14 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
     /// Sleeps in 0.1s slices so a close is honoured promptly.
     private func backoffBeforeReconnect(streak: Int, retryAfter: TimeInterval) {
         let expo = streak <= 0 ? 0.0 : min(Double(1 << min(streak, 4)) * 0.5, 8.0)
-        let total = min(max(expo, retryAfter), 15.0)
+        let total = min(max(expo, retryAfter), 15.0) * backoffScale
         if total <= 0 { return }
         var slept = 0.0
         while slept < total {
             if isClosed { return }
-            Thread.sleep(forTimeInterval: 0.1)
-            slept += 0.1
+            let slice = min(0.1, total - slept)
+            Thread.sleep(forTimeInterval: slice)
+            slept += slice
         }
     }
 
@@ -2062,8 +2093,20 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
             if let resolvedURL { recordResolvedURL(resolvedURL) }
             return true
         }
+        // The 200-ignored-Range rejection logged above; every other rejected
+        // status was previously silent, leaving the reconnect storm unexplained
+        // in the log.
+        if status != 200 {
+            EngineLog.emit(
+                "[AVIOReader] \(label) gen=\(generation) rejected response status=\(status) at offset \(requestedOffset)"
+                    + (retryAfter > 0 ? " retryAfter=\(Int(retryAfter))s" : ""),
+                category: .demux
+            )
+        }
         if Self.isResolvedExpiryStatus(status) {
             invalidateResolvedURL()
+        } else if Self.isResolvedHardServerError(status) {
+            invalidateResolvedURL(reason: "hard \(status) from pinned URL")
         }
         return false
     }

--- a/Sources/AetherEngine/Video/HLSVideoEngine+LiveReopen.swift
+++ b/Sources/AetherEngine/Video/HLSVideoEngine+LiveReopen.swift
@@ -255,6 +255,10 @@ extension HLSVideoEngine {
                 + "(\(attempts) failures, cap \(cap)); giving up (source not readable in this session)",
                 category: .session
             )
+            // The session is dead: no producer will be rebuilt and AVPlayer would park
+            // in waitingToPlay forever. Surface the same terminal failure as the
+            // produced-nothing arm so the host can tear down or retry.
+            onVODSourceFailed?(code)
             return
         }
         let frozen = currentPlaybackPositionProvider?() ?? 0

--- a/Tests/AetherEngineTests/ErrorEndedReconnectTests.swift
+++ b/Tests/AetherEngineTests/ErrorEndedReconnectTests.swift
@@ -1,0 +1,153 @@
+import Testing
+import Foundation
+@testable import AetherEngine
+
+/// A connection that ended in ERROR without delivering a single byte of its generation used
+/// to be routed through the no-connection reposition branch: `seekReconnect` cleared the
+/// unproductive streak and applied no backoff, so an origin refusing every refill (e.g. a
+/// connection-capped Xtream panel answering 500 at a range boundary) turned into an
+/// unbounded reconnect spiral (~15 connections/s, observed 925 reconnects in 60 s) that
+/// only ended when the segment provider tore the demuxer down from outside.
+///
+/// `.serialized`: these tests mutate the process-wide backoff-scale test hook.
+@Suite("Error-ended zero-byte reconnects", .serialized)
+struct ErrorEndedReconnectTests {
+
+    private final class PhaseLog: @unchecked Sendable {
+        private let lock = NSLock()
+        private var phases: [ReaderNetworkPhase] = []
+        func append(_ phase: ReaderNetworkPhase) {
+            lock.lock(); phases.append(phase); lock.unlock()
+        }
+        func contains(_ phase: ReaderNetworkPhase) -> Bool {
+            lock.lock(); defer { lock.unlock() }
+            return phases.contains(phase)
+        }
+    }
+
+    private final class AttemptCounter: @unchecked Sendable {
+        private let lock = NSLock()
+        private var counts: [Int64: Int] = [:]
+        func next(for offset: Int64) -> Int {
+            lock.lock(); defer { lock.unlock() }
+            let n = (counts[offset] ?? 0) + 1
+            counts[offset] = n
+            return n
+        }
+    }
+
+    /// The spiral itself: every refill refused with a hard 500. The reader must charge the
+    /// failure ladder (status accounting, backoff, `.reconnecting`, bounded give-up) instead
+    /// of reconnecting forever off the books.
+    @Test("an origin refusing every refill is retried with backoff and given up on",
+          .timeLimit(.minutes(2)))
+    func refusedRefillIsBoundedAndGivenUp() async throws {
+        AetherEngine.reconnectBackoffScaleForTesting = 0.02
+        defer { AetherEngine.reconnectBackoffScaleForTesting = 1.0 }
+
+        let firstRange: Int64 = 512 * 1024
+        let serverMaybe = ThrottledOriginServer(
+            totalSize: 64 * 1024 * 1024,
+            respond: { _, offset, _ in offset < firstRange ? .serve206 : .status(500) }
+        )
+        let server = try #require(serverMaybe)
+        defer { server.stop() }
+        let reader = AVIOReader(url: URL(string: "http://127.0.0.1:\(server.port)/movie.bin")!,
+                                boundedInitialFetch: firstRange)
+        defer { reader.markClosed(); reader.close() }
+        let phases = PhaseLog()
+        reader.onNetworkPhaseChanged = { phases.append($0) }
+        try reader.open()
+
+        let sliceCap = 256 * 1024
+        let buf = UnsafeMutablePointer<UInt8>.allocate(capacity: sliceCap)
+        defer { buf.deallocate() }
+        var got = 0
+        var result: Int32 = 0
+        while true {
+            let n = reader.read(into: buf, size: Int32(sliceCap))
+            if n <= 0 { result = n; break }
+            got += Int(n)
+        }
+
+        #expect(got == Int(firstRange), "the delivered first range must still be served")
+        #expect(result == -1, "a refused source must fail the read, not hang")
+        // Streak 0..12 then give-up: ~14 attempts. The bug produced hundreds; leave slack
+        // for the odd URLSession-level retry without letting a spiral pass.
+        let attemptsAtBoundary = server.requestedRanges.filter { $0.start == firstRange }.count
+        #expect(attemptsAtBoundary >= 2, "the failure must have been retried at all")
+        #expect(attemptsAtBoundary <= 20,
+                "reconnect spiral: \(attemptsAtBoundary) attempts at offset \(firstRange)")
+        #expect(phases.contains(.reconnecting),
+                "the failed refill never surfaced as `.reconnecting` to the host")
+    }
+
+    /// The counterpart the guard must not break: a SINGLE dropped refill connection is a
+    /// transient. The first ladder pass sees real progress since the last accounting, keeps
+    /// the streak at zero, applies no backoff, and the retry completes the read.
+    @Test("a single dropped refill connection recovers and completes the read",
+          .timeLimit(.minutes(2)))
+    func transientRefillFailureRecovers() async throws {
+        let firstRange: Int64 = 512 * 1024
+        let attempts = AttemptCounter()
+        let serverMaybe = ThrottledOriginServer(
+            totalSize: 64 * 1024 * 1024,
+            respond: { _, offset, _ in
+                offset == firstRange && attempts.next(for: offset) == 1
+                    ? .dropConnection : .serve206
+            }
+        )
+        let server = try #require(serverMaybe)
+        defer { server.stop() }
+        let reader = AVIOReader(url: URL(string: "http://127.0.0.1:\(server.port)/movie.bin")!,
+                                boundedInitialFetch: firstRange)
+        defer { reader.markClosed(); reader.close() }
+        try reader.open()
+
+        let sliceCap = 256 * 1024
+        let buf = UnsafeMutablePointer<UInt8>.allocate(capacity: sliceCap)
+        defer { buf.deallocate() }
+        let target = Int(firstRange) + 512 * 1024
+        var got = 0
+        while got < target {
+            let n = reader.read(into: buf, size: Int32(min(sliceCap, target - got)))
+            if n <= 0 { break }
+            got += Int(n)
+        }
+
+        #expect(got == target, "read stopped at \(got) of \(target) after a transient failure")
+        #expect(reader.unproductiveReconnectsForTesting == 0,
+                "a healed transient must not leave a failure streak behind")
+    }
+
+    /// Regression guard for the healthy path: a range boundary on a well-behaved origin
+    /// stays off the failure ladder entirely — no streak, no `.reconnecting`.
+    @Test("healthy range boundaries stay off the failure ladder", .timeLimit(.minutes(2)))
+    func healthyBoundariesKeepFastPath() async throws {
+        let firstRange: Int64 = 256 * 1024
+        let server = try #require(ThrottledOriginServer(totalSize: 64 * 1024 * 1024))
+        defer { server.stop() }
+        let reader = AVIOReader(url: URL(string: "http://127.0.0.1:\(server.port)/movie.bin")!,
+                                boundedInitialFetch: firstRange)
+        defer { reader.markClosed(); reader.close() }
+        let phases = PhaseLog()
+        reader.onNetworkPhaseChanged = { phases.append($0) }
+        try reader.open()
+
+        let sliceCap = 128 * 1024
+        let buf = UnsafeMutablePointer<UInt8>.allocate(capacity: sliceCap)
+        defer { buf.deallocate() }
+        let target = Int(firstRange) * 2
+        var got = 0
+        while got < target {
+            let n = reader.read(into: buf, size: Int32(sliceCap))
+            if n <= 0 { break }
+            got += Int(n)
+        }
+
+        #expect(got == target, "sequential read stopped early at \(got) of \(target)")
+        #expect(reader.unproductiveReconnectsForTesting == 0)
+        #expect(!phases.contains(.reconnecting),
+                "a planned range boundary must not read as a reconnect to the host")
+    }
+}

--- a/Tests/AetherEngineTests/ReadErrorReviveCapTests.swift
+++ b/Tests/AetherEngineTests/ReadErrorReviveCapTests.swift
@@ -1,0 +1,49 @@
+import Testing
+import Foundation
+@testable import AetherEngine
+
+/// #169: a mid-session VOD read error gets a bounded producer revive. Once the gate was
+/// exhausted, `handleVODReadErrorExit` used to log "giving up" and return WITHOUT any
+/// terminal surface — no producer, no error, AVPlayer parked in waitingToPlay forever.
+/// The cap-reached arm must fire `onVODSourceFailed` exactly like the produced-nothing arm.
+@Suite("VOD readError revive-cap exhaustion")
+struct ReadErrorReviveCapTests {
+
+    private final class Flag: @unchecked Sendable {
+        private let lock = NSLock()
+        private var _code: Int32?
+        var code: Int32? {
+            lock.lock(); defer { lock.unlock() }
+            return _code
+        }
+        func set(_ code: Int32) {
+            lock.lock(); _code = code; lock.unlock()
+        }
+    }
+
+    @Test("an exhausted revive gate surfaces onVODSourceFailed instead of dying silently")
+    func exhaustedGateSurfacesFailure() {
+        let engine = HLSVideoEngine(url: URL(fileURLWithPath: "/nonexistent/witness.mkv"),
+                                    dvModeAvailable: false)
+        engine.readErrorReviveGate = MuxerFailureReviveGate(maxAttempts: 0)
+        let failed = Flag()
+        engine.onVODSourceFailed = { failed.set($0) }
+
+        engine.handleVODReadErrorExit(-5)
+
+        #expect(failed.code == -5,
+                "the cap-reached arm must surface the terminal failure to the host")
+    }
+
+    @Test("the revive gate admits within its cap and refuses past it")
+    func gateAdmitsWithinCap() {
+        var gate = MuxerFailureReviveGate(maxAttempts: 2)
+        let first = gate.admit()
+        let second = gate.admit()
+        let third = gate.admit()
+        #expect(first)
+        #expect(second)
+        #expect(!third, "the third failure must exhaust a two-attempt gate")
+        #expect(gate.attempts == 3)
+    }
+}

--- a/Tests/AetherEngineTests/ResolvedURLInvalidationTests.swift
+++ b/Tests/AetherEngineTests/ResolvedURLInvalidationTests.swift
@@ -1,0 +1,87 @@
+import Testing
+import Foundation
+@testable import AetherEngine
+
+/// The reader pins the post-redirect URL after the first 200/206 (#12) and previously
+/// dropped the pin only for auth-expiry statuses (401/403/404/410). An aggregator whose
+/// redirect targets expire per connection answers every later range with a hard 5xx from
+/// the pinned URL, and the reader hammered that dead URL forever instead of re-resolving
+/// through the source URL for a fresh redirect.
+@Suite("Resolved-URL invalidation on hard server errors")
+struct ResolvedURLInvalidationTests {
+
+    private final class AttemptCounter: @unchecked Sendable {
+        private let lock = NSLock()
+        private var counts: [Int64: Int] = [:]
+        func next(for offset: Int64) -> Int {
+            lock.lock(); defer { lock.unlock() }
+            let n = (counts[offset] ?? 0) + 1
+            counts[offset] = n
+            return n
+        }
+    }
+
+    @Test("a hard 500 from the pinned URL falls back to the source URL for a fresh redirect",
+          .timeLimit(.minutes(2)))
+    func hard500FallsBackToSourceURL() async throws {
+        let firstRange: Int64 = 256 * 1024
+        let attempts = AttemptCounter()
+        // CDN: serves everything except the FIRST attempt at the boundary refill, which it
+        // refuses with a hard 500 — the expired-redirect-target shape.
+        let cdnMaybe = ThrottledOriginServer(
+            totalSize: 64 * 1024 * 1024,
+            respond: { _, offset, _ in
+                offset == firstRange && attempts.next(for: offset) == 1
+                    ? .status(500) : .serve206
+            }
+        )
+        let cdn = try #require(cdnMaybe)
+        defer { cdn.stop() }
+        // Source: redirects every request to the CDN, like an Xtream panel's 302 hop.
+        let cdnPort = cdn.port
+        let sourceMaybe = ThrottledOriginServer(
+            totalSize: 64 * 1024 * 1024,
+            respond: { _, _, _ in .redirect(to: "http://127.0.0.1:\(cdnPort)/cdn/movie.bin") }
+        )
+        let source = try #require(sourceMaybe)
+        defer { source.stop() }
+
+        let reader = AVIOReader(url: URL(string: "http://127.0.0.1:\(source.port)/movie.bin")!,
+                                boundedInitialFetch: firstRange)
+        defer { reader.markClosed(); reader.close() }
+        try reader.open()
+
+        let sliceCap = 128 * 1024
+        let buf = UnsafeMutablePointer<UInt8>.allocate(capacity: sliceCap)
+        defer { buf.deallocate() }
+        let target = Int(firstRange) + 256 * 1024
+        var got = 0
+        while got < target {
+            let n = reader.read(into: buf, size: Int32(min(sliceCap, target - got)))
+            if n <= 0 { break }
+            got += Int(n)
+        }
+        #expect(got == target, "read stopped at \(got) of \(target); the 500 was terminal")
+
+        // The pin sent the refill straight to the CDN (first attempt, 500), and the fix
+        // must send the RETRY through the source URL again — visible as a source-server
+        // request at the boundary offset, which only exists if the pin was dropped.
+        let sourceHitsAtBoundary = source.requestLog.filter { $0.start == firstRange }
+        #expect(!sourceHitsAtBoundary.isEmpty,
+                "retry never fell back to the source URL: \(source.requestLog)")
+        let cdnAttemptsAtBoundary = cdn.requestLog.filter { $0.start == firstRange }.count
+        #expect(cdnAttemptsAtBoundary >= 2,
+                "the CDN should see the failed attempt plus the redirected retry")
+    }
+
+    @Test("hard-server-error classification excludes rate limiting")
+    func classifierExcludesRateLimiting() {
+        #expect(AVIOReader.isResolvedHardServerError(500))
+        #expect(AVIOReader.isResolvedHardServerError(502))
+        #expect(AVIOReader.isResolvedHardServerError(504))
+        #expect(!AVIOReader.isResolvedHardServerError(503), "503 is rate limiting (#71)")
+        #expect(!AVIOReader.isResolvedHardServerError(429))
+        #expect(!AVIOReader.isResolvedHardServerError(404), "auth expiry is its own class")
+        #expect(!AVIOReader.isResolvedHardServerError(200))
+    }
+}

--- a/Tests/AetherEngineTests/ThrottledOriginServer.swift
+++ b/Tests/AetherEngineTests/ThrottledOriginServer.swift
@@ -11,17 +11,28 @@ import Foundation
 /// the client stops reading, write() parks on the full socket buffer, so `bytesWritten`
 /// plateauing IS the observable for working flow control.
 final class ThrottledOriginServer: @unchecked Sendable {
+    /// Per-request response override for failure-path tests. The default keeps every
+    /// existing test on the historical always-206 behaviour.
+    enum Directive {
+        case serve206
+        case status(Int, retryAfter: Int? = nil)
+        case redirect(to: String)
+        case dropConnection
+    }
+
     let port: UInt16
     private let listenFD: Int32
     private let totalSize: Int64
     private let chunkBytes: Int
     private let throttleUs: useconds_t
     private let firstByteDelayUs: @Sendable (_ isSuffix: Bool) -> useconds_t
+    private let respond: @Sendable (_ requestIndex: Int, _ offset: Int64, _ path: String) -> Directive
     private let lock = NSLock()
     private var _bytesWritten: Int64 = 0
     private var _connFDs: [Int32] = []
     private var _stopped = false
     private var _requestedRanges: [(start: Int64, end: Int64?)] = []
+    private var _requestLog: [(path: String, start: Int64, end: Int64?)] = []
 
     var bytesWritten: Int64 {
         lock.lock(); defer { lock.unlock() }
@@ -40,6 +51,13 @@ final class ThrottledOriginServer: @unchecked Sendable {
         return _requestedRanges.count
     }
 
+    /// Every request with its path, so a redirect test can tell source-URL hits from
+    /// pinned-URL hits.
+    var requestLog: [(path: String, start: Int64, end: Int64?)] {
+        lock.lock(); defer { lock.unlock() }
+        return _requestLog
+    }
+
     private var stopped: Bool {
         lock.lock(); defer { lock.unlock() }
         return _stopped
@@ -50,11 +68,13 @@ final class ThrottledOriginServer: @unchecked Sendable {
     /// that difference is what let the speculative tail fetch pass every test while never once
     /// winning its race in the field. `isSuffix` is true for the `bytes=-n` form.
     init?(totalSize: Int64, chunkBytes: Int = 256 * 1024, throttleUs: useconds_t = 5000,
-          firstByteDelayUs: @escaping @Sendable (_ isSuffix: Bool) -> useconds_t = { _ in 0 }) {
+          firstByteDelayUs: @escaping @Sendable (_ isSuffix: Bool) -> useconds_t = { _ in 0 },
+          respond: @escaping @Sendable (_ requestIndex: Int, _ offset: Int64, _ path: String) -> Directive = { _, _, _ in .serve206 }) {
         self.totalSize = totalSize
         self.chunkBytes = chunkBytes
         self.throttleUs = throttleUs
         self.firstByteDelayUs = firstByteDelayUs
+        self.respond = respond
 
         let fd = socket(AF_INET, SOCK_STREAM, 0)
         guard fd >= 0 else { return nil }
@@ -139,6 +159,11 @@ final class ThrottledOriginServer: @unchecked Sendable {
     /// Returns false when the connection should close (client gone, or a malformed request).
     private func serveOneRequest(_ fd: Int32) -> Bool {
         guard let request = readRequestHeader(fd) else { return false }
+        let path = request.components(separatedBy: "\r\n").first
+            .flatMap { line -> String? in
+                let parts = line.components(separatedBy: " ")
+                return parts.count >= 2 ? parts[1] : nil
+            } ?? "?"
         var offset: Int64 = 0
         var rangeEnd: Int64? = nil
         var isSuffix = false
@@ -162,7 +187,30 @@ final class ThrottledOriginServer: @unchecked Sendable {
         }
         lock.lock()
         _requestedRanges.append((offset, rangeEnd))
+        _requestLog.append((path, offset, rangeEnd))
+        let requestIndex = _requestLog.count - 1
         lock.unlock()
+
+        switch respond(requestIndex, offset, path) {
+        case .serve206:
+            break
+        case .status(let code, let retryAfter):
+            let header = "HTTP/1.1 \(code) Status\r\n"
+                + (retryAfter.map { "Retry-After: \($0)\r\n" } ?? "")
+                + "Content-Length: 0\r\n"
+                + "Connection: keep-alive\r\n\r\n"
+            return writeFully(fd, Array(header.utf8))
+        case .redirect(let location):
+            let header = "HTTP/1.1 302 Found\r\n"
+                + "Location: \(location)\r\n"
+                + "Content-Length: 0\r\n"
+                + "Connection: keep-alive\r\n\r\n"
+            return writeFully(fd, Array(header.utf8))
+        case .dropConnection:
+            shutdown(fd, SHUT_RDWR)
+            close(fd)
+            return false
+        }
 
         var pendingDelay = firstByteDelayUs(isSuffix)
         while pendingDelay > 0 && !stopped {


### PR DESCRIPTION
Fixes #307.

A connection that ended in error without delivering a single byte of its generation was routed through the no-connection reposition branch, whose `seekReconnect` clears the unproductive streak and applies no backoff. An origin refusing every refill (connection-capped Xtream panel answering 500 at a 32 MiB range boundary) therefore produced an unbounded reconnect spiral — ~15 connections/s, 925 reconnects in 60 s observed in the field — until the segment provider's forward-wait escalation tore the demuxer down and killed the session.

**Changes**

- `AVIOReader.readPersistent`: exclude error-ended zero-byte connections (`connEnded && !connEndedAtRangeEnd && !connEndedByBackpressure && !connFirstDataSeen`) from the reposition branch so they fall through to the existing ended-connection ladder — status accounting, Retry-After, exponential backoff, `.reconnecting` network phase, bounded give-up. Planned ends (completed range, hard-cap) and any generation that delivered at least one byte keep the fast path, so the #220 no-refetch behaviour is untouched (regression-tested).
- Drop the pinned post-redirect URL (#12) on hard 5xx (503 excluded — rate limiting, #71) and after two consecutive zero-progress failures, so the retry re-resolves through the source URL for a fresh redirect. Expired-per-connection redirect targets (Xtream aggregators) previously pinned forever.
- Log the previously silent non-200/206 response rejection with its status and offset.
- Fire `onVODSourceFailed` when the #169 readError revive cap is exhausted, instead of returning silently with AVPlayer parked in `waitingToPlay` forever. The host-facing message is made mid-session-neutral.
- Test seam: `reconnectBackoffScaleForTesting` (captured at reader init, precedent: `sourceThrottleKbpsForTesting`) so the bounded give-up is testable without a minute of real sleeping.
- `ThrottledOriginServer` gains an injectable per-request directive (`serve206 | status | redirect | dropConnection`) and a path-aware request log; defaults preserve every existing test.

**Alternative considered:** excluding all `connEnded && !connEndedAtRangeEnd` regardless of bytes delivered — rejected as the larger behaviour change; a generation that delivered data keeps today's semantics.

**Test plan**

- `swift test` on macOS 26: 1513 tests / 227 suites green, including three new suites:
  - `ErrorEndedReconnectTests` — spiral bounded (≤20 attempts vs. hundreds) with backoff, `.reconnecting` emitted, `-1` after the cap; a single dropped refill heals with no streak; healthy boundaries stay off the ladder with no `.reconnecting`.
  - `ResolvedURLInvalidationTests` — 302 source → CDN; hard 500 from the pinned CDN URL falls back to the source URL and completes; classifier unit test.
  - `ReadErrorReviveCapTests` — exhausted gate fires `onVODSourceFailed`.
- `aetherctl play` (macOS 26) against a loopback portal (302, expiring tokens) + CDN (500 on suffix ranges, 500 on first attempt at the 32 MiB frontier): heals invisibly — re-resolves through the portal, re-pins, plays to the end; with permanent 500s: bounded ladder → give-up → #169 revive → terminal `onVODSourceFailed` instead of an endless spiral.
- Field shape: Apple TV 4K, tvOS 26, 3.7 GB H.264/AAC MKV via Xtream aggregator (`max_connections=1`, 302→http, no suffix ranges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
