### PR TITLE
diag(io): name a backpressure end the transport ignores (#310 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,23 @@ the public-API contract.
 - **A VOD session whose readError revive cap is exhausted surfaces `onVODSourceFailed`**
   instead of dying silently with AVPlayer parked in `waitingToPlay` forever (#169).
 
+### Changed
+
+- **The persistent reader ends its connection at the window high water instead of suspending
+  the data task** (#310). A suspended task holds a dormant established flow whose closed
+  receive window sits unread for as long as the consumer takes to drain, roughly 100 s per
+  cycle at 1 Mbps and indefinitely while paused. On tvOS and iOS, where TCP for
+  Network.framework flows runs in the app process, that dormant state correlates
+  dose-response by media bitrate with 10 to 80 s episodes in which every nw flow in the
+  process goes deaf at once: established WebSockets time out unACKed and no new handshake
+  completes, while raw BSD sockets from the same process keep working. The reader now either
+  has an actively delivering connection or none at all, and the low-water frontier refill
+  re-requests exactly where delivery stopped, so nothing is discarded and nothing is
+  re-fetched. A paused player holds no connection. The cost is one extra range request per
+  drain cycle. The `winHardCap` escape hatch and the suspend machinery are gone with it, and
+  the memprobe reports `Parked=` (backpressure-ended, refill pending) in place of `Susp=` and
+  `PostMB=`. Reported and field-verified over 71 minutes on two Apple TV 4K by @rrgomes.
+
 ## [6.10.0] - 2026-08-07
 
 ([release notes](https://github.com/superuser404notfound/AetherEngine/releases/tag/6.10.0))

--- a/Sources/AetherEngine/Demuxer/AVIOReader.swift
+++ b/Sources/AetherEngine/Demuxer/AVIOReader.swift
@@ -333,6 +333,12 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
     /// winCond-guarded, cleared by `startPersistentConnection`.
     private var connEndedByBackpressure = false
 
+    /// #310: bytes that arrived after `connEndedByBackpressure` was set, i.e. after our own
+    /// cancel, and whether the one-shot "the cancel did not take" line has been emitted for
+    /// this generation. Both winCond-guarded, both cleared by `startPersistentConnection`.
+    private var postEndDeliveryBytes: Int64 = 0
+    private var postEndOvershootLogged = false
+
     /// #220: last byte the live connection was asked for, nil when the request was open-ended
     /// (live sources, and any source whose total size is not resolved yet). winCond-guarded.
     private var connRangeEnd: Int64?
@@ -1835,6 +1841,8 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
         connEnded = false
         connEndedByBackpressure = false
         connEndedAtRangeEnd = false
+        postEndDeliveryBytes = 0
+        postEndOvershootLogged = false
         connRangeEnd = resolvedBound.map { offset + $0 - 1 }
         connStatus = 0
         connRetryAfter = 0
@@ -1914,6 +1922,20 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
             lastFirstDataMs = firstDataMs ?? 0
         }
         let count = data.count
+        // #310: delivery that lands with the backpressure end ALREADY recorded, i.e. after our
+        // own cancel. A bounded in-flight tail is expected. A figure that keeps climbing is the
+        // witness that ending is as advisory as suspending was (#174 blocking, #220 suspend:
+        // each mechanism here has failed exactly this way once), and without a line naming it
+        // the next round would start from a memprobe and a guess. Counted before the append so
+        // it is attributable to the transport rather than to our own bookkeeping.
+        var overshootToLog: Int64? = nil
+        if connEndedByBackpressure {
+            postEndDeliveryBytes += Int64(count)
+            if postEndDeliveryBytes > Int64(Self.winHighWater), !postEndOvershootLogged {
+                postEndOvershootLogged = true
+                overshootToLog = postEndDeliveryBytes
+            }
+        }
         let base = window.count
         window.count = base + count
         window.withUnsafeMutableBytes { dst in
@@ -1967,6 +1989,12 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
                 + "connection, will re-request at the frontier once the consumer drains",
                 category: .demux)
             toCancel.cancel()
+        }
+        if let overshootToLog {
+            EngineLog.emit(
+                "[AVIOReader] \(label) gen=\(generation) \(overshootToLog / 1024 / 1024)MB delivered "
+                + "AFTER the backpressure end; the cancel is not stopping this transport",
+                category: .demux)
         }
         if let firstDataMs {
             // #93/#96 residual: a slow first-data gap is release-visible so a device trace can pair it

--- a/Tests/AetherEngineTests/Issue295RangeBoundaryRefetchTests.swift
+++ b/Tests/AetherEngineTests/Issue295RangeBoundaryRefetchTests.swift
@@ -67,5 +67,18 @@ struct Issue295RangeBoundaryRefetchTests {
         }
         #expect(regressions.isEmpty,
                 "a request started at or below its predecessor, i.e. re-requested delivered bytes: \(regressions.joined(separator: ", ")); all starts: \(starts)")
+
+        // Direction alone cannot price a re-fetch, and the defect was priced: 1506918 bytes
+        // delivered for a 764450 byte object, 1.97x what was read. Count it on the READER
+        // side, not the origin's: bytes the origin wrote into a socket we then cancelled were
+        // never delivered, so `bytesWritten` would make a healthy high-water end look like a
+        // re-fetch. What the reader accepted, minus what the consumer read, is exactly the
+        // resident window plus whatever is in flight. Measured margin on this fixture is the 64 KB
+        // tail probe; the 2 MB slack is set so one 4 MB detour block, the defect's unit of
+        // re-fetch, still fails it.
+        let overRead = reader.cumulativeBytesFetched - read
+        let resident = Int64(reader.windowDiagnostics.aheadBytes)
+        #expect(overRead <= resident + 2 * 1024 * 1024,
+                "the reader accepted \(overRead / (1024 * 1024)) MB beyond the \(read / (1024 * 1024)) MB consumed, with only \(resident / (1024 * 1024)) MB resident: bytes were fetched twice")
     }
 }


### PR DESCRIPTION
Follow-up to #317 (merged). Re #310, which stays open until the change is confirmed on a released build.

**A witness for the next round.** Every mechanism in this area has failed the same way exactly once: #174 delegate-blocking left the socket reading, #220 measured `suspend()` advisory with 911 MB arriving after it. Ending the connection is the third mechanism, and if some transport ignores the cancel the way it ignored the suspend, today's only evidence would be a memprobe window climbing with `Parked=1`. Bytes arriving after the end are now counted per generation and named once when they pass the high water:

```
[AVIOReader] pump gen=7 19MB delivered AFTER the backpressure end; the cancel is not stopping this transport
```

**The #295 guard, priced again.** Strictly increasing request starts is the right shape now that a cancelled range's undelivered tail is legitimately re-requested, but it cannot catch a re-fetch that starts above its predecessor, and the defect was a byte volume (1.97x what was read). The volume is counted on the reader side rather than the origin's: bytes the origin wrote into a socket we then cancelled were never delivered, so `bytesWritten` would make a healthy high-water end look like a re-fetch. Measured margin on that fixture is the 64 KB tail probe, so the slack is set at 2 MB, which still fails on one 4 MB detour block.

**Also here:** the CHANGELOG entry for #310 (the PR carried none).

**Merge note.** #317 was cut before `pumpIOWindow` landed on main (#306 telemetry), so the textually clean merge did not compile: that call site still declared the old four-field window tuple. Fixed inside the merge commit (1e45bf7e), not here.

**Test plan:** `swift test` on macOS 26, 1544 tests / 230 suites green; the retightened #295 test run three times for stability, and verified to report a 64 KB margin when its bound is forced to fail.