### PR TITLE
fix(video): escalate live reopen exhaustion for URL sources too

### DIFF
--- a/Sources/AetherEngine/Video/HLSVideoEngine+LiveReopen.swift
+++ b/Sources/AetherEngine/Video/HLSVideoEngine+LiveReopen.swift
@@ -95,6 +95,17 @@ extension HLSVideoEngine {
         return .none
     }
 
+    /// #199 follow-up pure decision: EVERY in-engine reopen transport that exhausts its budget must
+    /// halt production (dropping the blocking-reload advert, releasing held ?_HLS_msn= waiters) and
+    /// surface the loss to the host via onLiveSourceReset. #199 scoped that escalation to the factory
+    /// transport it introduced, which left a URL source's exhaustion as a zombie session: provider
+    /// un-halted, playlist frozen, host never told to retune. `.none` never reaches an exhaustion
+    /// site — it delegates to host retune before any reopen begins — and must stay out so a future
+    /// call-site reshuffle cannot double-signal that path.
+    static func liveReopenExhaustionEscalatesToHost(transport: LiveReopenTransport) -> Bool {
+        transport != .none
+    }
+
     func handlePumpFinished(_ prod: HLSSegmentProducer,
                                     reason: HLSSegmentProducer.PumpExitReason) {
         // #65 (VOD only): a broken backpressure wedge means AVPlayer is stuck behind a parked producer.
@@ -219,10 +230,10 @@ extension HLSVideoEngine {
                 + "\(barrenNow) reopen cycles; giving up (source considered dead)",
                 category: .session
             )
-            if reopenTransport == .customFactory {
-                // #199: same last-resort surface as reopen exhaustion; without it the recoverable
-                // exit reason skipped the halt above and the zombie session would hold blocking
-                // reloads it can never satisfy.
+            if Self.liveReopenExhaustionEscalatesToHost(transport: reopenTransport) {
+                // #199 follow-up: same last-resort surface for EVERY reopenable transport; the
+                // recoverable exit reason skipped the halt above, so without this the zombie
+                // session holds blocking reloads it can never satisfy and the host is never told.
                 provider?.markLiveProductionHalted()
                 onLiveSourceReset?()
             }
@@ -549,10 +560,10 @@ extension HLSVideoEngine {
             + "source considered permanently lost",
             category: .session
         )
-        if transport == .customFactory {
-            // #199: the in-engine transport is exhausted; surface the loss the way a factory-less
-            // custom source would have immediately, so the host can retune instead of holding a
-            // zombie session whose blocking-reload advert can never be satisfied.
+        if Self.liveReopenExhaustionEscalatesToHost(transport: transport) {
+            // #199 follow-up: the in-engine transport is exhausted; surface the loss the way a
+            // factory-less custom source would have immediately, so the host can retune instead of
+            // holding a zombie session whose blocking-reload advert can never be satisfied.
             provider?.markLiveProductionHalted()
             onLiveSourceReset?()
         }

--- a/Tests/AetherEngineTests/Issue199RerouteRecoveryTests.swift
+++ b/Tests/AetherEngineTests/Issue199RerouteRecoveryTests.swift
@@ -88,6 +88,20 @@ final class Issue199RerouteRecoveryTests: XCTestCase {
             sourceReopenableByURL: false, hasCustomSourceReopenFactory: false), .none)
     }
 
+    // MARK: - Reopen exhaustion escalation
+
+    func testEveryReopenableTransportEscalatesOnExhaustion() {
+        XCTAssertTrue(HLSVideoEngine.liveReopenExhaustionEscalatesToHost(transport: .url),
+            "a URL source that exhausts its reopen budget must halt production and tell the host; leaving it un-halted is a zombie session with a frozen playlist")
+        XCTAssertTrue(HLSVideoEngine.liveReopenExhaustionEscalatesToHost(transport: .customFactory),
+            "the original #199 escalation")
+    }
+
+    func testTransportlessSourcesNeverReachExhaustionEscalation() {
+        XCTAssertFalse(HLSVideoEngine.liveReopenExhaustionEscalatesToHost(transport: .none),
+            ".none delegates to host retune before any reopen begins; escalating it again would double-signal liveSourceReset")
+    }
+
     // MARK: - Fresh-reader factory
 
     func testMainVideoReaderVendsFreshIndependentReader() {


### PR DESCRIPTION
## Problem

Both live reopen-exhaustion sites escalate only for the `.customFactory` transport that #199 introduced:

- the barren-cycle cap in `handlePumpFinished` ("live source produced no segments across N reopen cycles; giving up"), and
- the attempt cap at the end of `performLiveReopen` ("live reopen FAILED after N attempts; source considered permanently lost").

A **URL-source** live session that exhausts its reopen budget reaches the same terminal state with neither `markLiveProductionHalted()` nor `onLiveSourceReset`: the provider keeps advertising blocking reloads it can never satisfy (the -15410 shape the halt latch exists for), the playlist stays frozen, and the host is never asked to retune. That is exactly the zombie window #199 closed for engine-created ingest readers — still open on the most common transport.

Found while tracing a field freeze (same session as #340/#341/#342): the incident itself died through the live-`muxerFailed` hole #341 covers, but this adjacent exhaustion path has the identical failure shape for URL sources whose reopens run dry.

## Fix

Extract the escalation decision as a pure function, `liveReopenExhaustionEscalatesToHost(transport:)`, covering **every** reopenable transport, and use it at both sites. `.none` deliberately stays out: a transport-less source delegates to host retune before any reopen begins, and escalating it again would double-signal `liveSourceReset`.

Behavior for `.customFactory` is unchanged; `.url` now halts + signals on exhaustion instead of zombifying.

## Tests

Pinned in `Issue199RerouteRecoveryTests` next to the existing transport-decision pins: `.url` and `.customFactory` escalate on exhaustion; `.none` never reaches the escalation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
