### PR TITLE
fix(airplay): the remote-HLS bypass reloads when it stands on its own origin (#316)

### DIFF
--- a/Sources/AetherEngine/AetherEngine.swift
+++ b/Sources/AetherEngine/AetherEngine.swift
@@ -4223,10 +4223,17 @@ public final class AetherEngine: ObservableObject {
         let wantAirPlay = active && !wired
         guard wantAirPlay != airPlayActive else { return }
         airPlayActive = wantAirPlay
-        // Loopback native path only: remote-HLS is already receiver-reachable. Reload so loadNative rebuilds
-        // the playback URL on the LAN IP + media playlist (active) or back on 127.0.0.1 master/media (inactive).
-        guard playbackBackend == .native, !loadedOptions.nativeRemoteHLS, loadedURL != nil else { return }
-        EngineLog.emit("[AirPlay] external playback \(wantAirPlay ? "active (wireless) -> LAN media reload" : "ended -> loopback reload")", category: .engine)
+        // Reload so the load path rebuilds the playback URL on the LAN IP (active) or back on 127.0.0.1
+        // (inactive). The remote-HLS bypass is exempt only while it plays the origin URL, which a receiver
+        // reaches by itself; with a #316 subtitle proxy mounted it stands on the engine's own loopback
+        // origin and needs the swap exactly like the loopback path. See AirPlayPlaylistDecision.
+        guard playbackBackend == .native, loadedURL != nil,
+              AirPlayPlaylistDecision.routeChangeNeedsReload(
+                isRemoteHLSBypass: loadedOptions.nativeRemoteHLS,
+                bypassServesLoopbackOrigin: remoteHLSSubtitleProxy != nil) else { return }
+        EngineLog.emit("[AirPlay] external playback \(wantAirPlay ? "active (wireless) -> LAN reload" : "ended -> loopback reload")"
+                       + (loadedOptions.nativeRemoteHLS ? " (remote-HLS bypass on its #316 subtitle origin)" : ""),
+                       category: .engine)
         Task { try? await reloadAtCurrentPosition() }
     }
 

--- a/Sources/AetherEngine/Native/AirPlayPlaylistDecision.swift
+++ b/Sources/AetherEngine/Native/AirPlayPlaylistDecision.swift
@@ -69,6 +69,29 @@ enum AirPlayPlaylistDecision {
         playlist == .master
     }
 
+    /// Whether a wireless-AirPlay route change has to reload the session so the playback URL is re-resolved
+    /// for the new route (#86, and #316 for the second case).
+    ///
+    /// The `nativeRemoteHLS` bypass was excluded wholesale on the premise that remote HLS is already
+    /// receiver-reachable, which held as long as the bypass could only ever play the origin URL. #316 gave
+    /// it a second shape: with text sidecars declared at load, the bypass plays a master the engine serves
+    /// from its own loopback origin, and that address means nothing on the receiver. So the discriminator
+    /// is not the backend, it is where the session's playback URL points.
+    ///
+    /// Both edges reload, matching the loopback path: engaging swaps the loopback host for the LAN IP,
+    /// ending puts the session back on 127.0.0.1 rather than leaving it depending on a LAN address that
+    /// outlives the receiver.
+    ///
+    /// - Parameters:
+    ///   - isRemoteHLSBypass: `LoadOptions.nativeRemoteHLS` for the loaded session.
+    ///   - bypassServesLoopbackOrigin: a #316 subtitle proxy is mounted, so the bypass is playing the
+    ///     engine's rewritten master off the loopback instead of the origin URL. Meaningless off the bypass.
+    static func routeChangeNeedsReload(isRemoteHLSBypass: Bool,
+                                       bypassServesLoopbackOrigin: Bool) -> Bool {
+        guard isRemoteHLSBypass else { return true }
+        return bypassServesLoopbackOrigin
+    }
+
     /// The loopback URL rewritten for the receiver: same port and query, the device's LAN IP for the host
     /// (the receiver cannot reach 127.0.0.1), and the path of the chosen playlist. `.master` keeps whatever
     /// the session resolved. The playlists' `EXT-X-MEDIA` and segment URIs are relative, so everything

--- a/Tests/AetherEngineTests/AirPlayPlaylistDecisionTests.swift
+++ b/Tests/AetherEngineTests/AirPlayPlaylistDecisionTests.swift
@@ -62,4 +62,22 @@ struct AirPlayPlaylistDecisionTests {
             base: base, lanIP: "192.168.8.166", playlist: .media))
         #expect(url.absoluteString == "http://192.168.8.166:52341/media.m3u8")
     }
