### PR TITLE
fix(frame-times): draw the producer epoch and flush generation process-wide (#314)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ the public-API contract.
 
 ### Fixed
 
+- **Frame-time epochs keep rising across a `load()`, so a host can tell one item's frames from the
+  next's.** `NativeVideoFrameTime.epoch` and `SoftwareVideoFrameTime.generation` both document the
+  rule that a higher value retires everything recorded under a lower one, but both were counted per
+  session: a load builds a new `HLSVideoEngine` (and a new software renderer), the counter restarted
+  at zero, and the rule inverted at exactly the seam it exists for. A report still arriving from the
+  outgoing session outranked everything the incoming one would ever emit, so a host that ordered by
+  it discarded the whole new item rather than the stale entries. Both values are now drawn from a
+  process-wide sequence, so the superseded session always ranks below the next one, and a superseded
+  session is also detached from the observer at teardown so in the ordinary case it falls silent
+  instead of racing. Successive values are strictly increasing but no longer consecutive; ordering
+  was always the contract (#314, reported by [@edde746](https://github.com/edde746)).
 - **The software renderer's metrics read builds across SDK generations again.**
   `loadRenderMetrics()` read `displayLayer.sampleBufferRenderer` and then suspended on that
   renderer's async accessor, and no single `await` on it satisfies both ends of the toolchain range:

--- a/README.md
+++ b/README.md
@@ -216,13 +216,16 @@ player.$currentAVPlayerItem                       // items swap in place; this i
 
 // Per muxed video frame, on both axes at once. Called on the producer's pump thread in DECODE order,
 // so `source` is not monotonic under B-frames; sort before using it as a frame-boundary list.
+// `epoch` rises strictly, process-wide: a restart and a load() both continue the sequence, so
+// "a higher epoch retires my older entries" separates one item's frames from the next's.
 player.setNativeVideoFrameTimeObserver { frame in
     frame.source; frame.item; frame.segmentIndex; frame.isKeyframe; frame.epoch
 }
 
 // The same question on the software path (#311), where the engine decodes and enqueues the source
 // timestamp unchanged: one axis, no segments, and the reports arrive past the reorder buffer in
-// ASCENDING presentation order. `generation` moves on every renderer flush, i.e. on a seek.
+// ASCENDING presentation order. `generation` moves on every renderer flush, i.e. on a seek, and
+// rises across a load() the same way `epoch` does.
 player.softwarePresentationTimebase               // the master clock, on the source axis
 player.setSoftwareVideoFrameTimeObserver { frame in
     frame.presentation; frame.generation

--- a/Sources/AetherEngine/AetherEngine+FrameTimes.swift
+++ b/Sources/AetherEngine/AetherEngine+FrameTimes.swift
@@ -12,6 +12,11 @@ extension AetherEngine {
     /// The observer is called on the producer's pump thread and must not block. It survives producer
     /// restarts and outlives a `load()`, so install it once; pass nil to remove it. Use
     /// `presentationAxisMap` to convert positions that are not frames (a cue time, a clock reading).
+    ///
+    /// A load is not a seam a consumer has to reason about: `NativeVideoFrameTime.epoch` keeps rising
+    /// across it (#314), so the same retire-the-older-epoch rule separates the outgoing item's frames
+    /// from the incoming one's. The superseded session is also detached at teardown, so in the ordinary
+    /// case it falls silent rather than racing the new one.
     public func setNativeVideoFrameTimeObserver(_ observer: NativeVideoFrameTimeObserver?) {
         nativeVideoFrameTimeObserver = observer
         nativeVideoSession?.setNativeVideoFrameTimeObserver(observer)
@@ -25,8 +30,9 @@ extension AetherEngine {
     /// to key a table by. See `SoftwareVideoFrameTime`.
     ///
     /// The observer is called on the decode thread and must not block. It outlives a `load()`, so
-    /// install it once; pass nil to remove it. Silent on every other path, including the remote-HLS
-    /// bypass, where AVPlayer owns decode and the engine never sees a frame.
+    /// install it once; pass nil to remove it. `SoftwareVideoFrameTime.generation` keeps rising across
+    /// that load (#314), so the item seam needs no separate handling. Silent on every other path,
+    /// including the remote-HLS bypass, where AVPlayer owns decode and the engine never sees a frame.
     public func setSoftwareVideoFrameTimeObserver(_ observer: SoftwareVideoFrameTimeObserver?) {
         softwareVideoFrameTimeObserver = observer
         softwareHost?.setVideoFrameTimeObserver(observer)

--- a/Sources/AetherEngine/AetherEngine.swift
+++ b/Sources/AetherEngine/AetherEngine.swift
@@ -4610,6 +4610,10 @@ public final class AetherEngine: ObservableObject {
             nativeHost = nil
             currentAVPlayer = nil
         }
+        // #314: detach before stop() so a pump still unwinding does not report frames into a table the
+        // host has already retired for the next item. Only the session's slot is cleared; the engine
+        // keeps the host's observer and re-arms the next session with it in load().
+        nativeVideoSession?.setNativeVideoFrameTimeObserver(nil)
         nativeVideoSession?.stop()
         nativeVideoSession = nil
         nativeSubtitleRenditionsServed = false
@@ -4633,6 +4637,9 @@ public final class AetherEngine: ObservableObject {
         }
 
         softwareCancellables.removeAll()
+        // #314: same detach on the software path, where the outgoing renderer's decode thread is what
+        // can still hand a frame over while the next host comes up.
+        softwareHost?.setVideoFrameTimeObserver(nil)
         softwareHost?.stop()
         softwarePiPSource = nil
         softwareHost = nil

--- a/Sources/AetherEngine/FrameTimeSequence.swift
+++ b/Sources/AetherEngine/FrameTimeSequence.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// Process-wide monotonic allocator for the discriminators a frame-time consumer orders by (#314).
+///
+/// `NativeVideoFrameTime.epoch` and `SoftwareVideoFrameTime.generation` both carry the same rule: a
+/// higher value retires every entry a consumer recorded under a lower one. A per-instance counter
+/// satisfies that only inside one session. `load()` builds a fresh session (and, on the software path,
+/// a fresh renderer), so the counter restarted at zero and the rule inverted across the seam: a
+/// straggling report from the outgoing session outranked everything the incoming one would ever emit,
+/// and a host that ordered by it dropped the whole new item rather than the stale entries.
+///
+/// Drawing the values process-wide restores the rule end to end. A superseded producer's last report
+/// is always lower than the next session's first, so "higher retires, lower is stale" holds across a
+/// load exactly as it does across a producer restart. It is an ordering guarantee, not a session
+/// fence: a straggler can still land in a freshly reset table and be retired a moment later by the new
+/// session's first report, which for a consumer whose lookup miss already means "not known yet, retry"
+/// is a transient rather than a wrong mapping.
+final class FrameTimeSequence: @unchecked Sendable {
+
+    private let lock = NSLock()
+    private var value: UInt64 = 0
+
+    /// The next value. Strictly increasing, never zero, and shared by every caller of this instance.
+    func next() -> UInt64 {
+        lock.lock(); defer { lock.unlock() }
+        value &+= 1
+        return value
+    }
+}

--- a/Sources/AetherEngine/NativeVideoFrameTime.swift
+++ b/Sources/AetherEngine/NativeVideoFrameTime.swift
@@ -28,9 +28,15 @@ public struct NativeVideoFrameTime: Sendable, Equatable {
     /// `AV_PKT_FLAG_KEY` on the source packet.
     public let isKeyframe: Bool
 
-    /// Producer epoch. Increments on every producer (re)start; a restart re-muxes segments from its
+    /// Producer epoch. Moves on at every producer (re)start; a restart re-muxes segments from its
     /// start index forward under a fresh shift, so entries from an older epoch describe bytes AVPlayer
     /// may no longer be able to reach. Drop a table's older epochs when this changes.
+    ///
+    /// Strictly increasing process-wide, across `load()` calls as well as within one session (#314):
+    /// the next item continues the sequence rather than restarting it, so a report that arrives from
+    /// the superseded producer while the next session is coming up always ranks below that session's
+    /// first, and the same "higher retires, lower is stale" rule sorts both cases. Successive epochs
+    /// are not consecutive and the values carry no meaning beyond their order.
     public let epoch: UInt64
 
     public init(source: CMTime, item: CMTime, segmentIndex: Int, isKeyframe: Bool, epoch: UInt64) {

--- a/Sources/AetherEngine/Renderer/SampleBufferRenderer.swift
+++ b/Sources/AetherEngine/Renderer/SampleBufferRenderer.swift
@@ -53,9 +53,16 @@ final class SampleBufferRenderer: @unchecked Sendable {
         reorderLock.unlock()
     }
 
-    /// #311: incremented by every flush, so a consumer can drop the frame times it recorded for
-    /// frames the compositor has since discarded. Guarded by `reorderLock`.
-    private var _flushGeneration: UInt64 = 0
+    /// #311: moved on by every flush, so a consumer can drop the frame times it recorded for frames the
+    /// compositor has since discarded. Guarded by `reorderLock`.
+    ///
+    /// Drawn from a process-wide allocator rather than counted from zero (#314). A load builds a new
+    /// renderer, and a renderer that started at zero would report below the outgoing one, which is the
+    /// order a consumer reads as "stale". The first value is drawn at init for the same reason: the
+    /// generation a renderer reports before its first flush has to rank above the previous renderer's
+    /// last, not tie with it. Successive values are therefore strictly increasing but not consecutive.
+    private static let flushGenerations = FrameTimeSequence()
+    private var _flushGeneration: UInt64 = SampleBufferRenderer.flushGenerations.next()
     var flushGeneration: UInt64 {
         reorderLock.lock()
         defer { reorderLock.unlock() }
@@ -279,7 +286,7 @@ final class SampleBufferRenderer: @unchecked Sendable {
         // however far the seek travelled.
         _newestEnqueuedPtsSeconds = nil
         // #311: everything reported before this point describes frames that are now gone.
-        _flushGeneration &+= 1
+        _flushGeneration = SampleBufferRenderer.flushGenerations.next()
         // Invalidate the format description cache; the next load() may open a stream with different colorimetry at the same resolution.
         cachedFormatDesc = nil
         cachedFormatKey = nil

--- a/Sources/AetherEngine/SoftwareVideoFrameTime.swift
+++ b/Sources/AetherEngine/SoftwareVideoFrameTime.swift
@@ -22,11 +22,16 @@ public struct SoftwareVideoFrameTime: Sendable, Equatable {
     /// `AetherEngine.softwarePresentationTimebase` reads, so no conversion stands between them.
     public let presentation: CMTime
 
-    /// Renderer flush generation. Increments whenever the renderer discards what it holds, which is
-    /// what a seek does, so entries recorded under an older generation describe frames the compositor
-    /// will never show. Drop a table's older generations when this changes. Same role as
+    /// Renderer flush generation. Moves on whenever the renderer discards what it holds, which is what
+    /// a seek does, so entries recorded under an older generation describe frames the compositor will
+    /// never show. Drop a table's older generations when this changes. Same role as
     /// `NativeVideoFrameTime.epoch`, different cause: there a producer restart re-muxes, here a flush
     /// empties the queue.
+    ///
+    /// Strictly increasing process-wide, across `load()` calls as well as within one session (#314). A
+    /// load builds a new renderer, and the sequence continues there rather than restarting, so a frame
+    /// the outgoing renderer still hands over always ranks below the new one's first. Successive
+    /// generations are not consecutive and the values carry no meaning beyond their order.
     public let generation: UInt64
 
     public init(presentation: CMTime, generation: UInt64) {

--- a/Sources/AetherEngine/Video/HLSVideoEngine.swift
+++ b/Sources/AetherEngine/Video/HLSVideoEngine.swift
@@ -158,15 +158,15 @@ public final class HLSVideoEngine: @unchecked Sendable {
         return _nativeVideoFrameTimeObserver
     }
 
-    /// Monotonic producer generation handed to each producer (#260). Own lock: `makeProducer` runs both
-    /// under `restartLock` (live reopen) and outside it (initial bring-up).
-    private let producerEpochLock = NSLock()
-    private var producerEpochCounter: UInt64 = 0
+    /// Monotonic producer generation handed to each producer (#260). Process-wide rather than per
+    /// session (#314): a `load()` builds a new HLSVideoEngine, and a per-instance counter would restart
+    /// under a host that is still holding the outgoing session's reports. Its own allocator, with its
+    /// own lock, because `makeProducer` runs both under `restartLock` (live reopen) and outside it
+    /// (initial bring-up), and because two sessions overlap while the outgoing one unwinds.
+    private static let producerEpochs = FrameTimeSequence()
 
     private func nextProducerEpoch() -> UInt64 {
-        producerEpochLock.lock(); defer { producerEpochLock.unlock() }
-        producerEpochCounter &+= 1
-        return producerEpochCounter
+        HLSVideoEngine.producerEpochs.next()
     }
 
     /// Sodalite#32: ordinal-aligned source stream indices for the native subtitle cue stores (nil entry =

--- a/Tests/AetherEngineTests/Issue311SoftwareFrameTimesTests.swift
+++ b/Tests/AetherEngineTests/Issue311SoftwareFrameTimesTests.swift
@@ -72,6 +72,10 @@ struct Issue311SoftwareFrameTimesTests {
     /// A seek flushes, and everything recorded before it describes frames the compositor no longer
     /// holds. Without a generation a consumer's table would keep entries that look current, and on a
     /// backward seek the two runs overlap in time, so the timestamps alone cannot separate them.
+    ///
+    /// The assertions are inequalities: since #314 the generation is drawn from a process-wide
+    /// sequence, so a renderer in a parallel test legitimately consumes values in between. Ordering is
+    /// the contract, consecutive values never were.
     @Test("a flush moves the generation, so pre-seek frames are distinguishable")
     func flushMovesTheGeneration() {
         let renderer = SampleBufferRenderer()
@@ -84,7 +88,7 @@ struct Issue311SoftwareFrameTimesTests {
         let before = renderer.flushGeneration
 
         renderer.flush(removingDisplayedImage: false)   // the seek
-        #expect(renderer.flushGeneration == before + 1)
+        #expect(renderer.flushGeneration > before)
 
         // Backward seek: the same timestamp comes round again under the new generation.
         renderer.enqueue(pixelBuffer: Self.makePixelBuffer(),
@@ -93,7 +97,7 @@ struct Issue311SoftwareFrameTimesTests {
 
         #expect(seen.values.count == 2)
         #expect(seen.values[0].presentation == seen.values[1].presentation)
-        #expect(seen.values[1].generation == seen.values[0].generation + 1)
+        #expect(seen.values[1].generation > seen.values[0].generation)
     }
 
     // MARK: - Installation

--- a/Tests/AetherEngineTests/Issue314FrameTimeSequenceTests.swift
+++ b/Tests/AetherEngineTests/Issue314FrameTimeSequenceTests.swift
@@ -1,0 +1,192 @@
+import CoreMedia
+import Foundation
+import Testing
+@testable import AetherEngine
+
+/// Fixtures/ is local-only by design (gitignored; Scripts/fetch-fixtures.sh regenerates the
+/// synthetic clips). The fixture-backed test skips via `.enabled(if:)` when a clip is absent, e.g. on CI.
+private func fixtureURL(_ name: String) -> URL {
+    URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .appendingPathComponent("Fixtures")
+        .appendingPathComponent(name)
+}
+
+private func fixtureExists(_ name: String) -> Bool {
+    FileManager.default.fileExists(atPath: fixtureURL(name).path)
+}
+
+private final class EpochCollector: @unchecked Sendable {
+    private let lock = NSLock()
+    private var frames: [NativeVideoFrameTime] = []
+
+    func record(_ frame: NativeVideoFrameTime) {
+        lock.lock(); frames.append(frame); lock.unlock()
+    }
+
+    func snapshot() -> [NativeVideoFrameTime] {
+        lock.lock(); defer { lock.unlock() }; return frames
+    }
+}
+
+private final class GenerationCollector: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: [SoftwareVideoFrameTime] = []
+
+    var values: [SoftwareVideoFrameTime] {
+        lock.lock(); defer { lock.unlock() }; return storage
+    }
+
+    func append(_ value: SoftwareVideoFrameTime) {
+        lock.lock(); storage.append(value); lock.unlock()
+    }
+}
+
+/// AE#314: the frame-time discriminators are ordered process-wide, not per session.
+///
+/// Both public frame-time types document the same rule: a higher value retires everything recorded
+/// under a lower one. A `load()` builds a new session and a new renderer, so per-instance counters made
+/// that rule invert at exactly the seam it is needed at, and a host that ordered by it dropped the new
+/// item's frames for as long as the item played.
+///
+/// Every assertion here is an inequality on purpose. The sequences are process-wide, so a test running
+/// in parallel legitimately consumes values in between; consecutive values are not part of the contract.
+@Suite("Frame-time sequences across loads (#314)")
+struct Issue314FrameTimeSequenceTests {
+
+    // MARK: - The allocator
+
+    @Test("the sequence is strictly increasing and never zero")
+    func sequenceIsStrictlyIncreasing() {
+        let sequence = FrameTimeSequence()
+        let values = (0..<8).map { _ in sequence.next() }
+
+        #expect(values.first == 1, "the first value must outrank an unset UInt64")
+        #expect(zip(values, values.dropFirst()).allSatisfy { $0 < $1 })
+    }
+
+    /// Two sessions overlap while the outgoing one unwinds, so the allocator is read from two threads
+    /// that no engine-side lock covers together. A dropped increment would hand two producers the same
+    /// epoch, which is the one value ordering cannot separate.
+    @Test("concurrent draws never collide")
+    func concurrentDrawsAreUnique() {
+        let sequence = FrameTimeSequence()
+        let sink = ValueSink()
+
+        DispatchQueue.concurrentPerform(iterations: 8) { _ in
+            for _ in 0..<500 { sink.append(sequence.next()) }
+        }
+
+        let drawn = sink.values
+        #expect(drawn.count == 4000)
+        #expect(Set(drawn).count == 4000, "two callers were handed the same value")
+    }
+
+    // MARK: - Software path
+
+    /// The load seam, without media: a load builds a new `SampleBufferRenderer`, and the outgoing one
+    /// has usually flushed at least once (any seek during the previous item). A renderer counting from
+    /// zero therefore came up *below* the one it replaces, and a host applying the documented rule
+    /// discarded every frame of the new item.
+    @Test("a new renderer reports above the one it replaces")
+    func newRendererOutranksTheOutgoingOne() throws {
+        let outgoing = SampleBufferRenderer()
+        let outgoingFrames = GenerationCollector()
+        outgoing.setFrameEnqueuedObserver { outgoingFrames.append($0) }
+
+        outgoing.enqueue(pixelBuffer: Self.makePixelBuffer(),
+                         pts: CMTime(seconds: 5.0, preferredTimescale: 600))
+        outgoing.drainReorderBuffer()
+        outgoing.flush(removingDisplayedImage: false)   // a seek in the outgoing item
+        outgoing.enqueue(pixelBuffer: Self.makePixelBuffer(),
+                         pts: CMTime(seconds: 60.0, preferredTimescale: 600))
+        outgoing.drainReorderBuffer()
+        let outgoingGeneration = try #require(outgoingFrames.values.last?.generation)
+
+        let incoming = SampleBufferRenderer()           // the load
+        let incomingFrames = GenerationCollector()
+        incoming.setFrameEnqueuedObserver { incomingFrames.append($0) }
+        incoming.enqueue(pixelBuffer: Self.makePixelBuffer(),
+                         pts: CMTime(seconds: 0.0, preferredTimescale: 600))
+        incoming.drainReorderBuffer()
+        let incomingGeneration = try #require(incomingFrames.values.first?.generation)
+
+        #expect(incomingGeneration > outgoingGeneration,
+                "new item reported generation \(incomingGeneration), outgoing item was at \(outgoingGeneration)")
+
+        // And a frame the outgoing renderer still hands over ranks below the new item, so it is retired
+        // by the new item's first report rather than retiring it.
+        outgoing.enqueue(pixelBuffer: Self.makePixelBuffer(),
+                         pts: CMTime(seconds: 61.0, preferredTimescale: 600))
+        outgoing.drainReorderBuffer()
+        let straggler = try #require(outgoingFrames.values.last?.generation)
+        #expect(straggler < incomingGeneration,
+                "straggler reported \(straggler), which outranks the new item's \(incomingGeneration)")
+    }
+
+    // MARK: - Native path
+
+    /// Same seam on the native path, where the sessions are real: two `HLSVideoEngine` instances stand
+    /// in for the two sides of a `load()`, which is exactly how the engine builds them.
+    @Test("a new native session reports above the one it replaces",
+          .enabled(if: fixtureExists("restart-witness-av.mp4"),
+                   "run Scripts/fetch-fixtures.sh to generate the witness clip"),
+          .timeLimit(.minutes(2)))
+    func newNativeSessionOutranksTheOutgoingOne() throws {
+        let outgoingFrames = EpochCollector()
+        let outgoing = HLSVideoEngine(url: fixtureURL("restart-witness-av.mp4"), dvModeAvailable: false)
+        outgoing.setNativeVideoFrameTimeObserver { outgoingFrames.record($0) }
+        _ = try outgoing.start()
+        defer { outgoing.stop() }
+        let outgoingProvider = try #require(outgoing.provider)
+        #expect(outgoingProvider.mediaSegment(at: 0) != nil)
+        let outgoingEpoch = try #require(outgoingFrames.snapshot().last?.epoch)
+
+        // The next item. The outgoing session is deliberately still alive here: that is the state the
+        // host sees while its pump unwinds, and the state the per-instance counter got wrong.
+        let incomingFrames = EpochCollector()
+        let incoming = HLSVideoEngine(url: fixtureURL("restart-witness-av.mp4"), dvModeAvailable: false)
+        incoming.setNativeVideoFrameTimeObserver { incomingFrames.record($0) }
+        _ = try incoming.start()
+        defer { incoming.stop() }
+        let incomingProvider = try #require(incoming.provider)
+        #expect(incomingProvider.mediaSegment(at: 0) != nil)
+        let incomingEpoch = try #require(incomingFrames.snapshot().first?.epoch)
+
+        #expect(incomingEpoch > outgoingEpoch,
+                "new session opened at epoch \(incomingEpoch), the outgoing one was at \(outgoingEpoch)")
+
+        // A restart in the new session still outranks its own first epoch, so the within-session rule
+        // (#260) is untouched by the process-wide draw.
+        incoming.requestRestart(at: 1)
+        let deadline = Date().addingTimeInterval(30)
+        var restarted: [NativeVideoFrameTime] = []
+        while Date() < deadline {
+            restarted = incomingFrames.snapshot().filter { $0.epoch > incomingEpoch }
+            if !restarted.isEmpty { break }
+            usleep(50_000)
+        }
+        #expect(!restarted.isEmpty, "restarted producer emitted no frame times within 30s")
+    }
+
+    // MARK: - Helpers
+
+    private final class ValueSink: @unchecked Sendable {
+        private let lock = NSLock()
+        private var storage: [UInt64] = []
+        var values: [UInt64] {
+            lock.lock(); defer { lock.unlock() }; return storage
+        }
+        func append(_ value: UInt64) {
+            lock.lock(); storage.append(value); lock.unlock()
+        }
+    }
+
+    private static func makePixelBuffer() -> CVPixelBuffer {
+        var pb: CVPixelBuffer?
+        CVPixelBufferCreate(kCFAllocatorDefault, 16, 16, kCVPixelFormatType_32BGRA, nil, &pb)
+        return pb!
+    }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -148,6 +148,7 @@ Sources/AetherEngine/
 ├── NativeVideoFrameTime.swift               Per-muxed-frame presentation times on both axes (#260): the value type + observer typealias; emitted from HLSSegmentProducer.finalizeAndWriteVideo
 ├── SoftwareVideoFrameTime.swift             Per-enqueued-frame presentation time on the software path (#311): one axis (source == presentation there), plus a flush generation that a seek moves; emitted from SampleBufferRenderer.flushFrame
 ├── AetherEngine+FrameTimes.swift            Public installers for both per-frame time observers (native re-armed on each session, software on each host) plus `softwarePresentationTimebase`, the render synchronizer's clock
+├── FrameTimeSequence.swift                  Process-wide monotonic allocator behind NativeVideoFrameTime.epoch and SoftwareVideoFrameTime.generation (#314), so the ordering rule holds across a load() and not only inside one session
 ├── PlayerState.swift                        PlaybackState, PlaybackPhase, VideoFormat, PlaybackBackend, LoadOptions, SourceProbe, TrackInfo, FontAttachment, MediaMetadata, SubtitleCue, SubtitleImage
 ├── LiveReloadPolicy.swift                   Pure decision functions for live reloads: rejoin at the live edge (no stale resume position), skip the pre-readiness zero seek
 ├── TransportControllable.swift              Common transport surface of the four playback hosts (single active-host dispatch)


### PR DESCRIPTION
Refs #314.

## The defect

`NativeVideoFrameTime.epoch` and `SoftwareVideoFrameTime.generation` both document the same rule: a higher value retires every entry a consumer recorded under a lower one. Both were counted per session, and a `load()` builds a new `HLSVideoEngine` (`AetherEngine+Loading.swift`) and a new `SampleBufferRenderer` (`SoftwarePlaybackHost`), so the counter restarted at exactly the seam the rule exists for.

The observer is engine-scoped and documented to outlive a load, so the outgoing producer keeps reporting until `load` stops it. A host that retired its table at the start of the load could be handed a frame from the outgoing producer at epoch N, adopt N as newest, and then reject every frame of the new session (epochs 1, 2, ...) as stale for the rest of the item. `epoch` is the only discriminator that could separate them: `source`, `item` and `segmentIndex` all restart near zero on a new item.

## The fix

One `FrameTimeSequence`, a process-wide monotonic allocator with its own lock, behind both counters:

- `HLSVideoEngine.producerEpochs` (static) feeds `nextProducerEpoch()`.
- `SampleBufferRenderer.flushGenerations` (static) feeds both the initial generation and every flush. The initial draw matters as much as the flush draw: a renderer that came up at zero would tie with, or rank below, the one it replaces.

That restores the documented rule end to end without a public struct change, and hosts that only compare epochs relatively need no changes. Values stay strictly increasing but are no longer consecutive; the doc comments now say so.

The software path was not in the issue's scope but carries the identical defect against the identical contract, so it is fixed in the same pass rather than left to be reported separately.

`stopInternal` additionally detaches the outgoing session and the outgoing software host from the observer before stopping them. That does not replace the ordering guarantee (a pump can have snapshotted the observer already), it just means the ordinary case is silence rather than a correctly-sorted straggler.

## Verification

New suite `Issue314FrameTimeSequenceTests`:

- the allocator is strictly increasing, never zero, and collision-free under 8 concurrent drawers (two sessions overlap while the outgoing one unwinds);
- a new `SampleBufferRenderer` reports above the one it replaces, and a straggler from the outgoing renderer ranks below the new one's first report (fixture-free, runs on CI);
- two `HLSVideoEngine` instances over the witness clip, standing in for the two sides of a load: the incoming session's first epoch outranks the outgoing session's last, and a restart inside the new session still opens above its own first epoch, so #260's within-session behaviour is untouched (fixture-gated).

Negative control: with the per-instance counters restored, the native witness fails with `(incomingEpoch -> 1) > (outgoingEpoch -> 1)`, plus both software assertions. Full suite green afterwards, 1552 tests in 232 suites.

`Issue311SoftwareFrameTimesTests` moves from `== before + 1` to `> before`, since a process-wide sequence is legitimately advanced by a renderer in a parallel test. Ordering was always the contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HX5zV3Fcf7Nzq4DYGdXvQE