### PR TITLE
fix(video): sequential EVENT startup - serve from the first finalized segment, skip the spacing scan (#370)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,23 @@ the public-API contract.
 
 ## [Unreleased]
 
-_Nothing yet._
+### Fixed
+
+- A sequential-origin session now serves its EVENT playlist from the first finalized
+  segment and no longer spends the origin's prefix on the keyframe-spacing scan (#370).
+  The startup gate reused a live sliding-window constant and demanded 2 published
+  durations — which, because a duration is only final when the NEXT segment's ledger
+  opens, meant 3 segment opens (~12-18 s of media) before AVPlayer's held playlist GET
+  was answered; on a stalling origin the GET sat out the full 30 s and the asset load
+  died on -12884 with ~12 s of media already on disk. A one-segment EVENT playlist is
+  legal HLS and the refresh counter already defeats the -12888 patience the live
+  constant guards against. The spacing scan's seek is a silent no-op on the
+  non-seekable sequential pb, so it consumed up to 30 s of the single byte-0-only
+  connection without the pump ever seeing those packets; sequential plans now go
+  straight to the target stride (the #358 holes the scan softens don't bite the append
+  playlist, whose zero-duration holes get no URI). A pump that dies before publishing
+  anything now also releases a held startup GET immediately instead of letting it sit
+  out the rest of its timeout.
 
 ## [6.25.1] - 2026-08-13
 

--- a/Sources/AetherEngine/Video/HLSVideoEngine+LiveReopen.swift
+++ b/Sources/AetherEngine/Video/HLSVideoEngine+LiveReopen.swift
@@ -223,6 +223,9 @@ extension HLSVideoEngine {
                     + "revive cannot resume at an offset, surfacing source failure",
                     category: .session
                 )
+                // #370: a startup-playlist GET may still be held on the server thread; the session
+                // is failing, so release it instead of sitting out the rest of its timeout.
+                provider?.abortSequentialStartupWait()
                 onVODSourceFailed?(code, "Source read failed")
             } else if Self.shouldReviveVODAfterReadError(
                 isLive: isLiveSession,
@@ -273,6 +276,7 @@ extension HLSVideoEngine {
                 + "(0 packets written, 0 segments cached); surfacing fatal source failure",
                 category: .session
             )
+            provider?.abortSequentialStartupWait()   // #370: release a held startup-playlist GET
             onVODSourceFailed?(FFmpegErr.eio, "Source produced no playable media")
             return
         }

