### PR TITLE
fix(io): latch the live join shape on rejection instead of assuming it (#331 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,16 +27,19 @@ the public-API contract.
   absorbed once, steady state plateaus at burst size with the connection never voluntarily
   ended, and the end-and-refill survives unchanged as the memory backstop for a "live" source
   that sustainedly outruns realtime.
-- **A live reconnect asks for the stream the way a join does, instead of at a byte frontier.**
+- **A live reconnect that the origin cannot satisfy asks for the stream the way a join does.**
   The reconnect request carried `Range: bytes=<frontier>-`, but the frontier is reader
-  bookkeeping — the window position delivered bytes are appended at — not a server-side byte
-  address, because a live origin has none. Panels that ignore the offset and serve "from now"
+  bookkeeping (the window position delivered bytes are appended at), and whether it means
+  anything server-side depends on the origin. Panels that ignore the offset and serve "from now"
   masked this; a panel that answers 416 to every offset it cannot satisfy turned each reconnect
   into an unrecoverable rejection loop (field trace: a panel that cleanly completes every
   response after its ~14 MB ring burst then 416'd the same frontier 35 generations in a row,
-  ~1/s, while the runway drained from 8 MB to zero and the session starved). Live requests are
-  now always `bytes=0-` — the one shape every origin serves, and the shape the join already
-  uses — and the append anchors the bytes at the frontier exactly as it always has.
+  ~1/s, while the runway drained from 8 MB to zero and the session starved). The rejection is
+  now the signal: the first 416 on a nonzero live offset latches the join shape (`bytes=0-`,
+  what every origin serves) for the rest of the session, so the loop costs one request and never
+  repeats. A live source that IS byte-addressable (a growing stream file, a misdeclared VOD)
+  keeps resuming at the frontier, which is what it answers correctly and where asking for byte
+  zero would re-deliver its whole buffer on top of the window.
 - **HTTP 509 from a pinned redirect target is treated as metering, not as a dead pin.**
   509 "Bandwidth Limit Exceeded" is what a connection-capped IPTV panel answers while the slot
   the reader is replacing has not been torn down server-side yet. It classified as a hard 5xx,

--- a/Sources/AetherEngine/Demuxer/AVIOReader.swift
+++ b/Sources/AetherEngine/Demuxer/AVIOReader.swift
@@ -396,6 +396,15 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
     /// did, and the checks that need the REQUESTED offset (a 200 that ignored Range, the size
     /// derived from a from-zero response) must not read the window's start instead. winCond-guarded.
     private var connRequestedOffset: Int64 = 0
+    /// #331: latched once a live origin answers 416 to a nonzero offset, i.e. proves it has no
+    /// byte addresses to resume at. From there every live request is the join shape (`bytes=0-`).
+    /// Latched rather than unconditional because the two live origin shapes want opposite things:
+    /// an IPTV panel serving a ring buffer cannot satisfy a frontier and rejects it outright,
+    /// while a live source that IS a growing file (a Jellyfin live stream file, a misdeclared VOD)
+    /// honours the frontier and resumes exactly where delivery stopped, and asking that one for
+    /// byte zero re-delivers the whole buffer on top of the window. One rejected request per reader
+    /// tells the two apart; guessing cannot. winCond-guarded.
+    private var liveOffsetsUnsatisfiable = false
 
     /// #220: winCond-guarded snapshot of the sliding window for the periodic memprobe.
     /// `ahead` is the undrained forward extent, the quantity `appendPersistentData` gates the
@@ -1978,6 +1987,7 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
             window = Data()
         }
         connRequestedOffset = offset
+        let askAsJoin = isLive && liveOffsetsUnsatisfiable
         connEnded = false
         connEndedByBackpressure = false
         connEndedAtRangeEnd = false
