### PR TITLE
fix(audio): the tap continuation's weak capture sat on the wrong closure

### DIFF
--- a/Sources/AetherEngine/Audio/Tap/AudioTapController.swift
+++ b/Sources/AetherEngine/Audio/Tap/AudioTapController.swift
@@ -23,9 +23,15 @@ final class AudioTapController {
         continuation = cont
         filter = AudioTapMonotonicFilter(downstream: { buf in _ = cont.yield(buf) })
         startReader { [weak self] stop in self?.stopReader = stop }
-        cont.onTermination = { _ in
+        // The weak capture belongs on the outer closure. Written on the inner Task it was
+        // decorative: `self` was still strongly captured here, so the continuation this
+        // controller owns retained the controller back. Every path releases the controller
+        // through `teardown()` (removeAudioTap, load, stop), so the strong reference bought
+        // nothing, and a future path that drops it without tearing down would have kept the
+        // reader running instead of stopping it.
+        cont.onTermination = { [weak self] _ in
             // Consumer cancelled (broke the for-await loop): tear down from the MainActor.
-            Task { @MainActor [weak self] in self?.teardown() }
+            Task { @MainActor in self?.teardown() }
         }
         return stream
     }


### PR DESCRIPTION
`AudioTapController.makeStream` wrote `[weak self]` on the `Task` inside `cont.onTermination`. The outer closure captured `self` strongly regardless, so the continuation this controller owns retained the controller back. Swift 6.3 flags it as `#ImplicitStrongCapture`; it showed up in @jihongboo's Xcode 27 beta build log on #313 and is unrelated to the SDK isolation thread there.

Not a leak in the shipped paths: `removeAudioTap`, `load` and `stop` all go through `teardown()`, which finishes the continuation and drops the handler. What the misplaced capture cost was the guarantee it appeared to give, a path that released the controller without tearing down would have kept the reader running instead of stopping it.

Moving the capture to the outer closure makes the declared intent the real one. `teardown()` is idempotent, so termination landing after teardown with a nil `self` is a no-op.

`swift build` clean, `swift test --filter AudioTap` 37/37.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HX5zV3Fcf7Nzq4DYGdXvQE