+
+    @Test("#86: the loopback session reloads on both edges of a route change")
+    func loopbackSessionReloadsOnBothEdges() {
+        #expect(AirPlayPlaylistDecision.routeChangeNeedsReload(
+            isRemoteHLSBypass: false, bypassServesLoopbackOrigin: false))
+    }
+
+    @Test("#316: a bypass standing on its own loopback origin reloads, or the receiver is handed 127.0.0.1")
+    func bypassOnLoopbackOriginReloads() {
+        #expect(AirPlayPlaylistDecision.routeChangeNeedsReload(
+            isRemoteHLSBypass: true, bypassServesLoopbackOrigin: true))
+    }
+
+    @Test("A bypass playing the origin directly is receiver-reachable and must not reload")
+    func bypassOnOriginDoesNotReload() {
+        #expect(!AirPlayPlaylistDecision.routeChangeNeedsReload(
+            isRemoteHLSBypass: true, bypassServesLoopbackOrigin: false))
+    }
 }


### PR DESCRIPTION
## What

The wireless-AirPlay route change (#86, #227) reloads the session so the playback URL is re-resolved onto the device's LAN IP. It excluded the `nativeRemoteHLS` bypass wholesale:

```swift
guard playbackBackend == .native, !loadedOptions.nativeRemoteHLS, loadedURL != nil else { return }
```

on the premise stated right above it, "remote-HLS is already receiver-reachable". That was true while the bypass could only ever play the origin URL.

## Why it is no longer true

#316 gave the bypass a second shape. With text sidecars declared at load, it plays a master the engine serves from its own loopback origin, and `127.0.0.1` means nothing on a receiver. Engaging AirPlay mid-playback handed the receiver an address it cannot fetch.

Nothing caught it downstream either: `handleRefusedAirPlayMaster` requires a `nativeVideoSession`, which this bypass never builds, so the progress watchdog and its media-playlist fallback both sit out. The result is the silent park documented in `AirPlayPlaylistDecision`: no `-11868`, no failed item.

Mounting the proxy *while already AirPlaying* was covered (`AetherEngine+Loading.swift:381`). The route change *afterwards* was not, and the comment at that site claiming "the route-change reload re-enters this path and re-resolves it" was describing a reload that never ran for this path.

## The change

The discriminator is not the backend, it is where the session's playback URL points. That goes into `AirPlayPlaylistDecision` as a pure function, matching the existing offline-testable gates in that file:

```swift
static func routeChangeNeedsReload(isRemoteHLSBypass: Bool,
                                   bypassServesLoopbackOrigin: Bool) -> Bool
```

Both edges reload, matching the loopback path: engaging swaps in the LAN IP, ending puts the session back on the loopback rather than leaving it depending on a LAN address that outlives the receiver.

The reload itself already works on this path, it was only never started. Verified by reading the two preconditions it depends on:

- `load()` seats the carryover registry at the #88 registration point (`AetherEngine.swift:2520`), which runs *before* the bypass branch, so `prepareRemoteHLSSubtitleProxy` sees the sidecars again and remounts the proxy.
- `loadedURL` holds the origin URL (`AetherEngine.swift:2440`), not the proxy URL, so the reload re-enters at the origin instead of treating the loopback master as its source.

## Tests

Three cases added to `AirPlayPlaylistDecisionTests`, red before the change (no such member), green after. Full suite: 1658 tests, 243 suites, passing.

## Not covered here

The device half. This is the same boundary as #316 itself: what a receiver does with the swapped URL cannot be observed headless. The reporter's PiP/AirPlay/wired-display pass is what would confirm it.

Refs #316.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HX5zV3Fcf7Nzq4DYGdXvQE