### PR TITLE
fix(io): notice a silently dead connection on wall-clock time (#309)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,25 @@ the public-API contract.
 
 ## [Unreleased]
 
-_Nothing yet._
+### Fixed
+
+- **A source connection that dies silently is now noticed on wall-clock time instead of on
+  consumer cadence.** `connStallTimeout` was evaluated in exactly one place, the read loop's
+  forward wait, so a transport that died while the sliding window could still serve reads was
+  detected only once a consumer happened to block on it: `bytesFetched` sat frozen for 4.5
+  minutes across a pause in the field report, and the reconnect fired only after the window had
+  drained. A generation with an installed transfer and no delivery for `connStallTimeout` is now
+  ended by a delivery-gap watchdog, whether or not a read is waiting on it, and the gap is named
+  in the log. The watchdog only ENDS: opening connections stays with the read thread, so a paused
+  player still holds no flow and cannot be driven into a timer-paced reconnect loop (#309).
+- **A faulted connection is replaced while read-ahead remains, not once it is spent.** The
+  frontier refill fired only for planned ends (a range delivered in full, a high-water end), so a
+  generation that ended in fault was replaced only after the window hit empty. The reader spent
+  its entire read-ahead before asking for a replacement and playback rejoined the clock with a
+  burst (+17 MB in one interval, 389 dropped frames in the field trace). Any reason for having no
+  flow now refills at low water; a fault additionally pays the failure ladder (status accounting,
+  pin invalidation, bounded give-up) with its backoff expressed as a next-attempt time rather than
+  as a sleep, so the demuxer keeps being served from the window between attempts (#309).
 
 ## [6.11.0] - 2026-08-07
 

--- a/Sources/AetherEngine/AetherEngine.swift
+++ b/Sources/AetherEngine/AetherEngine.swift
@@ -893,6 +893,14 @@ public final class AetherEngine: ObservableObject {
     /// ~13 exponential backoffs finish in test time instead of a minute of real sleeping.
     nonisolated(unsafe) static var reconnectBackoffScaleForTesting = 1.0
 
+    /// TEST-ONLY: overrides the reader's connection stall threshold in seconds (0 = the shipped
+    /// default). Read once by each `AVIOReader` at init, so set it before `load`/`start`. Lets the
+    /// #309 delivery-gap watchdog be exercised in test time instead of 20 s per case. Deliberately
+    /// NOT a `LoadOptions` field: #272 measured that a shorter threshold is WORSE under CPU
+    /// starvation (it redials exactly when there are no cycles to spare), and that conclusion is
+    /// unchanged. This is a test clock, not a tuning knob.
+    nonisolated(unsafe) static var connStallTimeoutForTesting: TimeInterval = 0
+
     /// Reads `AVPlayer.eligibleForHDRPlayback` and `AVPlayer.availableHDRModes` at call time.
     /// Eligibility is display-configuration aware on all platforms (its change notification fires
     /// on display connection/disconnection), so per-load reads pick up monitor changes; the value

--- a/Sources/AetherEngine/Demuxer/AVIOReader.swift
+++ b/Sources/AetherEngine/Demuxer/AVIOReader.swift
@@ -224,8 +224,9 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
     private static let winTrimBatch = 4 * 1024 * 1024
     // Forward seeks within this distance keep the live connection; beyond it, reconnect.
     private static let seekKeepForwardLimit = 8 * 1024 * 1024
-    // CDN stall threshold: no bytes for this long triggers reconnect.
-    private static let connStallTimeout: TimeInterval = 20
+    // CDN stall threshold: no bytes for this long triggers reconnect. Instance-captured (see
+    // `connStallTimeout`) so tests can shorten it; the shipped value is this one.
+    private static let connStallTimeoutDefault: TimeInterval = 20
     // A reconnect that delivers at least this much counts as progress; resets streak.
     private static let minReconnectProgress: Int64 = 512 * 1024
     // Cap on CONSECUTIVE unproductive reconnects; resets on real progress.
@@ -338,6 +339,22 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
     /// this generation. Both winCond-guarded, both cleared by `startPersistentConnection`.
     private var postEndDeliveryBytes: Int64 = 0
     private var postEndOvershootLogged = false
+
+    /// #309: when the current generation last delivered a byte, or when it started if it has
+    /// delivered none yet. The single input to the delivery-gap watchdog, and the reason that
+    /// watchdog can exist at all: the read loop's forward wait used to be the only place
+    /// `connStallTimeout` was ever evaluated, so a flow that died while the window could still
+    /// serve reads was noticed only once a consumer happened to block on it (observed in the field:
+    /// 4.5 minutes across a pause). The transport does not fill that gap either, since the
+    /// persistent request runs with `timeoutInterval = 0` on purpose. winCond-guarded.
+    private var lastDeliveryAt = DispatchTime.now()
+
+    /// #309: earliest time the read loop may replace a FAULTED connection from the serve path.
+    /// The failure ladder there cannot sleep (see `chargeFaultedRunwayRefill`), so its backoff is
+    /// a timestamp instead. `.distantPast` = attempt now, `.distantFuture` = the bounded give-up
+    /// has fired and only the empty-window path may still act. winCond-guarded, reset by
+    /// `startPersistentConnection`.
+    private var nextFaultedRefillAt = Date.distantPast
 
     /// #220: last byte the live connection was asked for, nil when the request was open-ended
     /// (live sources, and any source whose total size is not resolved yet). winCond-guarded.
@@ -465,6 +482,10 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
     private let throttleKbps: Int
     /// TEST-ONLY reconnect-backoff scale (1.0 = real timing), captured once from the static hook at init.
     private let backoffScale: Double
+    /// Stall threshold this reader runs with: `connStallTimeoutDefault`, or the TEST-ONLY hook when
+    /// set. One value for both detectors, because they are one policy: a connection that has
+    /// delivered nothing for this long is replaced, whether or not a read is waiting on it (#309).
+    private let connStallTimeout: TimeInterval
     private var throttleVClockNs: UInt64 = 0
     private let throttleLock = NSLock()
 
@@ -484,6 +505,8 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
         self.boundedInitialFetch = boundedInitialFetch.map { max(1, $0) }
         self.throttleKbps = AetherEngine.sourceThrottleKbpsForTesting
         self.backoffScale = AetherEngine.reconnectBackoffScaleForTesting
+        let stallOverride = AetherEngine.connStallTimeoutForTesting
+        self.connStallTimeout = stallOverride > 0 ? stallOverride : Self.connStallTimeoutDefault
     }
 
     /// Slow-CDN simulation: hold delivered bytes to `throttleKbps` by sleeping the demux thread before the
@@ -1284,30 +1307,49 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
                 unproductiveReconnects = 0      // real progress
                 rateLimitStreak = 0             // real progress clears the 429 give-up streak (#71)
                 emitNetworkPhase(.flowing)      // recovered: source delivering again (#85)
-                // #220/#310: the connection ended on purpose — its range was delivered in
-                // full, or it was ended at high water so no suspended flow sits dormant —
-                // and the consumer has now drawn down far enough that the next one should
-                // already be in flight. Requesting at the frontier rather than at the read
-                // position keeps every delivered byte, and doing it here rather than on an
-                // empty window is what stops a planned end from becoming a stall.
-                // A frontier AT the end of the file is not a frontier. The range that ended was the
-                // last one, and requesting `bytes=<fileSize>-` asks for nothing: origins answer it
-                // with an empty 206, the reconnect resets `winStart` past the last byte, and the
-                // window that was about to be read is dropped for it. On a trailing `moov` that
-                // turned one connection into three, since the parse then had to re-fetch what it
-                // had just been handed. Live keeps the old behaviour: its length is not
-                // authoritative and its end moves.
+                // No flow installed and the consumer has drawn down to low water: request at the
+                // frontier. #220/#310 built this for PLANNED ends (a range delivered in full, a
+                // high-water end); #309 made it the rule for every reason there is no flow, because
+                // the exception was the second half of that report. A generation that ended in
+                // FAULT was replaced only once the window hit EMPTY, so the reader spent its whole
+                // read-ahead first and playback rejoined the clock with a burst (the field trace's
+                // +17 MB interval and 389 dropped frames). Which reason it was still decides the
+                // POLICY: a planned end costs nothing, a fault pays the ladder
+                // (`chargeFaultedRunwayRefill`).
+                //
+                // Requesting at the frontier rather than at the read position keeps every delivered
+                // byte. A frontier AT the end of the file is not a frontier: the range that ended
+                // was the last one, and requesting `bytes=<fileSize>-` asks for nothing: origins
+                // answer it with an empty 206, the reconnect resets `winStart` past the last byte,
+                // and the window that was about to be read is dropped for it. On a trailing `moov`
+                // that turned one connection into three. Live keeps the old behaviour: its length is
+                // not authoritative and its end moves.
                 var refillFrom: Int64? = nil
+                var refillFaulted = false
+                var refillStatus = 0
+                var refillRetryAfter: TimeInterval = 0
                 let undrained = window.count - max(0, Int(position - winStart))
                 let frontier = winStart + Int64(window.count)
-                if connEndedAtRangeEnd || connEndedByBackpressure, activeTask == nil,
-                   undrained <= Self.winLowWater,
+                if activeTask == nil, undrained <= Self.winLowWater,
                    isLive || fileSize <= 0 || frontier < fileSize {
-                    refillFrom = frontier
+                    if connEndedAtRangeEnd || connEndedByBackpressure {
+                        refillFrom = frontier
+                    } else if connEnded, Date() >= nextFaultedRefillAt {
+                        refillFrom = frontier
+                        refillFaulted = true
+                        refillStatus = connStatus
+                        refillRetryAfter = connRetryAfter
+                    }
                 }
                 winCond.broadcast()
                 winCond.unlock()
-                if let refillFrom { timedReconnect(seek: false, at: refillFrom) }
+                if let refillFrom {
+                    if !refillFaulted || chargeFaultedRunwayRefill(at: refillFrom, ahead: undrained,
+                                                                   status: refillStatus,
+                                                                   retryAfter: refillRetryAfter) {
+                        timedReconnect(seek: false, at: refillFrom)
+                    }
+                }
                 continue
             }
 
@@ -1348,7 +1390,7 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
                 // Wait for the live connection to fill forward. A false return
                 // means connStallTimeout elapsed with no data (socket stall).
                 let waitStart = DispatchTime.now()
-                let signaled = winCond.wait(until: min(Date(timeIntervalSinceNow: Self.connStallTimeout), readDeadline))
+                let signaled = winCond.wait(until: min(Date(timeIntervalSinceNow: connStallTimeout), readDeadline))
                 winCond.unlock()
                 diag.recordStallWait(ms: msSince(waitStart), signaled: signaled)
                 // Check deadline before stall handling to avoid misrouting a
@@ -1489,11 +1531,68 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
     // without grinding a dead tuner for minutes.
     private static let reconnectMaxUnproductiveNeverProductive = 4
 
-    /// Exponential backoff (0.5s..8s) growing with streak; immediate on streak=0.
-    /// Sleeps in 0.1s slices so a close is honoured promptly.
-    private func backoffBeforeReconnect(streak: Int, retryAfter: TimeInterval) {
+    /// Exponential backoff (0.5s..8s) growing with streak; immediate on streak=0. How long the
+    /// ladder waits before its next attempt. Shared by the blocking backoff below and the
+    /// non-blocking one in `chargeFaultedRunwayRefill`, so both pace an origin identically.
+    private func backoffDelay(streak: Int, retryAfter: TimeInterval) -> TimeInterval {
         let expo = streak <= 0 ? 0.0 : min(Double(1 << min(streak, 4)) * 0.5, 8.0)
-        let total = min(max(expo, retryAfter), 15.0) * backoffScale
+        return min(max(expo, retryAfter), 15.0) * backoffScale
+    }
+
+    /// #309: account for replacing a FAULTED connection from the serve path, i.e. while the window
+    /// still holds read-ahead. Returns true when the caller should open the replacement.
+    ///
+    /// This is the same ladder the empty-window path runs (status accounting, pin invalidation,
+    /// bounded give-up), because a free reconnect off the books is exactly what #307 paid for. Two
+    /// deliberate differences:
+    ///
+    /// - It does not SLEEP. It runs on the demux thread with megabytes still resident, and a backoff
+    ///   sleep there would starve the demuxer of the very read-ahead that replacing early exists to
+    ///   protect. The wait is a next-attempt timestamp instead, so reads keep being served at full
+    ///   speed between attempts.
+    /// - It never returns the read as failed. A window that can still serve must not kill a session
+    ///   that still holds seconds of playback. At the cap it stops attempting (`.distantFuture`) and
+    ///   leaves termination to the empty-window ladder, where it has always lived.
+    ///
+    /// It also emits no `.reconnecting` phase: playback is uninterrupted here, and a phase that
+    /// flapped between `.flowing` and `.reconnecting` on every read would describe the reader's
+    /// bookkeeping rather than what the viewer sees. The empty-window path still emits it, which is
+    /// when playback genuinely starves. Demux-thread-only.
+    private func chargeFaultedRunwayRefill(at frontier: Int64, ahead: Int,
+                                           status: Int, retryAfter: TimeInterval) -> Bool {
+        let isRateLimited = (status == 429 || status == 503)
+        let giveUp = isRateLimited ? recordRateLimitAndShouldGiveUp()
+                                   : recordReconnectAndShouldGiveUp(status: status)
+        if giveUp {
+            winCond.lock()
+            nextFaultedRefillAt = .distantFuture
+            winCond.unlock()
+            EngineLog.emit(
+                "[AVIOReader] \(label) faulted refill exhausted at offset \(frontier) status=\(status);"
+                + " serving the remaining \(ahead / 1024)KB, then the read will fail",
+                category: .demux)
+            return false
+        }
+        let streak = isRateLimited ? rateLimitStreak : unproductiveReconnects
+        if !isRateLimited, unproductiveReconnects >= 2 {
+            invalidateResolvedURL(reason: "unproductive reconnect streak")
+        }
+        lastUnplannedReconnectAt = Date()
+        let delay = backoffDelay(streak: streak, retryAfter: retryAfter)
+        winCond.lock()
+        nextFaultedRefillAt = Date().addingTimeInterval(delay)
+        winCond.unlock()
+        EngineLog.emit(
+            "[AVIOReader] \(label) replacing a faulted connection at offset \(frontier) with"
+            + " \(ahead / 1024)KB of read-ahead left (streak=\(streak) status=\(status),"
+            + " next attempt in \(String(format: "%.1f", delay))s)",
+            category: .demux)
+        return true
+    }
+
+    /// Blocking form of the wait above: sleeps in 0.1s slices so a close is honoured promptly.
+    private func backoffBeforeReconnect(streak: Int, retryAfter: TimeInterval) {
+        let total = backoffDelay(streak: streak, retryAfter: retryAfter)
         if total <= 0 { return }
         var slept = 0.0
         while slept < total {
@@ -1848,6 +1947,8 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
         connRetryAfter = 0
         connStartedAt = DispatchTime.now()   // #93: time-to-first-data per generation
         connFirstDataSeen = false
+        lastDeliveryAt = connStartedAt       // #309: the gap is measured from here until data lands
+        nextFaultedRefillAt = .distantPast
         let oldTask = activeTask
         activeTask = nil
         winCond.broadcast()
@@ -1888,6 +1989,8 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
         winCond.unlock()
 
         task.resume()
+        // #309: from here the generation is watched on wall-clock time, not on consumer cadence.
+        armDeliveryGapWatchdog(generation: generation, after: connStallTimeout)
         // #240: not DEBUG-only any more, and it names its reader. This is the line a field report
         // needs to answer "who is on the link": with bounded ranges every 32 MiB refill starts a
         // generation, so an unlabelled sequence of them reads like several concurrent connections
@@ -1895,6 +1998,64 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
         EngineLog.emit(
             "[AVIOReader] \(label) conn start gen=\(generation) offset=\(offset)"
             + (resolvedBound.map { " len=\($0 / 1024 / 1024)MB" } ?? " open-ended"),
+            category: .demux)
+    }
+
+    /// #309: timer queue for the delivery-gap watchdog. Shared and serial: the work is one
+    /// timestamp comparison per armed generation and never touches the network.
+    private static let deliveryGapQueue = DispatchQueue(label: "aether.avio.delivery-gap")
+
+    /// #309: schedule the delivery-gap check for `generation`. One pending closure at a time per
+    /// generation: it either ends the connection or re-arms itself for the remaining gap, so a
+    /// healthy transfer costs one comparison per `connStallTimeout` instead of a repeating timer,
+    /// and a generation that has already ended arms nothing at all.
+    private func armDeliveryGapWatchdog(generation: Int, after delay: TimeInterval) {
+        Self.deliveryGapQueue.asyncAfter(deadline: .now() + delay) { [weak self] in
+            self?.checkDeliveryGap(generation: generation)
+        }
+    }
+
+    /// #309: end a generation that has an installed transfer and no delivery for
+    /// `connStallTimeout`. Same threshold and same action as the read loop's forward wait, with the
+    /// one precondition removed that made the field case invisible: that a consumer be blocked on
+    /// it. A window holding read-ahead, or a paused player holding all of it, no longer defers the
+    /// verdict.
+    ///
+    /// It ENDS, it never reconnects. Opening connections stays with the read thread, so a parked
+    /// consumer cannot be turned into a timer-driven reconnect loop (the #307 failure mode), and a
+    /// pause continues to hold no flow at all (the #310 invariant). The replacement is issued by
+    /// the read loop: at low water while read-ahead remains, immediately once the window is empty.
+    private func checkDeliveryGap(generation: Int) {
+        if isClosed { return }
+        winCond.lock()
+        // Nothing to watch: a newer generation owns the link, the connection already ended
+        // (delivered range, high-water end, transport error), or no transfer is installed.
+        guard generation == connGeneration, !connEnded, let task = activeTask else {
+            winCond.unlock()
+            return
+        }
+        let gap = Double(DispatchTime.now().uptimeNanoseconds - lastDeliveryAt.uptimeNanoseconds)
+            / 1_000_000_000
+        if gap < connStallTimeout {
+            winCond.unlock()
+            // Data landed since this closure was scheduled; wait out what is left of the window.
+            armDeliveryGapWatchdog(generation: generation, after: max(0.02, connStallTimeout - gap))
+            return
+        }
+        connEnded = true
+        activeTask = nil
+        let frontier = winStart + Int64(window.count)
+        let ahead = window.count - max(0, Int(position - winStart))
+        let sawData = connFirstDataSeen
+        winCond.broadcast()
+        winCond.unlock()
+        task.cancel()
+        // The witness the field case had no line for: `bytesFetched` sat frozen for minutes and
+        // nothing said so. Release-visible, and rare by construction (one per faulted generation).
+        EngineLog.emit(
+            "[AVIOReader] \(label) gen=\(generation) no delivery for \(String(format: "%.1f", gap))s"
+            + " at offset \(frontier) (\(ahead / 1024)KB read-ahead held,"
+            + " \(sawData ? "had delivered" : "never delivered") data); ending it",
             category: .demux)
     }
 
@@ -1913,6 +2074,7 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
             winCond.unlock()
             return
         }
+        lastDeliveryAt = DispatchTime.now()   // #309: the delivery-gap watchdog's only input
         var firstDataMs: Double? = nil
         if !connFirstDataSeen {
             connFirstDataSeen = true

--- a/Tests/AetherEngineTests/Issue309SilentTransportDeathTests.swift
+++ b/Tests/AetherEngineTests/Issue309SilentTransportDeathTests.swift
@@ -1,0 +1,261 @@
+import Testing
+import Foundation
+@testable import AetherEngine
+
+/// #309: a transport that dies silently while the window can still serve reads.
+///
+/// Two separate defects, and only the first one is in the report:
+/// - Detection. `connStallTimeout` was evaluated in exactly one place, inside the read loop's
+///   forward wait, so nothing noticed a dead flow while reads were satisfied from the window.
+///   The persistent request also sets `timeoutInterval = 0`, so the transport is not expected to
+///   notice either: the reader is the only detector there is, and it only ticked when a consumer
+///   happened to block.
+/// - Recovery. The frontier refill fired only for PLANNED ends (a delivered range, a high-water
+///   end). An error-ended generation was replaced only once the window had drained to EMPTY, so
+///   the reader spent 16 MB of read-ahead before asking for a replacement, and playback rejoined
+///   the clock with a burst (the field report's +17 MB interval and 389 dropped frames). Detecting
+///   the death instantly would not have changed that by itself.
+///
+/// The origin serves a range, stops writing mid-body, and keeps the socket open with no FIN, which
+/// is the reader-observable shape of the field case (URLSession surfaced nothing until the task was
+/// later cancelled).
+///
+/// `.serialized`: these tests mutate the process-wide stall-timeout, throttle and backoff hooks.
+@Suite("Silent transport death (#309)", .serialized)
+struct Issue309SilentTransportDeathTests {
+
+    private static let totalSize: Int64 = 256 * 1024 * 1024
+    /// The first data range. Its completion is what puts the refill at `silenceOffset`, and it
+    /// keeps the silent generation off offset 0, where the speculative tail fetch and the open's
+    /// own from-zero request live.
+    private static let firstRange: Int64 = 2 * 1024 * 1024
+    private static var silenceOffset: Int64 { firstRange }
+
+    /// Snapshot taken from the ORIGIN's thread at the moment it receives a given request, which is
+    /// the only way to observe how much read-ahead the reader still held when it asked for the
+    /// replacement. A loopback origin answers in microseconds, so timing cannot express this.
+    private final class RunwayProbe: @unchecked Sendable {
+        private let lock = NSLock()
+        private weak var reader: AVIOReader?
+        private var recorded: Int?
+        func attach(_ reader: AVIOReader) {
+            lock.lock(); self.reader = reader; lock.unlock()
+        }
+        func recordRunway() {
+            lock.lock()
+            let reader = self.reader
+            let alreadyRecorded = recorded != nil
+            lock.unlock()
+            guard !alreadyRecorded, let reader else { return }
+            let ahead = reader.windowDiagnostics.aheadBytes
+            lock.lock()
+            if recorded == nil { recorded = ahead }
+            lock.unlock()
+        }
+        var runwayAtRequest: Int? {
+            lock.lock(); defer { lock.unlock() }
+            return recorded
+        }
+    }
+
+    private final class AttemptCounter: @unchecked Sendable {
+        private let lock = NSLock()
+        private var counts: [Int64: Int] = [:]
+        func next(for offset: Int64) -> Int {
+            lock.lock(); defer { lock.unlock() }
+            let n = (counts[offset] ?? 0) + 1
+            counts[offset] = n
+            return n
+        }
+    }
+
+    private static func read(_ reader: AVIOReader, bytes target: Int, sliceCap: Int = 256 * 1024,
+                            deadline: TimeInterval = 30) -> Int {
+        let buf = UnsafeMutablePointer<UInt8>.allocate(capacity: sliceCap)
+        defer { buf.deallocate() }
+        var got = 0
+        let stopAt = Date().addingTimeInterval(deadline)
+        while got < target && Date() < stopAt {
+            let n = reader.read(into: buf, size: Int32(min(sliceCap, target - got)))
+            if n <= 0 { break }
+            got += Int(n)
+        }
+        return got
+    }
+
+    /// Poll instead of sleeping a fixed span: the observable is a state the origin reaches, and a
+    /// fixed sleep either wastes suite time or races the loopback round trip.
+    private static func waitUntil(_ budget: TimeInterval, _ condition: () -> Bool) async throws {
+        let stopAt = Date().addingTimeInterval(budget)
+        while Date() < stopAt {
+            if condition() { return }
+            try await Task.sleep(for: .milliseconds(20))
+        }
+    }
+
+    // MARK: - Detection
+
+    @Test("a flow that dies mid-window is ended without any read blocking on it",
+          .timeLimit(.minutes(2)))
+    func deadFlowIsEndedWithoutAWaitingRead() async throws {
+        let stallTimeout: TimeInterval = 0.6
+        AetherEngine.connStallTimeoutForTesting = stallTimeout
+        defer { AetherEngine.connStallTimeoutForTesting = 0 }
+
+        let silenceOffset = Self.silenceOffset
+        // Built into a local first: `#require` wraps its expression in a @Sendable closure, which a
+        // capturing origin closure cannot cross.
+        let serverMaybe = ThrottledOriginServer(
+            totalSize: Self.totalSize,
+            respond: { _, offset, _ in
+                offset == silenceOffset ? .serveThenGoSilent(afterBytes: 4 * 1024 * 1024) : .serve206
+            })
+        let server = try #require(serverMaybe)
+        defer { server.stop() }
+        let reader = AVIOReader(url: URL(string: "http://127.0.0.1:\(server.port)/movie.bin")!,
+                                boundedInitialFetch: Self.firstRange)
+        defer { reader.markClosed(); reader.close() }
+        try reader.open()
+
+        // The refill is issued BY a read, and only once the first range is no longer installed, so
+        // wait for that range to complete before consuming. Then consume enough to put the refill on
+        // the wire and far less than the 4 MB it delivers: from here on every read is satisfied from
+        // the window, which is precisely the state that used to defer detection indefinitely.
+        try await Self.waitUntil(10) { !reader.hasLiveConnectionForTesting }
+        #expect(Self.read(reader, bytes: 1024 * 1024) == 1024 * 1024)
+        try await Self.waitUntil(5) { server.requestedRanges.contains { $0.start == silenceOffset } }
+        #expect(server.requestedRanges.contains { $0.start == silenceOffset },
+                "the frontier refill never went out: \(server.requestedRanges)")
+
+        // No reads at all from here: the consumer is parked, exactly as a paused player is.
+        try await Self.waitUntil(stallTimeout * 6) { !reader.hasLiveConnectionForTesting }
+
+        #expect(!reader.hasLiveConnectionForTesting,
+                "a connection that delivered nothing for \(stallTimeout)s is still installed")
+        let diag = reader.windowDiagnostics
+        #expect(!diag.parked,
+                "window at \(diag.aheadBytes / (1024 * 1024)) MB: not a high-water end, so it must be recorded as a fault")
+        // The watchdog ENDS, it never reconnects: a parked consumer must not turn a dead flow into
+        // a reconnect loop, which is the failure mode #307 paid for.
+        #expect(server.requestedRanges.filter { $0.start == silenceOffset }.count == 1,
+                "the dead flow was re-requested while nothing drained: \(server.requestedRanges)")
+    }
+
+    @Test("a generation that never sees a first byte is ended too", .timeLimit(.minutes(2)))
+    func headersWithoutABodyAreEnded() async throws {
+        let stallTimeout: TimeInterval = 0.6
+        AetherEngine.connStallTimeoutForTesting = stallTimeout
+        AetherEngine.reconnectBackoffScaleForTesting = 0.02
+        defer {
+            AetherEngine.connStallTimeoutForTesting = 0
+            AetherEngine.reconnectBackoffScaleForTesting = 1.0
+        }
+
+        let silenceOffset = Self.silenceOffset
+        let attempts = AttemptCounter()
+        let serverMaybe = ThrottledOriginServer(
+            totalSize: Self.totalSize,
+            respond: { _, offset, _ in
+                offset == silenceOffset && attempts.next(for: offset) == 1
+                    ? .serveThenGoSilent(afterBytes: 0) : .serve206
+            })
+        let server = try #require(serverMaybe)
+        defer { server.stop() }
+        let reader = AVIOReader(url: URL(string: "http://127.0.0.1:\(server.port)/movie.bin")!,
+                                boundedInitialFetch: Self.firstRange)
+        defer { reader.markClosed(); reader.close() }
+        try reader.open()
+
+        try await Self.waitUntil(10) { !reader.hasLiveConnectionForTesting }
+        #expect(Self.read(reader, bytes: 512 * 1024) == 512 * 1024)
+        try await Self.waitUntil(5) { server.requestedRanges.contains { $0.start == silenceOffset } }
+        try await Self.waitUntil(stallTimeout * 6) { !reader.hasLiveConnectionForTesting }
+
+        #expect(!reader.hasLiveConnectionForTesting,
+                "a request answered with headers and no body stayed installed")
+        #expect(server.requestedRanges.filter { $0.start == silenceOffset }.count == 1,
+                "the ended generation was re-requested with nothing draining")
+
+        // Liveness: the retry (served normally) must carry the read past the first range.
+        let past = Self.read(reader, bytes: 4 * 1024 * 1024)
+        #expect(past == 4 * 1024 * 1024, "only \(past) B delivered after the empty response")
+    }
+
+    // MARK: - Recovery
+
+    @Test("the replacement is requested while read-ahead remains, not once it is spent",
+          .timeLimit(.minutes(3)))
+    func runwayIsRefilledBeforeItDrains() async throws {
+        let stallTimeout: TimeInterval = 0.5
+        AetherEngine.connStallTimeoutForTesting = stallTimeout
+        // A consumer at ~2 MB/s, so the 6 MB resident at the moment of death is worth seconds of
+        // playback rather than the microseconds a loopback memcpy would take. Without a paced
+        // consumer this test would measure the harness, not the reader.
+        AetherEngine.sourceThrottleKbpsForTesting = 16_000
+        defer {
+            AetherEngine.connStallTimeoutForTesting = 0
+            AetherEngine.sourceThrottleKbpsForTesting = 0
+        }
+
+        let silenceOffset = Self.silenceOffset
+        let silentBytes: Int64 = 4 * 1024 * 1024
+        let frontierAfterSilence = silenceOffset + silentBytes
+        let probe = RunwayProbe()
+        let serverMaybe = ThrottledOriginServer(
+            totalSize: Self.totalSize,
+            respond: { _, offset, _ in
+                if offset == frontierAfterSilence { probe.recordRunway() }
+                return offset == silenceOffset ? .serveThenGoSilent(afterBytes: silentBytes) : .serve206
+            })
+        let server = try #require(serverMaybe)
+        defer { server.stop() }
+        let reader = AVIOReader(url: URL(string: "http://127.0.0.1:\(server.port)/movie.bin")!,
+                                boundedInitialFetch: Self.firstRange)
+        defer { reader.markClosed(); reader.close() }
+        probe.attach(reader)
+        try reader.open()
+
+        // Read straight through the death. 7 MB is past everything the silenced generation and the
+        // first range delivered (6 MB), so completing it can only happen through a replacement.
+        let target = 7 * 1024 * 1024
+        let got = Self.read(reader, bytes: target, deadline: 60)
+        #expect(got == target, "read stopped at \(got / 1024) KB of \(target / 1024) KB")
+
+        let runway = try #require(probe.runwayAtRequest,
+                                  "the frontier after the silence was never requested: \(server.requestedRanges)")
+        #expect(runway >= 2 * 1024 * 1024,
+                "the replacement was asked for with only \(runway / 1024) KB of read-ahead left: the runway was spent before recovering")
+    }
+
+    // MARK: - Regression
+
+    @Test("a backpressure-parked reader is not treated as a dead flow", .timeLimit(.minutes(2)))
+    func parkedIsNotStalled() async throws {
+        let stallTimeout: TimeInterval = 0.5
+        AetherEngine.connStallTimeoutForTesting = stallTimeout
+        defer { AetherEngine.connStallTimeoutForTesting = 0 }
+
+        let server = try #require(ThrottledOriginServer(totalSize: Self.totalSize))
+        defer { server.stop() }
+        let reader = AVIOReader(url: URL(string: "http://127.0.0.1:\(server.port)/movie.bin")!)
+        defer { reader.markClosed(); reader.close() }
+        try reader.open()
+
+        // Nobody consumes: the window fills to high water, the connection is ended on purpose, and
+        // from then on there is no delivery at all. That is the state the watchdog must NOT read as
+        // a fault, or every paused player would reconnect on a timer.
+        try await Self.waitUntil(5) { reader.windowDiagnostics.parked }
+        try await Task.sleep(for: .seconds(stallTimeout * 4))
+
+        #expect(reader.windowDiagnostics.parked, "the high-water end must still own this state")
+        #expect(reader.unproductiveReconnectsForTesting == 0,
+                "a parked reader was charged \(reader.unproductiveReconnectsForTesting) failures")
+        #expect(server.requestedRanges.filter { $0.start == 0 }.count == 1,
+                "the watchdog re-requested a deliberately ended connection: \(server.requestedRanges)")
+
+        // And it still refills when the consumer comes back.
+        let got = Self.read(reader, bytes: 24 * 1024 * 1024)
+        #expect(got == 24 * 1024 * 1024, "only \(got / (1024 * 1024)) MB after the park")
+        #expect(reader.unproductiveReconnectsForTesting == 0)
+    }
+}