@@ -2006,15 +2016,17 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
         if let resolvedBound {
             request.setValue("bytes=\(offset)-\(offset + resolvedBound - 1)", forHTTPHeaderField: "Range")
         } else {
-            // Live: `offset` is reader bookkeeping (the window frontier the delivered bytes
-            // are appended at), not a server-side position — a live origin has no byte
-            // addresses, and panels disagree on what a nonzero offset means: some ignore it
-            // and serve from now (which is why the frontier request ever worked), others
-            // answer 416 to every offset they cannot satisfy, turning each reconnect into an
-            // unrecoverable rejection loop. Ask for the stream the way a join does
-            // (`bytes=0-`, the one shape every origin serves) and let the append anchor the
-            // bytes at the frontier, exactly as it already does.
-            request.setValue("bytes=\(isLive ? 0 : offset)-", forHTTPHeaderField: "Range")
+            // Live: `offset` is reader bookkeeping (the window frontier the delivered bytes are
+            // appended at), and whether it means anything server-side depends on the origin.
+            // Panels serving a ring buffer have no byte addresses at all: some ignore the offset
+            // and serve from now (which is why the frontier request ever worked), others answer
+            // 416 to every offset they cannot satisfy, which turned each reconnect into an
+            // unrecoverable rejection loop (#331). A live source that is a growing FILE resumes
+            // at the frontier correctly, and asking it for byte zero would re-deliver its whole
+            // buffer on top of the window. So keep the frontier until an origin rejects it, then
+            // ask the way a join does for the rest of the session; the append anchors the bytes
+            // at the frontier either way.
+            request.setValue("bytes=\(askAsJoin ? 0 : offset)-", forHTTPHeaderField: "Range")
         }
         request.timeoutInterval = 0  // long-lived; stalls handled by the reader
         applyExtraHeaders(&request)
@@ -2250,6 +2262,16 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
         // from byte 0 (silent corruption). Reject it. Live is exempt: transcode
         // reconnect legitimately answers 200 with "from now".
         let requestedOffset = (generation == connGeneration) ? connRequestedOffset : 0
+        // #331: the origin just told us its live stream has no byte address to resume at. Latch
+        // it, so every later request in this session is the join shape instead of repeating an
+        // offset that can only ever be rejected again. Nonzero offsets only: a 416 at zero is a
+        // different fault and must not silently change the request shape.
+        var latchedJoinShape = false
+        if generation == connGeneration, isLive, status == 416, requestedOffset > 0,
+           !liveOffsetsUnsatisfiable {
+            liveOffsetsUnsatisfiable = true
+            latchedJoinShape = true
+        }
         // Issue #70: the first from-0 data connection doubles as the size probe, so the
         // playback open skips probeFileSize() entirely. Derive the total from this
         // response (206 Content-Range, or Content-Length on a from-0 2xx). Write-once
@@ -2270,6 +2292,15 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
         if let headerMs, headerMs > 2000 {
             EngineLog.emit(
                 "[AVIOReader] gen=\(generation) response headers after \(Int(headerMs))ms status=\(status)",
+                category: .demux
+            )
+        }
+        // #331: name the latch once. A field capture that shows the reconnect shape change is the
+        // difference between "the origin has no byte addresses" and "the reconnect is broken".
+        if latchedJoinShape {
+            EngineLog.emit(
+                "[AVIOReader] \(label) live origin rejected offset \(requestedOffset) (416); "
+                + "requesting the stream as a join from here",
                 category: .demux
             )
         }

--- a/Tests/AetherEngineTests/LiveWindowBackpressureTests.swift
+++ b/Tests/AetherEngineTests/LiveWindowBackpressureTests.swift
@@ -104,8 +104,12 @@ struct LiveWindowBackpressureTests {
         }
         #expect(got >= target, "only \(got / (1024 * 1024)) MB delivered after the backstop")
         #expect(server.rangeRequestCount >= 2, "the frontier refill never fired")
