### PR TITLE
test(io): keep the #309 cases off process-wide hooks (#309 follow-up)

### DIFF
--- a/Sources/AetherEngine/AetherEngine.swift
+++ b/Sources/AetherEngine/AetherEngine.swift
@@ -893,14 +893,6 @@ public final class AetherEngine: ObservableObject {
     /// ~13 exponential backoffs finish in test time instead of a minute of real sleeping.
     nonisolated(unsafe) static var reconnectBackoffScaleForTesting = 1.0
 
-    /// TEST-ONLY: overrides the reader's connection stall threshold in seconds (0 = the shipped
-    /// default). Read once by each `AVIOReader` at init, so set it before `load`/`start`. Lets the
-    /// #309 delivery-gap watchdog be exercised in test time instead of 20 s per case. Deliberately
-    /// NOT a `LoadOptions` field: #272 measured that a shorter threshold is WORSE under CPU
-    /// starvation (it redials exactly when there are no cycles to spare), and that conclusion is
-    /// unchanged. This is a test clock, not a tuning knob.
-    nonisolated(unsafe) static var connStallTimeoutForTesting: TimeInterval = 0
-
     /// Reads `AVPlayer.eligibleForHDRPlayback` and `AVPlayer.availableHDRModes` at call time.
     /// Eligibility is display-configuration aware on all platforms (its change notification fires
     /// on display connection/disconnection), so per-load reads pick up monitor changes; the value

--- a/Sources/AetherEngine/Demuxer/AVIOReader.swift
+++ b/Sources/AetherEngine/Demuxer/AVIOReader.swift
@@ -482,9 +482,16 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
     private let throttleKbps: Int
     /// TEST-ONLY reconnect-backoff scale (1.0 = real timing), captured once from the static hook at init.
     private let backoffScale: Double
-    /// Stall threshold this reader runs with: `connStallTimeoutDefault`, or the TEST-ONLY hook when
-    /// set. One value for both detectors, because they are one policy: a connection that has
-    /// delivered nothing for this long is replaced, whether or not a read is waiting on it (#309).
+    /// Stall threshold this reader runs with, `connStallTimeoutDefault` unless a caller overrides it.
+    /// One value for both detectors, because they are one policy: a connection that has delivered
+    /// nothing for this long is replaced, whether or not a read is waiting on it (#309).
+    ///
+    /// An init parameter rather than a process-wide test hook on purpose. The hooks next to it are
+    /// read at every reader's init, so a test that sets one changes the behaviour of every reader any
+    /// CONCURRENTLY running suite happens to build, and swift-testing runs suites in parallel. A
+    /// shortened stall threshold leaking that way would make other suites reconnect early under
+    /// load. It is not a `LoadOptions` field either: #272 measured that a shorter threshold is worse
+    /// under CPU starvation, and that conclusion is unchanged.
     private let connStallTimeout: TimeInterval
     private var throttleVClockNs: UInt64 = 0
     private let throttleLock = NSLock()
@@ -493,7 +500,7 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
     /// origin at once and the line used to name none of them.
     private let label: String
 
-    init(url: URL, extraHeaders: [String: String] = [:], label: String = "source", chunkSize: Int = 4 * 1024 * 1024, prefetchEnabled: Bool = true, isLive: Bool = false, chunkRequestTimeout: TimeInterval = 35, chunkMaxRetries: Int = 3, boundedInitialFetch: Int64? = nil) {
+    init(url: URL, extraHeaders: [String: String] = [:], label: String = "source", chunkSize: Int = 4 * 1024 * 1024, prefetchEnabled: Bool = true, isLive: Bool = false, chunkRequestTimeout: TimeInterval = 35, chunkMaxRetries: Int = 3, boundedInitialFetch: Int64? = nil, connStallTimeout: TimeInterval = AVIOReader.connStallTimeoutDefault) {
         self.url = url
         self.label = label
         self.extraHeaders = extraHeaders
@@ -505,8 +512,7 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
         self.boundedInitialFetch = boundedInitialFetch.map { max(1, $0) }
         self.throttleKbps = AetherEngine.sourceThrottleKbpsForTesting
         self.backoffScale = AetherEngine.reconnectBackoffScaleForTesting
-        let stallOverride = AetherEngine.connStallTimeoutForTesting
-        self.connStallTimeout = stallOverride > 0 ? stallOverride : Self.connStallTimeoutDefault
+        self.connStallTimeout = max(0.05, connStallTimeout)
     }
 
     /// Slow-CDN simulation: hold delivered bytes to `throttleKbps` by sleeping the demux thread before the

--- a/Tests/AetherEngineTests/Issue255BodyReserveTests.swift
+++ b/Tests/AetherEngineTests/Issue255BodyReserveTests.swift
@@ -323,9 +323,17 @@ struct Issue255BodyReserveTests {
         defer { server.stop() }
 
         AVIOReader.peakBodyReserveForTesting = 0
+        // The budget matters here, because it bounds the wait for the staggered probe ladder:
+        // `sizeProbeStaggerSeconds + min(25, chunkRequestTimeout) + 2`. At 5 that is 7.75 s, and a
+        // loaded CI runner took longer than that to get the HEAD fallback's closure onto a thread:
+        // `open()` broke out of the wait, the reader fell back to streaming mode, and this test read
+        // "the HEAD fallback never ran" from a request log that only held the primary probe (one
+        // observed failure, green on the next run of the same commit). The wait exits as soon as a
+        // size resolves, so a wider ceiling costs nothing in the healthy case and only buys the
+        // fallback the room to actually be measured.
         let reader = AVIOReader(url: URL(string: "http://127.0.0.1:\(server.port)/big.mkv")!,
                                 chunkSize: 1024 * 1024, prefetchEnabled: false,
-                                chunkRequestTimeout: 5)
+                                chunkRequestTimeout: 15)
         defer { reader.markClosed(); reader.close() }
         try reader.open()
 

--- a/Tests/AetherEngineTests/Issue309SilentTransportDeathTests.swift
+++ b/Tests/AetherEngineTests/Issue309SilentTransportDeathTests.swift
@@ -20,7 +20,10 @@ import Foundation
 /// is the reader-observable shape of the field case (URLSession surfaced nothing until the task was
 /// later cancelled).
 ///
-/// `.serialized`: these tests mutate the process-wide stall-timeout, throttle and backoff hooks.
+/// `.serialized`: one case mutates the process-wide backoff-scale hook, and keeping the four off each
+/// other's timing is worth more than running them concurrently. The stall threshold and the consumer
+/// pace are deliberately NOT process-wide hooks: swift-testing runs suites in parallel, and a hook
+/// that every reader reads at init would reach into whatever suite happens to run alongside this one.
 @Suite("Silent transport death (#309)", .serialized)
 struct Issue309SilentTransportDeathTests {
 
@@ -69,8 +72,12 @@ struct Issue309SilentTransportDeathTests {
         }
     }
 
+    /// `bytesPerSecond` paces the CONSUMER inside this loop rather than through
+    /// `AetherEngine.sourceThrottleKbpsForTesting`. That hook is read at every reader's init, so
+    /// setting it would throttle the readers of every suite swift-testing happens to run in parallel
+    /// with this one. Pacing here is local by construction.
     private static func read(_ reader: AVIOReader, bytes target: Int, sliceCap: Int = 256 * 1024,
-                            deadline: TimeInterval = 30) -> Int {
+                            deadline: TimeInterval = 30, bytesPerSecond: Int = 0) -> Int {
         let buf = UnsafeMutablePointer<UInt8>.allocate(capacity: sliceCap)
         defer { buf.deallocate() }
         var got = 0
@@ -79,6 +86,9 @@ struct Issue309SilentTransportDeathTests {
             let n = reader.read(into: buf, size: Int32(min(sliceCap, target - got)))
             if n <= 0 { break }
             got += Int(n)
+            if bytesPerSecond > 0 {
+                Thread.sleep(forTimeInterval: Double(n) / Double(bytesPerSecond))
+            }
         }
         return got
     }
@@ -99,9 +109,6 @@ struct Issue309SilentTransportDeathTests {
           .timeLimit(.minutes(2)))
     func deadFlowIsEndedWithoutAWaitingRead() async throws {
         let stallTimeout: TimeInterval = 0.6
-        AetherEngine.connStallTimeoutForTesting = stallTimeout
-        defer { AetherEngine.connStallTimeoutForTesting = 0 }
-
         let silenceOffset = Self.silenceOffset
         // Built into a local first: `#require` wraps its expression in a @Sendable closure, which a
         // capturing origin closure cannot cross.
@@ -113,7 +120,8 @@ struct Issue309SilentTransportDeathTests {
         let server = try #require(serverMaybe)
         defer { server.stop() }
         let reader = AVIOReader(url: URL(string: "http://127.0.0.1:\(server.port)/movie.bin")!,
-                                boundedInitialFetch: Self.firstRange)
+                                boundedInitialFetch: Self.firstRange,
+                                connStallTimeout: stallTimeout)
         defer { reader.markClosed(); reader.close() }
         try reader.open()
 
@@ -144,12 +152,8 @@ struct Issue309SilentTransportDeathTests {
     @Test("a generation that never sees a first byte is ended too", .timeLimit(.minutes(2)))
     func headersWithoutABodyAreEnded() async throws {
         let stallTimeout: TimeInterval = 0.6
-        AetherEngine.connStallTimeoutForTesting = stallTimeout
         AetherEngine.reconnectBackoffScaleForTesting = 0.02
-        defer {
-            AetherEngine.connStallTimeoutForTesting = 0
-            AetherEngine.reconnectBackoffScaleForTesting = 1.0
-        }
+        defer { AetherEngine.reconnectBackoffScaleForTesting = 1.0 }
 
         let silenceOffset = Self.silenceOffset
         let attempts = AttemptCounter()
@@ -162,7 +166,8 @@ struct Issue309SilentTransportDeathTests {
         let server = try #require(serverMaybe)
         defer { server.stop() }
         let reader = AVIOReader(url: URL(string: "http://127.0.0.1:\(server.port)/movie.bin")!,
-                                boundedInitialFetch: Self.firstRange)
+                                boundedInitialFetch: Self.firstRange,
+                                connStallTimeout: stallTimeout)
         defer { reader.markClosed(); reader.close() }
         try reader.open()
 
@@ -187,15 +192,10 @@ struct Issue309SilentTransportDeathTests {
           .timeLimit(.minutes(3)))
     func runwayIsRefilledBeforeItDrains() async throws {
         let stallTimeout: TimeInterval = 0.5
-        AetherEngine.connStallTimeoutForTesting = stallTimeout
         // A consumer at ~2 MB/s, so the 6 MB resident at the moment of death is worth seconds of
         // playback rather than the microseconds a loopback memcpy would take. Without a paced
         // consumer this test would measure the harness, not the reader.
-        AetherEngine.sourceThrottleKbpsForTesting = 16_000
-        defer {
-            AetherEngine.connStallTimeoutForTesting = 0
-            AetherEngine.sourceThrottleKbpsForTesting = 0
-        }
+        let consumerBytesPerSecond = 2 * 1024 * 1024
 
         let silenceOffset = Self.silenceOffset
         let silentBytes: Int64 = 4 * 1024 * 1024
@@ -210,7 +210,8 @@ struct Issue309SilentTransportDeathTests {
         let server = try #require(serverMaybe)
         defer { server.stop() }
         let reader = AVIOReader(url: URL(string: "http://127.0.0.1:\(server.port)/movie.bin")!,
-                                boundedInitialFetch: Self.firstRange)
+                                boundedInitialFetch: Self.firstRange,
+                                connStallTimeout: stallTimeout)
         defer { reader.markClosed(); reader.close() }
         probe.attach(reader)
         try reader.open()
@@ -218,7 +219,8 @@ struct Issue309SilentTransportDeathTests {
         // Read straight through the death. 7 MB is past everything the silenced generation and the
         // first range delivered (6 MB), so completing it can only happen through a replacement.
         let target = 7 * 1024 * 1024
-        let got = Self.read(reader, bytes: target, deadline: 60)
+        let got = Self.read(reader, bytes: target, deadline: 60,
+                            bytesPerSecond: consumerBytesPerSecond)
         #expect(got == target, "read stopped at \(got / 1024) KB of \(target / 1024) KB")
 
         let runway = try #require(probe.runwayAtRequest,
@@ -232,12 +234,11 @@ struct Issue309SilentTransportDeathTests {
     @Test("a backpressure-parked reader is not treated as a dead flow", .timeLimit(.minutes(2)))
     func parkedIsNotStalled() async throws {
         let stallTimeout: TimeInterval = 0.5
-        AetherEngine.connStallTimeoutForTesting = stallTimeout
-        defer { AetherEngine.connStallTimeoutForTesting = 0 }
 
         let server = try #require(ThrottledOriginServer(totalSize: Self.totalSize))
         defer { server.stop() }
-        let reader = AVIOReader(url: URL(string: "http://127.0.0.1:\(server.port)/movie.bin")!)
+        let reader = AVIOReader(url: URL(string: "http://127.0.0.1:\(server.port)/movie.bin")!,
+                                connStallTimeout: stallTimeout)
         defer { reader.markClosed(); reader.close() }
         try reader.open()
 

--- a/Tests/AetherEngineTests/ThrottledOriginServer.swift
+++ b/Tests/AetherEngineTests/ThrottledOriginServer.swift
@@ -254,7 +254,7 @@ final class ThrottledOriginServer: @unchecked Sendable {
             // established connection with an unfinished body, so the reader sees no bytes, no EOF
             // and no error. `stop()` is what releases this thread and the socket.
             if let silentAfter, served >= silentAfter {
-                while !stopped { usleep(50_000) }
+                while !stopped { usleep(200_000) }
                 return false
             }
             var n = Int(min(Int64(chunkBytes), remaining - served))


### PR DESCRIPTION
Follow-up to #325. No behaviour change to the shipped path; it removes a test-side hazard and gives one unrelated test the budget it needs.

## What the branch CI failure actually was

The CI run on #325 failed `Issue255BodyReserveTests` "the HEAD size probe does not reserve the source it declares", and the same commit was green on `main` on the next run. The log names the cause arithmetically: `probeFileSize` bounds its wait at `sizeProbeStaggerSeconds + min(25, chunkRequestTimeout) + 2`, which at that test's `chunkRequestTimeout: 5` is 7.75 s, and the test failed after 7.806 s. The loaded runner did not get the staggered HEAD fallback's closure onto a thread inside that budget, `open()` broke out of the wait, the reader fell back to streaming mode, and the test read "the HEAD fallback never ran" from a request log holding only the primary probe. Its budget now has room. The wait still exits the moment a size resolves, so nothing changes when the origin behaves.

## The hazard worth removing

swift-testing runs suites in parallel, and `sourceThrottleKbpsForTesting` / the stall-timeout hook are read by every `AVIOReader` at ITS OWN init. For the seconds a test held them, they applied to readers built by whatever suite happened to be running alongside it. A 2 MB/s source throttle leaking that way starves another suite's reader outright, and a shortened stall threshold makes it reconnect early.

- `connStallTimeout` is now an init parameter, exactly like `chunkRequestTimeout`, and the process-wide hook that #325 added is deleted. Still not a `LoadOptions` field: #272 measured a shorter threshold to be worse under CPU starvation, unchanged.
- The runway test paces its own read loop instead of reaching for the global throttle.

## Measured

Saturated box (10 concurrent 1080p60 encodes, ~690% of 800%): three consecutive full-suite runs green. The suite also went from ~19.5 s to ~12.8 s under the same load, which is the leaked throttle no longer slowing other suites' readers down.

The #309 cases still pass and still fail when either half of the fix is disarmed; passing at all is now also the proof that the threshold parameter is wired, since at the shipped 20 s none of them would finish in time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)