### PR TITLE
Backpressure: end the connection at high water instead of suspending the task

### DIFF
--- a/Sources/AetherEngine/AetherEngine+Diagnostics.swift
+++ b/Sources/AetherEngine/AetherEngine+Diagnostics.swift
@@ -127,8 +127,8 @@ extension AetherEngine {
                 }
 
                 // #220: the two readers of a subtitled VOD session, separately attributable.
-                // `ahead` above winHighWater (16 MB) with `susp=0` is backpressure that never
-                // engaged; the pump's own window is the control.
+                // `ahead` far above winHighWater (16 MB) with `parked=0` is backpressure that
+                // never engaged; the pump's own window is the control.
                 //
                 // Both paths, not just software. On a direct-play source the native path runs
                 // the HLS loopback, so `HLSVideoEngine` demuxes from the origin through an
@@ -268,33 +268,31 @@ extension AetherEngine {
     }
 
     /// #220: one memprobe fragment per live `AVIOReader` window. `win` is the whole buffer,
-    /// `ahead` the undrained forward extent that `appendPersistentData` gates the suspend on.
-    /// `ahead` far above winHighWater (16 MB) while `susp=0` means the backpressure never
-    /// engaged, which is a different defect from a transport overshoot past a suspend that did.
-    /// `postMB` is what the transport delivered after the suspend was issued. #174 priced that
-    /// as a bounded in-flight overshoot; a value tracking the whole window says `suspend()` is
-    /// not stopping delivery, so the high water bounds nothing at all.
+    /// `ahead` the undrained forward extent that `appendPersistentData` gates the backpressure
+    /// end on. `ahead` far above winHighWater (16 MB) while `parked=0` means the backpressure
+    /// never engaged, which is a different defect from a transport overshoot past an end that
+    /// fired (#310: the end replaced the suspend, so the overshoot is bounded by one
+    /// delivery's in-flight amount rather than by whatever a suspended task lets through).
     ///
     /// #240: `FetchedMB` per reader is the link attribution. The aggregate `avioFetchedMB` cannot
     /// answer "who took the bandwidth", and the reporter of #240 had to infer a second reader from
     /// connection-start lines that carried no identity. Two counters side by side answer it directly:
     /// a session whose `prefFetchedMB` tracks `pumpFetchedMB` is reading the stream twice.
     nonisolated static func readerWindowFragment(
-        pump: (windowBytes: Int, aheadBytes: Int, suspended: Bool, postSuspendBytes: Int64)?,
-        prefetch: (windowBytes: Int, aheadBytes: Int, suspended: Bool, postSuspendBytes: Int64)?,
+        pump: (windowBytes: Int, aheadBytes: Int, parked: Bool)?,
+        prefetch: (windowBytes: Int, aheadBytes: Int, parked: Bool)?,
         pumpFetchedBytes: Int64? = nil,
         prefetchFetchedBytes: Int64? = nil
     ) -> String {
         func fragment(
             _ prefix: String,
-            _ w: (windowBytes: Int, aheadBytes: Int, suspended: Bool, postSuspendBytes: Int64)?,
+            _ w: (windowBytes: Int, aheadBytes: Int, parked: Bool)?,
             _ fetched: Int64?
         ) -> String {
             guard let w else { return "" }
             return "\(prefix)WinMB=\(w.windowBytes / 1024 / 1024) "
                 + "\(prefix)AheadMB=\(w.aheadBytes / 1024 / 1024) "
-                + "\(prefix)Susp=\(w.suspended ? 1 : 0) "
-                + "\(prefix)PostMB=\(w.postSuspendBytes / 1024 / 1024) "
+                + "\(prefix)Parked=\(w.parked ? 1 : 0) "
                 + (fetched.map { "\(prefix)FetchedMB=\($0 / 1024 / 1024) " } ?? "")
         }
         return fragment("pump", pump, pumpFetchedBytes)

--- a/Sources/AetherEngine/Demuxer/AVIOReader.swift
+++ b/Sources/AetherEngine/Demuxer/AVIOReader.swift
@@ -175,44 +175,40 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
 
     // MARK: - Persistent Mode (single forward-streaming connection, playback path)
 
-    // Backpressure: suspend the persistent task above highWater, resume below lowWater
-    // (#174). Suspend/resume is the only contractual flow control; blocking the delegate
-    // callback leaves the socket read running on TLS/H2 transports, and the undelivered
-    // body then accumulates in unbounded URLSession-internal allocations until jetsam.
+    // Backpressure: END the connection above highWater and re-request at the frontier once
+    // the consumer drains below lowWater. Nothing is discarded and nothing is re-fetched:
+    // every delivered byte stays in the window, and the next range starts exactly where
+    // delivery stopped.
     //
-    // #220 correction: "peak window ~= highWater + a few MB of in-flight" is NOT what the
-    // suspend delivers. Measured against an origin serving 2.5x media rate, 911 MB arrived
-    // AFTER the task was suspended, window still climbing linearly, `suspended` true
-    // throughout. `suspend()` is advisory: CFNetwork keeps draining the socket and delivering.
-    // The real bound is whatever backpressure TCP applies once its own buffers fill, which
-    // against a fast origin is far above anything this window was sized for. So the high
-    // water is the target, and `winHardCap` is the bound: past it the connection is ended
-    // deliberately and re-requested at the frontier once the window drains. See
-    // `endPersistentConnectionForBackpressure`.
+    // This is the third design here, and the history is load-bearing. #174 replaced
+    // delegate-blocking (no flow-control contract: TLS/H2 transports keep reading at line
+    // rate into unbounded URLSession-internal allocations until jetsam) with task
+    // suspend/resume. #220 then measured suspend() to be advisory — against an origin
+    // serving 2.5x media rate, 911 MB arrived AFTER the task was suspended — so a hard cap
+    // ended the connection when the suspend demonstrably had not taken.
+    //
+    // #310 is why the suspend is now gone entirely rather than capped: a data task left
+    // suspended holding an undelivered window keeps a dormant established flow whose closed
+    // receive window sits unread for as long as the consumer takes to drain — ~100 s per
+    // cycle at 1 Mbps media rate, indefinitely while paused. On tvOS/iOS (user-space
+    // networking: TCP for nw flows runs in the app process) that dormant state correlates,
+    // dose-response by media bitrate, with 10-80 s episodes in which every
+    // Network.framework flow in the process goes deaf at once — established WebSockets time
+    // out unACKed, no new nw handshake completes — while raw BSD sockets from the same
+    // process keep working. Ending the connection instead means the reader either has an
+    // ACTIVELY delivering flow or NO flow: there is no parked state for the substrate to
+    // rot in, and a paused player holds no connection at all. The price is one extra range
+    // request per drain cycle (every ~100 s at 1 Mbps; connects measure ~2 ms on LAN). The
+    // window peak is now bounded by construction at highWater plus one delivery's in-flight
+    // overshoot, which subsumes the former winHardCap escape hatch and the realloc-doubling
+    // peak it had to be sized against.
     private static let winHighWater = 16 * 1024 * 1024
     private static let winLowWater = 8 * 1024 * 1024
-    // #220 hard bound on the resident window. Above this the transport is demonstrably
-    // ignoring the suspend, and no amount of waiting brings it back down.
-    //
-    // 3x the high water, not 8x. The first attempt used 128 MB, reasoning that healthy
-    // sessions sit far below it. They do (16-21 MB measured on both macOS and tvOS, across
-    // both readers), but the cap is not the peak: the window is a `Data`, so crossing the cap
-    // means a realloc that holds the old and new buffers at once, and a field capture with
-    // this bound already working named `bigExact=160301056,135544832`, two blocks at 153 and
-    // 129 MB, with `size_in_use` still touching 1003 MB. The cap sets the peak at roughly
-    // twice its own value, so it has to be chosen against the peak that is affordable, not
-    // against the window that looks reasonable. It also caught that event with 4 MB to spare,
-    // which is not a margin.
-    //
-    // Lower costs reconnects only in the regime that is already broken: a healthy link never
-    // reaches it, and at the rates where the defect appears the excess is 1-2 MB/s, so the
-    // cycle is tens of seconds. No byte is discarded or re-fetched either way.
-    static let winHardCap = 48 * 1024 * 1024
-    // #220: how much the persistent reader asks for at a time. The resident window is then
-    // bounded by low water plus this, 40 MB, whatever the transport chooses to do with a
-    // suspend. Sized so the request rate stays modest (about one per 5 s on a 4K remux) while
-    // leaving clearance under winHardCap, so a firing cap still means something is wrong
-    // rather than being the normal ceiling.
+    // #220: how much the persistent reader asks for at a time. Bounds a single request's
+    // exposure by construction (an origin cannot serve more than it was asked for, whatever
+    // it thinks of flow control) and keeps the request cadence modest on a healthy link:
+    // one request per range boundary while the consumer keeps up, one per
+    // highWater-to-lowWater drain cycle when the origin outruns it.
     static let persistentRangeBytes: Int64 = 32 * 1024 * 1024
     // Keep this many bytes behind the cursor for small matroska backward re-reads.
     private static let winLookback = 2 * 1024 * 1024
@@ -232,7 +228,7 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
     /// How much of the file's head to retain for the return trip after a parse excursion. Measured
     /// landings across six container layouts and a field trace: 48, 1161, 5752 and 265159, all well
     /// inside this. Sized to hold that return without becoming a second buffer worth worrying about
-    /// next to the live window: this is charged against the same footprint that winHardCap bounds.
+    /// next to the live window: this is charged against the same footprint the high-water end bounds.
     static let headSpanMaxBytes = 4 * 1024 * 1024
 
     /// Speculative suffix fetch issued with `open()`, sized to cover the small trailing objects a
@@ -300,13 +296,9 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
     // Bumped on every (re)connect; stale delegate callbacks are ignored.
     private var connGeneration = 0
     private var activeTask: URLSessionDataTask?
-    // #174: true while the persistent task is suspended for window backpressure.
-    // winCond-guarded; every suspend/resume transition goes through this flag so the
-    // task's suspend count stays balanced.
-    private var persistentTaskSuspended = false
 
-    /// #174: winCond-guarded snapshot of the suspend state, internal so the task-level
-    /// backpressure is unit-tested against a loopback origin without private state access.
+    /// #174: winCond-guarded snapshots, internal so the task-level backpressure is
+    /// unit-tested against a loopback origin without private state access.
     /// #220: planned range ends must leave the failure budget alone.
     var unproductiveReconnectsForTesting: Int {
         winCond.lock()
@@ -323,21 +315,12 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
         return activeTask != nil
     }
 
-    var persistentTaskIsSuspendedForTesting: Bool {
-        winCond.lock()
-        defer { winCond.unlock() }
-        return persistentTaskSuspended
-    }
-
-    /// #220: bytes the delegate accepted while the task was ALREADY flagged suspended.
-    /// The #174 comment prices this as "the transport's in-flight amount", i.e. a bounded
-    /// overshoot. If it instead tracks the whole window, `suspend()` is not stopping delivery
-    /// and the 16 MB high water bounds nothing. winCond-guarded.
-    private var suspendedDeliveryBytes: Int64 = 0
-
-    /// #220: set when WE ended the connection at `winHardCap`, so the read loop re-requests at
-    /// the frontier without charging the reconnect to the unproductive-reconnect streak. Left
-    /// unset, a deliberate cap would spend the streak that exists to detect a dead source and
+    /// #220/#310: set when WE ended the connection at `winHighWater` (ending is the only
+    /// non-advisory flow control, and a task left suspended instead is a dormant flow — see
+    /// the backpressure doc block above). The read loop re-requests at the frontier — at low
+    /// water like a completed range, or immediately once the window is empty — without
+    /// charging the reconnect to the unproductive-reconnect streak. Left unset, a deliberate
+    /// end would spend the streak that exists to detect a dead source and
     /// `recordReconnectAndShouldGiveUp` would kill the reader on a perfectly healthy link.
     /// winCond-guarded, cleared by `startPersistentConnection`.
     private var connEndedByBackpressure = false
@@ -358,17 +341,17 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
     private var connRequestedOffset: Int64 = 0
 
     /// #220: winCond-guarded snapshot of the sliding window for the periodic memprobe.
-    /// `ahead` is the undrained forward extent, the quantity `appendPersistentData` gates
-    /// the suspend on, so a window sitting far above winHighWater with `suspended=false` is
-    /// backpressure that never engaged rather than a transport overshoot. `postSuspend`
-    /// separates those two: it is what arrived after the suspend was issued.
-    var windowDiagnostics: (windowBytes: Int, aheadBytes: Int, suspended: Bool, postSuspendBytes: Int64) {
+    /// `ahead` is the undrained forward extent, the quantity `appendPersistentData` gates the
+    /// backpressure end on. `parked` is true while the connection has been deliberately ended
+    /// at high water and the low-water refill has not fired yet (#310), so a long-lived
+    /// `parked` with `ahead` holding above lowWater reads as a stalled consumer, not a
+    /// transport fault.
+    var windowDiagnostics: (windowBytes: Int, aheadBytes: Int, parked: Bool) {
         winCond.lock()
         defer { winCond.unlock() }
         return (window.count,
                 window.count - max(0, Int(position - winStart)),
-                persistentTaskSuspended,
-                suspendedDeliveryBytes)
+                connEndedByBackpressure)
     }
     // #93 restart latency diagnostics (winCond-guarded): bytes dropped by the stale-generation
     // guard, plus per-generation time-to-first-data tracking.
@@ -576,8 +559,7 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
                 // a size; if not, abandon it (generation bump ignores a size landing in the
                 // race window). fileSize is read under the lock because the delegate thread now
                 // writes it (issue #70 review #4/#5).
-                let (haveSize, abandonedTask, wasSuspended) = resolveOptimisticOpen()
-                if wasSuspended { abandonedTask?.resume() }
+                let (haveSize, abandonedTask) = resolveOptimisticOpen()
                 abandonedTask?.cancel()
                 if !haveSize {
                     // The data connection resolved no size (no-length origin, a transient 429,
@@ -676,19 +658,17 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
     /// the read means a size that lands in the race window is ignored rather than racing a
     /// half-done teardown (issue #70 review #4/#5). Returns the session to cancel outside
     /// the lock. Demux thread, open-time only; leaves the AVIO context intact (unlike close()).
-    private func resolveOptimisticOpen() -> (haveSize: Bool, abandonedTask: URLSessionDataTask?, wasSuspended: Bool) {
+    private func resolveOptimisticOpen() -> (haveSize: Bool, abandonedTask: URLSessionDataTask?) {
         winCond.lock()
         defer { winCond.unlock() }
-        if fileSize > 0 { return (true, nil, false) }
+        if fileSize > 0 { return (true, nil) }
         connGeneration &+= 1
         let task = activeTask
-        let suspended = persistentTaskSuspended
-        persistentTaskSuspended = false
         activeTask = nil
         window = Data()
         connEnded = true
         winCond.broadcast()
-        return (false, task, suspended)
+        return (false, task)
     }
 
     // Close flags written on the teardown thread (markClosed / fullyClose) and read on the demux
@@ -777,8 +757,6 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
         // 15-30s cold reads. The AVIO context is untouched (close() still frees it); only the socket
         // is released. Grab under winCond, invalidate outside it (mirrors close()).
         let task = activeTask
-        let persistentWasSuspended = persistentTaskSuspended
-        persistentTaskSuspended = false
         activeTask = nil
         connEnded = true
         // #281: a speculative fetch outlives nothing. Same reasoning as the persistent GET above:
@@ -790,7 +768,6 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
         openPhaseActive = false
         winCond.broadcast()
         winCond.unlock()
-        if persistentWasSuspended { task?.resume() }
         task?.cancel()
         tailTask?.cancel()
     }
@@ -840,8 +817,6 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
         connGeneration &+= 1
         connEnded = true
         let task = activeTask
-        let persistentWasSuspended = persistentTaskSuspended
-        persistentTaskSuspended = false
         activeTask = nil
         window = Data()
         // #281: both spans hold real bytes (up to headSpanMaxBytes + tailPrefetchBytes), so they
@@ -855,7 +830,6 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
         winCond.broadcast()
         winCond.unlock()
         tailTask?.cancel()
-        if persistentWasSuspended { task?.resume() }
         // #220: the shared session is never invalidated, so the task has to be cancelled
         // explicitly. Invalidating used to be what released this connection.
         task?.cancel()
@@ -1185,10 +1159,10 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
             }
 
             // #220: `connEndedByBackpressure` is excluded on purpose. This reconnects at the
-            // READ position, which resets winStart and drops the window, so a hard-cap end
-            // would re-fetch up to winHardCap of already-resident bytes on every cycle. That
-            // case falls through to the drained-window path below, which re-requests at the
-            // frontier and keeps every delivered byte.
+            // READ position, which resets winStart and drops the window, so a backpressure
+            // end would re-fetch up to winHighWater of already-resident bytes on every
+            // cycle. That case refills at the frontier once the consumer draws down to low
+            // water (or immediately once the window is empty), keeping every delivered byte.
             //
             // `windowCanServe` is excluded for exactly the same reason, and the omission was
             // measurable: a range delivered IN FULL also clears `activeTask`, so a consumer
@@ -1281,19 +1255,12 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
                 unproductiveReconnects = 0      // real progress
                 rateLimitStreak = 0             // real progress clears the 429 give-up streak (#71)
                 emitNetworkPhase(.flowing)      // recovered: source delivering again (#85)
-                // #174: resume the suspended transfer once the drain crosses lowWater.
-                var toResume: URLSessionDataTask?
-                var refillFrom: Int64? = nil
-                let undrained = window.count - max(0, Int(position - winStart))
-                if persistentTaskSuspended, undrained <= Self.winLowWater {
-                    persistentTaskSuspended = false
-                    toResume = activeTask
-                }
-                // #220: the range ended on purpose and the consumer has now drawn down far
-                // enough that the next one should already be in flight. Requesting at the
-                // frontier rather than at the read position keeps every delivered byte, and
-                // doing it here rather than on an empty window is what stops a range boundary
-                // from becoming a stall.
+                // #220/#310: the connection ended on purpose — its range was delivered in
+                // full, or it was ended at high water so no suspended flow sits dormant —
+                // and the consumer has now drawn down far enough that the next one should
+                // already be in flight. Requesting at the frontier rather than at the read
+                // position keeps every delivered byte, and doing it here rather than on an
+                // empty window is what stops a planned end from becoming a stall.
                 // A frontier AT the end of the file is not a frontier. The range that ended was the
                 // last one, and requesting `bytes=<fileSize>-` asks for nothing: origins answer it
                 // with an empty 206, the reconnect resets `winStart` past the last byte, and the
@@ -1301,14 +1268,16 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
                 // turned one connection into three, since the parse then had to re-fetch what it
                 // had just been handed. Live keeps the old behaviour: its length is not
                 // authoritative and its end moves.
+                var refillFrom: Int64? = nil
+                let undrained = window.count - max(0, Int(position - winStart))
                 let frontier = winStart + Int64(window.count)
-                if connEndedAtRangeEnd, activeTask == nil, undrained <= Self.winLowWater,
+                if connEndedAtRangeEnd || connEndedByBackpressure, activeTask == nil,
+                   undrained <= Self.winLowWater,
                    isLive || fileSize <= 0 || frontier < fileSize {
                     refillFrom = frontier
                 }
                 winCond.broadcast()
                 winCond.unlock()
-                toResume?.resume()
                 if let refillFrom { timedReconnect(seek: false, at: refillFrom) }
                 continue
             }