-        #expect(server.requestedRanges.allSatisfy { $0.start == 0 },
-                "a live request carried a byte frontier the origin never promised to honour: \(server.requestedRanges)")
+        // #331 follow-up: this origin answers every offset it is given, which is the shape of a
+        // live source that is a growing file. The refill must RESUME at the frontier there, because
+        // asking a byte-addressable live origin for zero re-delivers its whole buffer on top of
+        // the window. The join shape is reserved for an origin that has rejected an offset.
+        #expect(server.requestedRanges.dropFirst().allSatisfy { $0.start > 0 },
+                "a refill against a range-honouring live origin restarted at byte zero: \(server.requestedRanges)")
         #expect(server.requestedRanges.allSatisfy { $0.end == nil },
                 "every live request must be open-ended: \(server.requestedRanges)")
     }
@@ -115,8 +119,9 @@ struct LiveWindowBackpressureTests {
     /// with a nonzero byte offset (a live stream has no byte addresses). Reconnecting
     /// "at the frontier" against such an origin is an unrecoverable rejection loop:
     /// every retry asks the same unsatisfiable offset until the runway drains and the
-    /// session starves. A live reconnect must ask for the stream the way a join does.
-    @Test("a live reconnect after a completed burst asks like a join, not at a frontier",
+    /// session starves. The rejection is the signal: one 416 latches the join shape for
+    /// the rest of the session, so the loop costs a single request and never repeats.
+    @Test("a rejected live frontier latches the join shape for the rest of the session",
           .timeLimit(.minutes(2)))
     func liveReconnectAsksLikeAJoin() async throws {
         // 4 MB per connection: the origin serves its "ring buffer" and completes the
@@ -149,7 +154,13 @@ struct LiveWindowBackpressureTests {
         #expect(got >= target,
                 "only \(got / (1024 * 1024)) MB delivered; the reconnect starved on a rejected frontier")
         #expect(server.rangeRequestCount >= 3, "expected one connection per burst cycle")
-        #expect(server.requestedRanges.allSatisfy { $0.start == 0 },
-                "a live reconnect carried a frontier offset: \(server.requestedRanges)")
+        // The latch costs exactly one rejected request per reader: the first reconnect asks at
+        // the frontier (right for a byte-addressable live source), is told 416, and every
+        // request after it is the join shape. Two or more rejections means the latch never took.
+        let rejected = server.requestedRanges.filter { $0.start > 0 }
+        #expect(rejected.count == 1,
+                "the join shape must be latched by the first rejection: \(server.requestedRanges)")
+        #expect(server.requestedRanges.last?.start == 0,
+                "a live reconnect went on carrying a frontier offset: \(server.requestedRanges)")
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #332 (merged). The live request shape is now decided by the origin's answer instead of by the `isLive` flag.

#332 made every live persistent request `bytes=0-`. That is right for a ring-buffer IPTV panel, which has no byte addresses and rejects a frontier with 416. It is wrong for the other live shape: a source that IS a growing file (a Jellyfin live stream file, a misdeclared VOD) answers the frontier correctly and resumes exactly where delivery stopped, and asking that one for byte zero re-delivers its whole buffer on top of the window. Both shapes reach `AVIOReader` through `LoadOptions.isLive`, which is a host declaration, so the flag cannot tell them apart.

## What changed

- The frontier is kept until an origin answers 416 to a nonzero live offset. That rejection latches the join shape (`bytes=0-`) for the rest of the reader's life. A ring-buffer panel pays exactly one rejected request per reader; a byte-addressable live source pays nothing.
- The latch is named once in the log, so a field capture separates "this origin has no byte addresses" from "the reconnect is broken".
- Nonzero offsets only: a 416 at offset zero is a different fault and must not silently change the request shape.

## Test plan

- `swift test`: 1623 tests green.
- `LiveWindowBackpressureTests` covers both origin shapes. Witness-checked in both directions by disabling the guard: never latching starves after one 4 MB burst (13 rejected requests at the same offset, reproducing the field trace); latching unconditionally makes the range-honouring origin's refill restart at byte zero.

Reported in #331 (kept open until the reporter retests on device)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HX5zV3Fcf7Nzq4DYGdXvQE