### PR TITLE
fix(io): a metered origin keeps its pinned redirect target (#307 follow-up)

### DIFF
--- a/Sources/AetherEngine/Demuxer/AVIOReader.swift
+++ b/Sources/AetherEngine/Demuxer/AVIOReader.swift
@@ -1454,7 +1454,12 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
             // the pin itself (an expired redirect target answers every offset alike),
             // not a transient: drop it so the retry re-resolves through the source URL
             // for a fresh redirect. No-op when nothing is pinned.
-            if unproductiveReconnects >= 2 || rateLimitStreak >= 2 {
+            //
+            // A rate-limit streak is deliberately NOT a reason to drop it: 429/503 says the
+            // origin is metering us, not that the target is dead (#71), and re-resolving
+            // spends a second request on the very origin that is refusing them. On the
+            // connection-capped panel behind #307 that is the request that cannot be spared.
+            if !isRateLimited, unproductiveReconnects >= 2 {
                 invalidateResolvedURL(reason: "unproductive reconnect streak")
             }
             let backoffStart = DispatchTime.now()

--- a/Tests/AetherEngineTests/ResolvedURLInvalidationTests.swift
+++ b/Tests/AetherEngineTests/ResolvedURLInvalidationTests.swift
@@ -7,7 +7,9 @@ import Foundation
 /// redirect targets expire per connection answers every later range with a hard 5xx from
 /// the pinned URL, and the reader hammered that dead URL forever instead of re-resolving
 /// through the source URL for a fresh redirect.
-@Suite("Resolved-URL invalidation on hard server errors")
+///
+/// `.serialized`: the rate-limit case mutates the process-wide backoff-scale test hook.
+@Suite("Resolved-URL invalidation on hard server errors", .serialized)
 struct ResolvedURLInvalidationTests {
 
     private final class AttemptCounter: @unchecked Sendable {
@@ -72,6 +74,58 @@ struct ResolvedURLInvalidationTests {
         let cdnAttemptsAtBoundary = cdn.requestLog.filter { $0.start == firstRange }.count
         #expect(cdnAttemptsAtBoundary >= 2,
                 "the CDN should see the failed attempt plus the redirected retry")
+    }
+
+    /// The counterpart: a metered origin (429/503) must KEEP the pin. Dropping it sends the
+    /// retry back through the source URL for a fresh redirect, which is a second request
+    /// against the origin that is already refusing them, and on a connection-capped panel
+    /// (#307) that is the request there is no room for.
+    @Test("a rate-limited refill keeps the pin instead of re-resolving through the source",
+          .timeLimit(.minutes(2)))
+    func rateLimitedRefillKeepsThePin() async throws {
+        AetherEngine.reconnectBackoffScaleForTesting = 0.02
+        defer { AetherEngine.reconnectBackoffScaleForTesting = 1.0 }
+
+        let firstRange: Int64 = 256 * 1024
+        let attempts = AttemptCounter()
+        // CDN: meters the first two attempts at the boundary refill, then serves.
+        let cdnMaybe = ThrottledOriginServer(
+            totalSize: 64 * 1024 * 1024,
+            respond: { _, offset, _ in
+                offset == firstRange && attempts.next(for: offset) <= 2
+                    ? .status(503) : .serve206
+            }
+        )
+        let cdn = try #require(cdnMaybe)
+        defer { cdn.stop() }
+        let cdnPort = cdn.port
+        let sourceMaybe = ThrottledOriginServer(
+            totalSize: 64 * 1024 * 1024,
+            respond: { _, _, _ in .redirect(to: "http://127.0.0.1:\(cdnPort)/cdn/movie.bin") }
+        )
+        let source = try #require(sourceMaybe)
+        defer { source.stop() }
+
+        let reader = AVIOReader(url: URL(string: "http://127.0.0.1:\(source.port)/movie.bin")!,
+                                boundedInitialFetch: firstRange)
+        defer { reader.markClosed(); reader.close() }
+        try reader.open()
+
+        let sliceCap = 128 * 1024
+        let buf = UnsafeMutablePointer<UInt8>.allocate(capacity: sliceCap)
+        defer { buf.deallocate() }
+        let target = Int(firstRange) + 256 * 1024
+        var got = 0
+        while got < target {
+            let n = reader.read(into: buf, size: Int32(min(sliceCap, target - got)))
+            if n <= 0 { break }
+            got += Int(n)
+        }
+        #expect(got == target, "read stopped at \(got) of \(target); the 503s were terminal")
+
+        let sourceHitsAtBoundary = source.requestLog.filter { $0.start == firstRange }
+        #expect(sourceHitsAtBoundary.isEmpty,
+                "a metered refill re-resolved through the source: \(source.requestLog)")
     }
 
     @Test("hard-server-error classification excludes rate limiting")

--- a/Tests/AetherEngineTests/ThrottledOriginServer.swift
+++ b/Tests/AetherEngineTests/ThrottledOriginServer.swift
@@ -207,6 +207,13 @@ final class ThrottledOriginServer: @unchecked Sendable {
                 + "Connection: keep-alive\r\n\r\n"
             return writeFully(fd, Array(header.utf8))
         case .dropConnection:
+            // `serve` leaves closing to `stop()`, which closes every fd still in `_connFDs`.
+            // Closing here without deregistering first frees a descriptor number the process
+            // can hand straight to the next socket, and `stop()` would then shut down whatever
+            // took it over. Deregister under the lock, then close exactly once.
+            lock.lock()
+            _connFDs.removeAll { $0 == fd }
+            lock.unlock()
             shutdown(fd, SHUT_RDWR)
             close(fd)
             return false


### PR DESCRIPTION
Follow-up to #308 (merged). Re #307, which stays open until the reporter retests on the device.

**The pin and rate limiting.** #308 dropped the post-redirect pin after two consecutive failures of either kind, including a 429/503 streak, while its own rationale (and the CHANGELOG entry) says a metered origin keeps it. Metering says the origin is refusing requests right now, not that the redirect target is dead (#71), and re-resolving sends the retry back through the source URL for a fresh redirect: a second request against the origin that is already refusing them. On the `max_connections=1` panel behind #307 that is exactly the request there is no room for. The hard-5xx arm and the zero-progress arm are unchanged.

**Test-origin double close.** The new `dropConnection` directive did `shutdown` + `close` on a descriptor that stays in `_connFDs`, and `stop()` closes every fd in there. Between the two, the process can hand that descriptor number to a new socket, and `stop()` would then shut down whatever took it over. Deregister first, then close once.

**Test plan**

- New: `a rate-limited refill keeps the pin instead of re-resolving through the source` (302 source to CDN, CDN meters the first two boundary attempts, then serves). Fails on the pre-follow-up condition (the source sees a boundary hit), passes now. Its suite gained `.serialized` because it mutates the backoff-scale hook.
- `swift test` on macOS 26: 1545 tests / 230 suites green.
- Reverting each #308 arm was checked against its test before the merge: the refused-refill test runs past its two-minute limit with the reposition guard reverted (the read never returns, which is the field symptom), and the fallback test never reaches the source URL with the pin invalidation reverted.