@@ -1347,16 +1316,6 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
             }
 
             if !ended {
-                // #174: a suspended task never delivers; resume before waiting (mirrors
-                // readStreaming). Reached when a within-window forward seek lands at the
-                // frontier while the transfer is parked above lowWater.
-                if persistentTaskSuspended {
-                    persistentTaskSuspended = false
-                    let toResume = activeTask
-                    winCond.unlock()
-                    toResume?.resume()
-                    continue
-                }
                 // Wait for the live connection to fill forward. A false return
                 // means connStallTimeout elapsed with no data (socket stall).
                 let waitStart = DispatchTime.now()
@@ -1388,14 +1347,16 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
 
             // Connection ended before EOF; reconnect at frontier. Honour Retry-After for 429/503.
             winCond.unlock()
-            // #220: we ended it ourselves at the hard cap and the consumer has now drained the
-            // window. Re-request immediately: no backoff (the origin never misbehaved), no
-            // streak charge (this is not an unproductive reconnect), no `.reconnecting` phase
-            // and no `lastUnplannedReconnectAt` (nothing here looks like a transcode respawn to
-            // the host). Without this the cap would spend the give-up budget on a healthy link.
+            // #220/#310: we ended it ourselves at high water and the consumer has now emptied
+            // the window (the low-water refill normally fires first; this is the backstop for
+            // a position that jumped to the frontier). Re-request immediately: no backoff (the
+            // origin never misbehaved), no streak charge (this is not an unproductive
+            // reconnect), no `.reconnecting` phase and no `lastUnplannedReconnectAt` (nothing
+            // here looks like a transcode respawn to the host). Without this the end would
+            // spend the give-up budget on a healthy link.
             if endedByBackpressure {
                 EngineLog.emit(
-                    "[AVIOReader] \(label) window drained after hard cap; re-requesting at \(frontier)",
+                    "[AVIOReader] \(label) window drained after backpressure end; re-requesting at \(frontier)",
                     category: .demux)
                 timedReconnect(seek: false, at: frontier)
                 continue
@@ -1823,7 +1784,7 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
         // still undrained data: the very next read then sat below `winStart`, took the backward
         // branch, and pulled those same bytes back over the network 4 MB at a time on the demux
         // read thread. Keeping them costs nothing (the new range covers only what follows) and the
-        // window stays bounded by `trimWindowLocked` and `winHardCap` exactly as before.
+        // window stays bounded by `trimWindowLocked` and the high-water end exactly as before.
         // The truncating case is the narrow race where the old connection appended past the
         // frontier the read loop computed before it unlocked; those bytes are re-delivered by the
         // new range, which is correct if slightly wasteful, and never leaves a hole.
@@ -1839,20 +1800,15 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
         connEndedByBackpressure = false
         connEndedAtRangeEnd = false
         connRangeEnd = resolvedBound.map { offset + $0 - 1 }
-        suspendedDeliveryBytes = 0
         connStatus = 0
         connRetryAfter = 0
         connStartedAt = DispatchTime.now()   // #93: time-to-first-data per generation
         connFirstDataSeen = false
         let oldTask = activeTask
-        let oldSuspended = persistentTaskSuspended
-        persistentTaskSuspended = false
         activeTask = nil
         winCond.broadcast()
         winCond.unlock()
 
-        // #174: balance a pending suspend before cancel (mirrors the streaming teardown).
-        if oldSuspended { oldTask?.resume() }
         oldTask?.cancel()
 
         if isClosed { return }
@@ -1898,9 +1854,9 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
             category: .demux)
     }
 