--- a/Tests/AetherEngineTests/ThrottledOriginServer.swift
+++ b/Tests/AetherEngineTests/ThrottledOriginServer.swift
@@ -18,6 +18,13 @@ final class ThrottledOriginServer: @unchecked Sendable {
         case status(Int, retryAfter: Int? = nil)
         case redirect(to: String)
         case dropConnection
+        /// #309: answer with the 206 header, deliver `afterBytes` of the promised body, then stop
+        /// writing WITHOUT closing the socket and without a FIN. The client keeps an established
+        /// connection that delivers nothing and never errors, which is the reader-observable state
+        /// behind #309 (the field case was a transport that died with URLSession surfacing nothing).
+        /// `afterBytes: 0` is the headers-but-no-body variant, i.e. a generation that never sees a
+        /// first byte.
+        case serveThenGoSilent(afterBytes: Int64)
     }
 
     let port: UInt16
@@ -191,9 +198,12 @@ final class ThrottledOriginServer: @unchecked Sendable {
         let requestIndex = _requestLog.count - 1
         lock.unlock()
 
+        var silentAfter: Int64? = nil
         switch respond(requestIndex, offset, path) {
         case .serve206:
             break
+        case .serveThenGoSilent(let afterBytes):
+            silentAfter = max(0, afterBytes)
         case .status(let code, let retryAfter):
             let header = "HTTP/1.1 \(code) Status\r\n"
                 + (retryAfter.map { "Retry-After: \($0)\r\n" } ?? "")
@@ -240,7 +250,15 @@ final class ThrottledOriginServer: @unchecked Sendable {
         let chunk = [UInt8](repeating: 0x55, count: chunkBytes)
         var served: Int64 = 0
         while served < remaining && !stopped {
-            let n = Int(min(Int64(chunkBytes), remaining - served))
+            // #309: the silent-death point. Neither close() nor shutdown(): the peer must keep an
+            // established connection with an unfinished body, so the reader sees no bytes, no EOF
+            // and no error. `stop()` is what releases this thread and the socket.
+            if let silentAfter, served >= silentAfter {
+                while !stopped { usleep(50_000) }
+                return false
+            }
+            var n = Int(min(Int64(chunkBytes), remaining - served))
+            if let silentAfter { n = Int(min(Int64(n), silentAfter - served)) }
             guard writeBody(fd, Array(chunk[0..<n])) else { return false }
             served += Int64(n)
             if throttleUs > 0 { usleep(throttleUs) }


### PR DESCRIPTION
Addresses #309. Two defects, and only the first one is in the report.

## Detection: the watchdog only ticked inside a waiting read()

`connStallTimeout` was evaluated in exactly one place, the read loop's forward wait (`AVIOReader.swift:1351` before this change), so a transport that died while the sliding window could still serve reads was noticed only once a consumer happened to block on it. The transport does not cover that gap either: the persistent request is issued with `request.timeoutInterval = 0` on purpose, so the reader is the only detector there is.

A delivery-gap watchdog now ends a generation that has an installed transfer and no delivery for `connStallTimeout`, whether or not a read is waiting on it. Same threshold, same action as the read-side wait; what is removed is the accidental exemption for a well-buffered reader. One pending closure per generation on a shared serial queue: it either ends the connection or re-arms itself for the remaining gap, so a healthy transfer costs one timestamp comparison per `connStallTimeout` and an ended generation arms nothing.

It only ENDS, it never reconnects. Opening connections stays with the read thread, so a paused player still holds no flow (the #310 invariant) and a parked consumer cannot be turned into a timer-paced reconnect loop (the #307 failure mode). The gap is named in a release-visible line, which is what the field case had no witness for.

The threshold stays 20 s and stays out of `LoadOptions`: #272 measured that a shorter one is worse under CPU starvation, and that conclusion is unchanged. The new hook is a test clock only.

## Recovery: a faulted connection waited for an EMPTY window

This is where the measured harm was, and detection alone would not have moved it. The frontier refill fired only for PLANNED ends (`connEndedAtRangeEnd || connEndedByBackpressure`); a generation that ended in fault was replaced only once `available == 0`. The reader therefore spent its entire read-ahead before asking for a replacement, which is why playback rejoined the clock with a burst (+17 MB in one interval, 389 dropped frames in the report) rather than simply carrying on.

The refill condition is now "no flow installed and the consumer has drawn down to low water", for every reason there is no flow. The reason still selects the policy: a planned end costs nothing, a fault pays the failure ladder (status accounting, pin invalidation, bounded give-up), with two deliberate differences from the empty-window ladder:

- **No backoff sleep.** It runs on the demux thread with megabytes still resident, and sleeping there would starve the demuxer of exactly the read-ahead that replacing early exists to protect. The wait is a next-attempt timestamp, so reads keep being served at full speed between attempts.
- **It never fails the read.** A window that can still serve must not kill a session holding seconds of playback. At the cap it stops attempting and leaves termination to the empty-window ladder, where it has always been. It also emits no `.reconnecting` phase while the window serves: playback is uninterrupted there, and a phase flapping per read would describe bookkeeping rather than what the viewer sees.

## The trade this makes, stated plainly

An origin that pauses for more than `connStallTimeout` mid-body while its socket stays alive now loses that connection, where a well-buffered reader used to ride the pause out. That is already the engine's policy whenever the window is thin (which is the common case on a slow link), so this makes it consistent rather than new; and for a live source a 20 s delivery gap means the content is gone from that connection anyway. The replacement is asked for at low water rather than immediately, so a hiccup shorter than the remaining runway costs one range request and no visible interruption.

## Verification

- `Issue309SilentTransportDeathTests`, against a loopback origin that stops writing mid-body without closing the socket and without a FIN, which is the reader-observable shape of the field case (`ThrottledOriginServer.Directive.serveThenGoSilent`). Four cases: a flow that dies mid-window is ended with no read blocking on it; a generation that never sees a first byte is ended too; the replacement is requested while read-ahead remains; and a backpressure-parked reader is NOT treated as a dead flow.
- Falsification, both parts separately: with the watchdog disarmed the dead flow stays installed after 6x the threshold; with the runway refill disabled the replacement is asked for with 0 KB of read-ahead left. The regression case passes in both arms.
- Full suite: 1548 tests, all passing.
- Real media, `aetherctl play --seconds 40` on a 365 MB moov-at-end MP4 through a Range-logging origin paced at 4 MB/s with a 60 ms header delay: identical request sequence and cadence to `main` (six requests, same offsets, ~9 s apart), zero watchdog lines, zero faults.

- Measured, with a positive control, that the transport really does not cover this: against an
  origin that answers 206 headers and then goes silent, a request with `timeoutInterval = 5`
  fails `-1001` after 5.0 s, while `timeoutInterval = 0` (what the persistent path uses) was
  still running after 100 s even though the session config carries the default 60 s
  `timeoutIntervalForRequest`. So a per-request 0 disables the idle timer and overrides the
  session value, and the pre-fix exposure was unbounded rather than capped at 60 s.

The runway assertion is read from the ORIGIN's thread at the moment it receives the replacement request, not from a wall clock: a loopback origin answers in microseconds, so timing could not express it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
