### PR TITLE
fix(telemetry): measure software throughput over the seconds bytes arrived in (#306 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ the public-API contract.
 
 ### Fixed
 
+- **The software path no longer reports 0.0 Mbps of throughput on a healthy session.**
+  `networkThroughputMbps` was a wall-clock mean over a 10 s window, but the reader fetches a large
+  range and then parks on backpressure until low water, so on a fast link most ticks of that window
+  carry no bytes at all: measured over a local origin, a healthy 2.8 Mbps VP9 session pulled 16.4 MB
+  in one tick and then exactly nothing for the next 23, while its runway drained from 16.0 to 8.3 MB.
+  The field read a confident 0.00 Mbps through all of it, which is the same false-with-confidence
+  zero #306 was filed about, one field over. It is measured over the seconds bytes actually arrived
+  in now, which is the quantity the native path already reports from `observedBitrate`, and it is nil
+  rather than zero when nothing arrived in the window at all. A host that wants a held reading can
+  keep the last non-nil value; a host given a zero could not tell a parked reader from a dead link.
+  A throttled origin is unaffected: every tick carries bytes there, and a starving 2 Mbps session
+  reads a steady 2.10 Mbps before and after (#306 follow-up, found while verifying
+  [@kskchaitanya1993](https://github.com/kskchaitanya1993)'s retest).
 - **Frame-time epochs keep rising across a `load()`, so a host can tell one item's frames from the
   next's.** `NativeVideoFrameTime.epoch` and `SoftwareVideoFrameTime.generation` both document the
   rule that a higher value retires everything recorded under a lower one, but both were counted per

--- a/Sources/AetherEngine/Diagnostics/LiveTelemetry.swift
+++ b/Sources/AetherEngine/Diagnostics/LiveTelemetry.swift
@@ -28,12 +28,21 @@ public struct LiveTelemetry: Equatable, Sendable {
     /// #306: bytes the playback reader has fetched but the demuxer has not consumed yet, i.e. the
     /// runway that exists ahead of the read cursor. Both paths; nil for sources with no `AVIOReader`
     /// (disc, custom provider). Bytes rather than seconds on purpose: seconds would need a bitrate
-    /// estimate baked in, and a host that wants one can divide by the throughput in this same snapshot.
+    /// estimate baked in, and a host that wants one divides by `averageBitrateMbps` from this same
+    /// snapshot. Not by `networkThroughputMbps`: that is the rate the link delivers at, so it answers
+    /// how long the runway took to fetch, not how long it will last at playback rate.
     public let readerWindowAheadBytes: Int?
     /// #306: the display's accumulated late-frame delay on the software path, nil on native and before
     /// the first metrics read. Cumulative for the session, so a rate comes from differencing two ticks.
     public let accumulatedFrameDelaySeconds: Double?
     public let cachedBytes: Int64?
+    /// The rate the source link delivers at while it is delivering, so it stays comparable between the
+    /// two paths: `observedBitrate` from the access log on native, and on the software path the
+    /// demuxer's own byte counter over the seconds bytes arrived in (#306 follow-up). Not a wall-clock
+    /// mean: the reader fetches a large range and parks on backpressure until low water, so a healthy
+    /// fast link is idle for most of a window and a mean over it would report 0.0 Mbps on a session
+    /// that is playing perfectly. nil when nothing arrived in the window at all, which is the honest
+    /// reading for "not measurable right now"; it is never zero to mean that.
     public let networkThroughputMbps: Double?
     public let networkTransferredBytes: Int64?
     public let avSyncGapMs: Double?

--- a/Sources/AetherEngine/Diagnostics/LiveTelemetrySampler.swift
+++ b/Sources/AetherEngine/Diagnostics/LiveTelemetrySampler.swift
@@ -29,6 +29,14 @@ struct RollingWindow<T: AdditiveArithmetic> {
     /// Populated slot count; sampler keeps instant-bitrate nil until count >= 2 (one sample = zero-second delta).
     var count: Int { filled ? capacity : index }
 
+    /// Populated slots carrying a non-zero sample. The playback reader fetches a large range and then
+    /// parks on backpressure until low water, so on a fast link most slots in the window are empty and
+    /// a mean over `count` measures the park rather than the link (#306 follow-up).
+    var activeCount: Int {
+        let active = filled ? buffer : Array(buffer.prefix(index))
+        return active.filter { $0 != .zero }.count
+    }
+
     mutating func reset() {
         for i in 0..<buffer.count { buffer[i] = .zero }
         index = 0
@@ -153,6 +161,25 @@ final class LiveTelemetrySampler {
         task = nil
     }
 
+    /// #306 follow-up: the rate the link delivers at, measured over the seconds bytes actually arrived
+    /// in rather than over wall-clock seconds.
+    ///
+    /// The playback reader fetches a large range and then parks on backpressure until low water, so on
+    /// a fast link most ticks of a window carry nothing at all: measured over a local origin, a healthy
+    /// 2.8 Mbps VP9 session pulled 16.4 MB in one tick and then sat at exactly zero for the next 23,
+    /// while the reader's runway drained from 16.0 to 8.3 MB. A wall-clock mean reports 0.00 Mbps
+    /// through all of that, which is the false-with-confidence zero #306 was filed about, one field
+    /// over. Dividing by the active seconds instead reports the link, and under-reports it at worst,
+    /// since a burst that finishes inside a tick is still charged the whole second.
+    ///
+    /// nil when the window holds fewer than two samples (a single sample spans no time) or when nothing
+    /// arrived in it at all. That mirrors the native path, where `observedBitrate` is published only
+    /// when it is finite and positive: "not measurable right now" is a gap, never a zero.
+    static func observedTransferMbps(windowBytes: Int64, activeSeconds: Int, samples: Int) -> Double? {
+        guard samples >= 2, activeSeconds > 0, windowBytes > 0 else { return nil }
+        return Double(windowBytes) * 8.0 / Double(activeSeconds) / 1_000_000.0
+    }
+
     private func tick() async {
         guard let engine = engine else { return }
 
@@ -171,6 +198,11 @@ final class LiveTelemetrySampler {
         } else {
             instantBitrateMbps = nil
         }
+
+        let observedTransferMbps = Self.observedTransferMbps(
+            windowBytes: byteWindow.sum,
+            activeSeconds: byteWindow.activeCount,
+            samples: byteWindow.count)
 
         let averageBitrateMbps: Double?
         if let start = sessionStartTime {
@@ -258,7 +290,9 @@ final class LiveTelemetrySampler {
             displayCushionSeconds = software.displayCushionSeconds
             accumulatedFrameDelaySeconds = software.accumulatedFrameDelaySeconds
             readerWindowAheadBytes = software.readerWindowAheadBytes
-            networkThroughputMbps = instantBitrateMbps  // SW: demuxer pulls the same bytes
+            // SW: the demuxer pulls the bytes itself, so the rate comes from its counter rather than
+            // from an access log. Over active seconds, not wall-clock ones: see observedTransferMbps.
+            networkThroughputMbps = observedTransferMbps
             networkTransferredBytes = demuxerBytes
             avSyncGapMs = nil          // HLSSegmentProducer doesn't run on SW path
             // Deliberately nil, see LiveTelemetry: the software pump is renderer-back-pressured, so

--- a/Tests/AetherEngineTests/Issue306SoftwareTelemetryTests.swift
+++ b/Tests/AetherEngineTests/Issue306SoftwareTelemetryTests.swift
@@ -46,6 +46,59 @@ struct Issue306SoftwareTelemetryTests {
         #expect(AetherEngine.pumpBytesFetched(software: 0, native: 8_192) == 0)
     }
 
+    // MARK: - The rate the link delivers at
+
+    /// Retest finding: the Network section only read sensibly on a struggling session. The reader
+    /// fetches a large range and parks on backpressure until low water, so on a fast link the window is
+    /// mostly empty. Measured over a local origin, a healthy 2.8 Mbps VP9 session pulled 16.4 MB in one
+    /// tick and then exactly nothing for 23 more, so a wall-clock mean published 0.00 Mbps while the
+    /// stream played perfectly, one field over from the zero #306 was filed about.
+    @Test("a parked reader reports the rate it delivered at, not a wall-clock mean over the park")
+    func burstyLinkReportsItsDeliveredRate() {
+        // The measured shape: 16.4 MB in one tick of a ten-second window, then silence.
+        let burst = LiveTelemetrySampler.observedTransferMbps(
+            windowBytes: 17_196_646, activeSeconds: 1, samples: 10)
+        #expect(burst != nil)
+        #expect((burst ?? 0) > 100.0, "a loopback burst reports its own rate, got \(burst ?? -1) Mbps")
+
+        // The same bytes charged to every second of the window is the reading that used to ship, and
+        // it is the one a host renders as a near-dead link.
+        let wallClockMean = Double(17_196_646) * 8.0 / 10.0 / 1_000_000.0
+        #expect((burst ?? 0) > wallClockMean)
+    }
+
+    /// A paced origin fills every tick, so both readings coincide there. This is the arm that must not
+    /// move: the reporter's throttled run is the one the section was already legible on.
+    @Test("a steadily paced link reads the same either way")
+    func pacedLinkIsUnchanged() {
+        // 2 Mbps for ten seconds: 250 000 bytes in each of ten ticks.
+        let rate = LiveTelemetrySampler.observedTransferMbps(
+            windowBytes: 2_500_000, activeSeconds: 10, samples: 10)
+        #expect(abs((rate ?? 0) - 2.0) < 0.001)
+    }
+
+    /// Nothing arrived in the whole window: that is a gap, not a rate of zero. A host cannot tell a
+    /// confident 0.0 Mbps from a dead link, and the reporter's overlay renders any non-nil number.
+    @Test("an idle window publishes nil rather than zero")
+    func idleWindowPublishesNil() {
+        #expect(LiveTelemetrySampler.observedTransferMbps(
+            windowBytes: 0, activeSeconds: 0, samples: 10) == nil)
+        // And a single sample spans no time at all, whatever it carries.
+        #expect(LiveTelemetrySampler.observedTransferMbps(
+            windowBytes: 4_096, activeSeconds: 1, samples: 1) == nil)
+    }
+
+    /// The window counts the slots that carried bytes, not the slots that exist.
+    @Test("the rolling window separates the seconds that carried bytes")
+    func rollingWindowCountsActiveSlots() {
+        var window = RollingWindow<Int64>(capacity: 10, zero: 0)
+        window.push(17_196_646)
+        for _ in 0..<9 { window.push(0) }
+        #expect(window.count == 10)
+        #expect(window.activeCount == 1)
+        #expect(window.sum == 17_196_646)
+    }
+
     // MARK: - The software snapshot
 
     @Test("a software tick publishes cushion, reader runway and dropped frames")


### PR DESCRIPTION
Refs #306. Found while verifying the retest on that issue, not reported.

## What the retest surfaced

The reporter's Network section only read sensibly on a *struggling* session, and their healthy run showed blanks they attributed to "nothing to measure". Reproducing that here says the healthy case was worse than a blank.

`networkThroughputMbps` on the software path was `instantBitrateMbps`: demuxer bytes over a 10 s wall-clock window. The reader fetches a large range and then parks on backpressure until low water, so on a fast link most ticks of that window carry no bytes at all.

Measured with `aetherctl play` against a 42 MB / 2.8 Mbps VP9 source over a local range-serving origin, before the change:

```
t=01 rx=16.4MB ahead=16.0MB
t=02 net=0.00Mbps rx=16.4MB ahead=15.5MB cushion=0.44s
...
t=23 net=0.00Mbps rx=16.4MB ahead=8.5MB  cushion=0.42s
t=25 net=6.92Mbps rx=24.6MB ahead=16.0MB      <- the next refill
```

23 consecutive ticks of a confident `0.00 Mbps` on a session playing perfectly, while the runway drained from 16.0 to 8.3 MB. That is the same false-with-confidence zero #306 was filed about, one field over. The reporter had already been bitten by it: they now guard on `> 0` rather than on non-nil, because their overlay renders any non-nil number it is handed.

## The change

Divide by the seconds that carried bytes, not by every second of the window, and publish nil rather than zero when nothing arrived in the window at all.

That is the quantity the native path already reports: `observedBitrate` in the access log is the rate observed *during* a download event, and the sampler already drops it when it is not positive. So the field means the same thing on both backends again, which was the point of having it.

Publishing the gap rather than a zero keeps the choice on the host side, the same reasoning as shipping the runway in bytes: a host that wants a held reading keeps the last non-nil value, while a host handed a zero cannot tell a parked reader from a dead link.

After, same source and origin:

```
t=02..t=24  (no net= field; nothing arrived, so there is no rate)
t=25 net=68.16Mbps rx=24.6MB ahead=16.1MB     <- the refill, at loopback speed
```

## The arm that must not move

The throttled run is the one the section was already legible on. With a 2 Mbps paced origin (30 ms latency) every tick carries bytes, so `activeCount == count` and both formulas agree:

```
t=02 net=2.10Mbps rx=0.6MB ahead=0.0MB cushion=0.00s
t=15 net=2.10Mbps rx=3.8MB ahead=0.0MB cushion=0.00s
t=30 net=2.10Mbps rx=7.5MB ahead=0.0MB cushion=0.00s
```

A 2.8 Mbps stream over a 2 Mbps link: steady link rate, `ahead=0`, `cushion=0`. Unchanged, and the starvation signature stays readable.

`instantBitrateMbps` is deliberately left alone. It is bytes per wall second on both paths, which is what makes it the stream rate rather than the link rate, and hosts calibrate against it today.

Also corrects the `readerWindowAheadBytes` doc comment, which told hosts to divide the runway by the throughput. That answers how long the runway took to fetch, not how long it will last at playback rate; the divisor is `averageBitrateMbps`. The reporter had already worked that out and quietly done it the right way.

## Tests

Four in `Issue306SoftwareTelemetryTests`, over the measured shape: the burst-then-park window reports its delivered rate rather than a wall-clock mean; a steadily paced link reads identically either way; an idle window and a single sample both publish nil; and `RollingWindow.activeCount` separates the slots that carried bytes from the slots that exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HX5zV3Fcf7Nzq4DYGdXvQE