-    /// Force-copies `data` into the sliding window and applies backpressure by
-    /// suspending the task once the window exceeds winHighWater (#174); readPersistent
-    /// resumes it when the consumer drains below winLowWater. Never blocks: parking this
+    /// Force-copies `data` into the sliding window and applies backpressure by ENDING the
+    /// connection once the window exceeds winHighWater (#310); readPersistent re-requests at
+    /// the frontier when the consumer drains below winLowWater. Never blocks: parking this
     /// delegate callback has no flow-control contract (TLS/H2 transports keep reading at
     /// line rate into unbounded internal buffers, the #174 EXC_RESOURCE). Force-copy
     /// releases source dispatch_data per delivery (same leak control as the chunk path).
@@ -1922,9 +1878,6 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
             lastFirstDataMs = firstDataMs ?? 0
         }
         let count = data.count
-        // #220: delivery that lands with the suspend flag already set. Counted before the
-        // append so it is attributable to the transport, not to our own bookkeeping.
-        if persistentTaskSuspended { suspendedDeliveryBytes += Int64(count) }
         let base = window.count
         window.count = base + count
         window.withUnsafeMutableBytes { dst in
@@ -1951,37 +1904,32 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
             connEnded = true
         }
         winCond.broadcast()
-        // Deliveries already dispatched before the suspend takes effect still land here
-        // (flag already set, no double-suspend), so the window can overshoot highWater by
-        // the transport's in-flight amount; the suspend count stays balanced via the flag.
-        var toSuspend: URLSessionDataTask?
+        // #310: past high water the connection is ENDED, not suspended. suspend() is
+        // advisory (#220: CFNetwork keeps draining and delivering), and a task that does
+        // park under it holds a dormant established flow whose closed receive window is the
+        // process-wide nw-starvation trigger this design replaces (see the backpressure doc
+        // block at the water marks). Deliveries already dispatched before the cancel takes
+        // effect still land here (same generation until the refill starts a new one), so
+        // the window can overshoot highWater by the transport's in-flight amount; the
+        // frontier is computed from what actually arrived, so nothing is discarded,
+        // re-fetched, or left as a hole. The window keeps every byte already delivered
+        // (they are valid and the consumer reads them) and the read loop re-requests at
+        // the frontier once the consumer drains below low water.
         var toCancel: URLSessionDataTask?
         let ahead = window.count - max(0, Int(position - winStart))
