### PR TITLE
fix(video): rebase the timeline across an archive chunk seam on a sequential origin (#368)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,20 @@ the public-API contract.
 
 ## [Unreleased]
 
-_Nothing yet._
+### Fixed
+
+- A sequential-origin VOD session now folds a timeline discontinuity the way live folds a
+  program boundary (#368). IPTV timeshift archives are chunked recordings whose every chunk
+  restarts near PTS 0; libavformat's 33-bit wrap correction turns that backward seam into a
+  +2^33 leap (device: dts delta 8226410192 ticks — 363524400 + 8226410192 = 2^33 exactly),
+  which reached the keyframe-gated cutter unmodified and walked its monotonic index to the
+  plan tail. After that the session was structurally dead: the playlist froze, the
+  backpressure park waited on a segment the playlist can never advertise, and the wedge
+  recovery's reposition is exactly what a sequential origin refuses. The existing live
+  rebase (both streams, same thresholds) now also runs for sequential-origin VOD; cutter,
+  ledger and append playlist need no change because they already operate on post-shift
+  output time. No `EXT-X-DISCONTINUITY` is added at the seam: the archive is
+  content-continuous and the output timeline stays continuous after the rebase.
 
 ## [6.25.1] - 2026-08-13
 

--- a/Sources/AetherEngine/Video/HLSSegmentProducer.swift
+++ b/Sources/AetherEngine/Video/HLSSegmentProducer.swift
@@ -170,6 +170,22 @@ final class HLSSegmentProducer: @unchecked Sendable {
     /// Live mode: cuts at keyframes past targetSegmentDurationSeconds; ignores segmentBoundaries.
     private let isLive: Bool
 
+    /// #368: a sequential-origin VOD session folds timeline discontinuities the way live does.
+    /// IPTV timeshift archives are chunked recordings; each chunk restarts near PTS 0, and
+    /// libavformat's 33-bit wrap correction turns the backward seam into +2^33 (device: dts delta
+    /// 8226410192 ticks, 363524400 + 8226410192 = 2^33 exactly). Without a rebase that leap reaches
+    /// the cutter as item-axis time and walks its index to the plan tail, after which the session is
+    /// structurally dead (frozen playlist, permanent park, refused re-anchor). The SW host already
+    /// folds these seams for forward-only VOD (SoftwarePlaybackHost.shouldFoldTimeline); this is the
+    /// producer-path equivalent. `isSourceReplay` stays in the shared path untouched: it requires a
+    /// recent unplanned reconnect, which a sequential origin (single connection, no reconnect)
+    /// can never have.
+    private let foldsSequentialTimeline: Bool
+
+    /// The timeline-rebase gate for both stream rebases: live program boundaries and sequential
+    /// chunk seams share one definition of "discontinuity" (the thresholds below).
+    private var rebasesTimelineOnDiscontinuity: Bool { isLive || foldsSequentialTimeline }
+
     private var liveCurrentSegmentIndex: Int
     private var liveSegmentStartPtsSeconds: Double = 0
     private var liveFirstSegmentOpened = false
@@ -224,6 +240,20 @@ final class HLSSegmentProducer: @unchecked Sendable {
     /// Tighter backward threshold (1.5 s) because any backward leap past the 0.5 s monotonic-glitch ceiling is a program boundary.
     /// 10 s symmetric threshold left a dead zone for short SSAI bumpers (~5 s reset); audio stutter resulted.
     static let discontinuityBackwardThresholdSeconds: Double = 1.5
+
+    /// #368: rebase math of the video-stream timeline rebase; pure so the 2^33 chunk-seam wrap can be
+    /// pinned in a unit test against the device trace. Output dts continues one fallback frame past
+    /// the last output, whatever the source leaped to.
+    static func rebasedVideoShift(
+        srcDts: Int64,
+        lastSrcDts: Int64,
+        oldShift: Int64,
+        fallbackDurationPts: Int64
+    ) -> (newShift: Int64, continuationDts: Int64) {
+        let lastOutputDts = lastSrcDts - oldShift
+        let continuationDts = lastOutputDts + max(fallbackDurationPts, 1)
+        return (srcDts - continuationDts, continuationDts)
+    }
 
     /// Derive audio shift so boundary packet lands exactly on the video seam regardless of source base.
     /// Fixes amux ad creatives (Pluto: video clock starts at 0, audio near 2^33); copying video shift directly hangs audio.
@@ -697,6 +727,8 @@ final class HLSSegmentProducer: @unchecked Sendable {
 
     /// Fires at live program boundary with updated videoShiftPts and seamOutputSeconds (AVPlayer clock position of the seam).
     /// Distinct from onVideoShiftKnown: the new shift is at the producer edge, AVPlayer renders it buffer+holdback later.
+    /// #368: also fires at a sequential chunk-seam rebase — the source-PTS consumers (A53 caption tap,
+    /// subtitle mapping) need the playlist axis moved the same way there.
     var onLiveTimelineRebase: (@Sendable (_ shiftPts: Int64, _ seamOutputSeconds: Double) -> Void)?
 
     enum PumpExitReason: Sendable, CustomStringConvertible {
@@ -855,6 +887,7 @@ final class HLSSegmentProducer: @unchecked Sendable {
         segmentBoundaries: [Int64],
         planAnchorVideoPts: Int64 = 0,
         isLive: Bool = false,
+        foldsSequentialTimeline: Bool = false,
         packedSideAudioStartPts: Int64? = nil,
         packedSideAudioFallbackDurationPts: Int64 = 0,
         bufferAheadSegments: Int = 10,
@@ -914,6 +947,7 @@ final class HLSSegmentProducer: @unchecked Sendable {
             baseIndex: baseIndex
         )
         self.isLive = isLive
+        self.foldsSequentialTimeline = foldsSequentialTimeline
         self.liveCurrentSegmentIndex = baseIndex
         self.videoFallbackDurationPts = videoFallbackDurationPts
         self.audioFallbackDurationPts = audioFallbackDurationPts
@@ -2304,10 +2338,12 @@ final class HLSSegmentProducer: @unchecked Sendable {
                         category: .session
                     )
                 }
-                // Live timeline rebase: a program boundary resets source dts to a small value.
-                // Per-frame monotonic gate would bump to lastValid+1, exceed reset pts, and DROP every subsequent packet.
-                // Correct repair: rebase OUTPUT dts to one frame past last output; add #EXT-X-DISCONTINUITY at seam.
-                if isLive, isVideoPkt, lastVideoSourceDts != Int64.min,
+                // Timeline rebase: a live program boundary — or, #368, a sequential-origin archive
+                // chunk seam — resets source dts to a distant value. Per-frame monotonic gate would
+                // bump to lastValid+1, exceed reset pts, and DROP every subsequent packet.
+                // Correct repair: rebase OUTPUT dts to one frame past last output; live additionally
+                // adds #EXT-X-DISCONTINUITY at the seam.
+                if rebasesTimelineOnDiscontinuity, isVideoPkt, lastVideoSourceDts != Int64.min,
                    videoShiftPts != Int64.min, packet.pointee.dts != Int64.min {
                     let jumpTicks = packet.pointee.dts - lastVideoSourceDts
                     let thresholdSeconds = jumpTicks < 0
@@ -2325,14 +2361,17 @@ final class HLSSegmentProducer: @unchecked Sendable {
                             exitReason = .sourceReplay
                             break readLoop
                         }
-                        let lastOutputDts = lastVideoSourceDts - videoShiftPts
-                        let continuationDts = lastOutputDts + max(videoFallbackDurationPts, 1)
-                        let newShift = packet.pointee.dts - continuationDts
+                        let (newShift, continuationDts) = Self.rebasedVideoShift(
+                            srcDts: packet.pointee.dts,
+                            lastSrcDts: lastVideoSourceDts,
+                            oldShift: videoShiftPts,
+                            fallbackDurationPts: videoFallbackDurationPts
+                        )
                         EngineLog.emit(
-                            "[HLSSegmentProducer] live video timeline rebase: "
+                            "[HLSSegmentProducer] video timeline rebase (\(isLive ? "live" : "sequential")): "
                             + "jumpTicks=\(jumpTicks) srcDts=\(packet.pointee.dts) "
                             + "lastSrcDts=\(lastVideoSourceDts) oldShift=\(videoShiftPts) "
-                            + "newShift=\(newShift) lastOutDts=\(lastOutputDts)",
+                            + "newShift=\(newShift) continuationDts=\(continuationDts)",
                             category: .session
                         )
                         if packedSideAudioClock != nil {
@@ -2352,8 +2391,15 @@ final class HLSSegmentProducer: @unchecked Sendable {
                             firstActualVideoPts = packet.pointee.pts
                         }
                         lastRawVideoPts = Int64.min
-                        pendingDiscontinuityFlag = true
-                        pendingForceCutFlag = true
+                        if isLive {
+                            // Live consumers get #EXT-X-DISCONTINUITY plus a forced cut. A sequential
+                            // chunk seam (#368) wants neither: the archive is content-continuous, the
+                            // output timeline stays continuous after the rebase, and the append
+                            // playlist's EXTINF comes from real muxed durations. (Both flags feed
+                            // only the live segment bookkeeping.)
+                            pendingDiscontinuityFlag = true
+                            pendingForceCutFlag = true
+                        }
                         // Hand seam OUTPUT dts (not video shift) to audio: audio derives its own shift from its OWN srcDts,
                         // so differing audio source bases (Pluto amux: audio near 2^33) are absorbed.
                         if let audio = audioConfig {
@@ -2376,7 +2422,7 @@ final class HLSSegmentProducer: @unchecked Sendable {
                         onLiveTimelineRebase?(newShift, seamOutputSeconds)
                     }
                 }
-                if isLive, isAudioPkt, lastAudioSourceDts != Int64.min,
+                if rebasesTimelineOnDiscontinuity, isAudioPkt, lastAudioSourceDts != Int64.min,
                    audioShiftPts != Int64.min, packet.pointee.dts != Int64.min,
                    let audio = audioConfig {
                     let jumpTicks = packet.pointee.dts - lastAudioSourceDts
@@ -2455,7 +2501,7 @@ final class HLSSegmentProducer: @unchecked Sendable {
                         }
                         pendingAudioInheritSeamOut = nil
                         EngineLog.emit(
-                            "[HLSSegmentProducer] live audio timeline rebase: "
+                            "[HLSSegmentProducer] audio timeline rebase (\(isLive ? "live" : "sequential")): "
                             + "jumpTicks=\(jumpTicks) srcDts=\(packet.pointee.dts) "
                             + "lastSrcDts=\(lastAudioSourceDts) oldShift=\(audioShiftPts) "
                             + "newShift=\(newShift) "

--- a/Sources/AetherEngine/Video/HLSVideoEngine.swift
+++ b/Sources/AetherEngine/Video/HLSVideoEngine.swift
@@ -2022,6 +2022,10 @@ public final class HLSVideoEngine: @unchecked Sendable {
             segmentBoundaries: segmentBoundaries,
             planAnchorVideoPts: firstKeyframePts,
             isLive: isLiveSession,
+            // #368: a forward-only chunked archive folds its chunk-seam PTS resets (incl. the
+            // libavformat 33-bit wrap correction) the way live folds program boundaries; without
+            // it the leap walks the cutter to the plan tail and the session deadlocks.
+            foldsSequentialTimeline: sequentialOriginPinsProducerToZero,
             packedSideAudioStartPts: packedSideAudioStartPts,
             packedSideAudioFallbackDurationPts: packedSideAudioFallbackDurationPts,
             bufferAheadSegments: forwardWindowSegments,
@@ -2117,6 +2121,7 @@ public final class HLSVideoEngine: @unchecked Sendable {
     /// Live program-boundary rebase. Unlike `handleVideoShiftKnown`, does NOT fire `onPlaylistShiftChanged`:
     /// AVPlayer renders at ~buffer+holdback behind the producer edge, so the host must keep the OLD shift
     /// until playback crosses `seamOutputSeconds`. Internal `playlistShiftSeconds` tracks the edge immediately.
+    /// #368: sequential chunk-seam rebases arrive here too, deliberately — same deferred-shift contract.
     func handleLiveTimelineRebase(_ shiftPts: Int64, seamOutputSeconds: Double) {
         let seconds = shiftPts == Int64.min ? 0 : Double(shiftPts) * sourceVideoTbSeconds
         setPlaylistShiftSeconds(seconds)

--- a/Tests/AetherEngineTests/TimelineRebaseMathTests.swift
+++ b/Tests/AetherEngineTests/TimelineRebaseMathTests.swift
@@ -1,0 +1,64 @@
+import XCTest
+@testable import AetherEngine
+
+/// #368: the timeline-rebase math shared by live program boundaries and sequential chunk seams.
+/// The wrap case pins the exact device trace of the field failure: an IPTV timeshift archive whose
+/// chunk restarts near PTS 0, which libavformat's 33-bit wrap correction turns into a +2^33 leap.
+final class TimelineRebaseMathTests: XCTestCase {
+
+    func testChunkSeamWrapContinuesOneFramePastLastOutput() {
+        // Device trace: seam-preceding dts 363524400, seam packet wrap-corrected to exactly 2^33
+        // (movenc rejected the inferred duration 8226410192; 363524400 + 8226410192 = 2^33).
+        let lastSrcDts: Int64 = 363_524_400
+        let srcDts: Int64 = 8_589_934_592
+        XCTAssertEqual(srcDts - lastSrcDts, 8_226_410_192)
+        XCTAssertEqual(srcDts, Int64(1) << 33)
+
+        let (newShift, continuationDts) = HLSSegmentProducer.rebasedVideoShift(
+            srcDts: srcDts,
+            lastSrcDts: lastSrcDts,
+            oldShift: 363_049_200,        // trace: video gate open shift
+            fallbackDurationPts: 1800     // 50 fps in 1/90000
+        )
+        // Output continuity: the seam packet lands exactly one frame past the last output dts.
+        let lastOutputDts: Int64 = 363_524_400 - 363_049_200
+        XCTAssertEqual(continuationDts, lastOutputDts + 1800)
+        XCTAssertEqual(srcDts - newShift, continuationDts)
+    }
+
+    func testBackwardChunkRestartContinuesForward() {
+        // The SW-host precedent trace: an 89 s chunk ends at raw 2717.9 s, the next starts at 0.04 s.
+        let (newShift, continuationDts) = HLSSegmentProducer.rebasedVideoShift(
+            srcDts: 3600,                 // 0.04 s @ 90 kHz
+            lastSrcDts: 244_611_000,      // 2717.9 s
+            oldShift: 100_000,
+            fallbackDurationPts: 1800
+        )
+        XCTAssertEqual(continuationDts, (244_611_000 - 100_000) + 1800)
+        XCTAssertEqual(3600 - newShift, continuationDts)   // output keeps moving forward
+        XCTAssertLessThan(newShift, 0)                     // backward seam => negative shift
+    }
+
+    func testLiveScaleJumpMatchesLegacyInlineMath() {
+        // A +30 s SSAI-scale jump: pins that the extraction changed nothing for live sessions.
+        let (newShift, continuationDts) = HLSSegmentProducer.rebasedVideoShift(
+            srcDts: 92_700_000,
+            lastSrcDts: 90_000_000,
+            oldShift: 0,
+            fallbackDurationPts: 1800
+        )
+        XCTAssertEqual(continuationDts, 90_001_800)
+        XCTAssertEqual(newShift, 92_700_000 - 90_001_800)
+    }
+
+    func testZeroFallbackStillAdvancesOneTick() {
+        let (newShift, continuationDts) = HLSSegmentProducer.rebasedVideoShift(
+            srcDts: 500,
+            lastSrcDts: 100,
+            oldShift: 0,
+            fallbackDurationPts: 0
+        )
+        XCTAssertEqual(continuationDts, 101)
+        XCTAssertEqual(500 - newShift, 101)
+    }
+}

--- a/Tests/AetherEngineTests/VODSegmentCutterTests.swift
+++ b/Tests/AetherEngineTests/VODSegmentCutterTests.swift
@@ -90,6 +90,21 @@ final class VODSegmentCutterTests: XCTestCase {
         XCTAssertEqual(c.index(pts: 20_000, isKeyframe: true), 2)
     }
 
+    /// #368 contract: the producer's chunk-seam rebase feeds this cutter CONTINUOUS item-axis dts,
+    /// so a seam advances at most one boundary like any other packet. A raw 2^33 wrap fed directly
+    /// (what the rebase prevents) saturates at the tail clamp in a single call — the field failure.
+    func testRebasedChunkSeamAdvancesOneBoundaryWhileRawWrapSaturates() {
+        var rebased = VODSegmentCutter(sourceBoundaries: fourSeg, planAnchorPts: 0, baseIndex: 0)
+        _ = rebased.index(pts: 0, isKeyframe: true)
+        XCTAssertEqual(rebased.index(pts: 3960, isKeyframe: false), 0)   // last pre-seam frame
+        XCTAssertEqual(rebased.index(pts: 4000, isKeyframe: true), 1)    // seam IRAP, rebased dts
+        XCTAssertEqual(rebased.index(pts: 8000, isKeyframe: true), 2)
+
+        var raw = VODSegmentCutter(sourceBoundaries: fourSeg, planAnchorPts: 0, baseIndex: 0)
+        _ = raw.index(pts: 0, isKeyframe: true)
+        XCTAssertEqual(raw.index(pts: 8_589_934_592, isKeyframe: true), 3)   // 2^33: tail clamp
+    }
+
     /// A restart whose gate overshot its target still opens at `baseIndex`: the producer rebases the
     /// gating keyframe onto the segment's advertised start, and the cutter sees exactly that.
     func testRestartGateOvershootStillOpensBaseIndex() {


### PR DESCRIPTION
Fixes #368.

## What happens today

On a sequential origin (`LoadOptions.sequentialOrigin`, IPTV timeshift archives), a chunk seam's PTS reset — wrap-corrected by libavformat into a +2^33 leap — reaches `VODSegmentCutter` as item-axis time and walks its monotonic index to the plan tail in one call. From there the session is structurally dead: the append playlist freezes (folded indices publish duration 0 and get no URI), the backpressure park waits for a fetch of `head − 10` that the playlist can never advertise, AVPlayer drains and stalls, and the #65 wedge recovery's reposition is exactly what a sequential origin categorically refuses. Field trace: 4 minutes of clean playback, stall, and a retry session that died the same way ~2 s in (the arithmetic fingerprint: `363524400 + 8226410192 = 2^33` exactly, surfaced by movenc as `Application provided duration: 8226410192 in stream 0 is invalid`).

## The fix

Run the existing live timeline rebase (video and audio, unchanged thresholds and pairing machinery) for sequential-origin VOD as well: `rebasesTimelineOnDiscontinuity = isLive || foldsSequentialTimeline`, with the engine passing `sequentialOriginPinsProducerToZero`. The cutter, ledger, and append playlist need no change — they operate on post-shift output time, so after the rebase the cutter keeps walking the same plan boundaries sequentially and EXTINF stays real.

Deliberate choices, spelled out in comments:

- **No new LoadOption.** `sequentialOrigin` is already the client's declaration "this is a forward-only chunked recording"; timeline continuity across its chunk seams is a correctness property of that declaration. `SoftwarePlaybackHost.shouldFoldTimeline` already folds these seams unconditionally for `isLive || !sourceSeekable` (its comment cites the same failure at +92726 s), so gating the producer path behind a second flag would make the two hosts behave differently for identical options.
- **No `EXT-X-DISCONTINUITY` at the seam.** The archive is content-continuous and the output timeline stays continuous after the rebase; the discontinuity/force-cut flags stay live-only (they feed only the live segment bookkeeping).
- `onLiveTimelineRebase` fires for sequential seams too, on purpose: the A53 caption tap and subtitle mapping need the playlist axis moved the same way, and `handleLiveTimelineRebase`'s deferred-shift contract is exactly right for it.
- `isSourceReplay` stays untouched in the shared path: it requires a recent unplanned reconnect, which a sequential origin (single connection, no reconnect) can never have.

## Tests

- `TimelineRebaseMathTests` (new): the rebase math extracted as a pure static and pinned against the device trace — the 2^33 wrap continues exactly one fallback frame past the last output, a backward chunk restart (the SW-host trace) keeps output moving forward, a live-scale jump proves the extraction changed nothing for live, and the zero-fallback floor.
- `VODSegmentCutterTests`: the #368 contract from the cutter's side — rebased continuous dts advances one boundary per cut, while a raw wrap-scale leap saturates at the tail clamp in a single call.
- Full suite green on macOS: 1827 Swift Testing + 509 XCTest, 0 failures.

## Test plan

- macOS: `swift test` (full suite, counts above).
- Device: Apple TV 4K, tvOS 26.6, Xtream timeshift archives of SRF channels (H.264 720p50; AC-3 field-coded open-GOP on one, AAC on the other) — the two field sessions that die today. Verification runs through the Syravo client after the next release is pinned; both failure signatures (4-minute freeze, instant retry death) are reliably reproducible there today.

Merges cleanly alongside the #369 and #370 PRs; the three-way combination is integration-tested locally (full suite green on the merged tree).
