### PR TITLE
A play gate that saw the switch start waits for its end (Sodalite#49)

### DIFF
--- a/Sources/AetherEngine/AetherEngine+Loading.swift
+++ b/Sources/AetherEngine/AetherEngine+Loading.swift
@@ -1674,12 +1674,14 @@ extension AetherEngine {
                 // #274: this reload preserved the criteria (resetDisplayCriteria: false) and re-applies none,
                 // so only a sole-writer host's re-write on the swapped item can still switch anything; the
                 // published (panel-clamped) format decides whether that can be a dynamic-range switch.
-                await displayCriteria.waitForSwitch(startGrace: Self.playGateGrace(
-                    criteriaUnchanged: false,
-                    engineIsCriteriaWriter: !loadedOptions.suppressDisplayCriteria,
-                    formatKnown: true,
-                    effectiveFormat: videoFormat
-                ))
+                await displayCriteria.waitForSwitch(
+                    startGrace: Self.playGateGrace(
+                        criteriaUnchanged: false,
+                        engineIsCriteriaWriter: !loadedOptions.suppressDisplayCriteria,
+                        formatKnown: true,
+                        effectiveFormat: videoFormat
+                    ),
+                    settleCap: loadedOptions.isLive ? .standard : .awaitObservedEnd)
                 try checkLoadCurrent(gen)
                 nativeHost?.play()
             }

--- a/Sources/AetherEngine/AetherEngine.swift
+++ b/Sources/AetherEngine/AetherEngine.swift
@@ -3136,12 +3136,17 @@ public final class AetherEngine: ObservableObject {
                 // #274: the 1000ms Stage 1 budget is the DV-cold-start bet on a sole-writer host's inbound
                 // write. Sessions no dynamic-range switch can reach (engine-writer, or SDR content) take the
                 // 200ms budget instead of paying it on every load.
-                await displayCriteria.waitForSwitch(startGrace: Self.playGateGrace(
-                    criteriaUnchanged: criteriaUnchanged,
-                    engineIsCriteriaWriter: !options.suppressDisplayCriteria,
-                    formatKnown: probeOpened,
-                    effectiveFormat: effectiveFormat
-                ))
+                await displayCriteria.waitForSwitch(
+                    startGrace: Self.playGateGrace(
+                        criteriaUnchanged: criteriaUnchanged,
+                        engineIsCriteriaWriter: !options.suppressDisplayCriteria,
+                        formatKnown: probeOpened,
+                        effectiveFormat: effectiveFormat
+                    ),
+                    // Sodalite#49: this gate runs after the item is ready, so waiting out an observed switch
+                    // blocks nothing else, and the panel is dark until it ends either way. Live keeps the
+                    // standard cap: a zap must not sit behind a panel handshake.
+                    settleCap: options.isLive ? .standard : .awaitObservedEnd)
                 try checkLoadCurrent(gen)
                 // automaticallyWaitsToMinimizeStalling=true (default) handles play-before-ready.
                 // #35: on a real SDR->HDR switch while serving a VOD master, drive the bounded

--- a/Sources/AetherEngine/Display/DisplayCriteriaController.swift
+++ b/Sources/AetherEngine/Display/DisplayCriteriaController.swift
@@ -124,6 +124,37 @@ final class DisplayCriteriaController {
     /// one of them is written on it.
     nonisolated static let stage2CapMs = 2000
 
+    /// What the settle wait is allowed to cost, decided by what else is waiting on it.
+    enum SettleCap: Equatable {
+        /// `stage2CapMs`. For a gate that runs *before* the item is built, where breaking out early is what
+        /// releases the load, and for live, where a zap must not sit behind a panel handshake.
+        case standard
+        /// Wait for the end that was observed to be coming, up to `observedEndCapMs`. For a gate that runs
+        /// after the item is ready: nothing else is pending, so the wait costs only itself.
+        case awaitObservedEnd
+    }
+
+    /// Ceiling for `awaitObservedEnd`. Only reachable when a start notification was recorded and its end
+    /// never arrives, which did not happen once across sixteen device switches; the real numbers are 2.8 s
+    /// for a dynamic-range switch and 3.55 s for a rate switch.
+    nonisolated static let observedEndCapMs = 6000
+
+    /// A gate that ran after the load, on a switch it saw start, waits for that switch to end.
+    ///
+    /// The measurement that decides this (Apple TV 4K 3rd gen, tvOS 26.5, 2026-08-09, SDR 25p on a 60 Hz
+    /// system, so a rate-only write with no pre-flight): the item was ready at +443 ms, the cap released
+    /// `play()` at +2130 ms, and the panel finished switching at +3555 ms. **The panel blanks throughout**,
+    /// which is the part no log shows: the first visible frame lands at +3555 ms either way, so releasing
+    /// early buys no picture at all and costs 1.4 s of content played into a dark screen.
+    ///
+    /// This is the answer to "a rate-only switch does not need to be waited out" (Sodalite#49, DrHurt). It
+    /// does not need to be waited out for *correctness*, since only a range change can fail AVPlayer, but
+    /// waiting is free where the panel is dark anyway, and not waiting is not.
+    nonisolated static func settleCapMs(cap: SettleCap, startRecorded: Bool) -> Int {
+        guard cap == .awaitObservedEnd, startRecorded else { return stage2CapMs }
+        return observedEndCapMs
+    }
+
     /// Both stages spend a deadline, not a poll count. `n` sleeps of `m` ms is only `n * m` on an idle
     /// scheduler: the same 40 x 50 ms Stage 2 ran 2082 ms in one of the reporter's runs and 2862 ms in
     /// another, on a device reporting `thermal=serious` throughout. A budget that stretches 40 % under the
@@ -490,7 +521,9 @@ final class DisplayCriteriaController {
     /// `consumesRecord: false` leaves the observation readable for the load's second gate. The pre-flight
     /// passes it: it waits an HDR switch out before the item is built, and the play gate that follows is
     /// entitled to the same start/end timestamps (#339).
-    func waitForSwitch(startGrace: StartGrace = .full, consumesRecord: Bool = true) async {
+    func waitForSwitch(startGrace: StartGrace = .full,
+                       consumesRecord: Bool = true,
+                       settleCap: SettleCap = .standard) async {
         #if os(tvOS)
         guard startGrace != .skip else { return }
         guard let window = resolveWindow() else { return }
@@ -600,6 +633,10 @@ final class DisplayCriteriaController {
         // in-progress flag clearing), else a bounded ~2s cap so a panel whose DV
         // switch is unobservable to the app can't gate the first frame the way the
         // old fixed 5s poll did.
+        // What this gate may spend waiting for the end, given who is waiting on it (`settleCapMs`).
+        let capMs = Self.settleCapMs(
+            cap: settleCap,
+            startRecorded: gateSnapshot.startedAt != nil || observation.hasNewStart(since: gateSnapshot))
         let stage2Entry = DispatchTime.now()
         func timing() -> String {
             // The panel's own switch duration whenever both notifications were seen. This is the number the
@@ -614,7 +651,7 @@ final class DisplayCriteriaController {
                                      totalMs: Self.elapsedMs(since: entry),
                                      startBeforeGateMs: preGateStartMs, switchMs: switchMs)
         }
-        while !Self.isBudgetSpent(elapsedMs: Self.elapsedMs(since: stage2Entry), budgetMs: Self.stage2CapMs) {
+        while !Self.isBudgetSpent(elapsedMs: Self.elapsedMs(since: stage2Entry), budgetMs: capMs) {
             try? await Task.sleep(for: .milliseconds(50))
             if observation.hasNewEnd(since: gateSnapshot) {
                 EngineLog.emit("[DisplayCriteria] switch settled via modeSwitchEnd (\(timing()))", category: .engine)

--- a/Tests/AetherEngineTests/DisplayCriteriaSwitchObservationTests.swift
+++ b/Tests/AetherEngineTests/DisplayCriteriaSwitchObservationTests.swift
@@ -190,3 +190,43 @@ struct DisplayCriteriaSwitchObservationTests {
             isFirstPoll: false, startNotificationFired: false, switchInProgress: false) == nil)
     }
 }
+
+// Sodalite#49, rate-only round: the play gate used to break out of a switch it had watched start, because
+// Stage 2's cap is sized for a gate that runs BEFORE the load. Device measurement (ATV 4K 3rd gen,
+// tvOS 26.5, SDR 25p on a 60 Hz system, so a rate-only write with no pre-flight): item ready +443 ms, cap
+// released play() +2130 ms, panel finished +3555 ms. The panel is dark the whole time, so the early release
+// bought no picture and cost 1.4 s of content played into a black screen.
+@Suite("DisplayCriteria settle cap by what waits on the gate (Sodalite#49)")
+struct DisplayCriteriaSettleCapTests {
+
+    @Test("A play gate that saw the switch start waits for its end")
+    func playGateAwaitsObservedEnd() {
+        #expect(DisplayCriteriaController.settleCapMs(cap: .awaitObservedEnd, startRecorded: true)
+            == DisplayCriteriaController.observedEndCapMs)
+    }
+
+    @Test("Without a recorded start there is no end to await, so the standard cap holds")
+    func unobservedSwitchKeepsTheStandardCap() {
+        // The unobservable-DV panel: nothing will report an end, so a longer ceiling is pure startup cost.
+        #expect(DisplayCriteriaController.settleCapMs(cap: .awaitObservedEnd, startRecorded: false)
+            == DisplayCriteriaController.stage2CapMs)
+    }
+
+    @Test("The pre-flight and live keep the standard cap whatever was recorded")
+    func standardCapIsUnconditional() {
+        // Pre-flight: breaking out early is what releases loadNative (AE#348). Live: a zap must not sit
+        // behind a panel handshake.
+        for recorded in [true, false] {
+            #expect(DisplayCriteriaController.settleCapMs(cap: .standard, startRecorded: recorded)
+                == DisplayCriteriaController.stage2CapMs)
+        }
+    }
+
+    @Test("The awaited ceiling clears the measured switches with room, and is still a ceiling")
+    func observedEndCapIsSized() {
+        // Measured: 2779-2898 ms dynamic range, ~3550 ms rate-only. Reachable only if a start was recorded
+        // and its end never arrives, which happened in none of sixteen device switches.
+        #expect(DisplayCriteriaController.observedEndCapMs > 3600)
+        #expect(DisplayCriteriaController.observedEndCapMs <= 6000)
+    }
+}


### PR DESCRIPTION
Follow-up to #345, on the configuration Sodalite#49 was originally filed on: a rate-only write, which takes no pre-flight at all.

## Measurement

Apple TV 4K (3rd gen), tvOS 26.5, SDR 25p on a 60 Hz system, two runs:

| | run 1 | run 2 |
|---|---|---|
| item ready | +443 ms | +286 ms |
| gate released `play()` (cap) | +2130 ms | +2068 ms |
| **panel finished switching** | **+3555 ms** | **+3550 ms** |

Two things this shows. A **rate** switch on this panel takes ~3.55 s, longer than the ~2.85 s of a dynamic-range switch, so the earlier figure was the range handshake rather than a panel constant. And the gate released 1.4 s early, because `stage2CapMs` is sized for a gate that runs *before* the load, where breaking out early is what releases `loadNative` (see the note on that constant, and AE#348).

The part no log shows: **the panel is dark for the whole switch.** The reporter confirmed it on the device. So the early release bought no picture at all, the first visible frame lands at +3555 ms either way, and the 1.4 s it "saved" were 1.4 s of the film played into a black screen.

## Change

A gate that runs after the item is ready blocks nothing else, so when it has recorded the switch starting it waits for the end, up to a 6 s ceiling (measured switches: 2779 to 2898 ms range, ~3550 ms rate, none came close).

Unchanged, deliberately:

- **the pre-flight**, where the early break-out is load-bearing until AE#348 makes the load concurrent
- **live**, where a zap must not sit behind a panel handshake
- **a switch with no recorded start**, the unobservable-DV panel: nothing will report an end there, so a longer ceiling would be pure startup cost

Because the wait ends on the observed end rather than on a duration, a panel that switches quickly pays only what it takes.

## On "a rate-only switch does not need to be waited out"

Raised on the Sodalite#49 thread. Correct as far as failure modes go: only a range change can fail AVPlayer outright. But the premise behind it, that waiting costs startup time, does not hold on a panel that blanks: there the wait is free and skipping it costs content instead. On a panel that switches without blanking the trade is the other way round, and this change is sized for that too, since it waits for the end rather than for a number.

## Verification

`swift test`: 1655 tests, green. tvOS build green. Device verification of this change is pending; the measurements above are from the build before it.