### PR TITLE
fix(render): Fixed Swift Concurrency build issue

### DIFF
--- a/Sources/AetherEngine/Renderer/SampleBufferRenderer.swift
+++ b/Sources/AetherEngine/Renderer/SampleBufferRenderer.swift
@@ -101,6 +101,7 @@ final class SampleBufferRenderer: @unchecked Sendable {
 
     /// nil where the metrics cannot be asked for: an OS predating the API, or the pre-tvOS-18 path
     /// where the queue target is the display layer itself rather than an `AVSampleBufferVideoRenderer`.
+    @MainActor
     func loadRenderMetrics() async -> RenderMetrics? {
         guard #available(tvOS 18.0, iOS 18.0, macOS 15.0, *) else { return nil }
         guard let m = await displayLayer.sampleBufferRenderer.videoPerformanceMetrics else { return nil }


### PR DESCRIPTION
<!-- Thanks for contributing to AetherEngine. Keep this short; the test plan is the part that matters most. -->

## Summary

Fixed Swift Concurrency build issue
/AetherEngine/Sources/AetherEngine/Renderer/SampleBufferRenderer.swift:106:42 Non-Sendable type 'AVSampleBufferVideoRenderer' of property 'sampleBufferRenderer' cannot exit main actor-isolated context

Closes #

## What changed

Added @MainActor in the `loadRenderMetrics` function.

-

## Test plan

<!-- Engine changes are format- and device-specific. Name the device, OS, and the exact media you tested against so a reviewer can reason about coverage. -->

- Device / OS:
- Source media (container / video codec + profile / audio / HDR-DV):
- Result:

## Checklist

- [ ] `CHANGELOG.md` updated
- [ ] Commit messages follow Conventional Commits (`feat(...)`, `fix(...)`, `chore(...)`)
- [ ] The fix lives in the engine, not in a host-side workaround
- [ ] Public API changes are intentional and documented
