### PR TITLE
Software path reports its own network telemetry (#306)

### DIFF
--- a/Sources/AetherEngine/AetherEngine+Diagnostics.swift
+++ b/Sources/AetherEngine/AetherEngine+Diagnostics.swift
@@ -137,8 +137,7 @@ extension AetherEngine {
                 // shape that lets a connection ignoring the suspend keep filling the window,
                 // and the #174 field crash it was built against (HTTPS origin, boringssl in
                 // the stack) was on this path. Reporting software-only hid that.
-                let pumpWin = self.softwareHost?.ioWindowDiagnostics
-                    ?? self.nativeVideoSession?.demuxer?.ioWindowDiagnostics
+                let pumpWin = self.pumpIOWindow
                 let prefetchWin = self.subtitleForwardPrefetchDemuxer?.ioWindowDiagnostics
                 let readerStr = Self.readerWindowFragment(
                     pump: pumpWin, prefetch: prefetchWin,
@@ -329,9 +328,30 @@ extension AetherEngine {
     }
 
 
-    /// `Demuxer.avioBytesFetched` via HLSVideoEngine. Used by `LiveTelemetrySampler` for instant + average bitrate. 0 on SW path or pre-start.
+    /// Lifetime bytes the session's playback reader pulled from the source. Feeds the sampler's
+    /// instant + average bitrate and `LiveTelemetry.demuxerBytesFetched`. 0 before a reader exists.
+    ///
+    /// #306: software first, native second, the same precedence the memprobe has always read the pump
+    /// with. A software session owns no `HLSVideoEngine`, so the native-only form returned 0 for the
+    /// whole session and every byte-derived figure a host can show (bitrate, throughput, transferred)
+    /// read zero on the one path that carries the exotic content.
     var demuxerBytesFetched: Int64 {
-        nativeVideoSession?.demuxerBytesFetched ?? 0
+        Self.pumpBytesFetched(software: softwareHost?.demuxerBytesFetched,
+                              native: nativeVideoSession?.demuxerBytesFetched)
+    }
+
+    /// #306: the precedence itself, as a function, so the ordering is assertable without a live
+    /// session on either path. Software first: only one of the two exists per session, and a
+    /// software session's counter is the one that used to be dropped.
+    nonisolated static func pumpBytesFetched(software: Int64?, native: Int64?) -> Int64 {
+        software ?? native ?? 0
+    }
+
+    /// The playback pump reader's sliding-window snapshot, from whichever path owns the reader.
+    /// nil for sources with no `AVIOReader` (disc, custom provider) and before the reader exists.
+    /// Named for the pump to keep it apart from the subtitle side reader, which has a window of its own.
+    var pumpIOWindow: (windowBytes: Int, aheadBytes: Int, suspended: Bool, postSuspendBytes: Int64)? {
+        softwareHost?.ioWindowDiagnostics ?? nativeVideoSession?.demuxer?.ioWindowDiagnostics
     }
 
     /// Resident bytes in the loopback HLS segment cache. nil when no native session is active.

--- a/Sources/AetherEngine/Diagnostics/LiveTelemetry.swift
+++ b/Sources/AetherEngine/Diagnostics/LiveTelemetry.swift
@@ -1,10 +1,12 @@
 import Foundation
 
 /// 1 Hz live playback telemetry snapshot. Nil fields are path-asymmetric:
-/// droppedFrameCount=nil on SW (dav1d doesn't drop; stalls show as falling observedFps);
 /// observedFps=nil on native (AVPlayer has no usable live FPS counter);
 /// avSyncGapMs=nil on SW (measured by HLSSegmentProducer which only runs on the native/HLS-loopback path);
-/// forwardBufferSeconds=nil on SW (no loadedTimeRanges equivalent).
+/// forwardBufferSeconds=nil on SW, and stays nil on purpose (#306): the software demux loop reads on
+/// renderer back-pressure, so there is no seconds-deep reservoir of arrived-but-unplayed media to
+/// report there. `displayCushionSeconds` and `readerWindowAheadBytes` are what that path holds instead,
+/// and putting either of them under the same name would report a near-stall on a healthy session.
 public struct LiveTelemetry: Equatable, Sendable {
     // Enthusiast section
     public let instantBitrateMbps: Double?
@@ -14,8 +16,23 @@ public struct LiveTelemetry: Equatable, Sendable {
     /// counter, since the common FLAC bridge is lossless VBR and has no fixed configured rate.
     public let audioBridgeBitrateMbps: Double?
     public let observedFps: Double?
+    /// Frames the display dropped: AVPlayer's access log on the native path, the render synchronizer's
+    /// own metrics on the software one (#306). Software sessions predating that read it as nil, as does
+    /// an OS without `videoPerformanceMetrics`.
     public let droppedFrameCount: Int?
     public let forwardBufferSeconds: Double?
+    /// #306: seconds of decoded video queued ahead of the clock on the software path, nil on native
+    /// (where `forwardBufferSeconds` is the analog). Sub-second by design, and the first thing an IO
+    /// hiccup eats into: this is a cushion, not a buffer.
+    public let displayCushionSeconds: Double?
+    /// #306: bytes the playback reader has fetched but the demuxer has not consumed yet, i.e. the
+    /// runway that exists ahead of the read cursor. Both paths; nil for sources with no `AVIOReader`
+    /// (disc, custom provider). Bytes rather than seconds on purpose: seconds would need a bitrate
+    /// estimate baked in, and a host that wants one can divide by the throughput in this same snapshot.
+    public let readerWindowAheadBytes: Int?
+    /// #306: the display's accumulated late-frame delay on the software path, nil on native and before
+    /// the first metrics read. Cumulative for the session, so a rate comes from differencing two ticks.
+    public let accumulatedFrameDelaySeconds: Double?
     public let cachedBytes: Int64?
     public let networkThroughputMbps: Double?
     public let networkTransferredBytes: Int64?
@@ -37,6 +54,9 @@ public struct LiveTelemetry: Equatable, Sendable {
         observedFps: Double?,
         droppedFrameCount: Int?,
         forwardBufferSeconds: Double?,
+        displayCushionSeconds: Double? = nil,
+        readerWindowAheadBytes: Int? = nil,
+        accumulatedFrameDelaySeconds: Double? = nil,
         cachedBytes: Int64?,
         networkThroughputMbps: Double?,
         networkTransferredBytes: Int64?,
@@ -55,6 +75,9 @@ public struct LiveTelemetry: Equatable, Sendable {
         self.observedFps = observedFps
         self.droppedFrameCount = droppedFrameCount
         self.forwardBufferSeconds = forwardBufferSeconds
+        self.displayCushionSeconds = displayCushionSeconds
+        self.readerWindowAheadBytes = readerWindowAheadBytes
+        self.accumulatedFrameDelaySeconds = accumulatedFrameDelaySeconds
         self.cachedBytes = cachedBytes
         self.networkThroughputMbps = networkThroughputMbps
         self.networkTransferredBytes = networkTransferredBytes

--- a/Sources/AetherEngine/Diagnostics/LiveTelemetrySampler.swift
+++ b/Sources/AetherEngine/Diagnostics/LiveTelemetrySampler.swift
@@ -60,15 +60,31 @@ struct NativeAVFReadings: Sendable {
     var isPlaybackBufferEmpty: Bool = false
 }
 
+/// #306: everything the software branch of a tick reads off the software host, as one value. Mirrors
+/// `NativeAVFReadings` in intent: the sampler reaches the host through a single injectable read, so
+/// that branch is exercisable without a decoding session, and the tick keeps no host state of its own.
+struct SoftwareReadings: Sendable {
+    /// Decoded video queued ahead of the clock (#303). Nil before the first enqueued frame.
+    var displayCushionSeconds: Double? = nil
+    /// Undrained forward extent of the pump reader's window. Nil for sources with no `AVIOReader`.
+    var readerWindowAheadBytes: Int? = nil
+    /// Frames the render synchronizer dropped, nil where the metrics cannot be asked for (pre-18 OS).
+    var droppedFrameCount: Int? = nil
+    /// Cumulative late-frame delay from the same metrics read.
+    var accumulatedFrameDelaySeconds: Double? = nil
+}
+
 /// Drives engine.diagnostics.liveTelemetry at 1 Hz. Reads existing engine counters; owns no playback state.
 /// Started with the memprobe task; stopped in stopInternal.
 @MainActor
 final class LiveTelemetrySampler {
     typealias NativeRead = @Sendable (AVPlayer, AVPlayerItem) -> NativeAVFReadings
+    typealias SoftwareRead = @MainActor (AetherEngine) async -> SoftwareReadings
 
     private weak var engine: AetherEngine?
     private var task: Task<Void, Never>?
     private let nativeRead: NativeRead
+    private let softwareRead: SoftwareRead
 
     /// Dedicated + serial: the sync XPC reads may block for seconds, which must not tie up the
     /// shared cooperative pool, and serial means a stalled tick back-pressures the next one
@@ -100,9 +116,12 @@ final class LiveTelemetrySampler {
     /// 23.976 fps frame of ~42 ms of legitimate forward progress).
     private static let eomParkFrozenEpsilonSeconds: Double = 0.05
 
-    init(engine: AetherEngine, nativeRead: @escaping NativeRead = LiveTelemetrySampler.batchReadNativeAVF) {
+    init(engine: AetherEngine,
+         nativeRead: @escaping NativeRead = LiveTelemetrySampler.batchReadNativeAVF,
+         softwareRead: @escaping SoftwareRead = LiveTelemetrySampler.readSoftwareHost) {
         self.engine = engine
         self.nativeRead = nativeRead
+        self.softwareRead = softwareRead
     }
 
     func start() {
@@ -182,11 +201,18 @@ final class LiveTelemetrySampler {
         let networkTransferredBytes: Int64?
         let avSyncGapMs: Double?
         let forwardBufferSeconds: Double?
+        // #306: software-path fields. Nil on every other backend, so a host reading them knows it is
+        // looking at the software pipeline and not at a zero that means "healthy".
+        let displayCushionSeconds: Double?
+        let accumulatedFrameDelaySeconds: Double?
+        var readerWindowAheadBytes: Int? = engine.pumpIOWindow?.aheadBytes
         var nativeReadings: NativeAVFReadings?
 
         switch engine.playbackBackend {
         case .native:
             observedFps = nil
+            displayCushionSeconds = nil
+            accumulatedFrameDelaySeconds = nil
             avSyncGapMs = engine.lastAVGapMs  // HLSSegmentProducer audio-gate-open vs video-gate-open (native path only)
             if let player = engine.currentAVPlayer, let item = player.currentItem {
                 let readings = await readNativeOffMain(player: player, item: item)
@@ -220,11 +246,25 @@ final class LiveTelemetrySampler {
             } else {
                 observedFps = nil
             }
-            droppedFrameCount = nil
+            // #306: the render-metrics read is async, so the session can end or be replaced under it
+            // exactly like the native batch above; publishing then would carry a dead session's
+            // numbers into the next one.
+            let hostBeforeRead = engine.softwareHost
+            let software = await softwareRead(engine)
+            guard !Task.isCancelled,
+                  engine.playbackBackend == .software,
+                  engine.softwareHost === hostBeforeRead else { return }
+            droppedFrameCount = software.droppedFrameCount
+            displayCushionSeconds = software.displayCushionSeconds
+            accumulatedFrameDelaySeconds = software.accumulatedFrameDelaySeconds
+            readerWindowAheadBytes = software.readerWindowAheadBytes
             networkThroughputMbps = instantBitrateMbps  // SW: demuxer pulls the same bytes
             networkTransferredBytes = demuxerBytes
             avSyncGapMs = nil          // HLSSegmentProducer doesn't run on SW path
-            forwardBufferSeconds = nil // SW host has no loadedTimeRanges equivalent
+            // Deliberately nil, see LiveTelemetry: the software pump is renderer-back-pressured, so
+            // there is no arrived-but-unplayed reservoir in seconds. displayCushionSeconds and
+            // readerWindowAheadBytes carry what this path actually holds.
+            forwardBufferSeconds = nil
 
         case .aether, .none, .audio:
             observedFps = nil
@@ -233,6 +273,8 @@ final class LiveTelemetrySampler {
             networkTransferredBytes = nil
             avSyncGapMs = nil
             forwardBufferSeconds = nil
+            displayCushionSeconds = nil
+            accumulatedFrameDelaySeconds = nil
         }
 
         // Feed the extractor yield gate (#93 startup): nil on non-native paths keeps the
@@ -251,6 +293,9 @@ final class LiveTelemetrySampler {
             observedFps: observedFps,
             droppedFrameCount: droppedFrameCount,
             forwardBufferSeconds: forwardBufferSeconds,
+            displayCushionSeconds: displayCushionSeconds,
+            readerWindowAheadBytes: readerWindowAheadBytes,
+            accumulatedFrameDelaySeconds: accumulatedFrameDelaySeconds,
             cachedBytes: engine.cachedBytes,
             networkThroughputMbps: networkThroughputMbps,
             networkTransferredBytes: networkTransferredBytes,
@@ -338,6 +383,21 @@ final class LiveTelemetrySampler {
             didSynthesizeEomPark = true
             engine.synthesizeEndOfMediaFromTailPark(playhead: playhead, loadedEnd: loadedEnd)
         }
+    }
+
+    /// #306: the real software read. `videoPerformanceMetrics` is an ASYNC AVFoundation accessor, so
+    /// the main actor suspends on it rather than blocking, which is the distinction #134 turns on: the
+    /// sync accessors are the ones that must never be touched here. Cushion and reader window are
+    /// lock-guarded in-process snapshots and cost nothing.
+    @MainActor
+    private static func readSoftwareHost(_ engine: AetherEngine) async -> SoftwareReadings {
+        guard let host = engine.softwareHost else { return SoftwareReadings() }
+        let metrics = await host.loadRenderMetrics()
+        return SoftwareReadings(
+            displayCushionSeconds: host.displayCushionSeconds,
+            readerWindowAheadBytes: engine.pumpIOWindow?.aheadBytes,
+            droppedFrameCount: metrics?.dropped,
+            accumulatedFrameDelaySeconds: metrics?.accumulatedDelay)
     }
 
     /// Hops the AVFoundation batch onto the dedicated read queue and back. The main actor only

--- a/Sources/aetherctl/PlaybackCmd.swift
+++ b/Sources/aetherctl/PlaybackCmd.swift
@@ -31,6 +31,24 @@ func runPlay(url: URL, seconds: Double, live: Bool, nativeHLS: Bool = false, dvr
     return box.value ?? 1
 }
 
+/// #306: the network half of the 1 Hz snapshot, appended to the transport line. Every field is
+/// omitted where the snapshot has none, so the software path's numbers can be read off a run instead
+/// of inferred from a memprobe half a minute wide. `rx` is the reader's lifetime pull, `ahead` the
+/// part of it the demuxer has not consumed, and `cushion` the decoded video queued past the clock.
+@MainActor
+private func networkTelemetryFragment(_ telemetry: LiveTelemetry?) -> String {
+    guard let telemetry else { return "" }
+    var out = ""
+    if let mbps = telemetry.networkThroughputMbps { out += String(format: " net=%.2fMbps", mbps) }
+    if let rx = telemetry.networkTransferredBytes { out += String(format: " rx=%.1fMB", Double(rx) / 1_048_576) }
+    if let ahead = telemetry.readerWindowAheadBytes { out += String(format: " ahead=%.1fMB", Double(ahead) / 1_048_576) }
+    if let cushion = telemetry.displayCushionSeconds { out += String(format: " cushion=%.2fs", cushion) }
+    if let fwd = telemetry.forwardBufferSeconds { out += String(format: " fwd=%.1fs", fwd) }
+    if let dropped = telemetry.droppedFrameCount { out += " drop=\(dropped)" }
+    if let delay = telemetry.accumulatedFrameDelaySeconds { out += String(format: " delay=%.2fs", delay) }
+    return out
+}
+
 /// Decoded-PCM continuity monitor fed by the engine audio tap (#95 infrastructure).
 /// Tracks per-buffer source-PTS abutment (gap = next.start - prev.end) and the running
 /// end-of-enqueued-audio position, so the telemetry loop can print the audio lead
@@ -270,6 +288,7 @@ private func playSmokeTest(url: URL, seconds: Double, live: Bool, nativeHLS: Boo
             // Decoded-audio lead over the master clock (source axis). Near-zero = renderer starving.
             line += String(format: " alead=%.2f abufs=%d", end - engine.sourceTime, monitor.bufferCount)
         }
+        line += networkTelemetryFragment(engine.liveTelemetry)
         print(line)
         // DVR-seek smoke: rewind 20 s mid-session, then live-edge return 15 s later, so the
         // telemetry shows whether the clock and the audio look-ahead recover from both.

--- a/Tests/AetherEngineTests/Issue306SoftwareTelemetryTests.swift
+++ b/Tests/AetherEngineTests/Issue306SoftwareTelemetryTests.swift
@@ -1,0 +1,154 @@
+import Foundation
+import Testing
+import AVFoundation
+@testable import AetherEngine
+
+/// #306: a software session publishes network telemetry of its own.
+///
+/// Two separate defects hid behind one symptom. The byte counter the sampler derives every
+/// byte-shaped figure from was read through `nativeVideoSession`, which a software session does not
+/// have, so bitrate, throughput and transferred bytes were a hard zero for the whole session rather
+/// than the real numbers. And the read-ahead the path does hold was computed for the memprobe only,
+/// so nothing on the public surface answered "is the network keeping up" where it matters most.
+@MainActor
+struct Issue306SoftwareTelemetryTests {
+
+    private func makeSoftwareEngine() throws -> AetherEngine {
+        let engine = try AetherEngine()
+        engine.playbackBackend = .software
+        return engine
+    }
+
+    private func waitUntil(
+        timeout: Duration = .seconds(90),
+        _ condition: @MainActor () -> Bool
+    ) async throws -> Bool {
+        let clock = ContinuousClock()
+        let start = clock.now
+        while !condition() {
+            if clock.now - start > timeout { return false }
+            try await Task.sleep(for: .milliseconds(20))
+        }
+        return true
+    }
+
+    // MARK: - The byte counter
+
+    /// The precedence, stated directly: only one of the two readers exists per session, and the
+    /// software one is the half that used to be dropped on the floor.
+    @Test("the pump byte counter prefers the software reader over the native one")
+    func pumpBytesPrefersSoftwareReader() {
+        #expect(AetherEngine.pumpBytesFetched(software: 4_096, native: nil) == 4_096)
+        #expect(AetherEngine.pumpBytesFetched(software: nil, native: 8_192) == 8_192)
+        #expect(AetherEngine.pumpBytesFetched(software: nil, native: nil) == 0)
+        // A software session that has read nothing yet is still the authority: falling back to the
+        // native side here would publish a stale counter from a previous native session.
+        #expect(AetherEngine.pumpBytesFetched(software: 0, native: 8_192) == 0)
+    }
+
+    // MARK: - The software snapshot
+
+    @Test("a software tick publishes cushion, reader runway and dropped frames")
+    func softwareTickPublishesReadAhead() async throws {
+        let engine = try makeSoftwareEngine()
+        let sampler = LiveTelemetrySampler(engine: engine, softwareRead: { _ in
+            SoftwareReadings(
+                displayCushionSeconds: 0.36,
+                readerWindowAheadBytes: 3_145_728,
+                droppedFrameCount: 8,
+                accumulatedFrameDelaySeconds: 0.21)
+        })
+        sampler.start()
+        let published = try await waitUntil { engine.diagnostics.liveTelemetry != nil }
+        #expect(published)
+        let snapshot = engine.diagnostics.liveTelemetry
+        #expect(snapshot?.displayCushionSeconds == 0.36)
+        #expect(snapshot?.readerWindowAheadBytes == 3_145_728)
+        #expect(snapshot?.droppedFrameCount == 8)
+        #expect(snapshot?.accumulatedFrameDelaySeconds == 0.21)
+        sampler.stop()
+    }
+
+    /// The cushion is a fraction of a second on a perfectly healthy session, so publishing it as the
+    /// forward buffer would report a near-stall with confidence. It stays nil, and the two fields that
+    /// carry the software path's runway say what they are.
+    @Test("the forward buffer stays nil on the software path")
+    func forwardBufferStaysNilOnSoftware() async throws {
+        let engine = try makeSoftwareEngine()
+        let sampler = LiveTelemetrySampler(engine: engine, softwareRead: { _ in
+            SoftwareReadings(displayCushionSeconds: 0.02)
+        })
+        sampler.start()
+        let published = try await waitUntil { engine.diagnostics.liveTelemetry != nil }
+        #expect(published)
+        #expect(engine.diagnostics.liveTelemetry?.forwardBufferSeconds == nil)
+        #expect(engine.diagnostics.liveTelemetry?.displayCushionSeconds == 0.02)
+        sampler.stop()
+    }
+
+    /// An OS without `videoPerformanceMetrics`, or a session before the first frame: the fields read
+    /// nil rather than zero. Zero is a measurement, nil is "not asked yet", and a host watchdog that
+    /// cannot tell them apart reads a cold start as a perfect one.
+    @Test("an unavailable metrics read publishes nil, not zero")
+    func unavailableMetricsPublishNil() async throws {
+        let engine = try makeSoftwareEngine()
+        let sampler = LiveTelemetrySampler(engine: engine, softwareRead: { _ in SoftwareReadings() })
+        sampler.start()
+        let published = try await waitUntil { engine.diagnostics.liveTelemetry != nil }
+        #expect(published)
+        #expect(engine.diagnostics.liveTelemetry?.droppedFrameCount == nil)
+        #expect(engine.diagnostics.liveTelemetry?.displayCushionSeconds == nil)
+        #expect(engine.diagnostics.liveTelemetry?.accumulatedFrameDelaySeconds == nil)
+        sampler.stop()
+    }
+
+    /// The metrics read is async, so a session can end under it. The native branch drops a snapshot
+    /// whose player was swapped mid-read; the software branch owes the same guarantee.
+    @Test("a backend change during the software read drops the snapshot")
+    func backendChangeDuringReadDropsSnapshot() async throws {
+        let engine = try makeSoftwareEngine()
+        let entered = AtomicBool(false)
+        let release = DispatchSemaphore(value: 0)
+        defer { release.signal() }
+        let sampler = LiveTelemetrySampler(engine: engine, softwareRead: { _ in
+            entered.set(true)
+            await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+                DispatchQueue.global().async {
+                    release.wait()
+                    continuation.resume()
+                }
+            }
+            return SoftwareReadings(displayCushionSeconds: 0.36)
+        })
+        sampler.start()
+        let readStarted = try await waitUntil { entered.get() }
+        #expect(readStarted)
+        // Teardown seam: the session ends while the metrics read is still in flight.
+        engine.playbackBackend = .none
+        release.signal()
+        try await Task.sleep(for: .milliseconds(200))
+        #expect(engine.diagnostics.liveTelemetry == nil)
+        sampler.stop()
+    }
+
+    /// The software fields are not a second name for values the native path already publishes: a
+    /// native tick leaves them nil whatever the software read would have returned.
+    @Test("a native tick leaves the software fields nil")
+    func nativeTickLeavesSoftwareFieldsNil() async throws {
+        let engine = try AetherEngine()
+        engine.playbackBackend = .native
+        engine.currentAVPlayer = AVPlayer(
+            playerItem: AVPlayerItem(url: URL(fileURLWithPath: "/nonexistent-306.mp4")))
+        let sampler = LiveTelemetrySampler(
+            engine: engine,
+            nativeRead: { _, _ in NativeAVFReadings(forwardBufferSeconds: 12.0) },
+            softwareRead: { _ in SoftwareReadings(displayCushionSeconds: 0.36, droppedFrameCount: 8) })
+        sampler.start()
+        let published = try await waitUntil { engine.diagnostics.liveTelemetry != nil }
+        #expect(published)
+        #expect(engine.diagnostics.liveTelemetry?.forwardBufferSeconds == 12.0)
+        #expect(engine.diagnostics.liveTelemetry?.displayCushionSeconds == nil)
+        #expect(engine.diagnostics.liveTelemetry?.accumulatedFrameDelaySeconds == nil)
+        sampler.stop()
+    }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -196,7 +196,7 @@ Sources/AetherEngine/
 │   ├── EngineDiagnostics.swift              engine.diagnostics: timer-sampled values (liveTelemetry) as a separate ObservableObject
 │   ├── EngineLog.swift                      Gated OSLog emission with severity levels (.verbose suppressed from default + host handler)
 │   ├── FFmpegLogBridge.swift                av_log_set_callback funnel: FFmpeg's internal warnings surface through EngineLog
-│   ├── LiveTelemetry.swift                  Value type emitted at 1 Hz: instant / avg bitrate, buffer, network, dropped frames, observed FPS, A/V sync gap, plus subsystem byte counters
+│   ├── LiveTelemetry.swift                  Value type emitted at 1 Hz: instant / avg bitrate, buffer, network, dropped frames, observed FPS, A/V sync gap, plus subsystem byte counters. The software path reports its own read bytes, throughput, reader runway (`readerWindowAheadBytes`), decoded cushion (`displayCushionSeconds`) and dropped / late frames (#306); `forwardBufferSeconds` stays nil there because a renderer-back-pressured pump holds no seconds-deep reservoir to report
 │   ├── FourCC.swift                         Printable FourCC rendering for codec-tag diagnostics
 │   ├── LiveTelemetrySampler.swift           @MainActor 1 Hz sampler that reads existing subsystem counters and assembles LiveTelemetry snapshots
 │   ├── PacketBalanceTracker.swift           Process-wide AVPacket alloc/free balance counter for leak diagnostics

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -68,7 +68,7 @@ Backed by the public `AetherEngine.swDecodeProbe(url:maxPackets:options:)` stati
 
 ## play
 
-Runs a full `load()` + `play()` session exactly like a host app and prints 1 Hz transport telemetry (state, phase, currentTime, sourceTime, buffered frontier, duration). Where `swdecode` proves the decoder, `play` proves the transport: it fails loud on the two silent failure modes of a session that "loads fine" but never actually plays (#107): exit 2 when the clock does not advance, exit 3 when a selected subtitle track produces no cues.
+Runs a full `load()` + `play()` session exactly like a host app and prints 1 Hz transport telemetry (state, phase, currentTime, sourceTime, buffered frontier, duration) plus the network half of the same `liveTelemetry` snapshot a host reads (`net` throughput, `rx` reader lifetime pull, `ahead` fetched-but-unconsumed window, `cushion` decoded video past the clock, `fwd` native forward buffer, `drop` / `delay`). Fields absent on the running path are omitted, so a software session reads `cushion` where a native one reads `fwd`. Note that `drop` climbs steadily in a CLI run: nothing binds a render surface, and the renderer drops what it cannot present. Where `swdecode` proves the decoder, `play` proves the transport: it fails loud on the two silent failure modes of a session that "loads fine" but never actually plays (#107): exit 2 when the clock does not advance, exit 3 when a selected subtitle track produces no cues.
 
 ```bash
 swift run aetherctl play <url>                                  # VOD load, 30 s telemetry


### PR DESCRIPTION
Closes the telemetry gap reported in #306: on a software session the Network section of a host's stats overlay had nothing truthful to put in it.

## Two defects, one symptom

**The byte counter was native-only.** `AetherEngine.demuxerBytesFetched` read through `nativeVideoSession`, which a software session does not own, so it returned 0 for the entire session. Everything derived from it (instant bitrate, average bitrate, `networkThroughputMbps`, `networkTransferredBytes`, `LiveTelemetry.demuxerBytesFetched`) was therefore a hard zero on the one path that carries VP9, AV1 without hardware decode and MPEG-4 Part 2. It now reads the pump with the precedence the memprobe has always used, software first, native second.

**The read-ahead was computed for the log only.** The cushion from #303 and the reader's sliding window existed but never reached the public snapshot.

## What is published now

| field | path | meaning |
|---|---|---|
| `displayCushionSeconds` | software | decoded video queued past the clock (#303) |
| `readerWindowAheadBytes` | both | fetched but not yet consumed by the demuxer, the runway that actually exists |
| `accumulatedFrameDelaySeconds` | software | cumulative late-frame delay from the render synchronizer |
| `droppedFrameCount` | now both | was nil on software; comes from `videoPerformanceMetrics` |

`forwardBufferSeconds` deliberately stays nil on software. The demux loop reads on renderer back-pressure, so there is no seconds-deep reservoir of arrived-but-unplayed media on that path, and publishing the sub-second cushion under the native path's name would report a near-stall on a healthy session. That is the same reasoning the reporter used to leave the rows blank rather than publish `bufferedPosition`, and it is what the extra fields exist for.

## Verification

`aetherctl play` now appends the network half of the snapshot to its 1 Hz line. Real VP9 session, rate-limited logging origin (30 ms latency, 8 Mbps):

```
t=02 ... net=3.28Mbps rx=1.2MB  ahead=0.6MB cushion=0.48s drop=9
t=08 ... net=5.73Mbps rx=5.9MB  ahead=4.1MB cushion=0.23s drop=99
t=14 ... net=6.63Mbps rx=10.7MB ahead=7.6MB cushion=0.29s drop=190
```

Every one of those read zero or nothing before. The native arm of the same harness is unchanged: `fwd` present, `cushion` / `delay` nil, `ahead` now populated from the pump reader. The climbing drop count is a headless-CLI artifact, nothing binds a render surface there.

Unit coverage in `Issue306SoftwareTelemetryTests`: counter precedence, the software fields reaching the snapshot, nil rather than zero when the metrics cannot be asked for, the teardown seam during the async metrics read, and the native path leaving the software fields nil. Full suite green (1531 tests).