### PR TITLE
fix(remote-hls): give the bypass a terminal state and act on a settled carriage verdict (#334)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,20 @@ the public-API contract.
 
 ## [Unreleased]
 
-_Nothing yet._
+### Fixed
+
+- **A `nativeRemoteHLS` session that never reached `readyToPlay` had no terminal state (#334).** An
+  origin that answers every request while AVFoundation can build no track from what it serves leaves
+  AVPlayer neither failing nor becoming ready, so `state` stayed `.loading` indefinitely: no error,
+  no timeout, and a host with nothing to retune on. The carriage machinery could not help, because
+  all of it is anchored at `readyToPlay`: the #293 probe settled `hevcInMPEGTS` and the verdict was
+  then only ever read by a loop that had not started, and the deferred segment-head probe waited 20 s
+  for a readiness that was not coming and gave up without reading. Three changes: a settled carriage
+  verdict now reroutes on its own (it is read off the source and needs no grace), the deferred probe
+  reads the segment head when the readiness ceiling expires instead of abandoning the case, and the
+  bypass has a 45 s ceiling on silence that publishes a real error when nothing became ready, nothing
+  rerouted and nothing failed. Readiness at any point, a reroute, or an AVPlayer failure all disarm
+  it, so slow origins and transcode spin-ups never meet it.
 
 ## [6.15.0] - 2026-08-08
 

--- a/Sources/AetherEngine/AetherEngine+Loading.swift
+++ b/Sources/AetherEngine/AetherEngine+Loading.swift
@@ -325,6 +325,10 @@ extension AetherEngine {
                   // back would ping-pong), and hosts can opt out via LoadOptions.
                   armVideoCarriageWatchdog: RemoteHLSIngestFallback.shouldArm(
                       isLive: options.isLive, fallbackEnabled: options.nativeRemoteHLSIngestFallback),
+                  // #334: the ceiling on silence this path never had. AVPlayer's "gave up" covers an
+                  // origin that stops answering; it does not cover one that answers everything while
+                  // AVFoundation builds no track, where nothing terminal is ever published.
+                  readinessDeadline: RemoteHLSReadinessDeadline.defaultBudgetSeconds,
                   isLive: options.isLive)
 
         // AE#154: surface the item's legible AVMediaSelectionGroup as `subtitleTracks` so hosts with

--- a/Sources/AetherEngine/Native/NativeAVPlayerHost.swift
+++ b/Sources/AetherEngine/Native/NativeAVPlayerHost.swift
@@ -104,6 +104,11 @@ final class NativeAVPlayerHost {
     static let carriageProbeReadinessTickSeconds = 0.05
     static let carriageProbeReadinessTicks = 400
 
+    /// #334: budget for the bypass's readiness deadline, nil on every path that has its own terminal
+    /// state (the loopback's live-reload watchdog, VOD). Set per load from `load(readinessDeadline:)`.
+    private var readinessDeadlineSeconds: Double?
+    private var readinessDeadlineTask: Task<Void, Never>?
+
     /// #35 (Sodalite) cold-DV-master startup-readiness gate. While the engine drives the bounded
     /// retry loop this is true, so a startup failure (`.failed` with any code, including a
     /// display-rejection) is NOT published: the gate polls `awaitStartupReadiness` and decides to
@@ -263,11 +268,12 @@ final class NativeAVPlayerHost {
     /// after an in-PiP recovery reload) and the pause bounces transport for nothing. The swap
     /// keeps transport intent, clocks and the old item alive until replaceCurrentItem hands
     /// AVPlayer the fresh one.
-    func load(url: URL, startPosition: Double?, perFrameHDR: Bool = true, skipInitialSeek: Bool = false, forwardBufferDuration: Double = 4.0, surfaceEndFailures: Bool = false, inPlaceSwap: Bool = false, httpHeaders: [String: String] = [:], armVideoCarriageWatchdog: Bool = false, isLive: Bool = false) {
+    func load(url: URL, startPosition: Double?, perFrameHDR: Bool = true, skipInitialSeek: Bool = false, forwardBufferDuration: Double = 4.0, surfaceEndFailures: Bool = false, inPlaceSwap: Bool = false, httpHeaders: [String: String] = [:], armVideoCarriageWatchdog: Bool = false, readinessDeadline: Double? = nil, isLive: Bool = false) {
         unloadCurrentItem(inPlaceSwap: inPlaceSwap)
 
         self.surfaceEndFailures = surfaceEndFailures
         self.carriageWatchdogArmed = armVideoCarriageWatchdog
+        self.readinessDeadlineSeconds = readinessDeadline
         self.isLiveSession = isLive
         Self.nextSessionID += 1
         sessionID = Self.nextSessionID
@@ -337,6 +343,11 @@ final class NativeAVPlayerHost {
         lastSuppressedStartupFailure = nil
         isReady = false
         seekableEnd = 0
+        // #334: the bypass's ceiling on silence. Started with the mount rather than at readyToPlay,
+        // because the session it exists for is exactly the one that never gets there.
+        if let budget = readinessDeadline {
+            startReadinessDeadline(item: item, budgetSeconds: budget)
+        }
 
         // #134: mirror seekableTimeRanges instead of reading it per call. The callback runs on
         // the item's queue where the re-read is a harmless off-main XPC; live playlist refreshes
@@ -1183,6 +1194,10 @@ final class NativeAVPlayerHost {
         carriageProbeTask?.cancel()
         carriageProbeTask = nil
         carriageProbeEvidence = .pending
+        // #334: the deadline belongs to the outgoing item too.
+        readinessDeadlineTask?.cancel()
+        readinessDeadlineTask = nil
+        readinessDeadlineSeconds = nil
         // Re-arm #50 hasEverPlayed: reused host must not inherit prior session's established state.
         hasEverPlayed = false
         // #93 recovery reload: same content, same position, playback must continue. Skip the
@@ -1312,7 +1327,21 @@ final class NativeAVPlayerHost {
                     + "so the segment head waits for readyToPlay rather than compete with the mount (#296)",
                     category: .engine
                 )
-                guard await self.awaitReadyForDeferredProbe(sid: sid) else { return }
+                switch await self.awaitReadyForDeferredProbe(sid: sid) {
+                case .abandoned:
+                    return
+                case .ceilingExpired:
+                    // #334: readiness is not coming. Deferring existed so the read would not compete
+                    // with the mount, and a mount that has not settled in 20 s is not competing for
+                    // anything; giving up here is what left the source unjudged and the session silent.
+                    EngineLog.emit(
+                        "[NativeAVPlayerHost] #\(sid) carriage probe: readyToPlay never arrived, "
+                        + "reading the segment head anyway rather than leaving the source unjudged (#334)",
+                        category: .engine
+                    )
+                case .ready:
+                    break
+                }
                 let verdict = await HLSCarriageProbe.classifyDeferredSegmentHead(
                     url: segmentURL, httpHeaders: httpHeaders)
                 guard !Task.isCancelled, self.sessionID == sid else { return }
@@ -1326,30 +1355,97 @@ final class NativeAVPlayerHost {
         _ verdict: MPEGTransportStreamCodecProbe.Verdict, sid: Int, from source: String
     ) {
         carriageProbeEvidence = verdict == .hevcInMPEGTS ? .transportStreamHEVC : .nativeCapable
+        // #334: a settled verdict is conclusive without the grace, so it must not wait for the timing
+        // loop that arms at readyToPlay. A source with no audio track either never reaches readiness at
+        // all, and that is precisely the session this verdict is the only fix for.
+        if RemoteHLSIngestFallback.shouldRerouteOnSettledEvidence(
+            carriageEvidence: carriageProbeEvidence,
+            videoTrackCount: currentVideoTrackCount(),
+            armed: carriageWatchdogArmed,
+            alreadyRejected: remoteHLSVideoCarriageRejected
+        ) {
+            EngineLog.emit(
+                "[NativeAVPlayerHost] #\(sid) carriage probe: \(verdict) from \(source) evidence; "
+                + "rerouting without waiting for readyToPlay (#334)",
+                category: .engine
+            )
+            carriageWatchdogTask?.cancel()
+            carriageWatchdogTask = nil
+            remoteHLSVideoCarriageRejected = true
+            return
+        }
         EngineLog.emit(
             "[NativeAVPlayerHost] #\(sid) carriage probe: \(verdict) from \(source) evidence (#293)",
             category: .engine
         )
     }
 
-    /// AE#296: hold the deferred segment-head read until the item is ready. The verdict cannot be acted on
-    /// before then anyway (the watchdog arms at readyToPlay), so waiting costs nothing and removes the one
-    /// window where the read is expensive: a connection lost while the mount is establishing its own can
-    /// cost the mount, one lost here can only cost the verdict, on a session that is already black. A
-    /// session that never reaches readyToPlay, or whose watchdog disarms first, spends no media byte at
-    /// all. Returns false when the wait was overtaken by cancellation, a new session or the ceiling.
+    /// #334: the wait has three outcomes, because "readiness never came" and "this session is gone" no
+    /// longer lead to the same place. Only the second abandons the probe.
+    private enum DeferredProbeWait { case ready, ceilingExpired, abandoned }
+
+    /// AE#296: hold the deferred segment-head read until the item is ready. It removes the one window
+    /// where the read is expensive: a connection lost while the mount is establishing its own can cost
+    /// the mount, one lost afterwards can only cost the verdict, on a session that is already black. A
+    /// session whose watchdog disarms first spends no media byte at all.
+    ///
+    /// #334 corrected the other half of that rationale. Waiting was said to cost nothing because the
+    /// verdict could not be acted on before readyToPlay anyway; it can now, and a source AVFoundation
+    /// builds no track at all for never reaches readiness, so the ceiling reports itself rather than
+    /// silently ending the probe.
     @MainActor
-    private func awaitReadyForDeferredProbe(sid: Int) async -> Bool {
+    private func awaitReadyForDeferredProbe(sid: Int) async -> DeferredProbeWait {
         var ticksWaited = 0
         while !isReady {
-            guard !Task.isCancelled,
-                  sessionID == sid,
-                  ticksWaited < Self.carriageProbeReadinessTicks else { return false }
+            guard !Task.isCancelled, sessionID == sid else { return .abandoned }
+            guard ticksWaited < Self.carriageProbeReadinessTicks else { return .ceilingExpired }
             ticksWaited += 1
             try? await Task.sleep(
                 nanoseconds: UInt64(Self.carriageProbeReadinessTickSeconds * 1_000_000_000))
         }
-        return !Task.isCancelled && sessionID == sid
+        return (!Task.isCancelled && sessionID == sid) ? .ready : .abandoned
+    }
+
+    /// Video tracks AVPlayer has actually built for the current item. Shared by the watchdog tick and
+    /// the #334 pre-readiness reroute so both judge the same thing.
+    @MainActor
+    private func currentVideoTrackCount() -> Int {
+        playerItem?.tracks.filter { $0.assetTrack?.mediaType == .video }.count ?? 0
+    }
+
+    /// #334: fail a bypass session that neither becomes ready nor fails. Runs from the mount rather than
+    /// from readyToPlay for the obvious reason. Everything that resolves the session disarms it, so the
+    /// budget is only ever spent by a session that was going to sit in `.loading` indefinitely.
+    @MainActor
+    private func startReadinessDeadline(item: AVPlayerItem, budgetSeconds: Double) {
+        let sid = sessionID
+        readinessDeadlineTask = Task { @MainActor [weak self] in
+            var deadline = RemoteHLSReadinessDeadline(
+                budgetSeconds: budgetSeconds, tickSeconds: Self.carriageWatchdogTickSeconds)
+            while !Task.isCancelled {
+                try? await Task.sleep(
+                    nanoseconds: UInt64(Self.carriageWatchdogTickSeconds * 1_000_000_000))
+                guard let self, !Task.isCancelled, self.sessionID == sid,
+                      self.playerItem === item else { return }
+                switch deadline.tick(isReady: self.isReady,
+                                     carriageRerouted: self.remoteHLSVideoCarriageRejected,
+                                     hasFailed: self.failureMessage != nil) {
+                case .keepWaiting:
+                    continue
+                case .disarm:
+                    return
+                case .fail:
+                    let message = RemoteHLSReadinessDeadline.failureMessage(budgetSeconds: budgetSeconds)
+                    EngineLog.emit(
+                        "[NativeAVPlayerHost] #\(sid) readiness deadline: no track, no readiness and no "
+                        + "failure in \(Int(budgetSeconds.rounded()))s; surfacing a terminal state (#334)",
+                        category: .engine
+                    )
+                    self.failureMessage = message
+                    return
+                }
+            }
+        }
     }
 
     /// AetherEngine#168 follow-up: after readyToPlay, poll `item.tracks` at the tick cadence against the
@@ -1373,7 +1469,7 @@ final class NativeAVPlayerHost {
                 variantHasVideoAttributes: variants.map { $0.videoAttributes != nil })
             while !Task.isCancelled {
                 guard let self, self.playerItem === item else { return }
-                let videoTrackCount = item.tracks.filter { $0.assetTrack?.mediaType == .video }.count
+                let videoTrackCount = self.currentVideoTrackCount()
                 let evidence = self.carriageProbeEvidence
                 switch watchdog.tick(
                     videoTrackCount: videoTrackCount,

--- a/Sources/AetherEngine/Native/RemoteHLSIngestFallback.swift
+++ b/Sources/AetherEngine/Native/RemoteHLSIngestFallback.swift
@@ -72,6 +72,24 @@ enum RemoteHLSIngestFallback {
         }
     }
 
+    /// #334: whether a carriage verdict that has just settled may reroute on its own, without the
+    /// readiness anchor the timing loop is armed at. The anchor exists for the grace-based verdict, where
+    /// "no track yet" is only meaningful once the item is otherwise healthy; a settled verdict is read off
+    /// the source's own playlists or PMT and needs no grace, and waiting for readiness loses the case it
+    /// was built for: a source with no audio either, where AVFoundation builds no track at all and
+    /// `readyToPlay` therefore never arrives. `videoTrackCount` is still consulted so a source that
+    /// contradicts the probe by building a track keeps its native session.
+    static func shouldRerouteOnSettledEvidence(
+        carriageEvidence: CarriageEvidence,
+        videoTrackCount: Int,
+        armed: Bool,
+        alreadyRejected: Bool
+    ) -> Bool {
+        guard armed, !alreadyRejected else { return false }
+        guard carriageEvidence == .transportStreamHEVC else { return false }
+        return videoTrackCount == 0
+    }
+
     /// Maps `AVAssetVariant.videoAttributes` presence per variant to the watchdog's evidence input:
     /// no variants at all = unknown (nil), any variant with video attributes = advertised, an all-audio
     /// variant set = a radio-style master where zero video tracks is the correct steady state.

--- a/Sources/AetherEngine/Native/RemoteHLSReadinessDeadline.swift
+++ b/Sources/AetherEngine/Native/RemoteHLSReadinessDeadline.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// AetherEngine#334: the terminal state the `nativeRemoteHLS` bypass never had.
+///
+/// The lean bypass deliberately runs without a readiness watchdog and leaves a dead upstream to
+/// AVPlayer's own "gave up" signal (`surfaceEndFailures`). That covers an origin that stops answering.
+/// It does not cover an origin that answers everything while AVFoundation can build no track from what
+/// it serves: no failure is ever raised, `readyToPlay` never arrives, and the session sits in `.loading`
+/// for as long as the host leaves it there. Field shape: a video-only channel carrying HEVC in MPEG-TS,
+/// where the carriage reroute is the fix but there is no audio track to reach readiness with either.
+///
+/// This is a ceiling on silence, not on how long a slow origin may take. Anything that resolves the
+/// session, readiness at any point, a carriage reroute, an AVPlayer failure that already published a
+/// terminal state, disarms it, so a Jellyfin transcode spin-up or a slow IPTV token handshake never
+/// meets it. Only a session where nothing at all happened for the whole budget fails.
+///
+/// Pure decision logic; the timing loop lives in NativeAVPlayerHost, like the carriage watchdog's.
+struct RemoteHLSReadinessDeadline {
+
+    enum Verdict: Equatable {
+        /// Still inside the budget with nothing resolved; poll again after the tick cadence.
+        case keepWaiting
+        /// The session resolved itself. Stop watching; nothing to publish.
+        case disarm
+        /// The budget passed with no readiness, no reroute and no failure: publish a terminal state.
+        case fail
+    }
+
+    /// 45 s. It has to outlast the deferred carriage probe's own readiness ceiling (20 s) plus the
+    /// segment-head read it then performs, or the deadline would fail sessions the probe was about to
+    /// reroute. Everything healthy disarms in the first second, so the budget only ever costs the
+    /// sessions that were going to hang anyway.
+    static let defaultBudgetSeconds: Double = 45
+
+    let budgetTicks: Int
+    private(set) var ticksObserved = 0
+
+    init(budgetSeconds: Double = RemoteHLSReadinessDeadline.defaultBudgetSeconds, tickSeconds: Double) {
+        self.budgetTicks = max(1, Int((budgetSeconds / tickSeconds).rounded()))
+    }
+
+    mutating func tick(isReady: Bool, carriageRerouted: Bool, hasFailed: Bool) -> Verdict {
+        if isReady || carriageRerouted || hasFailed { return .disarm }
+        ticksObserved += 1
+        return ticksObserved >= budgetTicks ? .fail : .keepWaiting
+    }
+
+    /// Published as the session's error text, so it has to name what happened rather than the symptom:
+    /// a host that reads "no track" knows to retune or to pick another source, one that reads
+    /// "failed to load" does not.
+    static func failureMessage(budgetSeconds: Double) -> String {
+        "The stream never became playable: AVFoundation built no track for it within "
+        + "\(Int(budgetSeconds.rounded()))s and the source's carriage could not be identified."
+    }
+}

--- a/Tests/AetherEngineTests/Issue334BypassTerminalStateTests.swift
+++ b/Tests/AetherEngineTests/Issue334BypassTerminalStateTests.swift
@@ -1,0 +1,105 @@
+import Testing
+@testable import AetherEngine
+
+/// #334: a settled carriage verdict is conclusive on its own, so it must not wait for a readiness
+/// anchor that a source AVFoundation can build no track for never reaches.
+@Suite("Carriage verdict acts without readiness (#334)")
+struct SettledCarriageEvidenceTests {
+
+    @Test("a settled HEVC-in-MPEG-TS verdict reroutes on its own")
+    func settledVerdictFires() {
+        #expect(RemoteHLSIngestFallback.shouldRerouteOnSettledEvidence(
+            carriageEvidence: .transportStreamHEVC, videoTrackCount: 0,
+            armed: true, alreadyRejected: false))
+    }
+
+    @Test("evidence that is not positive never reroutes")
+    func onlyPositiveEvidenceFires() {
+        #expect(RemoteHLSIngestFallback.shouldRerouteOnSettledEvidence(
+            carriageEvidence: .pending, videoTrackCount: 0,
+            armed: true, alreadyRejected: false) == false)
+        #expect(RemoteHLSIngestFallback.shouldRerouteOnSettledEvidence(
+            carriageEvidence: .nativeCapable, videoTrackCount: 0,
+            armed: true, alreadyRejected: false) == false)
+    }
+
+    /// A built track is the source itself contradicting the probe, and reality outranks the probe.
+    @Test("a video track that exists outranks the verdict")
+    func existingTrackOutranksVerdict() {
+        #expect(RemoteHLSIngestFallback.shouldRerouteOnSettledEvidence(
+            carriageEvidence: .transportStreamHEVC, videoTrackCount: 1,
+            armed: true, alreadyRejected: false) == false)
+    }
+
+    @Test("a session that never armed the fallback is left alone")
+    func unarmedSessionIsLeftAlone() {
+        #expect(RemoteHLSIngestFallback.shouldRerouteOnSettledEvidence(
+            carriageEvidence: .transportStreamHEVC, videoTrackCount: 0,
+            armed: false, alreadyRejected: false) == false)
+    }
+
+    @Test("the reroute is one-shot: a verdict republished after it does not fire again")
+    func rejectionIsOneShot() {
+        #expect(RemoteHLSIngestFallback.shouldRerouteOnSettledEvidence(
+            carriageEvidence: .transportStreamHEVC, videoTrackCount: 0,
+            armed: true, alreadyRejected: true) == false)
+    }
+}
+
+/// #334: the bypass had no terminal state. A source that serves every segment but produces no track
+/// leaves AVPlayer neither failing nor becoming ready, so `state` stayed `.loading` forever.
+@Suite("Bypass readiness deadline (#334)")
+struct RemoteHLSReadinessDeadlineTests {
+
+    @Test("budget in seconds becomes whole ticks")
+    func budgetConvertsToTicks() {
+        #expect(RemoteHLSReadinessDeadline(budgetSeconds: 45, tickSeconds: 0.5).budgetTicks == 90)
+    }
+
+    @Test("readiness disarms it, which is the common case")
+    func readinessDisarms() {
+        var deadline = RemoteHLSReadinessDeadline(budgetSeconds: 2, tickSeconds: 0.5)
+        #expect(deadline.tick(isReady: true, carriageRerouted: false, hasFailed: false) == .disarm)
+    }
+
+    @Test("a carriage reroute disarms it: that session is being rebuilt elsewhere")
+    func rerouteDisarms() {
+        var deadline = RemoteHLSReadinessDeadline(budgetSeconds: 2, tickSeconds: 0.5)
+        #expect(deadline.tick(isReady: false, carriageRerouted: true, hasFailed: false) == .disarm)
+    }
+
+    @Test("an AVPlayer failure already published a terminal state; do not publish a second one")
+    func existingFailureDisarms() {
+        var deadline = RemoteHLSReadinessDeadline(budgetSeconds: 2, tickSeconds: 0.5)
+        #expect(deadline.tick(isReady: false, carriageRerouted: false, hasFailed: true) == .disarm)
+    }
+
+    @Test("it waits out the whole budget before failing")
+    func failsOnlyAfterTheFullBudget() {
+        var deadline = RemoteHLSReadinessDeadline(budgetSeconds: 2, tickSeconds: 0.5)   // 4 ticks
+        #expect(deadline.tick(isReady: false, carriageRerouted: false, hasFailed: false) == .keepWaiting)
+        #expect(deadline.tick(isReady: false, carriageRerouted: false, hasFailed: false) == .keepWaiting)
+        #expect(deadline.tick(isReady: false, carriageRerouted: false, hasFailed: false) == .keepWaiting)
+        #expect(deadline.tick(isReady: false, carriageRerouted: false, hasFailed: false) == .fail)
+    }
+
+    /// A source that becomes ready late still cancels the deadline: the budget is a ceiling on
+    /// silence, not on how long a slow origin may take.
+    @Test("readiness on the last tick still wins over the expiry")
+    func lateReadinessStillDisarms() {
+        var deadline = RemoteHLSReadinessDeadline(budgetSeconds: 1.5, tickSeconds: 0.5)  // 3 ticks
+        _ = deadline.tick(isReady: false, carriageRerouted: false, hasFailed: false)
+        _ = deadline.tick(isReady: false, carriageRerouted: false, hasFailed: false)
+        #expect(deadline.tick(isReady: true, carriageRerouted: false, hasFailed: false) == .disarm)
+    }
+
+    @MainActor
+    @Test("the budget the bypass ships with clears the deferred probe's own ceiling")
+    func shippedBudgetOutlastsTheDeferredProbe() {
+        // The deferred segment-head probe waits 400 x 0.05 s for readiness and then reads the head
+        // anyway; failing the session before that verdict can arrive would defeat it.
+        let probeCeiling = Double(NativeAVPlayerHost.carriageProbeReadinessTicks)
+            * NativeAVPlayerHost.carriageProbeReadinessTickSeconds
+        #expect(RemoteHLSReadinessDeadline.defaultBudgetSeconds > probeCeiling + 10)
+    }
+}


