### PR TITLE
Make the panel mode switch observable, and stop guessing its end (#339)

### DIFF
--- a/Sources/AetherEngine/AetherEngine+Loading.swift
+++ b/Sources/AetherEngine/AetherEngine+Loading.swift
@@ -1638,6 +1638,10 @@ extension AetherEngine {
                 softwareHost?.play()
             } else {
                 EngineLog.emit("[AetherEngine] reload: loadNative enter audio=\(audioStreamIndex.map(String.init) ?? "nil") resumeAt=\(String(format: "%.2f", resumeAt))s", category: .engine)
+                // #339: the only write this reload can still produce is a sole-writer host's re-write on the
+                // swapped item, which happens inside loadNative. Arm before it, or the gate below is again
+                // reading a flag for a switch whose notifications it was not registered for.
+                if loadedOptions.suppressDisplayCriteria { displayCriteria.armSwitchObservation() }
                 try await loadNative(
                     url: url,
                     sourceHTTPHeaders: loadedOptions.httpHeaders,

--- a/Sources/AetherEngine/AetherEngine.swift
+++ b/Sources/AetherEngine/AetherEngine.swift
@@ -2850,6 +2850,11 @@ public final class AetherEngine: ObservableObject {
             // own from the AVPlayerItem formatDescription later. Clear a leftover engine criteria now
             // (didApply-gated no-op for hosts that always suppress) so the two writers can't fight.
             displayCriteria.reset()
+            // #339: AVKit's write lands inside loadNative, so the observation has to be armed before the
+            // load rather than when the play gate opens. After reset(), so a switch back to the default
+            // mode is not recorded as this session's. Audio-only loads reach clearStale too and have no
+            // panel handshake to observe.
+            if options.suppressDisplayCriteria { displayCriteria.armSwitchObservation() }
         }
 
         // 2.5. Post-handshake panel-mode snapshot.

--- a/Sources/AetherEngine/AetherEngine.swift
+++ b/Sources/AetherEngine/AetherEngine.swift
@@ -2831,7 +2831,9 @@ public final class AetherEngine: ObservableObject {
             ) {
             case .willSwitch:
                 didSwitchPanel = true
-                await displayCriteria.waitForSwitch()
+                // #339: consumesRecord: false, the play gate after loadNative is entitled to the same
+                // start/end timestamps; spending them here made it pay Stage 1's grace for a settled switch.
+                await displayCriteria.waitForSwitch(consumesRecord: false)
                 // Superseded during panel handshake: close local probe and unwind.
                 if loadGeneration != gen {
                     probe.markClosed()

--- a/Sources/AetherEngine/Display/DisplayCriteriaController.swift
+++ b/Sources/AetherEngine/Display/DisplayCriteriaController.swift
@@ -233,6 +233,32 @@ final class DisplayCriteriaController {
         case none
     }
 
+    /// May a raised EDR headroom end the settle wait?
+    ///
+    /// Only while no switch has been observed to start. The headroom rises *with* the dynamic-range
+    /// transition, so during a switch it reports "HDR is coming up", not "the panel is done". Device
+    /// measurement (Apple TV 4K 3rd gen, tvOS 26.5, 2026-08-09, notifications captured on all objects): a run
+    /// whose headroom reached 1.20 at +374 ms belonged to a switch whose end notification arrived at
+    /// +2851 ms. The gate released `play()` 2.5 s into a running HDMI handshake, which is the "first frame
+    /// hits a mid-transition panel" case the whole wait exists to prevent, and the shape Sodalite#49 was
+    /// filed on.
+    ///
+    /// With a start observed, the authoritative end is the end notification or the in-progress flag
+    /// clearing. Both were exact on that device: the flag cleared within 1 ms of the notification.
+    nonisolated static func headroomMayEndSettle(startObserved: Bool) -> Bool {
+        !startObserved
+    }
+
+    /// May the entry fast-exit take a raised headroom as "nothing to wait for"?
+    ///
+    /// Its purpose is the panel a previous session already drove into HDR: no transition is pending and the
+    /// wait would be dead time. A panel that is mid-switch produces the same raised headroom for the
+    /// opposite reason, so the in-progress flag has to agree. Same device run: the play gate read headroom
+    /// 1.20 at entry and returned in 0 ms while the switch had another 2.4 s to run.
+    nonisolated static func entryHeadroomIsSettled(headroomAboveOne: Bool, switchInProgress: Bool) -> Bool {
+        headroomAboveOne && !switchInProgress
+    }
+
     /// Whether a recorded switch belongs to the load whose gate is asking (#339).
     ///
     /// The record survives between loads, and two gates in one load can read it (an HDR write settles in the
@@ -381,7 +407,7 @@ final class DisplayCriteriaController {
         // #339: arm before the write. The switch this triggers can start and finish while the AVPlayerItem
         // is being built, and observers registered at gate entry miss both notifications; that is why two of
         // three device runs in Sodalite#49 never saw an end for a switch that was already over.
-        observation.arm(manager: displayManager)
+        observation.arm()
         displayManager.preferredDisplayCriteria = criteria
         didApply = true
         lastCriteriaWasHDR = isHDR
@@ -409,7 +435,7 @@ final class DisplayCriteriaController {
     func armSwitchObservation() {
         #if os(tvOS)
         guard let window = resolveWindow() else { return }
-        observation.arm(manager: window.avDisplayManager)
+        observation.arm()
         #endif
     }
 
@@ -450,9 +476,10 @@ final class DisplayCriteriaController {
         }
 
         // Fast exit: panel already in HDR (headroom already raised, e.g. a prior
-        // HDR/DV session left it there).
-        if observeHeadroom(screen) {
-            EngineLog.emit("[DisplayCriteria] no switch needed (EDR headroom \(String(format: "%.2f", screen.currentEDRHeadroom)) at entry)", category: .engine)
+        // HDR/DV session left it there) and not currently switching.
+        if Self.entryHeadroomIsSettled(headroomAboveOne: observeHeadroom(screen),
+                                       switchInProgress: displayManager.isDisplayModeSwitchInProgress) {
+            EngineLog.emit("[DisplayCriteria] no switch needed (EDR headroom \(String(format: "%.2f", screen.currentEDRHeadroom)) at entry, panel not switching)", category: .engine)
             return
         }
 
@@ -507,7 +534,9 @@ final class DisplayCriteriaController {
         if startSignal == .none {
             var isFirstPoll = true
             while !Self.isBudgetSpent(elapsedMs: Self.elapsedMs(since: entry), budgetMs: startGrace.budgetMs) {
-                if observation.hasNewEnd(since: gateSnapshot) || observeHeadroom(screen) {
+                let headroomSettles = observeHeadroom(screen)
+                    && Self.headroomMayEndSettle(startObserved: observation.hasNewStart(since: gateSnapshot))
+                if observation.hasNewEnd(since: gateSnapshot) || headroomSettles {
                     EngineLog.emit("[DisplayCriteria] settled during start phase (after \(Self.elapsedMs(since: entry))ms, EDR headroom \(String(format: "%.2f", screen.currentEDRHeadroom)))", category: .engine)
                     return
                 }
@@ -557,7 +586,9 @@ final class DisplayCriteriaController {
                 EngineLog.emit("[DisplayCriteria] switch settled via modeSwitchEnd (\(timing()))", category: .engine)
                 return
             }
-            if observeHeadroom(screen) {
+            // Only meaningful before a start was seen: the headroom rises with the transition, so during an
+            // observed switch it is the panel warming up, not the panel being done.
+            if observeHeadroom(screen), Self.headroomMayEndSettle(startObserved: startSignal == .preGateObserved || startSignal == .inGate) {
                 EngineLog.emit("[DisplayCriteria] switch settled via EDR (\(timing()), headroom \(String(format: "%.2f", screen.currentEDRHeadroom)))", category: .engine)
                 return
             }
@@ -721,34 +752,38 @@ private final class SwitchObservation: @unchecked Sendable {
     private var endCount = 0
     private var generation = 0
     private var tokens: [NSObjectProtocol] = []
-    private var observedManager: ObjectIdentifier?
 
-    /// Clear the record and, on first use or a display change, register for this manager. Called immediately
-    /// before a criteria write so everything the following gate reads belongs to that write.
-    func arm(manager: AVDisplayManager) {
-        let id = ObjectIdentifier(manager)
+    /// Clear the record and, on first use, register. Called immediately before a criteria write so
+    /// everything the following gate reads belongs to that write.
+    ///
+    /// `object: nil` is the load-bearing part. tvOS posts both notifications from an
+    /// **`AVSharedDisplayManager`**, not from the `AVDisplayManager` that `window.avDisplayManager` returns
+    /// and that `preferredDisplayCriteria` is written to. Filtering on that manager, which is what this code
+    /// did from the start, dropped every notification the settle gate exists to read. Device probe, Apple TV
+    /// 4K (3rd gen), tvOS 26.5, 2026-08-09, listening on all objects:
+    ///
+    ///     FIRED AVDisplayManagerModeSwitchStartNotification object=AVSharedDisplayManager@0x10b581a10
+    ///     our manager=AVDisplayManager@0x1036fdfa0
+    ///
+    /// Six start/end pairs arrived that way in three playbacks while the engine's filtered observers saw
+    /// none. That, not the registration point, is why no run in Sodalite#49 ever reported an end.
+    func arm() {
         lock.lock()
         startedAt = nil
         endedAt = nil
         startCount = 0
         endCount = 0
         generation += 1
-        let alreadyObserving = observedManager == id && !tokens.isEmpty
-        let stale = alreadyObserving ? [] : tokens
-        if !alreadyObserving {
-            tokens = []
-            observedManager = id
-        }
+        let needsRegistration = tokens.isEmpty
         lock.unlock()
 
-        guard !alreadyObserving else { return }
-        stale.forEach { NotificationCenter.default.removeObserver($0) }
+        guard needsRegistration else { return }
         // Weak, or the token retains the block retains this object for the process lifetime.
         let start = NotificationCenter.default.addObserver(
-            forName: .AVDisplayManagerModeSwitchStart, object: manager, queue: nil
+            forName: .AVDisplayManagerModeSwitchStart, object: nil, queue: nil
         ) { [weak self] _ in self?.record(isStart: true) }
         let end = NotificationCenter.default.addObserver(
-            forName: .AVDisplayManagerModeSwitchEnd, object: manager, queue: nil
+            forName: .AVDisplayManagerModeSwitchEnd, object: nil, queue: nil
         ) { [weak self] _ in self?.record(isStart: false) }
         lock.lock()
         tokens = [start, end]

--- a/Sources/AetherEngine/Display/DisplayCriteriaController.swift
+++ b/Sources/AetherEngine/Display/DisplayCriteriaController.swift
@@ -233,20 +233,32 @@ final class DisplayCriteriaController {
         case none
     }
 
-    /// May a raised EDR headroom end the settle wait?
+    /// May a raised EDR headroom end the wait?
     ///
-    /// Only while no switch has been observed to start. The headroom rises *with* the dynamic-range
-    /// transition, so during a switch it reports "HDR is coming up", not "the panel is done". Device
-    /// measurement (Apple TV 4K 3rd gen, tvOS 26.5, 2026-08-09, notifications captured on all objects): a run
-    /// whose headroom reached 1.20 at +374 ms belonged to a switch whose end notification arrived at
-    /// +2851 ms. The gate released `play()` 2.5 s into a running HDMI handshake, which is the "first frame
-    /// hits a mid-transition panel" case the whole wait exists to prevent, and the shape Sodalite#49 was
-    /// filed on.
+    /// The headroom rises *with* the dynamic-range transition, so during a switch it reports "HDR is coming
+    /// up", not "the panel is done". Device measurement (Apple TV 4K 3rd gen, tvOS 26.5, 2026-08-09): a run
+    /// whose headroom reached 1.20 at +374 ms belonged to a switch that ended at +2853 ms, and the gate
+    /// released `play()` 2.5 s into a running HDMI handshake. That is the "first frame hits a mid-transition
+    /// panel" case the whole wait exists to prevent, and the shape Sodalite#49 was filed on.
     ///
-    /// With a start observed, the authoritative end is the end notification or the in-progress flag
-    /// clearing. Both were exact on that device: the flag cleared within 1 ms of the notification.
-    nonisolated static func headroomMayEndSettle(startObserved: Bool) -> Bool {
-        !startObserved
+    /// The deciding input is whether **this load recorded a start notification at all**, not whether one
+    /// arrived since this gate opened. A load runs two gates (pre-flight, then play), the second finds the
+    /// record already consumed, and reading that as "no observable switch" let the headroom end the wait
+    /// 759 ms early on the very next device run. If a start was recorded, its end will be too, and the
+    /// notification or the in-progress flag is the authority: on that device the flag cleared within 1 ms of
+    /// the notification.
+    ///
+    /// Without a recorded start the headroom is the only end signal there is, which is the unobservable-DV
+    /// panel the Stage 2 cap exists for, so it keeps its say there.
+    nonisolated static func startPhaseHeadroomSettles(startRecorded: Bool, switchInProgress: Bool) -> Bool {
+        !startRecorded && !switchInProgress
+    }
+
+    /// Stage 2 has already classified a start, so the flag is expected to be set and cannot disqualify the
+    /// headroom the way it does in Stage 1; an unobservable-DV panel sticks it `true` for the whole switch.
+    /// A recorded start still rules the headroom out.
+    nonisolated static func settlePhaseHeadroomSettles(startRecorded: Bool) -> Bool {
+        !startRecorded
     }
 
     /// May the entry fast-exit take a raised headroom as "nothing to wait for"?
@@ -535,7 +547,9 @@ final class DisplayCriteriaController {
             var isFirstPoll = true
             while !Self.isBudgetSpent(elapsedMs: Self.elapsedMs(since: entry), budgetMs: startGrace.budgetMs) {
                 let headroomSettles = observeHeadroom(screen)
-                    && Self.headroomMayEndSettle(startObserved: observation.hasNewStart(since: gateSnapshot))
+                    && Self.startPhaseHeadroomSettles(
+                        startRecorded: gateSnapshot.startedAt != nil || observation.hasNewStart(since: gateSnapshot),
+                        switchInProgress: displayManager.isDisplayModeSwitchInProgress)
                 if observation.hasNewEnd(since: gateSnapshot) || headroomSettles {
                     EngineLog.emit("[DisplayCriteria] settled during start phase (after \(Self.elapsedMs(since: entry))ms, EDR headroom \(String(format: "%.2f", screen.currentEDRHeadroom)))", category: .engine)
                     return
@@ -586,9 +600,10 @@ final class DisplayCriteriaController {
                 EngineLog.emit("[DisplayCriteria] switch settled via modeSwitchEnd (\(timing()))", category: .engine)
                 return
             }
-            // Only meaningful before a start was seen: the headroom rises with the transition, so during an
-            // observed switch it is the panel warming up, not the panel being done.
-            if observeHeadroom(screen), Self.headroomMayEndSettle(startObserved: startSignal == .preGateObserved || startSignal == .inGate) {
+            // Only meaningful when this load recorded no start: the headroom rises with the transition, so
+            // during an observable switch it is the panel warming up, not the panel being done.
+            if observeHeadroom(screen), Self.settlePhaseHeadroomSettles(
+                startRecorded: gateSnapshot.startedAt != nil || observation.hasNewStart(since: gateSnapshot)) {
                 EngineLog.emit("[DisplayCriteria] switch settled via EDR (\(timing()), headroom \(String(format: "%.2f", screen.currentEDRHeadroom)))", category: .engine)
                 return
             }

--- a/Sources/AetherEngine/Display/DisplayCriteriaController.swift
+++ b/Sources/AetherEngine/Display/DisplayCriteriaController.swift
@@ -45,9 +45,10 @@ final class DisplayCriteriaController {
     private let observation = SwitchObservation()
     #endif
 
-    /// The arm generation whose record a gate has already read. A record is pre-gate evidence exactly once,
-    /// for the load it was armed in (`shouldConsumeObservation`).
-    private var consumedArmGeneration: Int = 0
+    /// The arm generation whose record has been spent. Only a gate that ends the load's wait spends it, so
+    /// both gates of one load see the same evidence while a later, unarmed gate sees none
+    /// (`recordIsFreshEvidence`).
+    private var spentArmGeneration: Int = 0
 
     /// The identifying inputs of an apply(): equal signatures mean the panel is already in the target mode.
     struct AppliedCriteria: Equatable {
@@ -273,12 +274,16 @@ final class DisplayCriteriaController {
 
     /// Whether a recorded switch belongs to the load whose gate is asking (#339).
     ///
-    /// The record survives between loads, and two gates in one load can read it (an HDR write settles in the
-    /// pre-flight, then the play gate runs). Consuming it once per arm keeps a switch from being credited
-    /// twice: without this, an engine-writer reload, which arms nothing because it re-applies nothing, would
-    /// read the previous load's start and wait out an end that can no longer arrive.
-    nonisolated static func shouldConsumeObservation(recordGeneration: Int, lastConsumedGeneration: Int) -> Bool {
-        recordGeneration != 0 && recordGeneration != lastConsumedGeneration
+    /// The record survives between loads, so a gate that runs without a preceding arm must not read it: an
+    /// engine-writer reload re-applies no criteria and arms nothing, and inheriting the previous load's start
+    /// would make it wait out an end that can no longer arrive.
+    ///
+    /// Marking the record spent is a separate decision (`consumesRecord`), because a load runs up to two
+    /// gates and both are entitled to the same evidence. The pre-flight deliberately does not spend it: on
+    /// the device, a play gate that opened after its switch had ended found the record already spent, fell
+    /// back to Stage 1 and paid its 200 ms grace for a switch it could have known was over.
+    nonisolated static func recordIsFreshEvidence(recordGeneration: Int, lastSpentGeneration: Int) -> Bool {
+        recordGeneration != 0 && recordGeneration != lastSpentGeneration
     }
 
     /// Pure verdict on the recorded timestamps.
@@ -470,7 +475,10 @@ final class DisplayCriteriaController {
     /// timeout. Presenting slightly early on that fallback is at worst cosmetic:
     /// the panel is mid re-sync (black) during the handshake and shows the correct
     /// frame once it locks. The decode/color-correctness guard is Stage 1 below.
-    func waitForSwitch(startGrace: StartGrace = .full) async {
+    /// `consumesRecord: false` leaves the observation readable for the load's second gate. The pre-flight
+    /// passes it: it waits an HDR switch out before the item is built, and the play gate that follows is
+    /// entitled to the same start/end timestamps (#339).
+    func waitForSwitch(startGrace: StartGrace = .full, consumesRecord: Bool = true) async {
         #if os(tvOS)
         guard startGrace != .skip else { return }
         guard let window = resolveWindow() else { return }
@@ -504,8 +512,8 @@ final class DisplayCriteriaController {
         var preGateStartMs: Int?
 
         let observed: ObservedSwitch
-        if Self.shouldConsumeObservation(recordGeneration: gateSnapshot.generation,
-                                         lastConsumedGeneration: consumedArmGeneration) {
+        if Self.recordIsFreshEvidence(recordGeneration: gateSnapshot.generation,
+                                      lastSpentGeneration: spentArmGeneration) {
             observed = Self.observedSwitch(
                 startedAtNanos: gateSnapshot.startedAt,
                 endedAtNanos: gateSnapshot.endedAt,
@@ -514,7 +522,7 @@ final class DisplayCriteriaController {
         } else {
             observed = .none
         }
-        consumedArmGeneration = gateSnapshot.generation
+        if consumesRecord { spentArmGeneration = gateSnapshot.generation }
 
         switch observed {
         case .settled(let before, let measured):

--- a/Sources/AetherEngine/Display/DisplayCriteriaController.swift
+++ b/Sources/AetherEngine/Display/DisplayCriteriaController.swift
@@ -107,9 +107,21 @@ final class DisplayCriteriaController {
     }
 
     /// Stage 2's ceiling: long enough that an unobservable DV switch does not gate the first frame the way
-    /// the old fixed 5 s poll did, short enough to stay a startup cost. The reporter's panel has been
-    /// measured taking ~2.9 s end to end, so this cap is knowingly exceeded there; raising it trades every
-    /// session's cold start against one panel and wants its own evidence (Sodalite#49).
+    /// the old fixed 5 s poll did, short enough to stay a startup cost.
+    ///
+    /// **Do not raise this to "fit" the measured switch duration.** Twelve device measurements (Apple TV 4K
+    /// 3rd gen, tvOS 26.5, 2026-08-09, dynamic-range and range-plus-rate alike) put a real switch at 2779 to
+    /// 2898 ms, so the pre-flight gate reliably breaks out here at ~2.0 s with the panel still switching.
+    /// That looks like a defect and is currently load-bearing: breaking out is what lets `loadNative` start
+    /// while the switch finishes, and the play gate then waits out whatever is left. Timed end to end:
+    ///
+    ///     cap 2000: pre-flight breaks +2020, load ~850 ms, play() at ~+2918
+    ///     cap 4000: pre-flight ends +2892 on the notification, load ~850 ms, play() at ~+3740
+    ///
+    /// The "corrected" cap costs a full load's worth of startup, ~820 ms here, because the load is serialised
+    /// behind the wait. The way to spend that time properly is to load *during* the switch rather than to
+    /// pick a cap that overlaps them by accident (AE#348); until then this number is doing two jobs and only
+    /// one of them is written on it.
     nonisolated static let stage2CapMs = 2000
 
     /// Both stages spend a deadline, not a poll count. `n` sleeps of `m` ms is only `n * m` on an idle

--- a/Sources/AetherEngine/Display/DisplayCriteriaController.swift
+++ b/Sources/AetherEngine/Display/DisplayCriteriaController.swift
@@ -39,6 +39,16 @@ final class DisplayCriteriaController {
     /// `apply()`, so an SDR route writes SDR criteria and never consults the proof.
     private var panelProvenToEngageHDR: Bool = false
 
+    #if os(tvOS)
+    /// #339: armed at the criteria write, not when the play gate opens, so an engine-written switch is
+    /// observable end to end instead of having to be guessed at from the in-progress flag.
+    private let observation = SwitchObservation()
+    #endif
+
+    /// The arm generation whose record a gate has already read. A record is pre-gate evidence exactly once,
+    /// for the load it was armed in (`shouldConsumeObservation`).
+    private var consumedArmGeneration: Int = 0
+
     /// The identifying inputs of an apply(): equal signatures mean the panel is already in the target mode.
     struct AppliedCriteria: Equatable {
         let isHDR: Bool
@@ -174,21 +184,22 @@ final class DisplayCriteriaController {
         return lastCriteriaWasHDR ? .engineHDR : .engineRateOnly
     }
 
-    /// How Stage 1 learned a switch was running. This is the one bit that separates "the panel was already
+    /// How the gate learned a switch was running. This is the one bit that separates "the panel was already
     /// switching while the AVPlayerItem was built" from "the switch started after the gate opened", the
-    /// ordering question Sodalite#49 was filed on and which no log line could answer. The observers are
-    /// registered on entry, so a switch that began earlier is only visible through the in-progress flag;
-    /// a start notification means it began inside the gate.
+    /// ordering question Sodalite#49 was filed on and which no log line could answer.
     ///
-    /// The flag alone only carries that meaning on the *first* poll. Reading it later conflates two
-    /// different events, and the reporter's second round hit exactly that: a run whose flag was false at
-    /// entry and rose 376 ms in was logged `pre-gate`, i.e. as a switch older than the gate it demonstrably
-    /// postdated. `inGateFlagOnly` is that case, kept separate because it indicts the observer registration
-    /// point rather than the panel.
+    /// Since #339 the notifications are recorded from the criteria write onward rather than from gate entry,
+    /// so `preGateObserved` answers that question with two timestamps. The flag-derived cases remain for what
+    /// the notifications miss, and each one now indicts something specific: `preGate` says a switch was
+    /// running that this session's write never announced, `inGateFlagOnly` says the start notification for a
+    /// switch inside the gate went missing. Both are measurements of the observation itself, which is what
+    /// makes the #339 change checkable on a device rather than only in review.
     enum StartSignal: String, Equatable {
-        /// In-progress flag already set on the first poll: the switch started before the gate, i.e. during
-        /// the load that built the item.
-        case preGate = "pre-gate"
+        /// Start notification recorded between the criteria write and the gate opening.
+        case preGateObserved = "pre-gate (start notification, before gate entry)"
+        /// In-progress flag set on the first poll with no start recorded since the write: the switch began
+        /// before the observation was armed, or its notification never arrived.
+        case preGate = "pre-gate (flag only, no start notification since the criteria write)"
         /// Mode-switch-start notification arrived while the gate was polling.
         case inGate = "in-gate"
         /// The flag rose after the first poll and no start notification ever arrived. The switch began
@@ -208,12 +219,60 @@ final class DisplayCriteriaController {
         return isFirstPoll ? .preGate : .inGateFlagOnly
     }
 
-    /// The two numbers a settle log needs to be usable: when Stage 1 saw the switch start, and how long the
-    /// whole gate took. Both used to be derived from the stage budgets rather than measured, so every settle
-    /// in every log read up to a full second slower than it was and no measurement of real switch latency
-    /// was possible (#49).
-    nonisolated static func timingSuffix(startSignal: StartSignal, stage1Ms: Int, totalMs: Int) -> String {
-        "start \(startSignal.rawValue) after \(stage1Ms)ms, total \(totalMs)ms"
+    /// What the observation already knows when the gate opens (#339). The observers are armed at the
+    /// criteria write, so a switch that started, or started and finished, while the item was being built is
+    /// knowable here instead of having to be inferred from a flag inside Stage 1.
+    enum ObservedSwitch: Equatable {
+        /// Start and end both recorded before the gate opened, and the panel is not switching now: there is
+        /// nothing left to wait for.
+        case settled(startBeforeGateMs: Int, switchMs: Int)
+        /// A start was recorded and no end followed it. Stage 1 has nothing left to discover, so the gate
+        /// goes straight to waiting the end out.
+        case running(startBeforeGateMs: Int)
+        /// Nothing usable recorded since the write.
+        case none
+    }
+
+    /// Whether a recorded switch belongs to the load whose gate is asking (#339).
+    ///
+    /// The record survives between loads, and two gates in one load can read it (an HDR write settles in the
+    /// pre-flight, then the play gate runs). Consuming it once per arm keeps a switch from being credited
+    /// twice: without this, an engine-writer reload, which arms nothing because it re-applies nothing, would
+    /// read the previous load's start and wait out an end that can no longer arrive.
+    nonisolated static func shouldConsumeObservation(recordGeneration: Int, lastConsumedGeneration: Int) -> Bool {
+        recordGeneration != 0 && recordGeneration != lastConsumedGeneration
+    }
+
+    /// Pure verdict on the recorded timestamps.
+    ///
+    /// Two asymmetries are deliberate. A `settled` conclusion needs *both* a start and an end, because an end
+    /// alone can belong to an older switch (the criteria reset a sole-writer load performs makes one), and
+    /// mistaking that for this session's settle would hand a DV P5 cold start to a panel still in SDR. And
+    /// `switchInProgress` may only veto, never confirm: the flag is documented as unreliable right after a
+    /// write, so it can move the gate towards waiting and never towards proceeding.
+    nonisolated static func observedSwitch(startedAtNanos: UInt64?,
+                                           endedAtNanos: UInt64?,
+                                           gateEntryNanos: UInt64,
+                                           switchInProgress: Bool) -> ObservedSwitch {
+        guard let started = startedAtNanos else { return .none }
+        let startBeforeGateMs = elapsedMs(fromNanos: started, toNanos: gateEntryNanos)
+        if let ended = endedAtNanos, ended >= started, !switchInProgress {
+            return .settled(startBeforeGateMs: startBeforeGateMs,
+                            switchMs: elapsedMs(fromNanos: started, toNanos: ended))
+        }
+        return .running(startBeforeGateMs: startBeforeGateMs)
+    }
+
+    /// The numbers a settle log needs to be usable: when the switch started relative to the gate, how long
+    /// the whole gate took, and, when both notifications were seen, how long the panel's switch actually
+    /// took. All three used to be unavailable: the stage budgets were reported instead of measurements
+    /// (#49), and a switch that completed before the gate opened produced no numbers at all (#339).
+    nonisolated static func timingSuffix(startSignal: StartSignal, stage1Ms: Int, totalMs: Int,
+                                         startBeforeGateMs: Int? = nil, switchMs: Int? = nil) -> String {
+        let start = startBeforeGateMs.map { "start \(startSignal.rawValue) \($0)ms before gate entry" }
+            ?? "start \(startSignal.rawValue) after \(stage1Ms)ms"
+        let measured = switchMs.map { ", switch \($0)ms end to end" } ?? ""
+        return "\(start), total \(totalMs)ms\(measured)"
     }
 
     /// Guarded against reversed arguments: unsigned uptime subtraction traps, and a diagnostic helper is a
@@ -319,6 +378,10 @@ final class DisplayCriteriaController {
 
         // Always pass the real rate; tvOS uses it when Match Frame Rate is on, ignores it otherwise (dynamic-range switch still fires).
         let criteria = AVDisplayCriteria(refreshRate: effectiveRate, formatDescription: desc)
+        // #339: arm before the write. The switch this triggers can start and finish while the AVPlayerItem
+        // is being built, and observers registered at gate entry miss both notifications; that is why two of
+        // three device runs in Sodalite#49 never saw an end for a switch that was already over.
+        observation.arm(manager: displayManager)
         displayManager.preferredDisplayCriteria = criteria
         didApply = true
         lastCriteriaWasHDR = isHDR
@@ -334,6 +397,19 @@ final class DisplayCriteriaController {
         return isHDR ? .willSwitch : .applied
         #else
         return .applied
+        #endif
+    }
+
+    /// Arm the mode-switch observation for a write this controller does not make.
+    ///
+    /// A sole-writer host (`LoadOptions.suppressDisplayCriteria`) leaves the criteria to AVKit, which writes
+    /// them from the AVPlayerItem's formatDescription somewhere inside the load. The engine has to be
+    /// listening before that load starts, not when the gate opens, or the same switch goes unobserved as in
+    /// the engine-writer case (#339). Idempotent: re-arming only clears the record and keeps the observers.
+    func armSwitchObservation() {
+        #if os(tvOS)
+        guard let window = resolveWindow() else { return }
+        observation.arm(manager: window.avDisplayManager)
         #endif
     }
 
@@ -380,23 +456,39 @@ final class DisplayCriteriaController {
             return
         }
 
-        // Observe the OS mode-switch notifications. Start marks the HDMI handshake
-        // beginning, more reliable than polling `isDisplayModeSwitchInProgress`,
-        // which can read false for a beat right after the criteria write. End is
-        // the authoritative "settled" signal.
-        let switchStarted = SwitchFlag()
-        let switchEnded = SwitchFlag()
-        let startToken = NotificationCenter.default.addObserver(
-            forName: .AVDisplayManagerModeSwitchStart,
-            object: displayManager, queue: nil
-        ) { _ in switchStarted.fire() }
-        let endToken = NotificationCenter.default.addObserver(
-            forName: .AVDisplayManagerModeSwitchEnd,
-            object: displayManager, queue: nil
-        ) { _ in switchEnded.fire() }
-        defer {
-            NotificationCenter.default.removeObserver(startToken)
-            NotificationCenter.default.removeObserver(endToken)
+        // What the observation armed at the criteria write already knows (#339). Everything the stages read
+        // from here on is measured against this snapshot, so an end belonging to an older switch (the reset
+        // a sole-writer load performs can produce one) cannot settle a gate waiting on a newer one.
+        let gateSnapshot = observation.snapshot()
+        var startSignal = StartSignal.none
+        var stage1Ms = 0
+        var preGateStartMs: Int?
+
+        let observed: ObservedSwitch
+        if Self.shouldConsumeObservation(recordGeneration: gateSnapshot.generation,
+                                         lastConsumedGeneration: consumedArmGeneration) {
+            observed = Self.observedSwitch(
+                startedAtNanos: gateSnapshot.startedAt,
+                endedAtNanos: gateSnapshot.endedAt,
+                gateEntryNanos: entry.uptimeNanoseconds,
+                switchInProgress: displayManager.isDisplayModeSwitchInProgress)
+        } else {
+            observed = .none
+        }
+        consumedArmGeneration = gateSnapshot.generation
+
+        switch observed {
+        case .settled(let before, let measured):
+            // The whole switch happened while the item was being built. Before #339 this run was
+            // indistinguishable from an unobservable panel and paid the full Stage 2 cap for it.
+            EngineLog.emit("[DisplayCriteria] switch settled before the gate opened (\(Self.timingSuffix(startSignal: .preGateObserved, stage1Ms: 0, totalMs: Self.elapsedMs(since: entry), startBeforeGateMs: before, switchMs: measured))); nothing left to wait for", category: .engine)
+            return
+        case .running(let before):
+            // Start already recorded: Stage 1 has nothing to discover, only the end is still open.
+            startSignal = .preGateObserved
+            preGateStartMs = before
+        case .none:
+            break
         }
 
         // Stage 1: `startGrace` for the switch to actually start. The handshake
@@ -409,33 +501,35 @@ final class DisplayCriteriaController {
         // the *first* poll means the panel was already switching while the item was built, which is the
         // ordering Sodalite#49 suspected. Reading that same flag on a later poll says the opposite (the
         // switch began after entry) and used to be logged as if it said the same, which is why the second
-        // round of reporter logs still could not answer the question. `classifyStart` holds that line.
-        var startSignal = StartSignal.none
-        var isFirstPoll = true
-        while !Self.isBudgetSpent(elapsedMs: Self.elapsedMs(since: entry), budgetMs: startGrace.budgetMs) {
-            if switchEnded.fired || observeHeadroom(screen) {
-                EngineLog.emit("[DisplayCriteria] settled during start phase (after \(Self.elapsedMs(since: entry))ms, EDR headroom \(String(format: "%.2f", screen.currentEDRHeadroom)))", category: .engine)
+        // round of reporter logs still could not answer the question. `classifyStart` holds that line, and
+        // with the observation armed at the write both of its flag-only verdicts now report a missing
+        // notification rather than standing in for one.
+        if startSignal == .none {
+            var isFirstPoll = true
+            while !Self.isBudgetSpent(elapsedMs: Self.elapsedMs(since: entry), budgetMs: startGrace.budgetMs) {
+                if observation.hasNewEnd(since: gateSnapshot) || observeHeadroom(screen) {
+                    EngineLog.emit("[DisplayCriteria] settled during start phase (after \(Self.elapsedMs(since: entry))ms, EDR headroom \(String(format: "%.2f", screen.currentEDRHeadroom)))", category: .engine)
+                    return
+                }
+                if let signal = Self.classifyStart(
+                    isFirstPoll: isFirstPoll,
+                    startNotificationFired: observation.hasNewStart(since: gateSnapshot),
+                    switchInProgress: displayManager.isDisplayModeSwitchInProgress) {
+                    startSignal = signal
+                    break
+                }
+                isFirstPoll = false
+                try? await Task.sleep(for: .milliseconds(10))
+            }
+            // Time spent, not the budget: the polls carry scheduler overhead, and everything downstream is
+            // reported relative to this (#49).
+            stage1Ms = Self.elapsedMs(since: entry)
+            if startSignal == .none {
+                // No switch started within the grace: panel already satisfies the criteria
+                // or the setter was a no-op. Don't block; AVPlayer tonemaps or errors for real.
+                EngineLog.emit("[DisplayCriteria] no switch started (EDR headroom \(String(format: "%.2f", screen.currentEDRHeadroom)) after \(stage1Ms)ms, budget \(startGrace.budgetMs)ms); proceeding", category: .engine)
                 return
             }
-            if let signal = Self.classifyStart(
-                isFirstPoll: isFirstPoll,
-                startNotificationFired: switchStarted.fired,
-                switchInProgress: displayManager.isDisplayModeSwitchInProgress) {
-                startSignal = signal
-                break
-            }
-            isFirstPoll = false
-            try? await Task.sleep(for: .milliseconds(10))
-        }
-        // Time spent, not the budget: the polls carry scheduler overhead, and everything downstream is
-        // reported relative to this (#49).
-        let stage1Ms = Self.elapsedMs(since: entry)
-        let startBudgetMs = startGrace.budgetMs
-        if startSignal == .none {
-            // No switch started within the grace: panel already satisfies the criteria
-            // or the setter was a no-op. Don't block; AVPlayer tonemaps or errors for real.
-            EngineLog.emit("[DisplayCriteria] no switch started (EDR headroom \(String(format: "%.2f", screen.currentEDRHeadroom)) after \(stage1Ms)ms, budget \(startBudgetMs)ms); proceeding", category: .engine)
-            return
         }
 
         // Stage 2: proceed as soon as ANY reliable signal says settled (the
@@ -445,12 +539,21 @@ final class DisplayCriteriaController {
         // old fixed 5s poll did.
         let stage2Entry = DispatchTime.now()
         func timing() -> String {
-            Self.timingSuffix(startSignal: startSignal, stage1Ms: stage1Ms,
-                              totalMs: Self.elapsedMs(since: entry))
+            // The panel's own switch duration whenever both notifications were seen. This is the number the
+            // `.brief` premise ("engine rate-only writes settle sub-second") has never been checked against
+            // on hardware, and before #339 an engine-written switch could not produce it at all.
+            let now = observation.snapshot()
+            let switchMs: Int? = {
+                guard let started = now.startedAt, let ended = now.endedAt, ended >= started else { return nil }
+                return Self.elapsedMs(fromNanos: started, toNanos: ended)
+            }()
+            return Self.timingSuffix(startSignal: startSignal, stage1Ms: stage1Ms,
+                                     totalMs: Self.elapsedMs(since: entry),
+                                     startBeforeGateMs: preGateStartMs, switchMs: switchMs)
         }
         while !Self.isBudgetSpent(elapsedMs: Self.elapsedMs(since: stage2Entry), budgetMs: Self.stage2CapMs) {
             try? await Task.sleep(for: .milliseconds(50))
-            if switchEnded.fired {
+            if observation.hasNewEnd(since: gateSnapshot) {
                 EngineLog.emit("[DisplayCriteria] switch settled via modeSwitchEnd (\(timing()))", category: .engine)
                 return
             }
@@ -588,13 +691,106 @@ final class DisplayCriteriaController {
 }
 
 #if os(tvOS)
-/// Minimal thread-safe one-shot flag set from an `AVDisplayManager` mode-switch
-/// notification (delivered on an arbitrary queue) and polled from the settle loop.
-private final class SwitchFlag: @unchecked Sendable {
+/// Records `AVDisplayManager` mode-switch notifications from the moment a criteria write is imminent.
+///
+/// `waitForSwitch` used to register these observers when it opened, which is after the engine's own write and
+/// sometimes after the switch that write triggers has already finished. Both notifications then landed
+/// outside the window and the gate fell back on `isDisplayModeSwitchInProgress`, a flag its own call site
+/// documents as unreliable right after a write. Sodalite#49's device logs are that defect twice over: two
+/// runs spent the entire Stage 2 cap waiting for an end that had happened, and a third labelled a switch it
+/// had watched begin as one that predated it (#339).
+///
+/// Notifications arrive on an arbitrary queue, so every field is lock-guarded. The counters exist to keep
+/// "recorded before I looked" apart from "arrived while I waited": an end belonging to an older switch must
+/// never settle a gate that is waiting on a newer one.
+private final class SwitchObservation: @unchecked Sendable {
+    struct Snapshot {
+        let startedAt: UInt64?
+        let endedAt: UInt64?
+        let startCount: Int
+        let endCount: Int
+        /// Bumped by every arm, 0 until the first one. Lets a gate tell a record written for this load from
+        /// one left by the previous load, which must not settle anything.
+        let generation: Int
+    }
+
     private let lock = NSLock()
-    private var value = false
-    var fired: Bool { lock.lock(); defer { lock.unlock() }; return value }
-    func fire() { lock.lock(); value = true; lock.unlock() }
+    private var startedAt: UInt64?
+    private var endedAt: UInt64?
+    private var startCount = 0
+    private var endCount = 0
+    private var generation = 0
+    private var tokens: [NSObjectProtocol] = []
+    private var observedManager: ObjectIdentifier?
+
+    /// Clear the record and, on first use or a display change, register for this manager. Called immediately
+    /// before a criteria write so everything the following gate reads belongs to that write.
+    func arm(manager: AVDisplayManager) {
+        let id = ObjectIdentifier(manager)
+        lock.lock()
+        startedAt = nil
+        endedAt = nil
+        startCount = 0
+        endCount = 0
+        generation += 1
+        let alreadyObserving = observedManager == id && !tokens.isEmpty
+        let stale = alreadyObserving ? [] : tokens
+        if !alreadyObserving {
+            tokens = []
+            observedManager = id
+        }
+        lock.unlock()
+
+        guard !alreadyObserving else { return }
+        stale.forEach { NotificationCenter.default.removeObserver($0) }
+        // Weak, or the token retains the block retains this object for the process lifetime.
+        let start = NotificationCenter.default.addObserver(
+            forName: .AVDisplayManagerModeSwitchStart, object: manager, queue: nil
+        ) { [weak self] _ in self?.record(isStart: true) }
+        let end = NotificationCenter.default.addObserver(
+            forName: .AVDisplayManagerModeSwitchEnd, object: manager, queue: nil
+        ) { [weak self] _ in self?.record(isStart: false) }
+        lock.lock()
+        tokens = [start, end]
+        lock.unlock()
+    }
+
+    /// First start since arming (so a switch is measured from its beginning), latest end.
+    private func record(isStart: Bool) {
+        let now = DispatchTime.now().uptimeNanoseconds
+        lock.lock()
+        if isStart {
+            startedAt = startedAt ?? now
+            startCount += 1
+        } else {
+            endedAt = now
+            endCount += 1
+        }
+        lock.unlock()
+    }
+
+    func snapshot() -> Snapshot {
+        lock.lock()
+        defer { lock.unlock() }
+        return Snapshot(startedAt: startedAt, endedAt: endedAt,
+                        startCount: startCount, endCount: endCount, generation: generation)
+    }
+
+    func hasNewStart(since snapshot: Snapshot) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return startCount > snapshot.startCount
+    }
+
+    func hasNewEnd(since snapshot: Snapshot) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return endCount > snapshot.endCount
+    }
+
+    deinit {
+        tokens.forEach { NotificationCenter.default.removeObserver($0) }
+    }
 }
 
 /// Times display-link ticks so the caller can read the active HDMI mode's refresh rate. Enough ticks

--- a/Tests/AetherEngineTests/DisplayCriteriaPlayGateTests.swift
+++ b/Tests/AetherEngineTests/DisplayCriteriaPlayGateTests.swift
@@ -125,8 +125,8 @@ struct DisplayCriteriaPlayGateTests {
     @Test("Reported timings are the measured ones, not the Stage 1 budget added back in")
     func timingSuffixReportsMeasuredValues() {
         let suffix = DisplayCriteriaController.timingSuffix(
-            startSignal: .preGate, stage1Ms: 5, totalMs: 55)
-        #expect(suffix == "start pre-gate after 5ms, total 55ms")
+            startSignal: .inGate, stage1Ms: 5, totalMs: 55)
+        #expect(suffix == "start in-gate after 5ms, total 55ms")
         // The line this replaces read "~1050ms" for exactly this switch: Stage 1's full 1000 ms budget,
         // which it never spent, plus one 50 ms Stage 2 tick.
         #expect(!suffix.contains("1050"))
@@ -135,8 +135,13 @@ struct DisplayCriteriaPlayGateTests {
 
     @Test("Start signal distinguishes a switch already running from one that began inside the gate")
     func startSignalNamesTheOrdering() {
-        // The whole point of #49: a pre-gate start means the panel was switching while the item was built.
-        #expect(DisplayCriteriaController.StartSignal.preGate.rawValue == "pre-gate")
+        // The whole point of #49. Since #339 the observation is armed at the criteria write, so a switch
+        // that was running while the item was built announces itself and the flag-only reading says exactly
+        // what it is: a switch this session's write never announced.
+        #expect(DisplayCriteriaController.StartSignal.preGateObserved.rawValue
+            == "pre-gate (start notification, before gate entry)")
+        #expect(DisplayCriteriaController.StartSignal.preGate.rawValue
+            == "pre-gate (flag only, no start notification since the criteria write)")
         #expect(DisplayCriteriaController.StartSignal.inGate.rawValue == "in-gate")
         #expect(DisplayCriteriaController.timingSuffix(
             startSignal: .inGate, stage1Ms: 120, totalMs: 300)

--- a/Tests/AetherEngineTests/DisplayCriteriaSwitchObservationTests.swift
+++ b/Tests/AetherEngineTests/DisplayCriteriaSwitchObservationTests.swift
@@ -77,14 +77,12 @@ struct DisplayCriteriaSwitchObservationTests {
 
     // MARK: - Whose switch is it
 
-    @Test("A record is pre-gate evidence once, for the load it was armed in")
-    func recordIsConsumedOnce() {
-        // Two gates run inside one load when an HDR write settles in the pre-flight and the play gate
-        // follows. The second must not be handed the same switch again.
-        #expect(DisplayCriteriaController.shouldConsumeObservation(
-            recordGeneration: 7, lastConsumedGeneration: 6))
-        #expect(!DisplayCriteriaController.shouldConsumeObservation(
-            recordGeneration: 7, lastConsumedGeneration: 7))
+    @Test("A record is evidence until a gate spends it, which the pre-flight does not")
+    func recordIsEvidenceUntilSpent() {
+        // Both gates of one load are entitled to the same switch: the pre-flight waits it out without
+        // spending the record, so the play gate can still see that it settled instead of paying Stage 1.
+        #expect(DisplayCriteriaController.recordIsFreshEvidence(recordGeneration: 7, lastSpentGeneration: 6))
+        #expect(!DisplayCriteriaController.recordIsFreshEvidence(recordGeneration: 7, lastSpentGeneration: 7))
     }
 
     @Test("A load that arms nothing reads no record: the previous load's switch is not its own")
@@ -92,10 +90,8 @@ struct DisplayCriteriaSwitchObservationTests {
         // An engine-writer reload re-applies no criteria, so it arms nothing. Reading the last load's start
         // would send it into Stage 2 to wait out an end that can no longer arrive, adding the full cap to a
         // load where nothing is switching.
-        #expect(!DisplayCriteriaController.shouldConsumeObservation(
-            recordGeneration: 0, lastConsumedGeneration: 0))
-        #expect(!DisplayCriteriaController.shouldConsumeObservation(
-            recordGeneration: 3, lastConsumedGeneration: 3))
+        #expect(!DisplayCriteriaController.recordIsFreshEvidence(recordGeneration: 0, lastSpentGeneration: 0))
+        #expect(!DisplayCriteriaController.recordIsFreshEvidence(recordGeneration: 3, lastSpentGeneration: 3))
     }
 
     // MARK: - Started, not finished

--- a/Tests/AetherEngineTests/DisplayCriteriaSwitchObservationTests.swift
+++ b/Tests/AetherEngineTests/DisplayCriteriaSwitchObservationTests.swift
@@ -45,12 +45,25 @@ struct DisplayCriteriaSwitchObservationTests {
 
     // MARK: - The headroom is not an end signal
 
-    @Test("A raised headroom ends the wait only while no switch has been seen to start")
-    func headroomIsNotAnEndSignalDuringASwitch() {
-        // Device run, ATV 4K 3rd gen, tvOS 26.5: headroom 1.20 at +374ms, end notification at +2851ms. The
-        // headroom rises with the transition, so mid-switch it says "HDR is coming", not "the panel is done".
-        #expect(DisplayCriteriaController.headroomMayEndSettle(startObserved: false))
-        #expect(!DisplayCriteriaController.headroomMayEndSettle(startObserved: true))
+    @Test("A recorded start rules the headroom out as an end signal, in both stages")
+    func headroomIsNotAnEndSignalForAnObservableSwitch() {
+        // Device run, ATV 4K 3rd gen, tvOS 26.5: headroom 1.20 at +374ms for a switch that ended at +2853ms.
+        #expect(!DisplayCriteriaController.startPhaseHeadroomSettles(startRecorded: true, switchInProgress: false))
+        #expect(!DisplayCriteriaController.settlePhaseHeadroomSettles(startRecorded: true))
+    }
+
+    @Test("Without a recorded start the headroom keeps its say: that is the unobservable-DV panel")
+    func headroomStillSettlesAnUnobservableSwitch() {
+        #expect(DisplayCriteriaController.startPhaseHeadroomSettles(startRecorded: false, switchInProgress: false))
+        // Stage 2 has classified a start already, so a stuck flag must not disqualify the only signal left.
+        #expect(DisplayCriteriaController.settlePhaseHeadroomSettles(startRecorded: false))
+    }
+
+    @Test("Stage 1 also refuses the headroom while the panel reports a switch in progress")
+    func startPhaseHeadroomRespectsTheFlag() {
+        // The second gate of a load finds the record consumed, so "no new start" is not "no switch": on the
+        // device that read ended the wait 759 ms before the switch did.
+        #expect(!DisplayCriteriaController.startPhaseHeadroomSettles(startRecorded: false, switchInProgress: true))
     }
 
     @Test("The entry fast-exit needs the in-progress flag to agree with the headroom")

--- a/Tests/AetherEngineTests/DisplayCriteriaSwitchObservationTests.swift
+++ b/Tests/AetherEngineTests/DisplayCriteriaSwitchObservationTests.swift
@@ -43,6 +43,25 @@ struct DisplayCriteriaSwitchObservationTests {
             gateEntryNanos: gateEntry, switchInProgress: false) == .none)
     }
 
+    // MARK: - The headroom is not an end signal
+
+    @Test("A raised headroom ends the wait only while no switch has been seen to start")
+    func headroomIsNotAnEndSignalDuringASwitch() {
+        // Device run, ATV 4K 3rd gen, tvOS 26.5: headroom 1.20 at +374ms, end notification at +2851ms. The
+        // headroom rises with the transition, so mid-switch it says "HDR is coming", not "the panel is done".
+        #expect(DisplayCriteriaController.headroomMayEndSettle(startObserved: false))
+        #expect(!DisplayCriteriaController.headroomMayEndSettle(startObserved: true))
+    }
+
+    @Test("The entry fast-exit needs the in-progress flag to agree with the headroom")
+    func entryFastExitRequiresAnIdlePanel() {
+        // Same run: the play gate read headroom 1.20 at entry and returned in 0 ms while the switch had
+        // 2.4 s left. A panel already in HDR and a panel mid-transition read identically here.
+        #expect(DisplayCriteriaController.entryHeadroomIsSettled(headroomAboveOne: true, switchInProgress: false))
+        #expect(!DisplayCriteriaController.entryHeadroomIsSettled(headroomAboveOne: true, switchInProgress: true))
+        #expect(!DisplayCriteriaController.entryHeadroomIsSettled(headroomAboveOne: false, switchInProgress: false))
+    }
+
     // MARK: - Whose switch is it
 
     @Test("A record is pre-gate evidence once, for the load it was armed in")

--- a/Tests/AetherEngineTests/DisplayCriteriaSwitchObservationTests.swift
+++ b/Tests/AetherEngineTests/DisplayCriteriaSwitchObservationTests.swift
@@ -1,0 +1,164 @@
+import Testing
+@testable import AetherEngine
+
+// #339: the mode-switch observers used to be registered when the play gate opened. The engine's own criteria
+// write happens in the pre-flight, before the item is built, so a switch could start and finish outside that
+// window: both notifications were lost and the gate was left inferring from `isDisplayModeSwitchInProgress`.
+// Two of the three device runs in Sodalite#49 spent the whole Stage 2 cap that way, waiting for an end that
+// had already happened.
+//
+// The observation is now armed at the write and the gate reads what it recorded. That verdict is a pure
+// function of four values, and the two asymmetries in it are the load-bearing part: an end alone must never
+// settle the gate (it can belong to an older switch, e.g. the criteria reset a sole-writer load performs),
+// and the in-progress flag may only veto a settle, never confirm one.
+@Suite("DisplayCriteria pre-gate switch observation (#339)")
+struct DisplayCriteriaSwitchObservationTests {
+
+    private let ms: UInt64 = 1_000_000
+    private var gateEntry: UInt64 { 10_000 * 1_000_000 }
+
+    // MARK: - Nothing to go on
+
+    @Test("Nothing recorded since the write leaves the gate to its normal Stage 1 poll")
+    func nothingRecorded() {
+        #expect(DisplayCriteriaController.observedSwitch(
+            startedAtNanos: nil, endedAtNanos: nil,
+            gateEntryNanos: gateEntry, switchInProgress: false) == .none)
+    }
+
+    @Test("An in-progress flag alone is not a recorded switch: Stage 1 still classifies it")
+    func flagAloneIsNotObserved() {
+        // The flag is what #49 showed to be unreliable right after a write; it cannot stand in for a start.
+        #expect(DisplayCriteriaController.observedSwitch(
+            startedAtNanos: nil, endedAtNanos: nil,
+            gateEntryNanos: gateEntry, switchInProgress: true) == .none)
+    }
+
+    @Test("An end with no start never settles the gate (it can belong to an older switch)")
+    func endWithoutStartIsNotSettled() {
+        // The sole-writer path resets the criteria before the load, which can produce an end of its own. If
+        // that settled the gate, a DV P5 cold start would be handed to a panel that is still SDR.
+        #expect(DisplayCriteriaController.observedSwitch(
+            startedAtNanos: nil, endedAtNanos: gateEntry - 300 * 1_000_000,
+            gateEntryNanos: gateEntry, switchInProgress: false) == .none)
+    }
+
+    // MARK: - Whose switch is it
+
+    @Test("A record is pre-gate evidence once, for the load it was armed in")
+    func recordIsConsumedOnce() {
+        // Two gates run inside one load when an HDR write settles in the pre-flight and the play gate
+        // follows. The second must not be handed the same switch again.
+        #expect(DisplayCriteriaController.shouldConsumeObservation(
+            recordGeneration: 7, lastConsumedGeneration: 6))
+        #expect(!DisplayCriteriaController.shouldConsumeObservation(
+            recordGeneration: 7, lastConsumedGeneration: 7))
+    }
+
+    @Test("A load that arms nothing reads no record: the previous load's switch is not its own")
+    func unarmedGateHasNoRecord() {
+        // An engine-writer reload re-applies no criteria, so it arms nothing. Reading the last load's start
+        // would send it into Stage 2 to wait out an end that can no longer arrive, adding the full cap to a
+        // load where nothing is switching.
+        #expect(!DisplayCriteriaController.shouldConsumeObservation(
+            recordGeneration: 0, lastConsumedGeneration: 0))
+        #expect(!DisplayCriteriaController.shouldConsumeObservation(
+            recordGeneration: 3, lastConsumedGeneration: 3))
+    }
+
+    // MARK: - Started, not finished
+
+    @Test("A start with no end sends the gate straight to Stage 2, with the start measured")
+    func startedButNotEnded() {
+        #expect(DisplayCriteriaController.observedSwitch(
+            startedAtNanos: gateEntry - 420 * ms, endedAtNanos: nil,
+            gateEntryNanos: gateEntry, switchInProgress: true) == .running(startBeforeGateMs: 420))
+    }
+
+    @Test("An end that predates the start belongs to the previous switch, so the new one is still running")
+    func endBeforeStartIsStale() {
+        #expect(DisplayCriteriaController.observedSwitch(
+            startedAtNanos: gateEntry - 200 * ms, endedAtNanos: gateEntry - 500 * ms,
+            gateEntryNanos: gateEntry, switchInProgress: false) == .running(startBeforeGateMs: 200))
+    }
+
+    @Test("The in-progress flag vetoes a settle: a start/end pair with the panel still switching keeps waiting")
+    func inProgressFlagVetoesSettle() {
+        #expect(DisplayCriteriaController.observedSwitch(
+            startedAtNanos: gateEntry - 900 * ms, endedAtNanos: gateEntry - 100 * ms,
+            gateEntryNanos: gateEntry, switchInProgress: true) == .running(startBeforeGateMs: 900))
+    }
+
+    // MARK: - Finished before the gate opened
+
+    @Test("Start and end both before the gate, panel idle: settled, with the switch measured end to end")
+    func settledBeforeGate() {
+        #expect(DisplayCriteriaController.observedSwitch(
+            startedAtNanos: gateEntry - 3_100 * ms, endedAtNanos: gateEntry - 200 * ms,
+            gateEntryNanos: gateEntry, switchInProgress: false)
+            == .settled(startBeforeGateMs: 3_100, switchMs: 2_900))
+    }
+
+    @Test("A start and end in the same instant still settle rather than falling through to a wait")
+    func zeroLengthSwitchSettles() {
+        let at = gateEntry - 50 * ms
+        #expect(DisplayCriteriaController.observedSwitch(
+            startedAtNanos: at, endedAtNanos: at,
+            gateEntryNanos: gateEntry, switchInProgress: false)
+            == .settled(startBeforeGateMs: 50, switchMs: 0))
+    }
+
+    @Test("Timestamps after the gate entry clamp to zero rather than trapping on unsigned subtraction")
+    func timestampsAfterEntryClampToZero() {
+        #expect(DisplayCriteriaController.observedSwitch(
+            startedAtNanos: gateEntry + 5 * ms, endedAtNanos: gateEntry + 9 * ms,
+            gateEntryNanos: gateEntry, switchInProgress: false)
+            == .settled(startBeforeGateMs: 0, switchMs: 4))
+    }
+
+    // MARK: - How the settle reads in the log
+
+    @Test("A pre-gate start reports its distance to the gate, not a Stage 1 duration it never spent")
+    func preGateTimingSuffix() {
+        let line = DisplayCriteriaController.timingSuffix(
+            startSignal: .preGateObserved, stage1Ms: 0, totalMs: 1_830,
+            startBeforeGateMs: 412, switchMs: nil)
+        #expect(line == "start pre-gate (start notification, before gate entry) 412ms before gate entry, total 1830ms")
+    }
+
+    @Test("The measured switch duration is appended whenever both notifications were seen")
+    func measuredSwitchIsReported() {
+        let line = DisplayCriteriaController.timingSuffix(
+            startSignal: .preGateObserved, stage1Ms: 0, totalMs: 90,
+            startBeforeGateMs: 3_100, switchMs: 2_900)
+        #expect(line.hasSuffix("total 90ms, switch 2900ms end to end"))
+    }
+
+    @Test("The in-gate form is unchanged, so #49's settle lines keep reading the same way")
+    func inGateTimingSuffixUnchanged() {
+        #expect(DisplayCriteriaController.timingSuffix(startSignal: .inGate, stage1Ms: 90, totalMs: 240)
+            == "start in-gate after 90ms, total 240ms")
+    }
+
+    @Test("Flag-only verdicts name what is missing: a notification, not an ordering")
+    func flagOnlySignalsNameTheDefect() {
+        #expect(DisplayCriteriaController.StartSignal.preGate.rawValue
+            == "pre-gate (flag only, no start notification since the criteria write)")
+        #expect(DisplayCriteriaController.StartSignal.inGateFlagOnly.rawValue
+            == "in-gate (flag only, start notification missed)")
+    }
+
+    // MARK: - Stage 1 classification is unchanged by the arming point
+
+    @Test("With a start recorded pre-gate the gate skips Stage 1, so classifyStart only sees in-gate starts")
+    func stage1StillClassifiesInGateStarts() {
+        #expect(DisplayCriteriaController.classifyStart(
+            isFirstPoll: true, startNotificationFired: true, switchInProgress: false) == .inGate)
+        #expect(DisplayCriteriaController.classifyStart(
+            isFirstPoll: true, startNotificationFired: false, switchInProgress: true) == .preGate)
+        #expect(DisplayCriteriaController.classifyStart(
+            isFirstPoll: false, startNotificationFired: false, switchInProgress: true) == .inGateFlagOnly)
+        #expect(DisplayCriteriaController.classifyStart(
+            isFirstPoll: false, startNotificationFired: false, switchInProgress: false) == nil)
+    }
+}


### PR DESCRIPTION
Device-verified on an Apple TV 4K (3rd generation), tvOS 26.5, HDR10 over HDMI, four rounds of three playbacks each. Fixes #339.

## What was wrong

`waitForSwitch` registered its `AVDisplayManagerModeSwitchStart` / `...End` observers with `object: <the display manager the criteria are written to>`. **tvOS posts them from an `AVSharedDisplayManager`**, so every one of them was dropped:

    [ModeSwitchProbe] FIRED AVDisplayManagerModeSwitchStartNotification object=AVSharedDisplayManager@0x10b581a10
    [ModeSwitchProbe] our manager=AVDisplayManager@0x1036fdfa0

Six start/end pairs arrived in three playbacks while the engine recorded none. With both notifications invisible, the gate fell back on `isDisplayModeSwitchInProgress` and on the EDR headroom, and the headroom peaks *during* the transition. The result was a gate that released `play()` **2478 ms before the panel finished switching**, which is the "first frame hits a mid-transition panel" case the wait exists to prevent, and the shape Sodalite#49 was reported as.

The original theory for #339, that the observers were merely registered too late, was wrong. Arming them at the criteria write is still in this PR as the first commit, and it earned its place differently: it made the settle line say `flag only, start notification missed`, which is what turned a suspicion into a one-run answer.

## The four changes

1. **Observe from the manager that posts.** `object: nil`, documented with the probe output above.
2. **Arm at the criteria write, not at the gate**, so a switch that starts and finishes during the load is knowable rather than invisible. Guarded three ways: an end without a start never settles a gate (a sole-writer load's criteria reset produces one, and crediting it would hand a DV P5 cold start to an SDR panel), the in-progress flag may only veto a settle, and a record is evidence only for the load it was armed in.
3. **The headroom is no longer an end signal for a switch we saw start.** The deciding input is whether this load recorded a start at all, not whether one arrived since this gate opened: a load runs two gates, and reading "no new start" as "no observable switch" ended a wait 759 ms early on the very next device run. Panels that record no start keep the headroom, which is the unobservable-DV case the cap exists for.
4. **Both gates of a load read the same record.** The pre-flight passes `consumesRecord: false`, so the play gate can settle immediately instead of paying Stage 1's grace to rediscover a switch that has ended.

## Measurements this produced

Twelve switches, dynamic-range and range-plus-rate alike: **2779, 2790, 2801, 2850, 2851, 2852, 2854, 2858, 2862, 2877, 2884, 2895 ms**. The in-progress flag cleared within 1 ms of the end notification, so on this panel it is an accurate second signal. The settle line now carries the number:

    [DisplayCriteria] switch settled via modeSwitchEnd (start pre-gate (start notification, before gate entry)
      0ms before gate entry, total 156ms, switch 2852ms end to end)

Gate exit relative to the real end of the switch, same configuration, across the rounds:

| round | worst case |
|---|---|
| before | 2478 ms **early** |
| after 1 + 2 | 759 ms **early** |
| after 3 | +42 ms late |
| after 4 | +26 ms late |

## Deliberately not changed

Budgets, the grace sizing and the 2000 ms Stage 2 cap. The cap is knowingly smaller than a real switch here, and that turns out to be load-bearing rather than broken: breaking out of it is what lets `loadNative` run while the switch finishes. Raising it to "fit" the measurement re-serialises the two and costs a full load, ~820 ms on this hardware. That is now written on the constant, and the way to spend the time properly is AE#348.

## Verification

`swift test`: 1651 tests, 242 suites, green. tvOS build green. 18 tests cover the pre-gate verdict, the three settle guards, both headroom rules and the evidence lifetime. Device: four rounds of three playbacks as above. The DV path is unchanged and untested here, the test panel does not support Dolby Vision.