### PR TITLE
Publish a first-frame-ready signal (#315)

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,13 @@ player.$playbackPhase  // unified: .idle/.loading/.playing/.paused/.seeking/.reb
                        // .stalled(reconnecting:)/.ended/.error. One source of truth for a status
                        // spinner; derived from state + isBuffering + isSeeking + source reconnect.
                        // Prefer this over stitching the raw signals or matching EngineLog text.
+player.$hasFirstFrameReadyForDisplay
+                       // the running path has a first frame ready for display, for the media THIS
+                       // load opened: the edge a black cover comes off on. readyToPlay is not that
+                       // edge (AVFoundation reaches it before the layer holds a picture, and it
+                       // stays true across a seek), so a cover lifted on isSessionReady lifts onto
+                       // black. Latched for the load, false again at the next load() / stop().
+                       // For "has this seek reached the screen" use seekEvents .landed instead.
 player.$currentAVPlayer // active AVPlayer, re-emitted on every reload (MPNowPlayingSession)
 
 // System Now-Playing on the native video path (tvOS / iOS). Off by default: an

--- a/Sources/AetherEngine/AetherEngine+Loading.swift
+++ b/Sources/AetherEngine/AetherEngine+Loading.swift
@@ -89,14 +89,41 @@ extension AetherEngine {
     /// `isReady` always feeds the public `isSessionReady` mirror and replays a deferred pre-ready host
     /// seek (#127); pass `settlePausedAtReadiness: false` for paths that skip the readiness -> .paused
     /// waypoint (autostarting loadRemoteHLS, where the terminal play() runs and readiness is a waypoint).
+    /// #315: fold a host's raw `isVideoReadyForDisplay` level into the load-scoped public latch.
+    ///
+    /// Two operators carry the whole contract. `dropFirst()` discards the value the publisher
+    /// replays on subscribe: every call site wires its sinks BEFORE it loads the host, so on a
+    /// reused native host that replay is still the outgoing item's picture, and taking it would
+    /// latch this load's flag on the previous load's frame. `prefix(1)` is the latch itself: after
+    /// the first rise nothing can lower it again, which is what keeps a host from re-covering the
+    /// few tens of milliseconds an item swap spends without a picture.
+    func latchFirstFrameReadyForDisplay(
+        from publisher: Published<Bool>.Publisher,
+        storeIn cancellables: inout Set<AnyCancellable>
+    ) {
+        publisher
+            .dropFirst()
+            .filter { $0 }
+            .prefix(1)
+            .sink { [weak self] _ in self?.hasFirstFrameReadyForDisplay = true }
+            .store(in: &cancellables)
+    }
+
+    /// `videoReadyForDisplay` is the host's raw layer level (#315); nil on the audio hosts, which
+    /// have nothing to display. It is folded, never mirrored: the engine's published flag is latched
+    /// for the load, so the seams that reuse a host and briefly lose the picture do not surface.
     private func wireCommonHostSinks(
         duration: Published<Double>.Publisher,
         isReady: Published<Bool>.Publisher,
         settlePausedAtReadiness: Bool = true,
         failureMessage: Published<String?>.Publisher,
         didReachEnd: Published<Bool>.Publisher,
+        videoReadyForDisplay: Published<Bool>.Publisher? = nil,
         storeIn cancellables: inout Set<AnyCancellable>
     ) {
+        if let videoReadyForDisplay {
+            latchFirstFrameReadyForDisplay(from: videoReadyForDisplay, storeIn: &cancellables)
+        }
         duration
             .sink { [weak self] value in
                 if value > 0 { self?.duration = value }
@@ -244,6 +271,7 @@ extension AetherEngine {
             settlePausedAtReadiness: !Self.loadPerformsAutostart(options),
             failureMessage: host.$failureMessage,
             didReachEnd: host.$didReachEnd,
+            videoReadyForDisplay: host.$isVideoReadyForDisplay,
             storeIn: &nativeCancellables
         )
         // Track AVPlayer's REAL transport state. Eager .playing caused a ~10 s black screen during Jellyfin transcode spin-up.
@@ -897,6 +925,7 @@ extension AetherEngine {
             isReady: host.$isReady,
             failureMessage: host.$failureMessage,
             didReachEnd: host.$didReachEnd,
+            videoReadyForDisplay: host.$isVideoReadyForDisplay,
             storeIn: &nativeCancellables
         )
         host.$timeControlStatus
@@ -1205,6 +1234,7 @@ extension AetherEngine {
             isReady: host.$isReady,
             failureMessage: host.$failureMessage,
             didReachEnd: host.$didReachEnd,
+            videoReadyForDisplay: host.$isVideoReadyForDisplay,
             storeIn: &softwareCancellables
         )
 

--- a/Sources/AetherEngine/AetherEngine.swift
+++ b/Sources/AetherEngine/AetherEngine.swift
@@ -520,6 +520,43 @@ public final class AetherEngine: ObservableObject {
     /// readiness from currentTime being pinned at 0.
     @Published public internal(set) var isSessionReady = false
 
+    /// #315: the running path has a first frame ready for display, for the media this `load()`
+    /// opened. This is the edge a black cover comes off on; `isSessionReady` is not that edge and
+    /// cannot be made into one.
+    ///
+    /// `isSessionReady` is `AVPlayerItem.readyToPlay`, which AVFoundation reaches before the layer
+    /// holds a picture and which stays true across a seek. Measured on a loopback origin, the
+    /// player's layer reports its first frame ~0.05 s into a load and `timeControlStatus` follows
+    /// at ~0.10 s; on a slow origin those separate by as much as the source is slow, and a load
+    /// opened paused never produces the second one at all. Hosts approximating presentation from
+    /// `phase == .playing/.paused && isSessionReady` therefore lift the cover onto black.
+    ///
+    /// What backs it: `AVPlayerLayer.isReadyForDisplay` on the native path,
+    /// `AVSampleBufferDisplayLayer.isReadyForDisplay` on the software one (below tvOS/iOS 17.4 and
+    /// macOS 14.4, where that property does not exist, the software path falls back to the first
+    /// frame handed to the renderer, one hop earlier than presentation). Audio-only sessions have
+    /// nothing to display and leave it false.
+    ///
+    /// Two things it does NOT claim:
+    ///
+    /// - **Not "the viewer sees it".** It is the pipeline's own statement that a first frame is
+    ///   ready. The engine's layer reaches it even when it is in no view hierarchy (measured), so
+    ///   a host that never bound a surface still gets true here while showing nothing (#298), and
+    ///   an `AVPlayerViewController` host presents through AVKit's own layer a frame or so later.
+    /// - **Not a level.** It is latched for the load: false at every `load()` and at `stop()`, true
+    ///   once and then held. The seams that reuse the running host (media fallback, the wired-HDMI
+    ///   AirPlay master swap, the #93 recovery reload, the AE#158 in-place handover) each drop the
+    ///   layer's picture for a few tens of milliseconds, measured, and this holds true through
+    ///   them: reporting them would make a host re-cover a seam it is deliberately not meant to
+    ///   see, and a falling edge would be ambiguous in exactly the way `SeekEvent` was introduced
+    ///   to fix, since nothing in a level says why it fell. A rebuild that goes back through
+    ///   `load()`, `reloadAtCurrentPosition()` included, does reset it: there the item is genuinely
+    ///   gone and its first frame has to be reached again.
+    ///
+    /// For "has this seek reached the screen", the per-seek answer is `SeekEvent.landed`, not this
+    /// flag: a seek keeps the previous frame up, so the layer never stops being ready for display.
+    @Published public internal(set) var hasFirstFrameReadyForDisplay = false
+
     /// #127: latest host seek issued while the native item was pre-ready; replayed at readiness.
     var pendingPreReadySeekSeconds: Double?
     /// AE#158: set by load() when the running item must survive until the new master attaches (PiP
@@ -2342,6 +2379,9 @@ public final class AetherEngine: ObservableObject {
         // #35/#93: a genuinely new item has not rendered yet; re-arm the cold-startup wedge suspension.
         // Scrub/seek/producer-restart never route through load(), so mid-stream #93 detection stays armed.
         hasRenderedFirstFrameMirror.set(false)
+        // The public #315 counterpart is un-latched by the stopInternal() above, which every load()
+        // runs. The seams that reuse the running host call host.load() directly, reach neither, and
+        // keep the latch through their few tens of ms without a picture.
         // Drop disc recognition memoized for the previous media. Track-switch reopens (audio / subtitle
         // side demuxer) deliberately keep it so a remote ISO is parsed once per session (#76); only a
         // genuinely new load clears it, which also keeps custom sources (shared placeholder URL) from
@@ -4627,6 +4667,8 @@ public final class AetherEngine: ObservableObject {
         // #127: readiness + deferred host seeks are session-scoped; the host-side sink can't clear them
         // once nativeCancellables are gone.
         isSessionReady = false
+        // #315: session-scoped for the same reason, and the host mirrors are being cut here.
+        hasFirstFrameReadyForDisplay = false
         pendingPreReadySeekSeconds = nil
 
         // Shut down cache-backed scrub-thumbnail FrameExtractors with the session.

--- a/Sources/AetherEngine/Native/NativeAVPlayerHost.swift
+++ b/Sources/AetherEngine/Native/NativeAVPlayerHost.swift
@@ -28,6 +28,18 @@ final class NativeAVPlayerHost {
     private var hasEverPlayed = false
     @Published private(set) var didReachEnd: Bool = false
 
+    /// #315: `AVPlayerLayer.isReadyForDisplay` for the item this host holds, which is the only
+    /// signal on this path for "there is a picture". `isReady` is the item's `readyToPlay`, which
+    /// AVFoundation reaches before the layer has presented anything and which stays true across a
+    /// seek, so a host lifting a black cover on it lifts it onto black.
+    ///
+    /// A LEVEL, not a latch: it falls whenever the layer loses its picture, which every item swap
+    /// does, including the in-place handover (measured: ~40 ms of false around a
+    /// `replaceCurrentItem`, even when the swap is meant to be invisible). The engine folds it into
+    /// the load-scoped `AetherEngine.hasFirstFrameReadyForDisplay`, which is what a host should
+    /// consume; nothing here is worth reacting to on its own.
+    @Published private(set) var isVideoReadyForDisplay: Bool = false
+
     /// Set per load; gates the AE#287 premature-end recovery, which only makes sense for a fixed-length
     /// presentation. A live session has no advertised end to fall short of.
     private var isLiveSession: Bool = false
@@ -265,15 +277,28 @@ final class NativeAVPlayerHost {
 
         EngineLog.emit("[NativeAVPlayerHost] #\(sid) load url=\(url.absoluteString) startPos=\(startPosition.map { String(format: "%.2fs", $0) } ?? "nil") headers=\(httpHeaders.isEmpty ? "none" : "\(httpHeaders.count)")", category: .engine)
 
-        // First-frame-visible diagnostic (see `layerReadyObservation`).
+        // First frame on screen, published as `isVideoReadyForDisplay` and stamped for the
+        // audio-leads-black-video gap (see `layerReadyObservation`).
+        //
+        // The install-time value is logged separately rather than taken through `.initial`, and it
+        // is deliberately not published: on a reused host the layer still reads true here, for the
+        // item this load is replacing. AVFoundation clears it ~40 ms later and raises it again for
+        // the new item, so only CHANGES observed from here on describe this session's picture
+        // (`unloadCurrentItem` has already published false).
+        EngineLog.emit(
+            "[NativeAVPlayerHost] #\(sid) layer.isReadyForDisplay=\(playerLayer.isReadyForDisplay) t+0.00s (carried in from the previous item when true)",
+            category: .engine
+        )
         layerReadyObservation = playerLayer.observe(
-            \.isReadyForDisplay, options: [.new, .initial]
-        ) { layer, change in
+            \.isReadyForDisplay, options: [.new]
+        ) { [weak self] layer, change in
+            let ready = change.newValue ?? layer.isReadyForDisplay
             let elapsed = Double(DispatchTime.now().uptimeNanoseconds - loadStart.uptimeNanoseconds) / 1_000_000_000
             EngineLog.emit(
-                "[NativeAVPlayerHost] #\(sid) layer.isReadyForDisplay=\(change.newValue ?? layer.isReadyForDisplay) t+\(String(format: "%.2f", elapsed))s",
+                "[NativeAVPlayerHost] #\(sid) layer.isReadyForDisplay=\(ready) t+\(String(format: "%.2f", elapsed))s",
                 category: .engine
             )
+            Task { @MainActor in self?.isVideoReadyForDisplay = ready }
         }
 
         let asset = AVURLAsset(url: url, options: Self.assetCreationOptions(httpHeaders: httpHeaders))
@@ -1138,6 +1163,10 @@ final class NativeAVPlayerHost {
         // Clear terminal flags: keepNativeHost reload reuses the host and @Published replays on subscribe; stale failureMessage/didReachEnd corrupt the new session (issue #15).
         failureMessage = nil
         didReachEnd = false
+        // #315: same reason. The layer itself still reads true for a few tens of ms past this point
+        // (AVFoundation clears it after the swap), so the published value leads the layer here on
+        // purpose: the outgoing item's picture is not this session's.
+        isVideoReadyForDisplay = false
         // AE#287: the recovery budget is per item, not per host.
         prematureEndRecoveryAttempts = 0
         lastPrematureEndRecoveryPlayhead = nil

--- a/Sources/AetherEngine/Native/SoftwarePlaybackHost.swift
+++ b/Sources/AetherEngine/Native/SoftwarePlaybackHost.swift
@@ -55,6 +55,20 @@ final class SoftwarePlaybackHost {
     @Published private(set) var failureMessage: String?
     @Published private(set) var didReachEnd: Bool = false
 
+    /// #315: `AVSampleBufferDisplayLayer.isReadyForDisplay` for the renderer's layer, this path's
+    /// answer to "there is a picture". Frames enqueued is not that answer: it counts what the
+    /// decoder handed over, and #298 is the report where every one of them went into a layer no
+    /// host had bound.
+    ///
+    /// A LEVEL that falls whenever the layer loses its picture; the engine folds it into the
+    /// load-scoped `AetherEngine.hasFirstFrameReadyForDisplay`, which is what hosts consume. A
+    /// session with no video stream never arms the observation and leaves this false.
+    @Published private(set) var isVideoReadyForDisplay: Bool = false
+
+    /// #315: `readyForDisplay` observation on the renderer's layer, re-armed per load and torn down
+    /// with the session.
+    private var readyForDisplayObserver: NSObjectProtocol?
+
     /// Fires (off-main) once per session the first time HDR10+ dynamic
     /// metadata appears on a decoded frame. Hooked by `AetherEngine` to
     /// upgrade the published `videoFormat` from `.hdr10` → `.hdr10Plus`.
@@ -350,6 +364,47 @@ final class SoftwarePlaybackHost {
         }
     }
 
+    /// #315: publish the renderer layer's own `readyForDisplay` as `isVideoReadyForDisplay`.
+    /// AVFoundation posts a notification for it rather than supporting KVO, and it arrived in
+    /// tvOS/iOS 17.4 and macOS 14.4, below the engine's own floor. Where it is missing the fallback
+    /// is the first frame handed to the renderer (`disarmedFallbackFirstFrame`), which is one hop
+    /// earlier than presentation and is documented as such on the public property.
+    private func armReadyForDisplayObserver() {
+        disarmReadyForDisplayObserver()
+        guard #available(tvOS 17.4, iOS 17.4, macOS 14.4, *) else { return }
+        let layer = renderer.displayLayer
+        readyForDisplayObserver = NotificationCenter.default.addObserver(
+            forName: .AVSampleBufferDisplayLayerReadyForDisplayDidChange,
+            object: layer,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                guard let self else { return }
+                let ready = self.renderer.displayLayer.isReadyForDisplay
+                guard ready != self.isVideoReadyForDisplay else { return }
+                EngineLog.emit(
+                    "[SWHost] layer.isReadyForDisplay=\(ready) after \(self.framesEnqueued) frames",
+                    category: .swPlayback
+                )
+                self.isVideoReadyForDisplay = ready
+            }
+        }
+    }
+
+    private func disarmReadyForDisplayObserver() {
+        if let readyForDisplayObserver {
+            NotificationCenter.default.removeObserver(readyForDisplayObserver)
+            self.readyForDisplayObserver = nil
+        }
+    }
+
+    /// #315 fallback below tvOS/iOS 17.4 and macOS 14.4: no `readyForDisplay` on the layer, so the
+    /// first frame the decoder hands the renderer is the closest observable. Called off-main.
+    nonisolated private func noteFirstFrameEnqueuedForDisplayFallback() {
+        guard #unavailable(tvOS 17.4, iOS 17.4, macOS 14.4) else { return }
+        Task { @MainActor [weak self] in self?.isVideoReadyForDisplay = true }
+    }
+
     /// Caching the chosen rate so resume() restores the right speed after a pause without the
     /// host needing to know its history. Lock-guarded: the demux/feeder threads read it at clock
     /// arming so a host rate change between load and arm is not lost (#107).
@@ -451,6 +506,9 @@ final class SoftwarePlaybackHost {
         self.videoStreamIndex = dem.videoStreamIndex
         let vtb = vStream.pointee.time_base
         self.videoTimeBaseSeconds = vtb.den > 0 ? Double(vtb.num) / Double(vtb.den) : 0
+        // #315: armed once there is a video stream to display. A fresh host means a fresh layer, so
+        // there is no carried-in picture to guard against here (the native path's problem).
+        armReadyForDisplayObserver()
 
         // DVR ring scratch dir mirrors SegmentCache's <tmpdir>/aether-segments/<uuid> convention.
         if isLive, let window = dvrWindowSeconds {
@@ -543,6 +601,7 @@ final class SoftwarePlaybackHost {
             self?.renderer.enqueue(pixelBuffer: pixelBuffer, pts: pts, hdr10PlusData: hdr10PlusData)
             // First-frame milestone: demux reached a video packet + decoder produced a pixel buffer.
             if self?.bumpFramesEnqueued() == 0 {
+                self?.noteFirstFrameEnqueuedForDisplayFallback()
                 let pfType = CVPixelBufferGetPixelFormatType(pixelBuffer)
                 EngineLog.emit(
                     "[SWHost] first video frame enqueued: "
@@ -931,6 +990,9 @@ final class SoftwarePlaybackHost {
         demuxer = nil
 
         isReady = false
+        // #315: the session's picture goes with the session. `flush()` above already removed it.
+        disarmReadyForDisplayObserver()
+        isVideoReadyForDisplay = false
     }
 
     var volume: Float {

--- a/Sources/aetherctl/PlaybackCmd.swift
+++ b/Sources/aetherctl/PlaybackCmd.swift
@@ -239,6 +239,20 @@ private func playSmokeTest(url: URL, seconds: Double, live: Bool, nativeHLS: Boo
         }
     }.store(in: &cancellables)
 
+    // #315: the cover-lift edge, stamped from the load call. Both transitions are printed: the
+    // false is the load un-latching it, the true is the running path reporting a first frame ready
+    // for display. Nothing here binds a render surface, so a true means the pipeline is ready, not
+    // that anything is on screen (that distinction is the property's own documentation).
+    let loadStart = DispatchTime.now()
+    engine.$hasFirstFrameReadyForDisplay
+        .dropFirst()
+        .sink { ready in
+            let elapsed = Double(DispatchTime.now().uptimeNanoseconds - loadStart.uptimeNanoseconds) / 1e9
+            print(String(format: "  FIRSTFRAME hasFirstFrameReadyForDisplay=%@ t+%.2fs",
+                         ready ? "true" : "false", elapsed))
+        }
+        .store(in: &cancellables)
+
     let options = LoadOptions(
         suppressDisplayCriteria: true,
         isLive: live,
@@ -347,6 +361,7 @@ private func playSmokeTest(url: URL, seconds: Double, live: Bool, nativeHLS: Boo
                           engine.sourceTime,
                           engine.bufferedPosition,
                           engine.duration)
+        line += " rfd=\(engine.hasFirstFrameReadyForDisplay ? "y" : "n")"
         if let monitor, let end = monitor.lastEndPTS {
             // Decoded-audio lead over the master clock (source axis). Near-zero = renderer starving.
             line += String(format: " alead=%.2f abufs=%d", end - engine.sourceTime, monitor.bufferCount)

--- a/Tests/AetherEngineTests/Issue315FirstFramePresentedTests.swift
+++ b/Tests/AetherEngineTests/Issue315FirstFramePresentedTests.swift
@@ -1,0 +1,86 @@
+import Testing
+import Combine
+@testable import AetherEngine
+
+/// #315: `hasFirstFrameReadyForDisplay`, the load-scoped statement that the running path has a
+/// picture. The layer property it folds needs a real AVPlayer / AVSampleBufferDisplayLayer, so the
+/// end-to-end edge is measured with `aetherctl play` (native: layer ready t+0.05 s, published
+/// t+0.16 s; software: ready after 6 enqueued frames) rather than here. What is testable here is
+/// the fold, and the fold is where the two ways to get this wrong live: inheriting the previous
+/// item's picture, and re-lowering the flag on a seam.
+@Suite("First-frame-ready latch (#315)")
+struct Issue315FirstFramePresentedTests {
+
+    /// Stands in for a playback host's `@Published private(set) var isVideoReadyForDisplay`.
+    @MainActor
+    final class HostDouble {
+        @Published var isVideoReadyForDisplay: Bool
+        init(_ initial: Bool) { isVideoReadyForDisplay = initial }
+    }
+
+    @MainActor
+    @Test("A reused host's carried-in picture does not latch this load")
+    func carriedInValueIsNotThisLoadsFrame() async throws {
+        let engine = try AetherEngine()
+        var cancellables = Set<AnyCancellable>()
+        // A native host kept across a reload still reports the OUTGOING item as ready at the moment
+        // the engine wires its sinks: host.load() (and its unloadCurrentItem) runs after the wiring.
+        let host = HostDouble(true)
+        engine.latchFirstFrameReadyForDisplay(from: host.$isVideoReadyForDisplay, storeIn: &cancellables)
+
+        #expect(engine.hasFirstFrameReadyForDisplay == false)
+
+        // AVFoundation clears the layer once the swap goes through, then raises it for the new item.
+        host.isVideoReadyForDisplay = false
+        #expect(engine.hasFirstFrameReadyForDisplay == false)
+        host.isVideoReadyForDisplay = true
+        #expect(engine.hasFirstFrameReadyForDisplay == true)
+    }
+
+    @MainActor
+    @Test("A fresh host's first frame latches it")
+    func freshHostLatchesOnFirstRise() async throws {
+        let engine = try AetherEngine()
+        var cancellables = Set<AnyCancellable>()
+        let host = HostDouble(false)
+        engine.latchFirstFrameReadyForDisplay(from: host.$isVideoReadyForDisplay, storeIn: &cancellables)
+
+        #expect(engine.hasFirstFrameReadyForDisplay == false)
+        host.isVideoReadyForDisplay = true
+        #expect(engine.hasFirstFrameReadyForDisplay == true)
+    }
+
+    @MainActor
+    @Test("A seam that drops the layer's picture does not lower it")
+    func latchHoldsThroughAPictureLessSeam() async throws {
+        let engine = try AetherEngine()
+        var cancellables = Set<AnyCancellable>()
+        let host = HostDouble(false)
+        engine.latchFirstFrameReadyForDisplay(from: host.$isVideoReadyForDisplay, storeIn: &cancellables)
+        host.isVideoReadyForDisplay = true
+
+        // The measured shape of an item swap on a reused host: ~40 ms of false, then true again.
+        // Media fallback, the AirPlay master swap, the #93 recovery and the AE#158 in-place handover
+        // all take it, and a host must not re-cover a picture for any of them.
+        host.isVideoReadyForDisplay = false
+        #expect(engine.hasFirstFrameReadyForDisplay == true)
+        host.isVideoReadyForDisplay = true
+        #expect(engine.hasFirstFrameReadyForDisplay == true)
+    }
+
+    @MainActor
+    @Test("stop() un-latches it")
+    func stopClearsTheLatch() async throws {
+        let engine = try AetherEngine()
+        var cancellables = Set<AnyCancellable>()
+        let host = HostDouble(false)
+        engine.latchFirstFrameReadyForDisplay(from: host.$isVideoReadyForDisplay, storeIn: &cancellables)
+        host.isVideoReadyForDisplay = true
+        #expect(engine.hasFirstFrameReadyForDisplay == true)
+
+        engine.stop()
+        // The session is gone, so no statement about a picture survives it. load() reaches the same
+        // reset through the stopInternal() in its prologue.
+        #expect(engine.hasFirstFrameReadyForDisplay == false)
+    }
+}


### PR DESCRIPTION
Reported in #315: `NativeAVPlayerHost.playerLayer.isReadyForDisplay` is the only real first-frame signal on the native path, and `nativeHost` is internal, so a host approximates presentation from `readyToPlay` instead. That is one edge too early on a load and no edge at all across a seek.

## What is published

`AetherEngine.hasFirstFrameReadyForDisplay` (`@Published`, load-scoped), folded from:

- native: `AVPlayerLayer.isReadyForDisplay` on the session's own layer,
- software: `AVSampleBufferDisplayLayer.isReadyForDisplay`. That property is explicitly not KVO-observable; AVFoundation posts `AVSampleBufferDisplayLayerReadyForDisplayDidChangeNotification` for it. It arrived in tvOS/iOS 17.4 and macOS 14.4, below the package floor, so older systems fall back to the first frame handed to the renderer, which is one hop earlier than presentation and is documented as such.

Audio-only sessions have nothing to display and leave it false.

## The two shape decisions

**Latched for the load, not mirrored as a level.** Measured on an unattached layer: `replaceCurrentItem` costs `isReadyForDisplay` about 40 ms of `false` and then raises it again, and that holds for the in-place handover too, the swap that exists precisely so a viewer sees nothing. Publishing the level would make every host re-cover seams they are deliberately not meant to react to, and a falling edge would be ambiguous in the way `SeekEvent` was introduced to fix. So the seams that reuse a running host (media fallback, wired-HDMI AirPlay master swap, the #93 recovery, the AE#158 handover) keep the latch; a rebuild that goes back through `load()`, `reloadAtCurrentPosition()` included, resets it with the item.

**It claims readiness, not visibility.** Both layers reach `isReadyForDisplay` while in no view hierarchy at all. Measured headless with `aetherctl`, native reports it at t+0.05 s and software after 6 enqueued frames, on the same run where the #298 "no host bound a render surface" warning fires. Calling it "presented" would have been a lie for exactly the hosts #298 is about, so the name and the docs say ready-for-display.

## Seeks

Not this flag: a seek keeps the previous frame on screen, so the layer never stops being ready for display (measured, `isReadyForDisplay` is unchanged across `seek`). The per-seek answer is `seekEvents` / `SeekEvent.landed(renderedTime:)`, which terminates each `.began` with landed / stalled / superseded under the seek's own id.

## The subtle part of the fold

Every call site wires its host sinks before it loads the host, so the value `@Published` replays on subscribe is, on a reused native host, still the outgoing item's picture. Taking it would latch this load's flag on the previous load's frame. `dropFirst()` discards it; `Issue315FirstFramePresentedTests` pins that case and fails without the guard.

## Verification

- `swift test`: 1560 tests in 233 suites, 0 failures
- `swift build -Xswiftc -strict-concurrency=complete`: clean
- `xcodebuild` tvOS Simulator and iOS Simulator: BUILD SUCCEEDED
- `aetherctl play` (native) and `aetherctl play --sw` on local fixtures: the new `FIRSTFRAME ... t+` line and the per-tick `rfd=y/n` show the edge on both paths

`aetherctl play` carries both, so the signal is capturable where the report came from.