### PR TITLE
SW path: fold PTS discontinuities on forward-only VOD, decouple audio decode-ahead from the video gate

### DIFF
--- a/Sources/AetherEngine/Native/SoftwarePlaybackHost.swift
+++ b/Sources/AetherEngine/Native/SoftwarePlaybackHost.swift
@@ -1146,6 +1146,7 @@ final class SoftwarePlaybackHost {
             return
         }
 
+        let diag = demuxDiag
         demuxQueue.async {
             Self.runDemuxLoop(
                 demuxer: dem,
@@ -1158,6 +1159,7 @@ final class SoftwarePlaybackHost {
                 condition: condition,
                 initialClockTime: initialClock,
                 currentRate: currentRate,
+                diag: diag,
                 ring: ring,
                 videoTimeBaseSeconds: vTbSec,
                 audioTimeBaseSeconds: aTbSec,
@@ -1631,6 +1633,7 @@ final class SoftwarePlaybackHost {
         condition: NSCondition,
         initialClockTime: CMTime,
         currentRate: @Sendable () -> Float,
+        diag: SWPlaybackDiagState? = nil,
         ring: PacketRingBuffer?,
         videoTimeBaseSeconds: Double,
         audioTimeBaseSeconds: Double,
@@ -1673,6 +1676,87 @@ final class SoftwarePlaybackHost {
         var audioPacketsSeen = 0
         var audioBuffersProduced = false
 
+        // VOD audio decoupling (#107 family). The combined loop paced EVERYTHING on the video
+        // renderer's ~10-frame queue, so interleaved audio could never build more than ~0.3 s
+        // of lead over the synchronizer clock. Any decode/deinterlace jitter beyond that
+        // starved the audio renderer, the synchronizer leapt to the next sample's PTS, the
+        // whole queued video was suddenly late and the layer dropped it - a visible forward
+        // skip (1080i50 archive replay trace: periodic +0.25 s clock leaps, 17 % renderer
+        // drops). Video packets now PARK in a bounded FIFO while audio keeps decoding up to
+        // AudioLookaheadPolicy.targetLeadSeconds ahead of the clock, and a genuine underrun
+        // pauses the clock for a rebuffer (AudioLookaheadPolicy.clockAction) instead of
+        // letting it free-run, mirroring the DVR feeder arm. Live-without-ring sessions keep
+        // the historical lockstep pacing: their delivery is origin-paced realtime and the DVR
+        // arm covers the sessions that need the pump.
+        var parkedVideo: [UnsafeMutablePointer<AVPacket>] = []
+        let parkedVideoCap = 256
+        var lastEnqueuedAudioPtsSec = Double.nan
+        var rebuffering = false
+        // The pause/rebuffer arm stays off until the source has proven it can deliver a real
+        // lead once: an exactly-realtime origin whose lead never leaves the start offset must
+        // not eat a rebuffer pause at every session start.
+        var everHadLead = false
+        var parkedSeekGeneration = seekGeneration()
+        let decoupleAudio = !isLive && audioDecoder != nil && audioOutput != nil
+
+        func freeParkedVideo() {
+            for p in parkedVideo {
+                av_packet_unref(p)
+                av_packet_free_safe(p)
+            }
+            parkedVideo.removeAll()
+        }
+
+        // Decode+enqueue parked video while the renderer will take it. Never blocks.
+        func drainParkedVideoNonblocking() {
+            while !parkedVideo.isEmpty, renderer.isReadyForMoreMediaData,
+                  !stopRequested(), !backgroundAudioOnly() {
+                let p = parkedVideo.removeFirst()
+                videoDecoder.decode(packet: p)
+                av_packet_unref(p)
+                av_packet_free_safe(p)
+            }
+        }
+
+        // Pause the master clock when the audio lead is genuinely exhausted, resume once the
+        // rebuffer target is met. In this loop there is no ring to distinguish decode lag
+        // from a dry source, so a sub-threshold lead IS treated as source-starved - the
+        // everHadLead latch keeps that from firing on realtime-paced sources that never had
+        // a lead to lose.
+        func applyAudioClockAction(sourceEnded: Bool) {
+            guard decoupleAudio, clockArmed(), let aOut = audioOutput else { return }
+            let lead = lastEnqueuedAudioPtsSec.isFinite
+                ? lastEnqueuedAudioPtsSec - aOut.currentTimeSeconds : 0
+            if lead >= AudioLookaheadPolicy.rebufferResumeLeadSeconds { everHadLead = true }
+            guard everHadLead, isPlaying() || rebuffering else { return }
+            switch AudioLookaheadPolicy.clockAction(
+                rebuffering: rebuffering,
+                lastFedAudioPTS: lastEnqueuedAudioPtsSec,
+                clockSeconds: aOut.currentTimeSeconds,
+                atRingEnd: true,
+                sourceEnded: sourceEnded
+            ) {
+            case .pauseForRebuffer:
+                rebuffering = true
+                EngineLog.emit(
+                    "[SWHost] audio lead exhausted (\(String(format: "%.2f", lead))s); "
+                    + "pausing clock for rebuffer",
+                    category: .swPlayback
+                )
+                aOut.pause()
+            case .resume:
+                rebuffering = false
+                EngineLog.emit(
+                    "[SWHost] rebuffered to \(String(format: "%.2f", lead))s audio lead; "
+                    + "resuming clock",
+                    category: .swPlayback
+                )
+                aOut.setRate(currentRate())
+            case .none:
+                break
+            }
+        }
+
         func demuxIteration() -> Bool {
             if !isPlaying() {
                 condition.lock()
@@ -1683,6 +1767,41 @@ final class SoftwarePlaybackHost {
                 }
                 condition.unlock()
                 return true
+            }
+
+            if decoupleAudio {
+                // Parked packets are pre-seek stale once the generation moves; the seek path
+                // has already flushed decoders and re-anchored the clock.
+                let gen = seekGeneration()
+                if gen != parkedSeekGeneration {
+                    parkedSeekGeneration = gen
+                    freeParkedVideo()
+                    lastEnqueuedAudioPtsSec = .nan
+                    rebuffering = false
+                }
+                drainParkedVideoNonblocking()
+                applyAudioClockAction(sourceEnded: false)
+                // Bounded park: audio has its lead, so block on the renderer taking video
+                // (the historical backpressure shape) before reading further.
+                if parkedVideo.count >= parkedVideoCap {
+                    while !parkedVideo.isEmpty, parkedVideo.count >= parkedVideoCap / 2,
+                          !stopRequested(), !backgroundAudioOnly() {
+                        if renderer.isReadyForMoreMediaData {
+                            drainParkedVideoNonblocking()
+                        } else if !isPlaying() {
+                            condition.lock()
+                            while !isPlaying() && !stopRequested() {
+                                autoreleasepool {
+                                    _ = condition.wait(until: Date(timeIntervalSinceNow: 0.5))
+                                }
+                            }
+                            condition.unlock()
+                        } else {
+                            Thread.sleep(forTimeInterval: 0.005)
+                        }
+                    }
+                    return true
+                }
             }
 
             let genBeforeRead = seekGeneration()
@@ -1696,6 +1815,20 @@ final class SoftwarePlaybackHost {
             }
 
             guard let packet else {
+                // Play the parked tail out before the flush, and release a rebuffer hold:
+                // nothing more will arrive, the queues must drain to end-of-media.
+                while !parkedVideo.isEmpty, !stopRequested(), !backgroundAudioOnly() {
+                    if renderer.isReadyForMoreMediaData {
+                        drainParkedVideoNonblocking()
+                    } else {
+                        Thread.sleep(forTimeInterval: 0.005)
+                    }
+                }
+                freeParkedVideo()
+                if rebuffering {
+                    rebuffering = false
+                    audioOutput?.setRate(currentRate())
+                }
                 videoDecoder.flush()
                 audioDecoder?.flush()
                 renderer.drainReorderBuffer()
@@ -1723,6 +1856,16 @@ final class SoftwarePlaybackHost {
                         let expectedContinuation = prevRawVideoPtsSec
                             + (frameIntervalSec > 0 ? frameIntervalSec : 0)
                         discontinuityOffsetSec += (rawPtsSec - expectedContinuation)
+                        // Feed the parked pre-seam tail to the decoder before the flush drops
+                        // its reference chain; the seam packet itself parks after this block.
+                        while !parkedVideo.isEmpty, !stopRequested(), !backgroundAudioOnly() {
+                            if renderer.isReadyForMoreMediaData {
+                                drainParkedVideoNonblocking()
+                            } else {
+                                Thread.sleep(forTimeInterval: 0.005)
+                            }
+                        }
+                        freeParkedVideo()
                         videoDecoder.flush()
                         audioDecoder?.flush()
                         renderer.drainReorderBuffer()
@@ -1791,6 +1934,25 @@ final class SoftwarePlaybackHost {
                 if backgroundAudioOnly() {
                     av_packet_unref(packet)
                     av_packet_free_safe(packet)
+                    return true
+                }
+                if decoupleAudio {
+                    // Park; the drains at the iteration top and the bounded-park gate feed the
+                    // renderer. Ownership moves to the FIFO - no free here.
+                    parkedVideo.append(packet)
+                    // Broken-audio clock-arming fallback still applies (decoupleAudio only
+                    // requires a DECLARED audio track, not a producing one).
+                    if !clockArmed(), let aOut = audioOutput,
+                       audioPacketsSeen >= 50, !audioBuffersProduced {
+                        let pktPtsSec = (packet.pointee.pts != Int64.min && videoTimeBaseSeconds > 0)
+                            ? Double(packet.pointee.pts) * videoTimeBaseSeconds : Double.nan
+                        let resolution = SWClockAnchorPolicy.resolve(
+                            initialSeconds: initialClockTime.seconds, firstSampleSeconds: pktPtsSec)
+                        armClock(aOut, resolution: resolution, initialClockTime: initialClockTime,
+                                 rate: currentRate(), onClockAnchored: onClockAnchored)
+                        markClockArmed()
+                    }
+                    drainParkedVideoNonblocking()
                     return true
                 }
                 // Back-pressure via SampleBufferRenderer.isReadyForMoreMediaData (not the deprecated layer property). Park on condition while paused to avoid 200 Hz CPU spin.
@@ -1873,6 +2035,10 @@ final class SoftwarePlaybackHost {
                     tapSink?(buf)   // #95: mirror before enqueue
                     aOut.enqueue(sampleBuffer: buf)
                 }
+                if decoupleAudio, let last = buffers.last {
+                    let pts = CMSampleBufferGetPresentationTimeStamp(last)
+                    if pts.isValid { lastEnqueuedAudioPtsSec = pts.seconds }
+                }
                 // Arm clock on first decoded audio buffer; latch so subsequent packets don't snap clock back.
                 if !clockArmed(), !buffers.isEmpty {
                     // #107: anchor at the buffer PTS when it deviates from the load anchor
@@ -1903,8 +2069,12 @@ final class SoftwarePlaybackHost {
             let keepGoing: Bool = autoreleasepool {
                 demuxIteration()
             }
+            diag?.update(lastAudioPts: lastEnqueuedAudioPtsSec,
+                         parked: parkedVideo.count,
+                         rebuffering: rebuffering)
             if !keepGoing { break }
         }
+        freeParkedVideo()
     }
 
     // MARK: - Time updates
@@ -1921,6 +2091,7 @@ final class SoftwarePlaybackHost {
                 // still on the pre-seek anchor and would drag the published position backwards.
                 guard !self.seekInFlight else { return }
                 let raw = aOut.currentTimeSeconds
+                self.emitDiagIfDue(clock: raw)
                 if raw.isFinite, raw >= 0 {
                     // Raw clock = source/subtitle axis; published alongside the mapped position (#107).
                     self.sourceClockSeconds = raw
@@ -1944,6 +2115,47 @@ final class SoftwarePlaybackHost {
             }
     }
 
+    // MARK: - SW diagnostics (1 Hz)
+
+    private let demuxDiag = SWPlaybackDiagState()
+    private var diagTickCounter = 0
+    private var diagPrevClock = Double.nan
+    private var diagPrevDropped = 0
+    private var diagPrevEnqueued = 0
+
+    /// 1 Hz [SWDiag] line: clock + clock delta, decoded-audio lead over the clock, parked
+    /// video FIFO depth, rebuffer state, and the display layer's OWN drop counter with its
+    /// per-second delta. The layer counter is the one place render-deadline misses are
+    /// visible - swDropped in the memprobe only counts pre-enqueue drops, so a session can
+    /// stutter visibly while every 30 s probe reads clean.
+    private func emitDiagIfDue(clock: Double) {
+        diagTickCounter += 1
+        guard diagTickCounter % 4 == 0 else { return }
+        let prevClock = diagPrevClock
+        diagPrevClock = clock
+        let d = demuxDiag.snapshot
+        let lead = d.lastAudioPts.isFinite && clock.isFinite ? d.lastAudioPts - clock : Double.nan
+        let enqueued = framesEnqueued
+        let dEnq = enqueued - diagPrevEnqueued
+        diagPrevEnqueued = enqueued
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            let m = await self.loadRenderMetrics()
+            let dropped = m?.dropped ?? -1
+            let dDrop = dropped >= 0 ? dropped - self.diagPrevDropped : 0
+            if dropped >= 0 { self.diagPrevDropped = dropped }
+            let dclk = clock.isFinite && prevClock.isFinite ? clock - prevClock : Double.nan
+            EngineLog.emit(
+                "[SWDiag] clk=\(String(format: "%.2f", clock)) "
+                + "dclk=\(dclk.isFinite ? String(format: "%.2f", dclk) : "-") "
+                + "aLead=\(lead.isFinite ? String(format: "%.2f", lead) : "-") "
+                + "parked=\(d.parked) rebuf=\(d.rebuffering ? "y" : "n") "
+                + "enq=+\(dEnq) layerDrop=\(dropped)(\(dDrop >= 0 ? "+" : "")\(dDrop))",
+                category: .swPlayback
+            )
+        }
+    }
+
     // MARK: - Errors
 
     enum HostError: Error, LocalizedError {
@@ -1963,4 +2175,29 @@ final class SoftwarePlaybackHost {
 func av_packet_free_safe(_ packet: UnsafeMutablePointer<AVPacket>) {
     var p: UnsafeMutablePointer<AVPacket>? = packet
     trackedPacketFree(&p)
+}
+
+/// 1 Hz SW-session diagnostics shared between the combined demux loop (writes once per
+/// iteration) and the host's time-update timer (reads + emits the [SWDiag] line). The native
+/// path has LagDiag; the SW path had only the 30 s memprobe, which is too coarse to see the
+/// clock leaps and layer-drop bursts a stuttering session is made of. Lock-guarded.
+final class SWPlaybackDiagState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _lastAudioPts = Double.nan
+    private var _parked = 0
+    private var _rebuffering = false
+
+    func update(lastAudioPts: Double, parked: Int, rebuffering: Bool) {
+        lock.lock()
+        _lastAudioPts = lastAudioPts
+        _parked = parked
+        _rebuffering = rebuffering
+        lock.unlock()
+    }
+
+    var snapshot: (lastAudioPts: Double, parked: Int, rebuffering: Bool) {
+        lock.lock()
+        defer { lock.unlock() }
+        return (_lastAudioPts, _parked, _rebuffering)
+    }
 }

--- a/Sources/AetherEngine/Native/SoftwarePlaybackHost.swift
+++ b/Sources/AetherEngine/Native/SoftwarePlaybackHost.swift
@@ -2122,6 +2122,7 @@ final class SoftwarePlaybackHost {
     private var diagPrevClock = Double.nan
     private var diagPrevDropped = 0
     private var diagPrevEnqueued = 0
+    private var diagPrevDelay: TimeInterval = 0
 
     /// 1 Hz [SWDiag] line: clock + clock delta, decoded-audio lead over the clock, parked
     /// video FIFO depth, rebuffer state, and the display layer's OWN drop counter with its
@@ -2144,13 +2145,33 @@ final class SoftwarePlaybackHost {
             let dropped = m?.dropped ?? -1
             let dDrop = dropped >= 0 ? dropped - self.diagPrevDropped : 0
             if dropped >= 0 { self.diagPrevDropped = dropped }
+            // Accumulated render delay is the one metric that shows frames displayed LATE:
+            // a layer that stalls a few seconds and then catches up (picture leaps forward,
+            // audio uninterrupted) drops nothing and enqueues on pace - only this grows.
+            let delay = m?.accumulatedDelay ?? -1
+            let dDelay = delay >= 0 ? delay - self.diagPrevDelay : 0
+            if delay >= 0 { self.diagPrevDelay = delay }
             let dclk = clock.isFinite && prevClock.isFinite ? clock - prevClock : Double.nan
+            let layer = self.renderer.displayLayer
+            let surface = layer.superlayer != nil
+                ? "\(Int(layer.bounds.width))x\(Int(layer.bounds.height))" : "DETACHED"
+            let r4d: String
+            if #available(tvOS 17.4, iOS 17.4, macOS 14.4, *) {
+                r4d = layer.isReadyForDisplay ? "y" : "n"
+            } else {
+                r4d = "-"
+            }
             EngineLog.emit(
                 "[SWDiag] clk=\(String(format: "%.2f", clock)) "
                 + "dclk=\(dclk.isFinite ? String(format: "%.2f", dclk) : "-") "
                 + "aLead=\(lead.isFinite ? String(format: "%.2f", lead) : "-") "
                 + "parked=\(d.parked) rebuf=\(d.rebuffering ? "y" : "n") "
-                + "enq=+\(dEnq) layerDrop=\(dropped)(\(dDrop >= 0 ? "+" : "")\(dDrop))",
+                + "enq=+\(dEnq) layerDrop=\(dropped)(\(dDrop >= 0 ? "+" : "")\(dDrop)) "
+                + "delay=\(delay >= 0 ? String(format: "%.2f", delay) : "-")"
+                + "(\(dDelay >= 0 ? "+" : "")\(String(format: "%.2f", dDelay))) "
+                + "corr=\(m?.corrupted ?? -1) "
+                + "status=\(self.renderer.diagStatusName) surf=\(surface) "
+                + "r4d=\(r4d)",
                 category: .swPlayback
             )
         }

--- a/Sources/AetherEngine/Native/SoftwarePlaybackHost.swift
+++ b/Sources/AetherEngine/Native/SoftwarePlaybackHost.swift
@@ -486,6 +486,16 @@ final class SoftwarePlaybackHost {
         isLive && codecID == AV_CODEC_ID_AAC && sampleRate == 0
     }
 
+    /// Pure decision: whether the demux loop folds PTS discontinuities into one continuous
+    /// timeline. Live always folds (encoder restarts mid-session). A forward-only non-live
+    /// source folds too: sequential-origin IPTV timeshift archives are chunked recordings
+    /// whose every chunk restarts at PTS ~0, FFmpeg's wrap correction turns that backward
+    /// jump into a ~26.5 h forward one, and a non-seekable pb offers no seek-based recovery.
+    /// Seekable VOD keeps its trusted container timeline untouched.
+    nonisolated static func shouldFoldTimeline(isLive: Bool, sourceSeekable: Bool) -> Bool {
+        isLive || !sourceSeekable
+    }
+
     // MARK: - Load
 
     func load(
@@ -1152,6 +1162,8 @@ final class SoftwarePlaybackHost {
                 videoTimeBaseSeconds: vTbSec,
                 audioTimeBaseSeconds: aTbSec,
                 isLive: liveSession,
+                foldTimeline: Self.shouldFoldTimeline(
+                    isLive: liveSession, sourceSeekable: dem.isSourceSeekable),
                 noteEdge: noteEdge,
                 isPlaying: getIsPlaying,
                 stopRequested: getStopRequested,
@@ -1623,6 +1635,7 @@ final class SoftwarePlaybackHost {
         videoTimeBaseSeconds: Double,
         audioTimeBaseSeconds: Double,
         isLive: Bool,
+        foldTimeline: Bool,
         noteEdge: @Sendable (Double) -> Void,
         isPlaying: @Sendable () -> Bool,
         stopRequested: @Sendable () -> Bool,
@@ -1641,12 +1654,18 @@ final class SoftwarePlaybackHost {
     ) {
         // Clock arming: one-shot latch (seekClock is not idempotent -- re-calling snaps clock back to initialClockTime). Shared with host so a seek before first audio isn't overridden by a late re-arm.
 
-        // Live PTS-discontinuity (SW): accrue (jumpedPts - expectedContinuation) into discontinuityOffset; subtract from all subsequent PTS so the whole pipeline sees one continuous timeline. Threshold 10s (mirrors native producer); flush decoders at the seam.
+        // PTS-discontinuity fold (SW): accrue (jumpedPts - expectedContinuation) into discontinuityOffset; subtract from all subsequent PTS so the whole pipeline sees one continuous timeline. Threshold 10s (mirrors native producer); flush decoders at the seam.
+        // Runs for live AND for forward-only (sequential-origin) VOD: IPTV timeshift archives are
+        // chunked recordings whose every chunk restarts at PTS ~0 (device trace: 89 s chunk ending
+        // at raw 2717.9 s, next chunk at 0.04 s; FFmpeg's 33-bit wrap correction turned that -2718 s
+        // into +92726 s, the renderer then waited 25 h for the frame's display time and died with
+        // -12080). Seekable VOD keeps the fold off: its timeline is trusted, and a threshold-sized
+        // jump there is a container seek artifact the native path also leaves alone.
         let discontinuityThresholdSeconds = 10.0
         var prevRawVideoPtsSec = Double.nan
         var frameIntervalSec = 0.0
         var discontinuityOffsetSec = 0.0
-        var loggedSWDiscontinuity = false
+        var loggedSeamCount = 0
 
         // Clock-arming fallback bookkeeping: a declared audio track whose
         // decoder never produces buffers (corrupt stream) must not leave
@@ -1693,8 +1712,8 @@ final class SoftwarePlaybackHost {
 
             let streamIdx = packet.pointee.stream_index
 
-            // Discontinuity runs before any timestamp read; offset applied to both streams. Non-live SW skips.
-            if isLive, streamIdx == videoStreamIndex, videoTimeBaseSeconds > 0,
+            // Discontinuity runs before any timestamp read; offset applied to both streams.
+            if foldTimeline, streamIdx == videoStreamIndex, videoTimeBaseSeconds > 0,
                packet.pointee.pts != Int64.min {
                 let rawPtsSec = Double(packet.pointee.pts) * videoTimeBaseSeconds
                 if !prevRawVideoPtsSec.isNaN {
@@ -1707,15 +1726,19 @@ final class SoftwarePlaybackHost {
                         videoDecoder.flush()
                         audioDecoder?.flush()
                         renderer.drainReorderBuffer()
-                        if !loggedSWDiscontinuity {
-                            loggedSWDiscontinuity = true
+                        // Chunked archives seam every minute or two; log each seam (bounded by the
+                        // 10 s threshold to at most one line per 10 s of content) with a soft cap
+                        // so a pathological source cannot flood the log.
+                        if loggedSeamCount < 20 {
+                            loggedSeamCount += 1
                             EngineLog.emit(
-                                "[SWHost] live PTS discontinuity: prevPts="
+                                "[SWHost] PTS discontinuity #\(loggedSeamCount): prevPts="
                                 + "\(String(format: "%.2f", prevRawVideoPtsSec))s "
                                 + "rawPts=\(String(format: "%.2f", rawPtsSec))s "
                                 + "delta=\(String(format: "%.2f", deltaSec))s -> "
                                 + "offset=\(String(format: "%.2f", discontinuityOffsetSec))s "
-                                + "(timeline held continuous)",
+                                + "(timeline held continuous)"
+                                + (loggedSeamCount == 20 ? " [further seams unlogged]" : ""),
                                 category: .swPlayback
                             )
                         }
@@ -1726,8 +1749,8 @@ final class SoftwarePlaybackHost {
                 prevRawVideoPtsSec = rawPtsSec
             }
 
-            // Apply discontinuity offset to timestamps in-place (live only); converts seconds to stream TB ticks.
-            if isLive, discontinuityOffsetSec != 0 {
+            // Apply discontinuity offset to timestamps in-place; converts seconds to stream TB ticks.
+            if foldTimeline, discontinuityOffsetSec != 0 {
                 let tbSec = (streamIdx == videoStreamIndex)
                     ? videoTimeBaseSeconds : audioTimeBaseSeconds
                 if tbSec > 0 {

--- a/Sources/AetherEngine/Renderer/SampleBufferRenderer.swift
+++ b/Sources/AetherEngine/Renderer/SampleBufferRenderer.swift
@@ -378,6 +378,10 @@ final class SampleBufferRenderer: @unchecked Sendable {
         }
     }
 
+    /// [SWDiag] surface: current queue-target status for the 1 Hz diagnostic line. A mid-session
+    /// flip away from `rendering` is the layer-side stall the per-frame counters cannot show.
+    var diagStatusName: String { statusName }
+
     /// Internal (not private) for #177 regression tests: the PAR-keyed cache behavior is the fix.
     func createSampleBuffer(from pixelBuffer: CVPixelBuffer, pts: CMTime) -> CMSampleBuffer? {
         // Cache hit avoids CMVideoFormatDescriptionCreateForImageBuffer allocation + CF refcount churn on every frame.

--- a/Tests/AetherEngineTests/SWTimelineFoldTests.swift
+++ b/Tests/AetherEngineTests/SWTimelineFoldTests.swift
@@ -1,0 +1,22 @@
+import Testing
+@testable import AetherEngine
+
+/// `SoftwarePlaybackHost.shouldFoldTimeline`: when the SW demux loop folds PTS discontinuities
+/// into one continuous timeline. Live always folded; a forward-only non-live source now folds
+/// too - IPTV timeshift archives are chunked recordings whose every chunk restarts at PTS ~0
+/// (device trace: an 89 s chunk ending at raw 2717.9 s, the next chunk opening at 0.04 s;
+/// FFmpeg's 33-bit wrap correction read that as +92726 s, the renderer waited 25 h for the
+/// frame's display time and died with -12080).
+@Suite("SW timeline fold decision")
+struct SWTimelineFoldTests {
+
+    @Test("forward-only VOD folds PTS discontinuities like live; seekable VOD does not")
+    func timelineFoldDecision() {
+        #expect(SoftwarePlaybackHost.shouldFoldTimeline(isLive: false, sourceSeekable: false) == true)
+        #expect(SoftwarePlaybackHost.shouldFoldTimeline(isLive: true, sourceSeekable: true) == true)
+        #expect(SoftwarePlaybackHost.shouldFoldTimeline(isLive: true, sourceSeekable: false) == true)
+        // A seekable file's container timeline is trusted; threshold-sized jumps there are
+        // seek artifacts the native path also leaves alone.
+        #expect(SoftwarePlaybackHost.shouldFoldTimeline(isLive: false, sourceSeekable: true) == false)
+    }
+}


### PR DESCRIPTION
## Problem

Two SW-path weaknesses surfaced while chasing an IPTV catch-up bug on device (tvOS 26.6), both independent of the source that exposed them:

1. **The live PTS-discontinuity fold is gated `isLive`, and non-live sessions run unprotected.** A forward-only VOD source (chunked timeshift archive) restarted its timestamps at PTS ~0 every ~85 s; FFmpeg's 33-bit wrap correction read the -2718 s jump as **+92726 s**, the renderer waited 25 hours for the frame's display time, and the video queue died with `FigVideoQueueRemote -12080` - picture and sound frozen ~90 s into every session.
2. **The combined demux loop paces everything on the video renderer's ~10-frame queue**, so interleaved audio can never build more than ~0.3 s of lead over the synchronizer clock (the master clock). Any decode/deinterlace jitter beyond that starves the audio renderer and the clock leaps; a timeline gap lets the free-running clock run away while the picture freezes. The DVR feeder arm has `AudioLookaheadPolicy` for exactly this; the combined loop had nothing.

## Change

- **`fix(sw)` fold** - the discontinuity fold gate widens to the new pure decision `shouldFoldTimeline(isLive:sourceSeekable:)`: live folds as before, and a forward-only non-live source folds too (its timeline is served as-is and a non-seekable pb offers no seek-based recovery). Seekable VOD keeps its trusted container timeline untouched. Seams log per occurrence with a soft cap of 20 lines.
- **`fix(sw)` audio decoupling** - video packets park in a bounded FIFO (drained at the renderer's pace) while audio keeps decoding up to `AudioLookaheadPolicy.targetLeadSeconds` ahead of the clock, and a genuine audio underrun **pauses the clock for a rebuffer** via the same policy the DVR feeder uses, with an `everHadLead` latch so exactly-realtime origins do not eat a spurious pause at session start. At a fold seam the parked pre-seam tail is decoded before the flush drops its reference chain. Live-without-ring sessions keep the historical lockstep pacing.
- **`diag(sw)`** - the SW path gains a 1 Hz `[SWDiag]` line (clock + delta, decoded-audio lead, parked depth, rebuffer state, the display layer's own drop counter, accumulated render delay with per-second delta, queue-target status, surface state, `isReadyForDisplay`). The native path has LagDiag; SW sessions only had the 30 s memprobe, which is too coarse to see the clock leaps and layer-drop bursts a stuttering session is made of. It also names a headless-harness artifact: a never-bound layer (`surf=DETACHED`) drops ~8 frames/s that a bound one does not.

## Verification

- `SWTimelineFoldTests` pins the fold decision; full suite green (1632 tests).
- Device: with the fold active, the chunked archive's seams fold cleanly instead of freezing into -12080; `[SWDiag]` on a healthy session reads `dclk=1.00`, `aLead` 3-5 s sawtooth, `layerDrop` flat, `delay=0.00`.
- On an M-series Mac via `aetherctl play`: clock exact across 5+ minutes, no rebuffer churn on fast origins, rebuffer pause/resume behaves on origins that deliver below realtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)