-        if ahead > Self.winHighWater, !persistentTaskSuspended, !isClosed {
-            persistentTaskSuspended = true
-            toSuspend = activeTask
-        }
-        // #220: the suspend did not take. Ending the connection is the only bound left; the
-        // window keeps every byte already delivered (they are valid and the consumer reads
-        // them) and the read loop re-requests at the frontier once it has drained. Nothing is
-        // discarded and nothing is re-fetched.
-        if ahead > Self.winHardCap, !connEndedByBackpressure, !isClosed {
+        if ahead > Self.winHighWater, !connEnded, !isClosed, activeTask != nil {
             connEndedByBackpressure = true
             connEnded = true
             toCancel = activeTask
             activeTask = nil
-            persistentTaskSuspended = false
             winCond.broadcast()
         }
         winCond.unlock()
-        toSuspend?.suspend()
         if let toCancel {
             EngineLog.emit(
-                "[AVIOReader] \(label) window hard cap: \(ahead / 1024 / 1024)MB resident with the task "
-                + "suspended (\(suspendedDeliveryBytes / 1024 / 1024)MB arrived after the "
-                + "suspend); ending the connection, will re-request at the frontier",
+                "[AVIOReader] \(label) window high water: \(ahead / 1024 / 1024)MB ahead; ending the "
+                + "connection, will re-request at the frontier once the consumer drains",
                 category: .demux)
-            toCancel.resume()   // balance the suspend so the cancel is not charged to a parked task
             toCancel.cancel()
         }
         if let firstDataMs {
@@ -2077,10 +2025,14 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
             // task must not stay installed.
             activeTask = nil
         }
+        // #310: our own high-water cancel completes here as NSURLErrorCancelled. That end was
+        // already logged where it was decided; reporting it as an error too would make every
+        // drain cycle against a fast origin read like a transport fault.
+        let deliberateEnd = isCurrentGen && connEndedByBackpressure
         let windowAhead = isCurrentGen ? (window.count - max(0, Int(position - winStart))) : 0
         winCond.broadcast()
         winCond.unlock()
-        if let error {
+        if let error, !(deliberateEnd && (error as? URLError)?.code == .cancelled) {
             EngineLog.emit("[AVIOReader] \(label) conn gen=\(generation) ended with error: \(error.localizedDescription)", category: .demux)
         }
         if isCurrentGen && isLive {

--- a/Sources/AetherEngine/Demuxer/Demuxer.swift
+++ b/Sources/AetherEngine/Demuxer/Demuxer.swift
@@ -191,7 +191,7 @@ public final class Demuxer: @unchecked Sendable {
     /// #220: sliding-window snapshot of this demuxer's network reader, nil for disc / custom /
     /// file providers that have no window. Surfaced per demuxer (pump and subtitle side reader
     /// are separate readers against the same origin) in the periodic memprobe.
-    var ioWindowDiagnostics: (windowBytes: Int, aheadBytes: Int, suspended: Bool, postSuspendBytes: Int64)? {
+    var ioWindowDiagnostics: (windowBytes: Int, aheadBytes: Int, parked: Bool)? {
         (avioProvider as? AVIOReader)?.windowDiagnostics
     }
 

--- a/Sources/AetherEngine/Native/SoftwarePlaybackHost.swift
+++ b/Sources/AetherEngine/Native/SoftwarePlaybackHost.swift
@@ -32,7 +32,7 @@ final class SoftwarePlaybackHost {
 
     /// #220: the pump demuxer's network sliding window, for the periodic memprobe. Paired with
     /// the subtitle side reader's own window, the two connections are separately attributable.
-    var ioWindowDiagnostics: (windowBytes: Int, aheadBytes: Int, suspended: Bool, postSuspendBytes: Int64)? {
+    var ioWindowDiagnostics: (windowBytes: Int, aheadBytes: Int, parked: Bool)? {
         demuxer?.ioWindowDiagnostics
     }
 

--- a/Tests/AetherEngineTests/Issue174PersistentReadBackpressureTests.swift
+++ b/Tests/AetherEngineTests/Issue174PersistentReadBackpressureTests.swift
@@ -2,29 +2,29 @@ import Testing
 import Foundation
 @testable import AetherEngine
 
-/// #174: the persistent reader applied backpressure by BLOCKING the URLSession delegate
-/// callback until the consumer drained below winHighWater. Blocking the delegate has no
-/// flow-control contract: whether the connection stops reading from the socket is a
-/// transport implementation detail. Plain HTTP/1.1 happens to park after a few MB of
-/// internal buffering, but the field crash (HTTPS origin, boringssl in the crashing
-/// stack, iPadOS) shows the TLS/H2 path keeps pulling at line rate and buffers the
-/// undelivered body in unbounded internal allocations (cold pages compress, then
-/// EXC_RESOURCE at the jetsam limit). Real, contractual flow control is task
-/// suspend/resume ("a task, while suspended, produces no network traffic"), the same
-/// mechanism the streaming path already uses (streamHighWater / streamLowWater).
+/// Backpressure history (#174 → #220 → #310) — each design fixed the previous one's failure
+/// mode, and these tests pin the current one:
+/// - #174: delegate-blocking had no flow-control contract (TLS/H2 transports keep reading at
+///   line rate into unbounded URLSession-internal allocations until jetsam) and was replaced
+///   with task suspend/resume.
+/// - #220: suspend() measured advisory — 911 MB arrived after a suspend — so requests became
+///   bounded ranges and a hard cap ended a connection the suspend failed to park.
+/// - #310: a task that DID park held a dormant established flow whose closed receive window
+///   starves every Network.framework flow in the process on user-space-networking OSes
+///   (tvOS/iOS). The suspend is gone: at winHighWater the connection is ENDED and the read
+///   loop re-requests at the frontier once the consumer drains below winLowWater. A stalled
+///   or paused consumer therefore holds NO connection at all — which is what these tests pin.
 ///
-/// These tests run a loopback HTTP/1.1 origin that counts every body byte it manages to
-/// write. The load-bearing assertion is the suspend state itself (the transport-agnostic
-/// mechanism); the origin byte bound is the regression guard that catches a backpressure
-/// removal without a replacement.
-@Suite("AVIOReader persistent backpressure (#174)")
+/// They run a loopback HTTP/1.1 origin that counts every body byte it manages to write and
+/// records every Range it is asked for.
+@Suite("AVIOReader persistent backpressure (#174/#220/#310)")
 struct Issue174PersistentReadBackpressureTests {
 
 
     // MARK: - Tests
 
-    @Test("stalled consumer parks the origin connection instead of buffering at line rate")
-    func stalledConsumerParksOrigin() async throws {
+    @Test("a stalled consumer is left with no live connection, not a parked one")
+    func stalledConsumerEndsOriginConnection() async throws {
         let server = try #require(ThrottledOriginServer(totalSize: 512 * 1024 * 1024))
         defer { server.stop() }
         let reader = AVIOReader(url: URL(string: "http://127.0.0.1:\(server.port)/movie.bin")!)
@@ -35,25 +35,34 @@ struct Issue174PersistentReadBackpressureTests {
         // (muxer backpressured on SegmentCache high water, no read ever advances position).
         try await Task.sleep(for: .seconds(3))
 
-        // Origin line rate here is ~50 MB/s. Without real flow control the origin keeps
-        // serving (~150 MB in 3 s) into URLSession's internal buffering. With task-suspend
-        // backpressure it parks at winHighWater plus socket/transport buffer slack.
-        #expect(server.bytesWritten < 64 * 1024 * 1024,
+        // The #310 contract, in order of importance: the flow is GONE (a suspended task is a
+        // dormant flow), the end is recorded as backpressure so the refill path owns it, the
+        // window parked near winHighWater, the refill has not fired with nothing draining,
+        // and the origin was never asked to serve past the one bounded range.
+        #expect(!reader.hasLiveConnectionForTesting,
+                "a stalled consumer must hold no connection")
+        let diag = reader.windowDiagnostics
+        #expect(diag.parked,
+                "the end must be recorded as backpressure so the refill path owns it")
+        #expect(diag.aheadBytes < 32 * 1024 * 1024,
+                "window held \(diag.aheadBytes / (1024 * 1024)) MB against a 16 MB high water")
+        #expect(server.requestedRanges.filter { $0.start == 0 }.count == 1,
+                "the refill must not fire while nothing drains: \(server.requestedRanges)")
+        #expect(server.bytesWritten < 48 * 1024 * 1024,
                 "origin served \(server.bytesWritten / (1024 * 1024)) MB into a stalled consumer")
-        #expect(reader.persistentTaskIsSuspendedForTesting,
-                "the persistent task must be suspended once the window exceeds winHighWater")
     }
 
-    @Test("resuming consumption after a stall delivers fresh bytes (resume liveness)")
+    @Test("resuming consumption after a stall delivers fresh bytes at the frontier (refill liveness)")
     func drainAfterStallResumesDelivery() async throws {
-        let server = try #require(ThrottledOriginServer(totalSize: 256 * 1024 * 1024))
+        let totalSize: Int64 = 256 * 1024 * 1024
+        let server = try #require(ThrottledOriginServer(totalSize: totalSize))
         defer { server.stop() }
         let reader = AVIOReader(url: URL(string: "http://127.0.0.1:\(server.port)/movie.bin")!)
         defer { reader.markClosed(); reader.close() }
         try reader.open()
 
-        // Stall long enough for the suspend to engage, then consume far more than the
-        // window: delivery must keep flowing, which proves the task was resumed.
+        // Stall long enough for the high-water end to engage, then consume far more than the
+        // window: delivery must keep flowing, which proves the frontier refill runs.
         try await Task.sleep(for: .seconds(2))
 
         let sliceCap = 256 * 1024
@@ -68,10 +77,19 @@ struct Issue174PersistentReadBackpressureTests {
             got += Int(n)
         }
         #expect(got >= target, "only \(got / (1024 * 1024)) MB delivered after the stall")
+
+        // Every data-connection range must start at or past the previous one: a reconnect
+        // that reset below the frontier would be re-fetching resident bytes. The open-time
+        // speculative tail fetch is the one legitimate out-of-order range; it lives at the
+        // far end of the file and is excluded by position.
+        let dataStarts = server.requestedRanges.map(\.start)
+            .filter { $0 < totalSize - Int64(1024 * 1024) }
+        #expect(dataStarts == dataStarts.sorted(),
+                "a refill went backwards past the frontier: \(server.requestedRanges)")
     }
 
-    @Test("teardown while suspended releases the task and does not hang")
-    func teardownWhileSuspended() async throws {
+    @Test("teardown during the backpressure-ended state does not hang")
+    func teardownWhileParked() async throws {
         let server = try #require(ThrottledOriginServer(totalSize: 512 * 1024 * 1024))
         defer { server.stop() }
         let reader = AVIOReader(url: URL(string: "http://127.0.0.1:\(server.port)/movie.bin")!)
@@ -79,11 +97,11 @@ struct Issue174PersistentReadBackpressureTests {
 
         try await Task.sleep(for: .seconds(2))
 
-        // Completing without a hang is the assertion; the suspended flag must be cleared
-        // so the balanced resume-before-cancel actually happened.
+        // Completing without a hang is the assertion: nothing may be left waiting on a
+        // connection that was deliberately ended and will never refill after close.
         reader.markClosed()
         reader.close()
-        #expect(!reader.persistentTaskIsSuspendedForTesting)
+        #expect(!reader.hasLiveConnectionForTesting)
     }
 
     /// #220: bounded ranges cannot be exercised against an origin that ignores the range end.

--- a/Tests/AetherEngineTests/Issue220PrefetchTelemetryTests.swift
+++ b/Tests/AetherEngineTests/Issue220PrefetchTelemetryTests.swift
@@ -101,44 +101,30 @@ struct Issue220PrefetchTelemetryTests {
         #expect(AetherEngine.readerWindowFragment(pump: nil, prefetch: nil).isEmpty)
     }
 
-    /// The discriminator the kill needs: `ahead` far above winHighWater with `Susp=0` is
-    /// backpressure that never engaged, not a transport overshoot past a suspend that did.
-    @Test("both readers report window, ahead and suspend state")
+    /// The discriminator the kill needs: `ahead` far above winHighWater with `Parked=0` is
+    /// backpressure that never engaged, not an in-flight overshoot past an end that fired (#310).
+    @Test("both readers report window, ahead and parked state")
     func bothReadersReported() {
         let fragment = AetherEngine.readerWindowFragment(
-            pump: (windowBytes: 12 * 1024 * 1024, aheadBytes: 8 * 1024 * 1024,
-                   suspended: false, postSuspendBytes: 0),
+            pump: (windowBytes: 12 * 1024 * 1024, aheadBytes: 8 * 1024 * 1024, parked: false),
             prefetch: (windowBytes: 1024 * 1024 * 1024, aheadBytes: 1020 * 1024 * 1024,
-                       suspended: false, postSuspendBytes: 0))
+                       parked: false))
         #expect(fragment.contains("pumpWinMB=12 "))
         #expect(fragment.contains("pumpAheadMB=8 "))
-        #expect(fragment.contains("pumpSusp=0 "))
+        #expect(fragment.contains("pumpParked=0 "))
         #expect(fragment.contains("prefWinMB=1024 "))
         #expect(fragment.contains("prefAheadMB=1020 "))
-        #expect(fragment.contains("prefSusp=0 "))
+        #expect(fragment.contains("prefParked=0 "))
     }
 
-    @Test("a suspended reader is flagged")
-    func suspendedReaderFlagged() {
+    /// #310: parked now means the connection was deliberately ENDED at high water and the
+    /// low-water refill has not fired yet — a reader in this state holds no flow at all.
+    @Test("a parked reader is flagged")
+    func parkedReaderFlagged() {
         let fragment = AetherEngine.readerWindowFragment(
             pump: nil,
-            prefetch: (windowBytes: 17 * 1024 * 1024, aheadBytes: 17 * 1024 * 1024,
-                       suspended: true, postSuspendBytes: 1024 * 1024))
+            prefetch: (windowBytes: 17 * 1024 * 1024, aheadBytes: 17 * 1024 * 1024, parked: true))
         #expect(!fragment.contains("pump"))
-        #expect(fragment.contains("prefSusp=1 "))
-    }
-
-    /// #220: the quantity that decided the issue. A suspend that works leaves `PostMB` at the
-    /// transport's in-flight amount; one that does not leaves it tracking the whole window, and
-    /// the two are only distinguishable because this is reported separately from `AheadMB`.
-    @Test("post-suspend delivery is reported per reader")
-    func postSuspendDeliveryReported() {
-        let fragment = AetherEngine.readerWindowFragment(
-            pump: (windowBytes: 16 * 1024 * 1024, aheadBytes: 16 * 1024 * 1024,
-                   suspended: true, postSuspendBytes: 2 * 1024 * 1024),
-            prefetch: (windowBytes: 612 * 1024 * 1024, aheadBytes: 609 * 1024 * 1024,
-                       suspended: true, postSuspendBytes: 911 * 1024 * 1024))
-        #expect(fragment.contains("pumpPostMB=2 "))
-        #expect(fragment.contains("prefPostMB=911 "))
+        #expect(fragment.contains("prefParked=1 "))
     }
 }

--- a/Tests/AetherEngineTests/Issue295RangeBoundaryRefetchTests.swift
+++ b/Tests/AetherEngineTests/Issue295RangeBoundaryRefetchTests.swift
@@ -51,17 +51,21 @@ struct Issue295RangeBoundaryRefetchTests {
         }
         try? await Task.sleep(nanoseconds: 200_000_000)
 
-        let ranges = dataRanges(server, fileSize: total)
-        var overlaps: [String] = []
-        var covered: [(Int64, Int64)] = []
-        for r in ranges {
-            let end = r.end ?? total - 1
-            for c in covered where r.start <= c.1 && end >= c.0 {
-                overlaps.append("[\(r.start)-\(end)] overlaps [\(c.0)-\(c.1)]")
-            }
-            covered.append((r.start, end))
+        // #310 changed what "no re-fetch" looks like on the wire. A connection can now be
+        // ENDED at winHighWater with the tail of its range undelivered, and the refill then
+        // legitimately re-requests that undelivered tail — so REQUESTED spans may overlap a
+        // cancelled predecessor's. What pins the #295 defect is direction: the refill and
+        // every request after it start at the delivered frontier, which only moves forward,
+        // while the defect's detour re-fetches fired at the READ position, below the refill
+        // it had just issued. Strictly increasing request starts therefore hold exactly
+        // when no delivered byte is asked for again.
+        let starts = dataRanges(server, fileSize: total).map(\.start)
+        #expect(starts.count >= 2, "the read never crossed a range boundary: \(starts)")
+        var regressions: [String] = []
+        for (a, b) in zip(starts, starts.dropFirst()) where b <= a {
+            regressions.append("\(b) after \(a)")
         }
-        #expect(overlaps.isEmpty,
-                "delivered bytes were fetched again: \(overlaps.joined(separator: ", ")); all ranges: \(ranges)")
+        #expect(regressions.isEmpty,
+                "a request started at or below its predecessor, i.e. re-requested delivered bytes: \(regressions.joined(separator: ", ")); all starts: \(starts)")
     }
 }


