### PR TITLE
Software path: presentation timebase + per-frame times (#311)

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,9 +219,17 @@ player.$currentAVPlayerItem                       // items swap in place; this i
 player.setNativeVideoFrameTimeObserver { frame in
     frame.source; frame.item; frame.segmentIndex; frame.isKeyframe; frame.epoch
 }
+
+// The same question on the software path (#311), where the engine decodes and enqueues the source
+// timestamp unchanged: one axis, no segments, and the reports arrive past the reorder buffer in
+// ASCENDING presentation order. `generation` moves on every renderer flush, i.e. on a seek.
+player.softwarePresentationTimebase               // the master clock, on the source axis
+player.setSoftwareVideoFrameTimeObserver { frame in
+    frame.presentation; frame.generation
+}
 ```
 
-Subtitle cues land in raw source PTS; render the overlay against `player.sourceTime` (see [docs/formats.md › Subtitles](docs/formats.md#subtitles)). A host compositing its own overlay onto the native path (libass and friends) needs the item axis too, since that is what the compositor pairs its samples against: `presentationAxisMap` converts arbitrary positions, `setNativeVideoFrameTimeObserver` reports the frames themselves. Both return nothing rather than a guess when no axis is established, because a defaulted shift is indistinguishable from a measured one at the call site. The 1 Hz diagnostics snapshot lives on `player.diagnostics.liveTelemetry`, off-the-engine for the same render-stability reason. Frame extraction, authored-ASS styling, and the full published surface are documented in [docs/formats.md](docs/formats.md).
+Subtitle cues land in raw source PTS; render the overlay against `player.sourceTime` (see [docs/formats.md › Subtitles](docs/formats.md#subtitles)). A host compositing its own overlay onto the native path (libass and friends) needs the item axis too, since that is what the compositor pairs its samples against: `presentationAxisMap` converts arbitrary positions, `setNativeVideoFrameTimeObserver` reports the frames themselves. On the software path neither is needed: `softwarePresentationTimebase` hands out the clock the frames are presented against and `setSoftwareVideoFrameTimeObserver` reports them, both on the same axis as the cues. Both return nothing rather than a guess when no axis is established, because a defaulted shift is indistinguishable from a measured one at the call site. The 1 Hz diagnostics snapshot lives on `player.diagnostics.liveTelemetry`, off-the-engine for the same render-stability reason. Frame extraction, authored-ASS styling, and the full published surface are documented in [docs/formats.md](docs/formats.md).
 
 Install via Swift Package Manager:
 

--- a/Sources/AetherEngine/AetherEngine+FrameTimes.swift
+++ b/Sources/AetherEngine/AetherEngine+FrameTimes.swift
@@ -1,4 +1,5 @@
 import Foundation
+import CoreMedia
 
 extension AetherEngine {
 
@@ -14,5 +15,35 @@ extension AetherEngine {
     public func setNativeVideoFrameTimeObserver(_ observer: NativeVideoFrameTimeObserver?) {
         nativeVideoFrameTimeObserver = observer
         nativeVideoSession?.setNativeVideoFrameTimeObserver(observer)
+    }
+
+    /// Report the presentation time of every video frame the software path enqueues (#311).
+    ///
+    /// The software-path counterpart to `setNativeVideoFrameTimeObserver`, and a separate call
+    /// because it answers a differently shaped question: this path decodes and presents the source
+    /// timestamp unchanged, so there is one axis rather than two, and no segments or producer epochs
+    /// to key a table by. See `SoftwareVideoFrameTime`.
+    ///
+    /// The observer is called on the decode thread and must not block. It outlives a `load()`, so
+    /// install it once; pass nil to remove it. Silent on every other path, including the remote-HLS
+    /// bypass, where AVPlayer owns decode and the engine never sees a frame.
+    public func setSoftwareVideoFrameTimeObserver(_ observer: SoftwareVideoFrameTimeObserver?) {
+        softwareVideoFrameTimeObserver = observer
+        softwareHost?.setVideoFrameTimeObserver(observer)
+    }
+
+    /// The timebase the software path presents against, or nil on every other path and before a
+    /// session exists (#311).
+    ///
+    /// This is the master clock: the render synchronizer drives both the audio renderer and the video
+    /// display layer, so a `CALayer` overlay timed against it is timed against the same clock the
+    /// frames are. It reads the SOURCE axis, which is the axis of `SoftwareVideoFrameTime.presentation`
+    /// and of the subtitle cues the engine emits, so nothing has to be converted between them.
+    ///
+    /// Read-only in intent: `CMTimebase` is mutable and Core Media cannot enforce that, but the engine
+    /// owns transport here. Setting rate or time on it fights `play()`, `pause()` and `seek(to:)` and
+    /// desynchronises audio from video.
+    public var softwarePresentationTimebase: CMTimebase? {
+        softwareHost?.presentationTimebase
     }
 }

--- a/Sources/AetherEngine/AetherEngine+Loading.swift
+++ b/Sources/AetherEngine/AetherEngine+Loading.swift
@@ -1128,6 +1128,9 @@ extension AetherEngine {
             self?.publishLiveWindow(edgeSessionTime: edge)
         }
         self.softwareHost = host
+        // #311: a load builds a new host and a new renderer, so an observer installed once by the
+        // host app has to be carried across the seam, exactly as the native session does at load.
+        host.setVideoFrameTimeObserver(softwareVideoFrameTimeObserver)
         // SW-PiP: publish the bridge once the session owns its layer (the layer object is stable for
         // the session; the host attaches it to the view and, on PiP start, to the system window).
         softwarePiPSource = SoftwarePiPSource(layer: host.displayLayer, isLive: isLive, engine: self)

--- a/Sources/AetherEngine/AetherEngine.swift
+++ b/Sources/AetherEngine/AetherEngine.swift
@@ -1154,6 +1154,10 @@ public final class AetherEngine: ObservableObject {
     /// re-installed on each new native session; see `setNativeVideoFrameTimeObserver`.
     var nativeVideoFrameTimeObserver: NativeVideoFrameTimeObserver?
 
+    /// The software path's equivalent (#311), held for the same reason: a `load()` builds a fresh
+    /// host, and the observer has to survive it. See `setSoftwareVideoFrameTimeObserver`.
+    var softwareVideoFrameTimeObserver: SoftwareVideoFrameTimeObserver?
+
     func setPresentationAxis(_ map: PresentationAxisMap) {
         presentationAxis = map
         presentationAxisMirror.set(map)

--- a/Sources/AetherEngine/Native/SoftwarePlaybackHost.swift
+++ b/Sources/AetherEngine/Native/SoftwarePlaybackHost.swift
@@ -148,6 +148,24 @@ final class SoftwarePlaybackHost {
                                               sourceClock: sourceClockSeconds)
     }
 
+    /// #311: the timebase the master clock runs on, or nil before the session owns one. This is the
+    /// `AVSampleBufferRenderSynchronizer`'s timebase, and it is created unconditionally, including for
+    /// a source with no audio track, so on this path it exists for the whole session rather than only
+    /// when something is playing.
+    ///
+    /// It reads the SOURCE axis, the same axis as `SoftwareVideoFrameTime.presentation` and as the
+    /// subtitle cues, so an overlay paced against it needs no conversion.
+    var presentationTimebase: CMTimebase? {
+        audioOutput?.synchronizer.timebase
+    }
+
+    /// #311: forwarded to the renderer, which is where a frame is actually handed over. Set through
+    /// the host rather than on the renderer directly so the engine has one place to re-arm it across
+    /// a `load()`, the same shape the native path uses for its own observer.
+    func setVideoFrameTimeObserver(_ observer: SoftwareVideoFrameTimeObserver?) {
+        renderer.setFrameEnqueuedObserver(observer)
+    }
+
     /// #303: the renderer's own view of what reached the display. Async because the AVFoundation
     /// accessor is; the memprobe already runs in an async context, so it is read there rather than
     /// cached, and the line never carries a stale snapshot.

--- a/Sources/AetherEngine/Renderer/SampleBufferRenderer.swift
+++ b/Sources/AetherEngine/Renderer/SampleBufferRenderer.swift
@@ -43,6 +43,25 @@ final class SampleBufferRenderer: @unchecked Sendable {
     /// Drop frames before this PTS after a seek (prevents keyframe-to-target fast-forward). Cleared after the first passing frame.
     private var skipUntilPTS: CMTime?
 
+    /// #311: fires for every frame handed to the queue target, on the decode thread. Guarded by
+    /// `reorderLock` for the swap only; the call itself happens with no lock held, so a host that
+    /// re-enters the renderer from it cannot deadlock.
+    private var _frameEnqueuedObserver: SoftwareVideoFrameTimeObserver?
+    func setFrameEnqueuedObserver(_ observer: SoftwareVideoFrameTimeObserver?) {
+        reorderLock.lock()
+        _frameEnqueuedObserver = observer
+        reorderLock.unlock()
+    }
+
+    /// #311: incremented by every flush, so a consumer can drop the frame times it recorded for
+    /// frames the compositor has since discarded. Guarded by `reorderLock`.
+    private var _flushGeneration: UInt64 = 0
+    var flushGeneration: UInt64 {
+        reorderLock.lock()
+        defer { reorderLock.unlock() }
+        return _flushGeneration
+    }
+
     /// Cached CMVideoFormatDescription keyed by dimensions + pixel format + colorimetry + pixel aspect ratio. CMVideoFormatDescriptionCreateForImageBuffer snapshots color AND aspect attachments at creation, so a mid-stream change at same dimensions must invalidate the cache; a PAR-less first frame froze a PAR-less description for the whole stream and collapsed anamorphic content to coded dimensions (#177). Guarded by reorderLock; nil'd by flush().
     private var cachedFormatDesc: CMVideoFormatDescription?
     private var cachedFormatKey: FormatDescriptionKey?
@@ -245,6 +264,8 @@ final class SampleBufferRenderer: @unchecked Sendable {
         // backward seek would keep reporting the pre-seek timestamp and read as a cushion of
         // however far the seek travelled.
         _newestEnqueuedPtsSeconds = nil
+        // #311: everything reported before this point describes frames that are now gone.
+        _flushGeneration &+= 1
         // Invalidate the format description cache; the next load() may open a stream with different colorimetry at the same resolution.
         cachedFormatDesc = nil
         cachedFormatKey = nil
@@ -310,6 +331,15 @@ final class SampleBufferRenderer: @unchecked Sendable {
             EngineLog.emit("[Renderer] isReadyForMoreMediaData=false at enqueue #\(enqueueCount + 1) status=\(statusName)", category: .swPlayback)
         }
         target.enqueue(sampleBuffer)
+
+        // #311: reported here rather than at admission, so it describes frames the compositor has
+        // been given. A frame refused for an unschedulable timestamp, skipped after a seek, or lost
+        // to a failed sample-buffer creation never reaches this line and is never reported.
+        reorderLock.lock()
+        let observer = _frameEnqueuedObserver
+        let generation = _flushGeneration
+        reorderLock.unlock()
+        observer?(SoftwareVideoFrameTime(presentation: pts, generation: generation))
 
         enqueueCount += 1
         // Sparse milestones so a stall is distinguishable from "logging stopped at #30"; bounded to 4 lines/hour at 60 fps.

--- a/Sources/AetherEngine/SoftwareVideoFrameTime.swift
+++ b/Sources/AetherEngine/SoftwareVideoFrameTime.swift
@@ -1,0 +1,40 @@
+import Foundation
+import CoreMedia
+
+/// #311: the presentation time of one software-decoded frame, reported as it is handed to the
+/// compositor.
+///
+/// Separate from `NativeVideoFrameTime` on purpose. That type answers a question this path does not
+/// have: the native path muxes what it demuxes, so a frame lives on two axes that differ, in a
+/// segment, under a producer epoch that a restart invalidates. Here the engine decodes and enqueues
+/// the source timestamp unchanged, so source and presentation coincide by construction and there are
+/// no segments to index. Reusing the wider type would have meant three fields carrying a value with
+/// no meaning on this path, and a consumer cannot tell a placeholder from a measurement.
+///
+/// Frames arrive in **ascending presentation order**, unlike the native path's decode-order stream:
+/// they are reported past the reorder buffer, so a B-frame run is already sorted. Everything reported
+/// here also passed the unschedulable-timestamp gate and any post-seek skip, so each one is a frame
+/// the compositor has been given, not merely one that was decoded.
+public struct SoftwareVideoFrameTime: Sendable, Equatable {
+
+    /// Presentation timestamp of the enqueued frame, in the source time base. This is the axis
+    /// subtitle cues and chapters live on, and the axis the timebase from
+    /// `AetherEngine.softwarePresentationTimebase` reads, so no conversion stands between them.
+    public let presentation: CMTime
+
+    /// Renderer flush generation. Increments whenever the renderer discards what it holds, which is
+    /// what a seek does, so entries recorded under an older generation describe frames the compositor
+    /// will never show. Drop a table's older generations when this changes. Same role as
+    /// `NativeVideoFrameTime.epoch`, different cause: there a producer restart re-muxes, here a flush
+    /// empties the queue.
+    public let generation: UInt64
+
+    public init(presentation: CMTime, generation: UInt64) {
+        self.presentation = presentation
+        self.generation = generation
+    }
+}
+
+/// Called once per enqueued software-decoded frame, on the decode thread. Must not block: it runs
+/// inline with the frame handover, so time spent here is time the next frame is not being decoded.
+public typealias SoftwareVideoFrameTimeObserver = @Sendable (SoftwareVideoFrameTime) -> Void

--- a/Sources/aetherctl/PlaybackCmd.swift
+++ b/Sources/aetherctl/PlaybackCmd.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Combine
+import CoreMedia
 import AetherEngine
 
 // MARK: - play
@@ -10,7 +11,7 @@ import AetherEngine
 /// and log every overlay cue that arrives. Repro harness for "loads but never
 /// plays" reports and for live teletext end-to-end validation (#107).
 func runPlay(url: URL, seconds: Double, live: Bool, nativeHLS: Bool = false, dvrWindow: Double?, subsPick: String?, hostCalls: [String], audioStats: Bool = false, seekEvery: Double? = nil, seekPattern: [Double] = [], startPosition: Double? = nil, mallocCensus: Bool = false, forceSoftware: Bool = false,
-                    censusThresholdMB: Int? = nil, censusHz: Double? = nil) -> Int32 {
+                    censusThresholdMB: Int? = nil, censusHz: Double? = nil, frameTimes: Bool = false) -> Int32 {
     EngineLog.handler = { print($0) }
     if mallocCensus {
         AetherEngine.setLargeAllocationCensusEnabled(
@@ -24,7 +25,7 @@ func runPlay(url: URL, seconds: Double, live: Bool, nativeHLS: Bool = false, dvr
     // CFRunLoopRun, not a blocking semaphore: AetherEngine is @MainActor, so parking the main thread would deadlock the executor.
     let box = UncheckedBox<Int32?>(nil)
     Task { @MainActor in
-        box.value = await playSmokeTest(url: url, seconds: seconds, live: live, nativeHLS: nativeHLS, dvrWindow: dvrWindow, subsPick: subsPick, hostCalls: hostCalls, audioStats: audioStats, seekEvery: seekEvery, seekPattern: seekPattern, startPosition: startPosition)
+        box.value = await playSmokeTest(url: url, seconds: seconds, live: live, nativeHLS: nativeHLS, dvrWindow: dvrWindow, subsPick: subsPick, hostCalls: hostCalls, audioStats: audioStats, seekEvery: seekEvery, seekPattern: seekPattern, startPosition: startPosition, frameTimes: frameTimes)
         CFRunLoopStop(CFRunLoopGetMain())
     }
     CFRunLoopRun()
@@ -47,6 +48,52 @@ private func networkTelemetryFragment(_ telemetry: LiveTelemetry?) -> String {
     if let dropped = telemetry.droppedFrameCount { out += " drop=\(dropped)" }
     if let delay = telemetry.accumulatedFrameDelaySeconds { out += String(format: " delay=%.2fs", delay) }
     return out
+}
+
+/// #311: records the software path's per-frame reports, from the decode thread. Also checks the
+/// API's own claim while it is at it: these arrive past the reorder buffer, so `ooo` (a report whose
+/// presentation time precedes its predecessor within one generation) must stay 0 on real media.
+final class FrameTimeProbe: @unchecked Sendable {
+    private let lock = NSLock()
+    private var total = 0
+    private var sinceTick = 0
+    private var last: CMTime?
+    private var lastInGeneration: CMTime?
+    private var generation: UInt64 = 0
+    private var generations: Set<UInt64> = []
+    private var outOfOrder = 0
+
+    func record(_ frame: SoftwareVideoFrameTime) {
+        lock.lock()
+        defer { lock.unlock() }
+        total += 1
+        sinceTick += 1
+        generations.insert(frame.generation)
+        if frame.generation != generation {
+            generation = frame.generation
+            lastInGeneration = nil
+        }
+        if let previous = lastInGeneration, CMTimeCompare(frame.presentation, previous) < 0 {
+            outOfOrder += 1
+        }
+        lastInGeneration = frame.presentation
+        last = frame.presentation
+    }
+
+    /// Frames since the previous call, and the state at this instant.
+    func drainTick() -> (frames: Int, last: CMTime?, generation: UInt64, outOfOrder: Int) {
+        lock.lock()
+        defer { lock.unlock() }
+        let n = sinceTick
+        sinceTick = 0
+        return (n, last, generation, outOfOrder)
+    }
+
+    func summary() -> String {
+        lock.lock()
+        defer { lock.unlock() }
+        return "frames=\(total) outOfOrder=\(outOfOrder) generations=\(generations.sorted())"
+    }
 }
 
 /// Decoded-PCM continuity monitor fed by the engine audio tap (#95 infrastructure).
@@ -156,7 +203,7 @@ private func seekIntentDrill(
 }
 
 @MainActor
-private func playSmokeTest(url: URL, seconds: Double, live: Bool, nativeHLS: Bool = false, dvrWindow: Double?, subsPick: String?, hostCalls: [String], audioStats: Bool, seekEvery: Double? = nil, seekPattern: [Double] = [], startPosition: Double? = nil) async -> Int32 {
+private func playSmokeTest(url: URL, seconds: Double, live: Bool, nativeHLS: Bool = false, dvrWindow: Double?, subsPick: String?, hostCalls: [String], audioStats: Bool, seekEvery: Double? = nil, seekPattern: [Double] = [], startPosition: Double? = nil, frameTimes: Bool = false) async -> Int32 {
     let engine: AetherEngine
     do {
         engine = try AetherEngine()
@@ -198,6 +245,15 @@ private func playSmokeTest(url: URL, seconds: Double, live: Bool, nativeHLS: Boo
         dvrWindowSeconds: dvrWindow,
         nativeRemoteHLS: nativeHLS
     )
+    // #311: installed BEFORE the load on purpose. The engine holds it and arms the host it builds,
+    // which is the documented usage and the part a host would otherwise have to re-do per load.
+    let frameProbe = frameTimes ? FrameTimeProbe() : nil
+    if let frameProbe {
+        engine.setSoftwareVideoFrameTimeObserver { [weak frameProbe] frame in
+            frameProbe?.record(frame)
+        }
+    }
+
     do {
         let probe = try await engine.load(url: url, startPosition: startPosition, options: options)
         // Mirror AetherPlayer's Open URL flow: a probe-flagged live source is reloaded
@@ -249,6 +305,13 @@ private func playSmokeTest(url: URL, seconds: Double, live: Bool, nativeHLS: Boo
 
     print("")
     print("backend=\(engine.playbackBackend.rawValue) duration=\(String(format: "%.1f", engine.duration))s isLive=\(engine.isLive)")
+    if frameTimes {
+        if let timebase = engine.softwarePresentationTimebase {
+            print(String(format: "  timebase: present, time=%.3fs rate=%.2f", timebase.time.seconds, timebase.rate))
+        } else {
+            print("  timebase: nil (not the software path)")
+        }
+    }
     for track in engine.audioTracks {
         print("  audio    id=\(track.id) codec=\(track.codec) lang=\(track.language ?? "?") ch=\(track.channels)\(track.isDefault ? " default" : "")")
     }
@@ -289,6 +352,17 @@ private func playSmokeTest(url: URL, seconds: Double, live: Bool, nativeHLS: Boo
             line += String(format: " alead=%.2f abufs=%d", end - engine.sourceTime, monitor.bufferCount)
         }
         line += networkTelemetryFragment(engine.liveTelemetry)
+        if let frameProbe {
+            let tick = frameProbe.drainTick()
+            line += " ft=\(tick.frames)"
+            if let last = tick.last { line += String(format: " ftLast=%.3fs", last.seconds) }
+            line += " ftGen=\(tick.generation) ooo=\(tick.outOfOrder)"
+            // The clock the frames are presented against, read through the public property. Its
+            // proximity to ftLast is the point: one axis, no conversion between them.
+            if let timebase = engine.softwarePresentationTimebase {
+                line += String(format: " tb=%.3fs", timebase.time.seconds)
+            }
+        }
         print(line)
         // DVR-seek smoke: rewind 20 s mid-session, then live-edge return 15 s later, so the
         // telemetry shows whether the clock and the audio look-ahead recover from both.
@@ -391,6 +465,9 @@ private func playSmokeTest(url: URL, seconds: Double, live: Bool, nativeHLS: Boo
     }
     if let monitor {
         print("audio continuity: \(monitor.summary)")
+    }
+    if let frameProbe {
+        print("frame times: \(frameProbe.summary())")
     }
     print("final t=\(String(format: "%.2f", finalTime))s state=\(String(describing: endState)) cues=\(cueCount)")
     if case .error(let message) = endState {

--- a/Sources/aetherctl/main.swift
+++ b/Sources/aetherctl/main.swift
@@ -471,6 +471,9 @@ if first == "play" {
     // Resume anchor, the same one load(startPosition:) takes. AE#287 needs it: the reporter's hard
     // park only reproduces when a rebuilt session opens exactly at the video-exhaustion boundary.
     let playStartPosition = takeDoubleFlag("--start-position", from: &rest)
+    // #311: install the software frame-time observer and read the presentation timebase, so the
+    // per-frame boundaries and the clock a host would pace an overlay against are both observable.
+    let frameTimes = takeFlag("--frame-times", from: &rest)
     rejectStrayFlags(rest, subcommand: "play")
     if let playThrottleKbps {
         AetherEngine.setSourceThrottleKbpsForTesting(playThrottleKbps)
@@ -483,7 +486,7 @@ if first == "play" {
         exit(64)
     }
     exit(runPlay(url: parseSourceURL(urlArg), seconds: seconds, live: live, nativeHLS: nativeHLS, dvrWindow: dvrWindow, subsPick: subsPick, hostCalls: hostCalls, audioStats: audioStats, seekEvery: seekEvery, seekPattern: seekPattern, startPosition: playStartPosition, mallocCensus: mallocCensus, forceSoftware: playForceSW,
-                 censusThresholdMB: censusThresholdMB, censusHz: censusHz))
+                 censusThresholdMB: censusThresholdMB, censusHz: censusHz, frameTimes: frameTimes))
 }
 
 if ["probe", "serve", "validate", "swdecode", "extract", "audio", "customio"].contains(first) {

--- a/Tests/AetherEngineTests/Issue311SoftwareFrameTimesTests.swift
+++ b/Tests/AetherEngineTests/Issue311SoftwareFrameTimesTests.swift
@@ -1,0 +1,153 @@
+import Foundation
+import Testing
+import AVFoundation
+import CoreMedia
+@testable import AetherEngine
+
+/// #311: the software path reports the frames it enqueues, and hands out the clock it presents them
+/// against, so a host can pace a bitmap overlay (libass) frame-exactly without an AVPlayer.
+///
+/// The reporting point is the handover, not the admission: a frame that the renderer refuses, skips
+/// after a seek, or fails to wrap in a sample buffer is one the compositor never receives, and a
+/// presenter that stamped an overlay for it would place it at a boundary that does not exist.
+@Suite("Software frame times (#311)")
+struct Issue311SoftwareFrameTimesTests {
+
+    // MARK: - What gets reported
+
+    @Test("every enqueued frame is reported, in ascending presentation order")
+    func reportsEnqueuedFramesInOrder() {
+        let renderer = SampleBufferRenderer()
+        let seen = Collector()
+        renderer.setFrameEnqueuedObserver { seen.append($0) }
+
+        // Decode order with a B-frame run. The reorder buffer holds 4, so handing over 6 frames
+        // pushes the two oldest out, and those two are what the compositor has been given.
+        for seconds in [0.00, 0.12, 0.04, 0.08, 0.20, 0.16] {
+            renderer.enqueue(pixelBuffer: Self.makePixelBuffer(),
+                             pts: CMTime(seconds: seconds, preferredTimescale: 600))
+        }
+        let reported = seen.values.map { $0.presentation.seconds }
+        #expect(reported == [0.00, 0.04])
+
+        // EOF drains the rest, still in ascending order rather than the order they arrived.
+        renderer.drainReorderBuffer()
+        #expect(seen.values.map { $0.presentation.seconds } == [0.00, 0.04, 0.08, 0.12, 0.16, 0.20])
+    }
+
+    @Test("a frame refused at the unschedulable-PTS gate is never reported")
+    func untimedFrameIsNotReported() {
+        let renderer = SampleBufferRenderer()
+        let seen = Collector()
+        renderer.setFrameEnqueuedObserver { seen.append($0) }
+
+        renderer.enqueue(pixelBuffer: Self.makePixelBuffer(), pts: .invalid)
+        renderer.drainReorderBuffer()
+
+        #expect(seen.values.isEmpty)
+        #expect(renderer.untimedFramesDropped == 1)
+    }
+
+    @Test("frames skipped after a seek are never reported")
+    func skippedFramesAreNotReported() {
+        let renderer = SampleBufferRenderer()
+        let seen = Collector()
+        renderer.setFrameEnqueuedObserver { seen.append($0) }
+        renderer.setSkipThreshold(CMTime(seconds: 10.0, preferredTimescale: 600))
+
+        // The decoder runs from the preceding keyframe, so these arrive and are dropped.
+        for seconds in [9.0, 9.5] {
+            renderer.enqueue(pixelBuffer: Self.makePixelBuffer(),
+                             pts: CMTime(seconds: seconds, preferredTimescale: 600))
+        }
+        renderer.enqueue(pixelBuffer: Self.makePixelBuffer(),
+                         pts: CMTime(seconds: 10.0, preferredTimescale: 600))
+        renderer.drainReorderBuffer()
+
+        #expect(seen.values.map { $0.presentation.seconds } == [10.0])
+    }
+
+    // MARK: - Generation
+
+    /// A seek flushes, and everything recorded before it describes frames the compositor no longer
+    /// holds. Without a generation a consumer's table would keep entries that look current, and on a
+    /// backward seek the two runs overlap in time, so the timestamps alone cannot separate them.
+    @Test("a flush moves the generation, so pre-seek frames are distinguishable")
+    func flushMovesTheGeneration() {
+        let renderer = SampleBufferRenderer()
+        let seen = Collector()
+        renderer.setFrameEnqueuedObserver { seen.append($0) }
+
+        renderer.enqueue(pixelBuffer: Self.makePixelBuffer(),
+                         pts: CMTime(seconds: 30.0, preferredTimescale: 600))
+        renderer.drainReorderBuffer()
+        let before = renderer.flushGeneration
+
+        renderer.flush(removingDisplayedImage: false)   // the seek
+        #expect(renderer.flushGeneration == before + 1)
+
+        // Backward seek: the same timestamp comes round again under the new generation.
+        renderer.enqueue(pixelBuffer: Self.makePixelBuffer(),
+                         pts: CMTime(seconds: 30.0, preferredTimescale: 600))
+        renderer.drainReorderBuffer()
+
+        #expect(seen.values.count == 2)
+        #expect(seen.values[0].presentation == seen.values[1].presentation)
+        #expect(seen.values[1].generation == seen.values[0].generation + 1)
+    }
+
+    // MARK: - Installation
+
+    @Test("removing the observer stops the reports")
+    func observerCanBeRemoved() {
+        let renderer = SampleBufferRenderer()
+        let seen = Collector()
+        renderer.setFrameEnqueuedObserver { seen.append($0) }
+        renderer.enqueue(pixelBuffer: Self.makePixelBuffer(),
+                         pts: CMTime(seconds: 1.0, preferredTimescale: 600))
+        renderer.drainReorderBuffer()
+        #expect(seen.values.count == 1)
+
+        renderer.setFrameEnqueuedObserver(nil)
+        renderer.enqueue(pixelBuffer: Self.makePixelBuffer(),
+                         pts: CMTime(seconds: 2.0, preferredTimescale: 600))
+        renderer.drainReorderBuffer()
+        #expect(seen.values.count == 1)
+    }
+
+    /// Both are nil on a path that has no software host, rather than a zero timebase or a callback
+    /// that never fires for a reason the host cannot see.
+    @Test("the timebase is nil without a software session")
+    @MainActor
+    func timebaseIsNilWithoutSession() throws {
+        let engine = try AetherEngine()
+        #expect(engine.softwarePresentationTimebase == nil)
+
+        // Installing before a load is the documented usage: the engine holds it and re-arms the
+        // next host with it.
+        engine.setSoftwareVideoFrameTimeObserver { _ in }
+        #expect(engine.softwareVideoFrameTimeObserver != nil)
+        engine.setSoftwareVideoFrameTimeObserver(nil)
+        #expect(engine.softwareVideoFrameTimeObserver == nil)
+    }
+
+    // MARK: - Helpers
+
+    private final class Collector: @unchecked Sendable {
+        private let lock = NSLock()
+        private var storage: [SoftwareVideoFrameTime] = []
+        var values: [SoftwareVideoFrameTime] {
+            lock.lock(); defer { lock.unlock() }
+            return storage
+        }
+        func append(_ value: SoftwareVideoFrameTime) {
+            lock.lock(); storage.append(value); lock.unlock()
+        }
+    }
+
+    private static func makePixelBuffer() -> CVPixelBuffer {
+        var pb: CVPixelBuffer?
+        CVPixelBufferCreate(kCFAllocatorDefault, 16, 16, kCVPixelFormatType_32BGRA, nil, &pb)
+        return pb!
+    }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -146,7 +146,8 @@ Sources/AetherEngine/
 ├── PresentationAxis.swift                   Display-axis fold for disc titles (source PTS <-> 0-based published axis, AE#105)
 ├── PresentationAxisMap.swift                Source axis <-> item axis (#260): the seam history of producer shifts as a piecewise-constant map, plus its off-main mirror. Written by the shift-changed / rebased handlers, read by the clock fold, the live thumbnail path and hosts
 ├── NativeVideoFrameTime.swift               Per-muxed-frame presentation times on both axes (#260): the value type + observer typealias; emitted from HLSSegmentProducer.finalizeAndWriteVideo
-├── AetherEngine+FrameTimes.swift            Public installer for the per-frame time observer, re-armed on each native session
+├── SoftwareVideoFrameTime.swift             Per-enqueued-frame presentation time on the software path (#311): one axis (source == presentation there), plus a flush generation that a seek moves; emitted from SampleBufferRenderer.flushFrame
+├── AetherEngine+FrameTimes.swift            Public installers for both per-frame time observers (native re-armed on each session, software on each host) plus `softwarePresentationTimebase`, the render synchronizer's clock
 ├── PlayerState.swift                        PlaybackState, PlaybackPhase, VideoFormat, PlaybackBackend, LoadOptions, SourceProbe, TrackInfo, FontAttachment, MediaMetadata, SubtitleCue, SubtitleImage
 ├── LiveReloadPolicy.swift                   Pure decision functions for live reloads: rejoin at the live edge (no stale resume position), skip the pre-readiness zero seek
 ├── TransportControllable.swift              Common transport surface of the four playback hosts (single active-host dispatch)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -86,6 +86,8 @@ swift run aetherctl play --live --native-hls <master.m3u8>      # nativeRemoteHL
 
 `--native-hls` sets `LoadOptions.nativeRemoteHLS`, the path a host uses for a live channel AVPlayer can play itself. It is the only way to exercise the #168 carriage watchdog and the #293 carriage probe from the CLI (`hlslive` loads the ingest reader directly and never mounts natively). Pair it with `--live`; without that the m3u8 goes to the raw live path, which rejects it by design.
 
+`--frame-times` installs the #311 software frame-time observer BEFORE `load()` (the documented usage: the engine re-arms each new host with it) and reads `softwarePresentationTimebase`. Per tick it appends `ft` (frames reported since the last tick), `ftLast` (newest reported presentation time), `ftGen` (renderer flush generation, which a seek moves) and `ooo`, the count of reports that arrived out of presentation order. `ooo` is the API's own claim under test: these are reported past the reorder buffer, so it must stay 0. `tb` is the timebase read at the same instant, and its closeness to `ftLast` is the point, both are on the source axis with nothing to convert between them.
+
 `--audio-stats` installs the engine audio tap and watches the decoded PCM itself: an `AGAP` line for every source-PTS discontinuity > 2 ms between consecutive buffers, and per-second `alead` (last decoded audio PTS minus the synchronizer clock) plus `abufs` (buffers delivered) appended to the telemetry. `alead` is the audio renderer's safety margin: on the SW live path the look-ahead pump holds it near `AudioLookaheadPolicy.targetLeadSeconds`; a collapse toward zero means the source or the feeder cannot keep real time (this is how the #107 audio-chopping report was diagnosed).
 
 ## segverify


### PR DESCRIPTION
Both halves of #311, which are only useful together: a bitmap overlay (libass) over software-decoded video needs a clock to pace against and the frame boundaries to land on.

## What is public now

```swift
player.softwarePresentationTimebase               // CMTimebase?, the master clock
player.setSoftwareVideoFrameTimeObserver { frame in
    frame.presentation                            // CMTime, source axis
    frame.generation                              // UInt64, moves on every renderer flush
}
```

The timebase is the render synchronizer's, which drives the audio renderer and the display layer both, and it is created unconditionally, so it exists for the whole session even on a source with no audio track. It reads the **source** axis, the same axis as the cues the engine emits, so nothing needs converting between them.

## Why a separate type instead of `NativeVideoFrameTime`

The reporter asked for the existing callback, and the honest answer is that three of that type's five fields have no meaning here. `source` and `item` exist because the native path muxes what it demuxes and the axes differ; here the engine enqueues the source timestamp unchanged. `segmentIndex` indexes segments this path does not produce. `epoch` keys a producer restart that does not happen.

Filling those with placeholders would put a value in a field a consumer cannot distinguish from a measurement, so `SoftwareVideoFrameTime` carries what this path actually knows. `generation` keeps the one job `epoch` really does: entries recorded under an older generation describe frames the compositor has thrown away, which is exactly what a seek does. A backward seek makes that concrete, since the same timestamp comes round again and the timestamps alone cannot separate the two runs.

## Where it is reported

At the handover in `flushFrame`, not at admission. A frame refused for an unschedulable timestamp (#298), skipped after a seek, or lost to a failed sample-buffer creation never reaches that line, so it is never reported as a boundary that exists. Being past the reorder buffer also means these arrive in **ascending presentation order**, unlike the native path's decode-order stream.

## Verification

`aetherctl play --frame-times` installs the observer before `load()` (the documented usage: the engine re-arms each new host) and reads the timebase. Real VP9 session over a rate-limited origin, with a seek at t=12:

```
  timebase: present, time=0.000s rate=0.00
  t=05 ... ft=30 ftLast=5.100s  ftGen=0 ooo=0 tb=5.049s
  t=12 ... ft=30 ftLast=12.200s ftGen=0 ooo=0 tb=12.153s
  SEEKLANDED target=6.01 in 2ms
  t=13 ... ft=32 ftLast=7.067s  ftGen=1 ooo=0 tb=7.015s
frame times: frames=490 outOfOrder=0 generations=[0, 1]
```

30 to 33 frames per second on 30 fps content, `ftLast` running about 50 ms ahead of the timebase (that gap is the decode cushion, and its size is why the two have to be on one axis), the generation stepping at the seek, and `ooo=0` over 490 frames, which measures the ascending-order claim rather than asserting it.

Unit coverage in `Issue311SoftwareFrameTimesTests`: reported in ascending order past a B-frame run, unschedulable and post-seek-skipped frames never reported, generation stepping across a flush with the same timestamp on both sides, observer removal, and both surfaces nil without a software session. Full suite green (1537 tests).

Out of scope, as the reporter framed it: the remote-HLS bypass, where AVPlayer owns decode and the engine never sees a frame.