### PR TITLE
feat(engine): publish the effective video route (#321)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,17 @@ the public-API contract.
 
 ## [Unreleased]
 
-_Nothing yet._
+### Added
+
+- **`AetherEngine.videoRoute`: the pipeline actually serving the session (#321).** `LoadOptions
+  .nativeRemoteHLS` is the request, not the outcome. The #168 carriage watchdog reroutes onto the
+  ingest loopback mid-session, #199 takes it straight away for a remembered master, AE#268 does the
+  same for a HEVC-in-MPEG-TS VOD, and AE#154 / AE#246 move the other way onto the bypass; none of it
+  was observable, because `loadedOptions` is internal and `playbackBackend` is `.native` for both
+  native pipelines. The new `@Published` value publishes `.remoteBypass` / `.loopback` / `.software`
+  / `.audio` / `.none` and is derived from `playbackBackend` plus the session's effective options,
+  so it cannot desync from them. Hosts can now decide who draws subtitles, and react to a reroute
+  instead of inferring it. `aetherctl play` prints `route=` next to `backend=`.
 
 ## [6.14.0] - 2026-08-07
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,13 @@ player.$playbackPhase  // unified: .idle/.loading/.playing/.paused/.seeking/.reb
                        // .stalled(reconnecting:)/.ended/.error. One source of truth for a status
                        // spinner; derived from state + isBuffering + isSeeking + source reconnect.
                        // Prefer this over stitching the raw signals or matching EngineLog text.
+player.$videoRoute     // pipeline actually serving the session: .remoteBypass (AVPlayer on the
+                       // origin URL) / .loopback / .software / .audio / .none. LoadOptions
+                       // .nativeRemoteHLS is only the request: the carriage watchdog, the
+                       // remembered verdict and the HLS reroutes move a session between the
+                       // bypass and the loopback, mid-session too. Branch on this where behaviour
+                       // differs per pipeline, above all who draws subtitles: on .remoteBypass
+                       // AVPlayer renders the origin's renditions, elsewhere the host renders.
 player.$hasFirstFrameReadyForDisplay
                        // the running path has a first frame ready for display, for the media THIS
                        // load opened: the edge a black cover comes off on. readyToPlay is not that

--- a/Sources/AetherEngine/AetherEngine.swift
+++ b/Sources/AetherEngine/AetherEngine.swift
@@ -485,8 +485,29 @@ public final class AetherEngine: ObservableObject {
     var sourceStartSeconds: Double = 0
 
     /// Active playback backend: `.native` (AVPlayer) or `.software` (SoftwarePlaybackHost/dav1d/libavcodec).
-    /// Exposed for diagnostic overlays; hosts should not branch on it.
-    @Published public internal(set) var playbackBackend: PlaybackBackend = .none
+    /// Exposed for diagnostic overlays; hosts should not branch on it. Branch on `videoRoute` instead,
+    /// which also separates the two native pipelines (#321).
+    @Published public internal(set) var playbackBackend: PlaybackBackend = .none {
+        didSet { recomputeVideoRoute() }
+    }
+
+    /// Pipeline actually serving this session (#321), including the reroutes the host never asked for.
+    /// Derived from `playbackBackend` + `loadedOptions.nativeRemoteHLS`, the two properties every reroute
+    /// site already writes, so it cannot desync from them. See `VideoRoute` for the transitions.
+    @Published public internal(set) var videoRoute: VideoRoute = .none
+
+    /// Idempotent: assigns only on a real change, so options writes that leave the route alone (the
+    /// per-reopen replay) do not flap the publisher. Logs every route the session takes; the drop to
+    /// `.none` is teardown, which carries no route information and is already loud in the log.
+    private func recomputeVideoRoute() {
+        let next = VideoRoute.derive(backend: playbackBackend,
+                                     nativeRemoteHLS: loadedOptions.nativeRemoteHLS)
+        guard videoRoute != next else { return }
+        videoRoute = next
+        if next != .none {
+            EngineLog.emit("[AetherEngine] #321: effective video route = \(next.rawValue)", category: .engine)
+        }
+    }
 
     /// Master enable for background playback (iOS: PiP + background audio; tvOS: PiP keepalive). Default on.
     public var backgroundPlaybackEnabled = true
@@ -1223,8 +1244,11 @@ public final class AetherEngine: ObservableObject {
     /// subtitle side-demuxer, background reload) so auth, matchContentEnabled, and dvh1 tag survive pipeline
     /// rebuilds. Without replay, audio-switch was silently reverting matchContentEnabled=true to false, causing
     /// HDR HEVC to route via the master playlist on a non-DV panel and surface "Öffnen fehlgeschlagen".
-    /// Read by AetherEngine+FrameExtractor.
-    private(set) var loadedOptions: LoadOptions = .init()
+    /// Read by AetherEngine+FrameExtractor. Every internal reroute (#154, #168, #199, #246, #268) reaches
+    /// the published route through this property, so its writes feed `recomputeVideoRoute` (#321).
+    private(set) var loadedOptions: LoadOptions = .init() {
+        didSet { recomputeVideoRoute() }
+    }
 
     #if DEBUG
     /// Test-only: install LoadOptions without a load (#88 unit tests exercise selection gating).

--- a/Sources/AetherEngine/PlayerState.swift
+++ b/Sources/AetherEngine/PlayerState.swift
@@ -31,6 +31,45 @@ public enum PlaybackBackend: String, Sendable, Equatable {
     case audio
 }
 
+/// Which pipeline is actually serving the session (#321). `LoadOptions.nativeRemoteHLS` records what the
+/// host asked for; the engine can change the effective route after that, and until now only a log line
+/// said so. Observe `$videoRoute` for decisions that differ per pipeline, above all who owns subtitle
+/// drawing: on `.remoteBypass` AVPlayer renders the origin's own legible renditions, on `.loopback` and
+/// `.software` the host's renderer does.
+///
+/// Derived from `playbackBackend` + the session's effective options, never assigned on its own, so it
+/// cannot drift from the running session (the `playbackPhase` arrangement, #85).
+///
+/// Route changes the host does not request:
+/// - `.remoteBypass` -> `.loopback` when the #168 carriage watchdog finds no video track on a master
+///   that advertises one, when the #199 memory routes a known such master straight onto the ingest, and
+///   when the AE#268 probe classifies a VOD playlist as HEVC-in-MPEG-TS;
+/// - `.loopback` -> `.remoteBypass` when AE#154 / AE#246 find an HLS playlist on the loopback path.
+public enum VideoRoute: String, Sendable, Equatable {
+    /// Nothing loaded, or the session was torn down.
+    case none
+    /// AVPlayer plays the origin URL directly (`LoadOptions.nativeRemoteHLS`). No demuxer, no local
+    /// server: media selection, subtitle drawing and buffering all belong to AVFoundation.
+    case remoteBypass
+    /// Demuxer plus local HLS-fMP4 server feeding AVPlayer. The engine owns the source connection and
+    /// the subtitle pipeline; this is the default video route.
+    case loopback
+    /// FFmpeg / dav1d into AVSampleBufferDisplayLayer.
+    case software
+    /// An audio-only session. There is no video pipeline to route.
+    case audio
+
+    /// Single point where a backend and the session's effective remote-HLS bit become a route.
+    static func derive(backend: PlaybackBackend, nativeRemoteHLS: Bool) -> VideoRoute {
+        switch backend {
+        case .none, .aether: return .none
+        case .native: return nativeRemoteHLS ? .remoteBypass : .loopback
+        case .software: return .software
+        case .audio: return .audio
+        }
+    }
+}
+
 /// What playback is doing right now, as one observable (#85). Derived from `state`, `isBuffering`,
 /// `isSeeking`, and the reader network phase, so it can never desync from them. Observe `$playbackPhase`
 /// instead of stitching `state == .loading` + `$isBuffering` + `$isSeeking` together, and instead of

--- a/Sources/aetherctl/PlaybackCmd.swift
+++ b/Sources/aetherctl/PlaybackCmd.swift
@@ -328,7 +328,10 @@ private func playSmokeTest(url: URL, seconds: Double, live: Bool, nativeHLS: Boo
     }
 
     print("")
-    print("backend=\(engine.playbackBackend.rawValue) duration=\(String(format: "%.1f", engine.duration))s isLive=\(engine.isLive)")
+    // #321: route, not just backend. `.native` covers both the loopback and the remote bypass, and an
+    // internal reroute can have moved this run off the route the flags asked for.
+    print("backend=\(engine.playbackBackend.rawValue) route=\(engine.videoRoute.rawValue) "
+          + "duration=\(String(format: "%.1f", engine.duration))s isLive=\(engine.isLive)")
     if frameTimes {
         if let timebase = engine.softwarePresentationTimebase {
             print(String(format: "  timebase: present, time=%.3fs rate=%.2f", timebase.time.seconds, timebase.rate))

--- a/Tests/AetherEngineTests/Issue321VideoRouteTests.swift
+++ b/Tests/AetherEngineTests/Issue321VideoRouteTests.swift
@@ -1,0 +1,117 @@
+import Combine
+import Testing
+@testable import AetherEngine
+
+/// Pure derivation of the effective video route (#321). `LoadOptions.nativeRemoteHLS` records the
+/// request; the route records what actually ended up serving the session after the internal reroutes
+/// (#168 carriage watchdog, #199 remembered verdict, AE#268 carriage probe, AE#154 / AE#246).
+@Suite("VideoRoute.derive (#321)")
+struct VideoRouteDeriveTests {
+
+    @Test("no backend means no route, whatever the request asked for")
+    func noBackendHasNoRoute() {
+        #expect(VideoRoute.derive(backend: .none, nativeRemoteHLS: false) == VideoRoute.none)
+        #expect(VideoRoute.derive(backend: .none, nativeRemoteHLS: true) == VideoRoute.none)
+    }
+
+    @Test("a native backend splits on the remote-HLS bit, which is the whole point")
+    func nativeSplitsOnRemoteHLS() {
+        #expect(VideoRoute.derive(backend: .native, nativeRemoteHLS: true) == .remoteBypass)
+        #expect(VideoRoute.derive(backend: .native, nativeRemoteHLS: false) == .loopback)
+    }
+
+    @Test("the software path is a route of its own, the request bit cannot reach it")
+    func softwareIgnoresRequest() {
+        #expect(VideoRoute.derive(backend: .software, nativeRemoteHLS: false) == .software)
+        #expect(VideoRoute.derive(backend: .software, nativeRemoteHLS: true) == .software)
+    }
+
+    @Test("an audio-only session reports no video route")
+    func audioIgnoresRequest() {
+        #expect(VideoRoute.derive(backend: .audio, nativeRemoteHLS: false) == .audio)
+        #expect(VideoRoute.derive(backend: .audio, nativeRemoteHLS: true) == .audio)
+    }
+
+    @Test("the retired .aether backend carries no route")
+    func retiredBackendHasNoRoute() {
+        #expect(VideoRoute.derive(backend: .aether, nativeRemoteHLS: false) == VideoRoute.none)
+    }
+}
+
+/// Engine-level wiring: the published route is derived from `playbackBackend` + `loadedOptions`, the
+/// two properties every reroute site already writes, so it cannot drift away from the running session.
+@Suite("AetherEngine.videoRoute wiring (#321)")
+@MainActor
+struct VideoRouteEngineTests {
+
+    @Test("a declared bypass is not a route until a backend exists")
+    func requestAloneIsNotARoute() throws {
+        let engine = try AetherEngine()
+        #expect(engine.videoRoute == VideoRoute.none)
+
+        engine.setLoadedOptionsForTesting(LoadOptions(nativeRemoteHLS: true))
+        #expect(engine.videoRoute == VideoRoute.none)
+
+        engine.playbackBackend = .native
+        #expect(engine.videoRoute == .remoteBypass)
+    }
+
+    /// The #168 watchdog and the #199 remembered verdict both take a declared bypass onto the
+    /// live-ingest loopback by clearing the bit on the options the session actually runs with.
+    @Test("clearing the bit mid-session republishes the loopback route")
+    func rerouteOntoLoopbackRepublishes() throws {
+        let engine = try AetherEngine()
+        engine.setLoadedOptionsForTesting(LoadOptions(nativeRemoteHLS: true))
+        engine.playbackBackend = .native
+        #expect(engine.videoRoute == .remoteBypass)
+
+        engine.setLoadedOptionsForTesting(LoadOptions(nativeRemoteHLS: false))
+        #expect(engine.videoRoute == .loopback)
+    }
+
+    /// AE#154 / AE#246 run the other direction: a playlist that reached the loopback is handed to the
+    /// bypass, and `loadedOptions.nativeRemoteHLS` flips to true underneath the same native backend.
+    @Test("setting the bit mid-session republishes the bypass route")
+    func rerouteOntoBypassRepublishes() throws {
+        let engine = try AetherEngine()
+        engine.setLoadedOptionsForTesting(LoadOptions(nativeRemoteHLS: false))
+        engine.playbackBackend = .native
+        #expect(engine.videoRoute == .loopback)
+
+        engine.setLoadedOptionsForTesting(LoadOptions(nativeRemoteHLS: true))
+        #expect(engine.videoRoute == .remoteBypass)
+    }
+
+    @Test("a software dispatch reports the software route even with the bit still set")
+    func softwareDispatch() throws {
+        let engine = try AetherEngine()
+        engine.setLoadedOptionsForTesting(LoadOptions(nativeRemoteHLS: true))
+        engine.playbackBackend = .software
+        #expect(engine.videoRoute == .software)
+    }
+
+    @Test("teardown drops the route back to none")
+    func teardownClearsRoute() throws {
+        let engine = try AetherEngine()
+        engine.setLoadedOptionsForTesting(LoadOptions(nativeRemoteHLS: true))
+        engine.playbackBackend = .native
+        #expect(engine.videoRoute == .remoteBypass)
+
+        engine.playbackBackend = .none      // what stopInternal() writes
+        #expect(engine.videoRoute == VideoRoute.none)
+    }
+
+    @Test("an options write that leaves the route alone does not re-emit")
+    func unchangedRouteDoesNotReemit() throws {
+        let engine = try AetherEngine()
+        var seen: [VideoRoute] = []
+        let sub = engine.$videoRoute.sink { seen.append($0) }
+        defer { sub.cancel() }
+
+        engine.playbackBackend = .native                                    // -> .loopback
+        engine.setLoadedOptionsForTesting(LoadOptions(isLive: true))        // still .loopback
+        engine.setLoadedOptionsForTesting(LoadOptions(dvrWindowSeconds: 90))// still .loopback
+
+        #expect(seen == [VideoRoute.none, .loopback])
+    }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -103,6 +103,25 @@ Precedence (highest first): `error > ended > idle > loading > seeking > stalled 
 
 Hosts should observe `$playbackPhase` instead of combining `state == .loading`, `$isBuffering`, and `$isSeeking`, and instead of regex-matching `EngineLog` for stall / reconnect, which is no longer needed.
 
+### Effective video route (`videoRoute`)
+
+`LoadOptions.nativeRemoteHLS` records what the host asked for. It is not what ends up serving the session: the engine reroutes on its own findings, and `playbackBackend` cannot tell the two native pipelines apart because both are `.native`. `AetherEngine.videoRoute` publishes the pipeline actually running, derived the same way `playbackPhase` is (a pure fold over `playbackBackend` and the session's effective options, recomputed from each one's `didSet`, re-emitted only on a real change), so it cannot become a second opinion about the session.
+
+- `.remoteBypass` is AVPlayer on the origin URL: no demuxer, no local server. AVFoundation owns media selection, buffering, and subtitle drawing.
+- `.loopback` is the demuxer plus the local HLS-fMP4 server, the default video route. The engine owns the source connection and the subtitle pipeline.
+- `.software`, `.audio` and `.none` mirror the corresponding backends.
+
+Routes the host did not ask for:
+
+| Transition | Trigger |
+| --- | --- |
+| `.remoteBypass` -> `.loopback` | #168 carriage watchdog: readyToPlay, but no video track for a master that advertises one (HEVC in MPEG-TS). Mid-session. |
+| `.remoteBypass` -> `.loopback` | #199: the same master's verdict is remembered, so the next load skips the doomed mount entirely. At load time. |
+| `.remoteBypass` -> `.loopback` | AE#268: the playlist plus the first segment's PMT identify a finite HEVC-in-MPEG-TS VOD. At load time. |
+| `.loopback` -> `.remoteBypass` | AE#154 / AE#246: an HLS playlist reached the loopback path, which cannot demux it. At load time. |
+
+Branch on this where host behaviour differs per pipeline: who draws subtitles (AVPlayer on the bypass, the host's renderer on loopback and software), and whether a composited PiP overlay is meaningful at all. Observing it also makes the mid-session reroute an event rather than a log line.
+
 ## SwiftUI `Menu` in custom player chrome
 
 On tvOS 26, the focused row of an open SwiftUI `Menu` blinks whenever any SwiftUI render transaction runs in the hosting tree, even one fully contained in an unrelated leaf view (a `TimelineView(.periodic)` wall clock, a playbar observing `engine.clock`, a subtitle overlay). Minimal repro: a `Menu` next to a `TimelineView(.periodic(from: .now, by: 1))`, open the menu, the focused item blinks once per second. This is a SwiftUI issue, not an engine one; reported to Apple by an AetherEngine adopter (see [AetherEngine#29](https://github.com/superuser404notfound/AetherEngine/issues/29)).


### PR DESCRIPTION
Closes nothing on its own: #321 stays open until the reporter has the value in hand.

`LoadOptions.nativeRemoteHLS` is the request. What actually serves the session can differ, and until now nothing said so:

- #168 carriage watchdog: live bypass -> ingest loopback, mid-session
- #199 remembered verdict: same move, at load time
- AE#268 carriage probe: finite HEVC-in-MPEG-TS VOD -> ingest, at load time
- AE#154 / AE#246: loopback -> bypass, at load time

`loadedOptions` is internal and `playbackBackend` is `.native` for both native pipelines, so the split was invisible.

## What this adds

`@Published public internal(set) var videoRoute: VideoRoute` with `.none` / `.remoteBypass` / `.loopback` / `.software` / `.audio`.

Derived, not stored twice: a pure fold over `playbackBackend` and the session's effective options, recomputed from each one's `didSet`, assigned only on a real change. That is the `playbackPhase` arrangement, and it is what keeps a future reroute site from forgetting to update the route: every reroute already writes one of those two properties.

The reporter's motivating case is subtitle ownership. On the bypass AVPlayer draws the origin's legible renditions; on the loopback and the software path the host's renderer does. Guess wrong and you draw nothing, or every cue twice.

## Verification

- 1606 tests in 238 suites green, including 12 new ones (derivation table plus engine wiring: request-without-backend, both reroute directions, software dispatch, teardown, no re-emit on an unrelated options write)
- `-strict-concurrency=complete` clean, tvOS Simulator BUILD SUCCEEDED
- Real media, not only units: a local MP4 settles on `route=loopback`; the Apple CMAF master (`bipbop_adv_example_hevc`) takes the AE#154 reroute and publishes `route=remoteBypass` at the moment of the reroute, with no misleading `.loopback` emission in front of it

`aetherctl play` prints `route=` next to `backend=`, so the value is capturable from the harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HX5zV3Fcf7Nzq4DYGdXvQE