### PR DESCRIPTION
Closes #310.

**What this changes.** The persistent reader no longer suspends its data task at `winHighWater`. It ends the connection — the mechanism the `winHardCap` escape hatch already used — and the low-water frontier refill re-requests exactly where delivery stopped, through the same path a completed range uses. Nothing is discarded and nothing is re-fetched; the reader now either has an actively delivering connection or no connection at all, and a stalled or paused consumer holds no flow whatsoever.

**Why.** Per #310: a task left suspended holding an undelivered window keeps a dormant established flow whose closed receive window sits unread for as long as the consumer takes to drain — ~100 s per cycle at 1 Mbps, indefinitely while paused — and on tvOS that dormant state correlates, dose-response by media bitrate, with 10-80 s episodes in which every Network.framework flow in the app process goes deaf at once. And by your own #220 measurement, suspend() was never contractual flow control (911 MB arrived after a suspend) — the hard cap existed precisely because the suspend could fail to take. Ending at high water removes the pathological state instead of bounding it.

**Field verification.** Two Apple TV 4K (3rd gen), tvOS 26, 6.7.0 plus this change, a 71-minute synchronized-playback session on the worst-case title from #310's dose-response table (h264 1080p, ~1 Mbps — the regime that previously produced ~9-11 episodes in 80 minutes): zero episodes, zero WebSocket receive errors, zero connection-setup timeouts. ~110 end-and-rerequest cycles per device (one per ~39 s; pump and subtitle-prefetch readers both cycling); the low-water refill won every cycle — the empty-window backstop never fired, so a boundary never became a stall. Two deliberate 3-minute pauses each held zero connections and resumed cleanly. Observed cost: one extra range request per drain cycle, ~2 ms connects on LAN.

**What rides along** (separable if you'd rather take them differently):

- `winHardCap` and its branch are removed — the window is now bounded by construction at high water plus one delivery's in-flight overshoot, well under the cap and the realloc-doubling peak it had to be sized against.
- The suspend machinery (flag, balance-before-cancel paths, post-suspend delivery accounting) is removed, and the deliberate cancel's completion is no longer logged as a transport error.
- `windowDiagnostics` reports `parked` (backpressure-ended, refill pending) in place of `suspended`/`postSuspendBytes`; the memprobe fragment says `Parked=` instead of `Susp=`/`PostMB=`. Easy to restore the old tuple shape if you have consumers.
- Tests: the #174 suite now pins the new contract (a stalled consumer holds no live connection, the parked flag is set, no refill churn while nothing drains, origin bytes bounded; refill liveness and monotonic frontier after a drain). The #295 test's no-overlap assertion is retightened to strictly increasing request starts, since a cancelled range's undelivered tail is now legitimately re-requested — the same offsets-not-counts principle as your eb6ec3f4 hardening, against which this branch is verified.

The core is the high-water end plus the low-water refill; everything else is negotiable.