### PR DESCRIPTION
Re #334. Found while verifying #321 against a synthetic live master.

A `nativeRemoteHLS` session whose item never reaches `readyToPlay` had no way out. The lean bypass runs without a readiness watchdog on purpose and leaves a dead upstream to AVPlayer's own "gave up" signal, which covers an origin that stops answering. It does not cover one that answers everything while AVFoundation builds no track from what it serves: nothing fails, nothing becomes ready, `state` stays `.loading`.

The carriage machinery could not rescue it, because all of it hangs off the same anchor: the #293 probe settled `hevcInMPEGTS` and the verdict was then only read by a loop that arms at `readyToPlay`, and the deferred segment-head probe waited out its 20 s readiness ceiling and returned without reading the one thing that could judge the source.

## Three changes

1. **A settled verdict reroutes on its own.** It is read off the source's playlists or PMT and needs no grace. A video track that does exist still outranks it, so a source contradicting the probe keeps its native session.
2. **The deferred probe reads the segment head when the ceiling expires** instead of abandoning the case. Deferring existed so the read would not compete with the mount; a mount that has not settled in 20 s is not competing for anything.
3. **The bypass gets a ceiling on silence.** 45 s with no readiness, no reroute and no failure publishes a real error. Readiness at any point, a reroute, or an AVPlayer failure disarm it, so a slow IPTV handshake or a Jellyfin transcode spin-up never meets it. The budget also clears the deferred probe's own 20 s ceiling plus its segment read, which is asserted in a test rather than left to a comment.

## Verification

12 new tests (verdict-acts-without-readiness table, deadline table), 1618 tests in 240 suites green, `-strict-concurrency=complete` clean, tvOS Simulator BUILD SUCCEEDED.

Each layer was also run against a synthetic live master carrying HEVC in MPEG-TS with **no audio track**, which is the shape that produced the hang:

| Fixture | Before | After |
| --- | --- | --- |
| `CODECS="hvc1..."` | 25 s in `state=loading`, verdict logged and unused | reroutes ~1 s in, `state=playing` |
| no `CODECS` | same hang, segment head never read | ceiling log, head read, reroute at ~20 s, plays |
| `CODECS="avc1..."` while carrying HEVC | hang with nothing able to judge it | terminal `.error` at 45 s |

Internal surface only (`RemoteHLSReadinessDeadline` and the new `load(readinessDeadline:)` parameter are not public), so this is a patch-level behaviour fix: sessions that used to hang now either play or fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HX5zV3Fcf7Nzq4DYGdXvQE