--- a/Sources/AetherEngine/Video/HLSVideoEngine.swift
+++ b/Sources/AetherEngine/Video/HLSVideoEngine.swift
@@ -993,13 +993,26 @@ public final class HLSVideoEngine: @unchecked Sendable {
                 // keyframe-gated cutter leaves every one of them without a segment while the playlist
                 // still offers it. Measure the spacing instead of assuming the target fits it.
                 let anchorSeconds = Double(anchorPts) * Double(videoTimeBase.num) / Double(videoTimeBase.den)
-                let spacing = measureKeyframeSpacing(
-                    demuxer: dem,
-                    videoStreamIndex: videoIndex,
-                    videoTimeBase: videoTimeBase,
-                    fromSeconds: anchorSeconds
-                )
-                let stride = Self.uniformStrideSeconds(spacing: spacing)
+                let spacing: KeyframeSpacing
+                let stride: Double
+                if sequentialOriginPinsProducerToZero {
+                    // #370: the spacing scan starts with a seek — a silent no-op on the non-seekable
+                    // sequential pb — and then consumes up to 30 s of the single byte-0-only
+                    // connection; those packets never reach the pump, so the session starts late and
+                    // silently drops the archive's first GOP(s). The #358 holes the scan exists to
+                    // soften don't bite this path: the append playlist gives zero-duration holes no
+                    // URI and its EXTINF is real by construction.
+                    spacing = .unknown
+                    stride = Self.targetSegmentDuration
+                } else {
+                    spacing = measureKeyframeSpacing(
+                        demuxer: dem,
+                        videoStreamIndex: videoIndex,
+                        videoTimeBase: videoTimeBase,
+                        fromSeconds: anchorSeconds
+                    )
+                    stride = Self.uniformStrideSeconds(spacing: spacing)
+                }
                 plan = Self.buildUniformSegmentPlan(
                     videoTimeBase: videoTimeBase,
                     sourceDurationSeconds: durationSeconds,
@@ -1028,11 +1041,15 @@ public final class HLSVideoEngine: @unchecked Sendable {
                     ? "\(keyframes.count) IRAPs in index, need >=2"
                     : "index unusable (\(keyframes.count) IRAPs, coverage=\(String(format: "%.1f", coverageSeconds))s, largestGap=\(String(format: "%.1f", largestGapSeconds))s)"
                 let spacingText: String
-                switch spacing {
-                case .measured(let s): spacingText = "measured IRAP spacing \(String(format: "%.3f", s))s"
-                case .exceedsBudget(let s): spacingText = "IRAP spacing exceeds the \(String(format: "%.0f", s))s scan budget"
-                case .singleKeyframeInSource: spacingText = "source holds one IRAP, no second to space against"
-                case .unknown: spacingText = "IRAP spacing unknown (no keyframe scanned)"
+                if sequentialOriginPinsProducerToZero {
+                    spacingText = "spacing scan skipped (sequential origin: the scan would consume the non-replayable prefix)"
+                } else {
+                    switch spacing {
+                    case .measured(let s): spacingText = "measured IRAP spacing \(String(format: "%.3f", s))s"
+                    case .exceedsBudget(let s): spacingText = "IRAP spacing exceeds the \(String(format: "%.0f", s))s scan budget"
+                    case .singleKeyframeInSource: spacingText = "source holds one IRAP, no second to space against"
+                    case .unknown: spacingText = "IRAP spacing unknown (no keyframe scanned)"
+                    }
                 }
                 EngineLog.emit(
                     "[HLSVideoEngine] segment plan: uniform stride fallback (\(reason), anchorPts=\(anchorPts), "

--- a/Sources/AetherEngine/Video/VideoSegmentProvider.swift
+++ b/Sources/AetherEngine/Video/VideoSegmentProvider.swift
@@ -281,6 +281,19 @@ final class VideoSegmentProvider: HLSSegmentProvider, @unchecked Sendable {
     private var _seqDurations: [Double] = []
     /// Producer reached true source EOF: the next playlist build appends ENDLIST. Guarded by stateLock.
     private var _seqEnded = false
+    /// #370: the pump died before publishing anything; a held startup-playlist GET must not sit out
+    /// the rest of its timeout for a session that is already failing. Guarded by stateLock.
+    private var _seqStartupAborted = false
+
+    /// #370: never hold the first media playlist for more than ONE published duration. The live
+    /// constant this gate reused (`LiveEdgePolicy.minStartupSegments = 2`) guards a SLIDING window
+    /// whose live-edge holdback can't fit one segment; an EVENT playlist starts at media sequence 0,
+    /// grows append-only, and its refresh counter already defeats AVPlayer's unchanged-playlist
+    /// patience (-12888). The cost of demanding 2 was concrete: a published duration needs the NEXT
+    /// segment's ledger open, so "2 durations" = 3 segment opens ≈ 12-18 s of media through a
+    /// possibly-stalling origin — the field session held AVPlayer's playlist GET for the full 30 s
+    /// and the asset load timed out (-12884) with ~12 s of media already on disk.
+    static let sequentialStartupSegments = 1
 
     init(
         cache: SegmentCache,
@@ -421,7 +434,7 @@ final class VideoSegmentProvider: HLSSegmentProvider, @unchecked Sendable {
         firstSegmentCondition.unlock()
     }
 
-    /// Hold the first media playlist until the startup segments exist (mirrors the live gate:
+    /// Hold the first media playlist until the startup segment exists (mirrors the live gate:
     /// an empty playlist is a broken asset to AVPlayer, which never re-polls it). A fast
     /// archive origin cuts the first segments within a second.
     func waitForSequentialStartupSegments(timeout: TimeInterval) -> Bool {
@@ -430,11 +443,25 @@ final class VideoSegmentProvider: HLSSegmentProvider, @unchecked Sendable {
         defer { firstSegmentCondition.unlock() }
         while true {
             stateLock.lock()
-            let ready = _seqDurations.count >= LiveEdgePolicy.minStartupSegments || _seqEnded
+            let ready = _seqDurations.count >= Self.sequentialStartupSegments || _seqEnded
+            let aborted = _seqStartupAborted
             stateLock.unlock()
             if ready { return true }
+            if aborted { return false }
             if !firstSegmentCondition.wait(until: deadline) { return false }
         }
+    }
+
+    /// #370: release a held startup-playlist GET when the pump dies before publishing anything.
+    /// The session is failing anyway; holding the server thread for the rest of the timeout only
+    /// delays the host's failure surface.
+    func abortSequentialStartupWait() {
+        stateLock.lock()
+        _seqStartupAborted = true
+        stateLock.unlock()
+        firstSegmentCondition.lock()
+        firstSegmentCondition.broadcast()
+        firstSegmentCondition.unlock()
     }
 
     /// Called on each playlist build. For live: advances firstVisible to max(0, highWater - window),

--- a/Tests/AetherEngineTests/SequentialAppendPlaylistTests.swift
+++ b/Tests/AetherEngineTests/SequentialAppendPlaylistTests.swift
@@ -114,6 +114,40 @@ struct SequentialAppendPlaylistTests {
                 "a source running past its declared window must not outgrow the asset")
     }
 
+    // MARK: - Startup gate (#370)
+
+    @Test("one finalized segment releases the startup gate")
+    func startupGateReleasesOnFirstSegment() {
+        // A published duration needs the NEXT segment's ledger open, so the old 2-segment demand
+        // was really 3 segment opens (~12-18 s of media) through a possibly-stalling origin.
+        let provider = makeProvider()
+        provider.appendSequentialSegmentDuration(index: 0, durationSeconds: 6.0)
+        #expect(provider.waitForSequentialStartupSegments(timeout: 0.2))
+    }
+
+    @Test("an empty session times out instead of blocking past its deadline")
+    func startupGateTimesOutEmpty() {
+        let provider = makeProvider()
+        #expect(!provider.waitForSequentialStartupSegments(timeout: 0.05))
+    }
+
+    @Test("EOF with zero segments still releases the gate")
+    func startupGateReleasesOnEnded() {
+        let provider = makeProvider()
+        provider.markSequentialEnded()
+        #expect(provider.waitForSequentialStartupSegments(timeout: 0.2))
+    }
+
+    @Test("a dead pump releases a held startup GET immediately")
+    func startupGateAborts() {
+        let provider = makeProvider()
+        provider.abortSequentialStartupWait()
+        let start = Date()
+        #expect(!provider.waitForSequentialStartupSegments(timeout: 5.0))
+        #expect(Date().timeIntervalSince(start) < 1.0,
+                "the abort must release the wait, not let it sit out the timeout")
+    }
+
     // MARK: - Blast radius
 
     /// Live playlists must render exactly as before. Their segment URIs carry the media sequence


### PR DESCRIPTION
Fixes #370. Two startup costs that together kept a sequential-origin session from ever starting on a slow or stalling origin — AVPlayer's first playlist GET was held the full 30 s and the asset load died on `-1008`/CoreMedia `-12884` while ~12 s of media already sat on disk.

## Commit 1: serve the EVENT playlist from its first finalized segment

`waitForSequentialStartupSegments` reused `LiveEdgePolicy.minStartupSegments = 2`, a sliding-window constant whose `-12888` rationale (a 1-segment live window with holdback that can't fit) does not apply to an append-only EVENT playlist: it starts at media sequence 0, grows monotonically, and `#EXT-X-SODALITE-REFRESH` already defeats the unchanged-playlist patience. The demand was also steeper than it looks: a sequential duration is only final when the NEXT segment's ledger opens (real EXTINF = nextStart − start), so "2 published durations" meant 3 segment opens ≈ 12-18 s of media through the origin. The gate is now `sequentialStartupSegments = 1` on the provider (`LiveEdgePolicy` untouched — its constant stays correct for live).

The publish lag itself stays, deliberately: published EVENT entries must not mutate, and capture / duration-known already coincide at the earliest knowable moment — the fix is to stop demanding two of them, not to publish provisional durations that would need correcting.

Also: a pump that dies before publishing anything now releases a held startup GET immediately (`abortSequentialStartupWait`, called from both fatal VOD surfaces) instead of letting the server thread sit out the rest of its timeout while the session is already surfacing failure.

## Commit 2: plan without spending the origin's prefix on the spacing scan

For the uniform-stride fallback plan, `measureKeyframeSpacing` starts with a seek — a silent no-op on the non-seekable sequential pb — and then consumes up to 20000 packets / 30 s of content from the single byte-0-only connection. Those packets never reach the pump, so the session both started late and silently dropped the archive's first GOP(s). In both field traces the measurement (0.48 s and 2.0 s) fell below the 4 s floor anyway, so the scan bought nothing. Sequential plans now go straight to the target stride; the #358 holes the scan exists to soften don't bite this path, because the append playlist gives zero-duration holes no URI and its EXTINF is real by construction. Live and seekable VOD keep the scan.

## Tests

- `SequentialAppendPlaylistTests`: one finalized segment releases the gate; an empty session still times out; EOF with zero segments still releases (the ENDLIST arm); an aborted wait returns immediately instead of sitting out its timeout.
- Full suite green on macOS: 1831 Swift Testing + 504 XCTest, 0 failures.

## Test plan

- macOS: `swift test` (full suite, counts above).
- Device: Apple TV 4K, tvOS 26.6, SRF Xtream timeshift (H.264 720p50 AAC) against a throttled/stalling origin — the field session that never started; verified through the Syravo client after the next release is pinned.

Fully independent of the #368/#369 PRs; the three-way combination is integration-tested locally (full suite green on the merged tree).
