### PR TITLE
fix(io): bound the rate-limited keep-pin grace, then spend one re-resolve (#380)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,30 @@ the public-API contract.
 
 ## [Unreleased]
 
-_Nothing yet._
+### Fixed
+
+- **A rate-limited streak that outlives the lingering-slot grace drops the pinned redirect target
+  for one re-resolve through the source (#380).** 509 has two field shapes. The one the keep-pin
+  rule was built for (#307 follow-up): a connection-capped panel refusing while the slot of the
+  connection being replaced lingers — it frees in seconds and the pin is fine. The one it broke:
+  a resume after minutes of pause, where the reader held no connection (#310) and the pinned edge
+  target's session expired server-side, so it answers 509 forever while a fresh redirect through
+  the source connects on the first try (field trace: 20 generations of 509 across ~85 s at one
+  offset, then a source-resolved reader delivered first data in 452 ms). The pin now survives
+  `rateLimitRepinStreak` (3) paced attempts and is then dropped for exactly one re-resolve; the
+  fresh target's 200/206 re-pins, and a permanently metering origin pays the same bounded
+  give-up as before, with the re-resolve spent inside the same seven attempts.
+- **Window-served reads no longer reset the reconnect streaks (#380).** Draining read-ahead is
+  not network progress: the reset ran in the same read iteration as the faulted-refill decision,
+  so a refused replacement was charged streak=1 for as long as the runway lasted, and neither
+  the re-resolve rung nor the bounded give-up was reachable until the window was empty — and one
+  served byte after an exhaustion restarted the whole ladder. The streaks now reset only when
+  the current generation has delivered data.
+- **The faulted-refill pacing survives the reconnect it authorises (#380).**
+  `startPersistentConnection` reset the next-attempt timestamp the ladder had just set, so
+  "next attempt in Ns" fired as fast as the consumer could read, and the give-up latch was
+  erased by the next reconnect from any path. The timestamp is now released by first data or an
+  intentional reposition — the two events that genuinely end a faulted lineage.
 
 ## [6.26.0] - 2026-08-15
 

--- a/Sources/AetherEngine/Demuxer/AVIOReader.swift
+++ b/Sources/AetherEngine/Demuxer/AVIOReader.swift
@@ -113,7 +113,10 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
     /// connection-capped IPTV panel answers while its slot is still occupied by the
     /// connection being replaced — the slot frees in seconds, the pinned redirect target
     /// is fine, and re-resolving through the portal spends the one request there is no
-    /// room for (519ae26e, #307 follow-up).
+    /// room for (519ae26e, #307 follow-up). That grace is bounded, not absolute: a 509
+    /// that outlives `rateLimitRepinStreak` paced attempts is a pinned edge target whose
+    /// session expired (a resume after minutes of pause), and there the pin is dropped
+    /// for one re-resolve through the source.
     static func isRateLimitStatus(_ status: Int) -> Bool {
         return status == 429 || status == 503 || status == 509
     }
@@ -321,6 +324,13 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
     // Distinct axis from unproductiveReconnects: NOT reset by seekReconnect, so parse-driven
     // seeks cannot mask a throttled origin into an infinite reconnect loop (AetherEngine#71).
     private static let rateLimitMaxStreak = 6
+    // Rate-limited attempts that keep the pinned redirect target before one attempt through the
+    // source URL is spent on a fresh redirect. Three paced attempts (~7 s of ladder) ride out the
+    // lingering-slot 509 of a connection-capped panel (#307 follow-up: the slot frees in seconds);
+    // a streak that reaches this rung is the other shape — a pinned edge target whose session
+    // expired during a long pause and refuses forever, where only a re-resolve heals. Internal so
+    // the rung is unit-tested without a live origin.
+    static let rateLimitRepinStreak = 3
 
     /// NSCondition guards all persistent-mode fields and serves as the
     /// edge-triggered condition variable for read waits and backpressure.
@@ -1403,8 +1413,16 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
                 position = curPosition + Int64(copyNow)
                 totalRead += copyNow
                 trimWindowLocked()
-                unproductiveReconnects = 0      // real progress
-                rateLimitStreak = 0             // real progress clears the 429 give-up streak (#71)
+                // "Real progress" is the CURRENT generation having delivered — draining read-ahead
+                // is not. An unguarded reset here ran in the same iteration as the faulted-refill
+                // decision below, so a connection-capped origin refusing every replacement was
+                // charged streak=1 forever while the runway drained (field trace: a post-pause 509
+                // storm held streak=1 across 4 MB of served reads, and the bounded give-up and the
+                // re-resolve rung were both unreachable until the window hit empty).
+                if connFirstDataSeen {
+                    unproductiveReconnects = 0      // real progress
+                    rateLimitStreak = 0             // real progress clears the 429 give-up streak (#71)
+                }
                 emitNetworkPhase(.flowing)      // recovered: source delivering again (#85)
                 // No flow installed and the consumer has drawn down to low water: request at the
                 // frontier. #220/#310 built this for PLANNED ends (a range delivered in full, a
@@ -1563,11 +1581,21 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
             // not a transient: drop it so the retry re-resolves through the source URL
             // for a fresh redirect. No-op when nothing is pinned.
             //
-            // A rate-limit streak is deliberately NOT a reason to drop it: 429/503/509 says the
-            // origin is metering us, not that the target is dead (#71), and re-resolving
+            // A rate-limit streak keeps the pin for `rateLimitRepinStreak` attempts: 429/503/509
+            // says the origin is metering us, not that the target is dead (#71), and re-resolving
             // spends a second request on the very origin that is refusing them. On the
-            // connection-capped panel behind #307 that is the request that cannot be spared.
-            if !isRateLimited, unproductiveReconnects >= 2 {
+            // connection-capped panel behind #307 that is the request that cannot be spared — and
+            // its lingering-slot 509 clears within an attempt or two. But a streak that OUTLIVES
+            // that grace is the other 509 shape: a pinned edge target whose session died during a
+            // long pause answers 509 forever, while a fresh redirect through the source connects
+            // on the first try (field trace: 20 generations of 509 against the pin across ~85 s,
+            // then a source-resolved reader delivered in 452 ms). Past the grace the pin IS the
+            // problem; drop it once and let the 200/206 re-pin the fresh target.
+            if isRateLimited {
+                if rateLimitStreak >= Self.rateLimitRepinStreak {
+                    invalidateResolvedURL(reason: "rate-limited x\(rateLimitStreak) through pinned URL")
+                }
+            } else if unproductiveReconnects >= 2 {
                 invalidateResolvedURL(reason: "unproductive reconnect streak")
             }
             let backoffStart = DispatchTime.now()
@@ -1598,6 +1626,11 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
     private func seekReconnect(at offset: Int64) {
         unproductiveReconnects = 0
         bytesAtLastReconnect = cumulativeBytesFetched
+        // A reposition starts a new lineage: the faulted-refill pacing belongs to the frontier
+        // it was charged at, and holding a seek's refill to it would pace a healthy target.
+        winCond.lock()
+        nextFaultedRefillAt = .distantPast
+        winCond.unlock()
         startPersistentConnection(at: offset)
     }
 
@@ -1648,7 +1681,8 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
     /// - It does not SLEEP. It runs on the demux thread with megabytes still resident, and a backoff
     ///   sleep there would starve the demuxer of the very read-ahead that replacing early exists to
     ///   protect. The wait is a next-attempt timestamp instead, so reads keep being served at full
-    ///   speed between attempts.
+    ///   speed between attempts. The timestamp outlives the reconnect it authorises
+    ///   (`startPersistentConnection` must not clear it) — it is released by first data or a seek.
     /// - It never returns the read as failed. A window that can still serve must not kill a session
     ///   that still holds seconds of playback. At the cap it stops attempting (`.distantFuture`) and
     ///   leaves termination to the empty-window ladder, where it has always lived.
@@ -1673,7 +1707,14 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
             return false
         }
         let streak = isRateLimited ? rateLimitStreak : unproductiveReconnects
-        if !isRateLimited, unproductiveReconnects >= 2 {
+        // Same pin rungs as the empty-window ladder: a hard-error streak drops the pin early, a
+        // rate-limited streak keeps it through the lingering-slot grace and drops it only when
+        // the refusals outlive that shape (the stale-edge-session 509, see the ladder comment).
+        if isRateLimited {
+            if rateLimitStreak >= Self.rateLimitRepinStreak {
+                invalidateResolvedURL(reason: "rate-limited x\(rateLimitStreak) through pinned URL")
+            }
+        } else if unproductiveReconnects >= 2 {
             invalidateResolvedURL(reason: "unproductive reconnect streak")
         }
         lastUnplannedReconnectAt = Date()
@@ -2054,7 +2095,13 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
         connStartedAt = DispatchTime.now()   // #93: time-to-first-data per generation
         connFirstDataSeen = false
         lastDeliveryAt = connStartedAt       // #309: the gap is measured from here until data lands
-        nextFaultedRefillAt = .distantPast
+        // `nextFaultedRefillAt` is deliberately NOT reset here. The faulted-refill ladder sets it
+        // just before authorising this very reconnect, so a reset on connection start erased the
+        // pacing it had just announced — every "next attempt in Ns" fired as fast as the consumer
+        // could read (field trace: a 509-refusing origin was retried on read cadence, streak=1).
+        // The timestamp is cleared by proof of delivery (`appendPersistentData`, first data) and
+        // by an intentional reposition (`seekReconnect`), the two events that genuinely end a
+        // faulted lineage.
         let oldTask = activeTask
         activeTask = nil
         winCond.broadcast()
@@ -2198,6 +2245,10 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
             // #281 retest: the price of one round trip against this origin, which is what bounds
             // how long a read may wait for bytes that are already on the wire.
             lastFirstDataMs = firstDataMs ?? 0
+            // Delivery is the proof that ends a faulted lineage: release the refill pacing (and
+            // a give-up latch — an origin that recovered after the faulted ladder capped out may
+            // fault again later and deserves a fresh ladder, not `.distantFuture` forever).
+            nextFaultedRefillAt = .distantPast
         }
         let count = data.count
         // #310: delivery that lands with the backpressure end ALREADY recorded, i.e. after our

--- a/Tests/AetherEngineTests/ResolvedURLInvalidationTests.swift
+++ b/Tests/AetherEngineTests/ResolvedURLInvalidationTests.swift
@@ -23,6 +23,51 @@ struct ResolvedURLInvalidationTests {
         }
     }
 
+    /// Synchronous on purpose (`Thread.sleep` is off limits in an async test body): paces the
+    /// consumer so served reads interleave with the reconnect ladder, and reads until the
+    /// reader fails the read. Returns the bytes served and the terminal return value.
+    private static func pacedReadToFailure(_ reader: AVIOReader, sliceCap: Int,
+                                           bytesPerSecond: Int) -> (got: Int, result: Int32) {
+        let buf = UnsafeMutablePointer<UInt8>.allocate(capacity: sliceCap)
+        defer { buf.deallocate() }
+        var got = 0
+        while true {
+            let n = reader.read(into: buf, size: Int32(sliceCap))
+            if n <= 0 { return (got, n) }
+            got += Int(n)
+            Thread.sleep(forTimeInterval: Double(n) / Double(bytesPerSecond))
+        }
+    }
+
+    /// Models an origin whose redirect targets are per-session leases: the source mints a
+    /// numbered lease per resolve, and the first request that hits the metered boundary
+    /// latches every lease minted so far as DEAD (the sessions that existed when the fault
+    /// began). Only a lease minted by a later re-resolve is alive — the stale-edge-session
+    /// shape a long pause produces.
+    private final class LeaseLatch: @unchecked Sendable {
+        private let lock = NSLock()
+        private var minted = 0
+        private var staleCeiling: Int?
+        func mint() -> Int {
+            lock.lock(); defer { lock.unlock() }
+            minted += 1
+            return minted
+        }
+        func isStale(path: String) -> Bool {
+            let lease = Int(path.components(separatedBy: "lease=").last ?? "") ?? 0
+            lock.lock(); defer { lock.unlock() }
+            if staleCeiling == nil { staleCeiling = minted }
+            return lease <= staleCeiling!
+        }
+        /// Source resolves spent AFTER the fault began — the price of healing, which the
+        /// bounded rung must keep at exactly one.
+        var mintsAfterFault: Int {
+            lock.lock(); defer { lock.unlock() }
+            guard let staleCeiling else { return 0 }
+            return minted - staleCeiling
+        }
+    }
+
     @Test("a hard 500 from the pinned URL falls back to the source URL for a fresh redirect",
           .timeLimit(.minutes(2)))
     func hard500FallsBackToSourceURL() async throws {
@@ -183,7 +228,10 @@ struct ResolvedURLInvalidationTests {
 
     /// An origin that answers 509 forever must get the PACED rate-limit ladder and its
     /// bounded give-up — not the hard-5xx treatment (pin dropped every attempt, retries
-    /// through the portal at zero backoff until the unproductive cap).
+    /// through the portal at zero backoff until the unproductive cap). Past the keep-pin
+    /// grace it spends the bounded re-resolve rung — one class of retries through the
+    /// source, not one per attempt — and gives up on the ladder when the fresh target
+    /// refuses identically.
     @Test("a permanent 509 pays the rate-limit ladder and gives up cleanly",
           .timeLimit(.minutes(2)))
     func permanent509TakesTheRateLimitLadder() async throws {
@@ -228,9 +276,125 @@ struct ResolvedURLInvalidationTests {
         #expect(boundaryAttempts >= 2, "the ladder must retry a metered origin")
         #expect(boundaryAttempts <= 7,
                 "509 must give up at the bounded rate-limit cap, not grind: \(boundaryAttempts) attempts")
+        // The keep-pin grace holds for the first attempts, then the rung spends the
+        // re-resolve: some retries reach the source, but bounded by the ladder — never
+        // the hard-5xx shape of one portal round trip per attempt at zero backoff.
         let sourceHitsAtBoundary = source.requestLog.filter { $0.start == firstRange }
-        #expect(sourceHitsAtBoundary.isEmpty,
-                "a metered origin must keep the pin throughout: \(source.requestLog)")
+        #expect(!sourceHitsAtBoundary.isEmpty,
+                "a 509 outliving the grace must re-resolve through the source: \(source.requestLog)")
+        #expect(sourceHitsAtBoundary.count <= 4,
+                "re-resolves must stay bounded by the ladder: \(source.requestLog)")
+    }
+
+    /// The other 509 shape, and the reason the keep-pin grace is bounded: a pinned edge
+    /// target whose session died during a long pause answers 509 FOREVER, while a fresh
+    /// redirect through the source connects on the first try (field trace: 20 generations
+    /// of 509 against the pin across ~85 s at one offset, then a source-resolved reader
+    /// delivered first data in 452 ms). Past `rateLimitRepinStreak` attempts the pin must
+    /// be dropped for exactly ONE re-resolve, and the fresh target's 206 re-pins.
+    @Test("a 509 outliving the keep-pin grace re-resolves once through the source",
+          .timeLimit(.minutes(2)))
+    func stalePinned509HealsThroughTheSource() async throws {
+        AetherEngine.reconnectBackoffScaleForTesting = 0.02
+        defer { AetherEngine.reconnectBackoffScaleForTesting = 1.0 }
+
+        let firstRange: Int64 = 256 * 1024
+        let leases = LeaseLatch()
+        // CDN: a lease minted before the boundary fault is a dead session and refuses that
+        // offset forever; a lease minted by a later resolve serves.
+        let cdnMaybe = ThrottledOriginServer(
+            totalSize: 64 * 1024 * 1024,
+            respond: { _, offset, path in
+                guard offset == firstRange else { return .serve206 }
+                return leases.isStale(path: path) ? .status(509) : .serve206
+            }
+        )
+        let cdn = try #require(cdnMaybe)
+        defer { cdn.stop() }
+        let cdnPort = cdn.port
+        let sourceMaybe = ThrottledOriginServer(
+            totalSize: 64 * 1024 * 1024,
+            respond: { _, _, _ in
+                .redirect(to: "http://127.0.0.1:\(cdnPort)/cdn/movie.bin?lease=\(leases.mint())")
+            }
+        )
+        let source = try #require(sourceMaybe)
+        defer { source.stop() }
+
+        let reader = AVIOReader(url: URL(string: "http://127.0.0.1:\(source.port)/movie.bin")!,
+                                boundedInitialFetch: firstRange)
+        defer { reader.markClosed(); reader.close() }
+        try reader.open()
+
+        let sliceCap = 128 * 1024
+        let buf = UnsafeMutablePointer<UInt8>.allocate(capacity: sliceCap)
+        defer { buf.deallocate() }
+        let target = Int(firstRange) + 256 * 1024
+        var got = 0
+        while got < target {
+            let n = reader.read(into: buf, size: Int32(min(sliceCap, target - got)))
+            if n <= 0 { break }
+            got += Int(n)
+        }
+        #expect(got == target, "read stopped at \(got) of \(target); the stale pin was terminal")
+
+        // 1 free replacement of the planned range end + the grace attempts, all against the
+        // dead lease; the rung's attempt is the one that goes through the source.
+        let boundaryAttempts = cdn.requestLog.filter { $0.start == firstRange }.count
+        #expect(boundaryAttempts == AVIOReader.rateLimitRepinStreak + 1,
+                "expected the grace against the pin plus one healed attempt, got \(boundaryAttempts)")
+        #expect(leases.mintsAfterFault == 1,
+                "healing must cost exactly one source resolve, spent \(leases.mintsAfterFault): \(source.requestLog)")
+        let sourceHitsAtBoundary = source.requestLog.filter { $0.start == firstRange }
+        #expect(sourceHitsAtBoundary.count == 1,
+                "the re-resolve carries the boundary range once: \(source.requestLog)")
+    }
+
+    /// A consumer still being served from the window must not soften the ladder: window
+    /// bytes are not network progress, so the streak keeps charging across served reads
+    /// and both the re-resolve rung and the bounded give-up stay reachable. Before this
+    /// held, a paced consumer reset the streak on every read and a refused origin was
+    /// retried at streak=1 for as long as the runway lasted (the post-pause field trace:
+    /// 20 generations across ~85 s, none of them counted).
+    @Test("a draining window does not reset the rate-limit ladder", .timeLimit(.minutes(2)))
+    func drainingWindowKeepsTheLadderCharged() async throws {
+        AetherEngine.reconnectBackoffScaleForTesting = 0.02
+        defer { AetherEngine.reconnectBackoffScaleForTesting = 1.0 }
+
+        let firstRange: Int64 = 2 * 1024 * 1024
+        let cdnMaybe = ThrottledOriginServer(
+            totalSize: 64 * 1024 * 1024,
+            respond: { _, offset, _ in
+                offset == firstRange ? .status(509) : .serve206
+            }
+        )
+        let cdn = try #require(cdnMaybe)
+        defer { cdn.stop() }
+        let cdnPort = cdn.port
+        let sourceMaybe = ThrottledOriginServer(
+            totalSize: 64 * 1024 * 1024,
+            respond: { _, _, _ in .redirect(to: "http://127.0.0.1:\(cdnPort)/cdn/movie.bin") }
+        )
+        let source = try #require(sourceMaybe)
+        defer { source.stop() }
+
+        let reader = AVIOReader(url: URL(string: "http://127.0.0.1:\(source.port)/movie.bin")!,
+                                boundedInitialFetch: firstRange)
+        defer { reader.markClosed(); reader.close() }
+        try reader.open()
+
+        // Paced at ~2 MB/s so the 2 MB of read-ahead is worth a second of served reads
+        // while the ladder runs — the window-serve/streak interleaving under test.
+        let (got, result) = Self.pacedReadToFailure(reader, sliceCap: 128 * 1024,
+                                                    bytesPerSecond: 2 * 1024 * 1024)
+
+        #expect(got == Int(firstRange),
+                "everything before the metered boundary must still be served (got \(got))")
+        #expect(result == -1, "a permanently refused source must fail the read, not hang")
+        let boundaryAttempts = cdn.requestLog.filter { $0.start == firstRange }.count
+        #expect(boundaryAttempts >= 3, "the ladder must retry a metered origin")
+        #expect(boundaryAttempts <= 7,
+                "served reads reset the streak: \(boundaryAttempts) attempts at the boundary")
     }
 
     @Test("hard-server-error classification excludes rate limiting")


### PR DESCRIPTION
Fixes #380.

## What

A pause of a few minutes, then resume, froze VOD playback for ~60 s on a connection-capped
panel: the pinned post-redirect URL answered 509 to 20 consecutive generations (~85 s) while a
fresh redirect through the source connected in 452 ms. Three coupled defects kept the reader
grinding the dead pin until the segment layer tore the producer down from outside — the full
trace and analysis are in the issue.

## How

- **The keep-pin grace is now bounded.** The rule from the #307 follow-up (`8a8e00b0`) models
  the lingering slot, which frees in seconds — and for that shape nothing changes: the pin
  survives `rateLimitRepinStreak` (3) paced attempts, which is the existing two-attempt tests'
  territory plus margin. A rate-limited streak that reaches the rung is the other shape (a
  pinned edge session that expired during a long idle and refuses forever), and there the pin
  is dropped for exactly one re-resolve through the source; the fresh target's 200/206 re-pins.
  Both ladders (`chargeFaultedRunwayRefill` and the empty-window path) share the rung; the
  hard-error rung (`unproductiveReconnects >= 2`) is unchanged.
- **Window-served reads no longer reset the streaks.** Draining read-ahead is not network
  progress: the reset ran in the same read iteration as the faulted-refill decision, so every
  attempt against the refusing origin was charged streak=1 while the runway drained, the
  bounded give-up and the new rung were unreachable, and one served byte after an exhaustion
  restarted the whole ladder. The streaks now reset only when the current generation has
  delivered data (`connFirstDataSeen`, already winCond-guarded in that branch).
- **The faulted-refill pacing survives the reconnect it authorises.**
  `startPersistentConnection` reset `nextFaultedRefillAt` as part of starting the very attempt
  the charge had just paced, so "next attempt in Ns" never held and attempts ran on read
  cadence. The reset moved to the two events that genuinely end a faulted lineage: first data
  (`appendPersistentData`) and an intentional reposition (`seekReconnect`). The `.distantFuture`
  give-up latch actually latches now, and first data re-arms it for a later, unrelated fault.

## Test plan

- `swift test` on macOS 26: **1867 tests green**.
- New in `ResolvedURLInvalidationTests` (both verified failing on the unfixed base):
  - *"a 509 outliving the keep-pin grace re-resolves once through the source"* — a two-server
    rig where the source mints per-request lease URLs and the CDN 509s dead leases forever.
    Fixed: heals at `rateLimitRepinStreak + 1` boundary attempts with exactly one post-fault
    source resolve. Unfixed base: 7 attempts, zero resolves, read dies at the boundary.
  - *"a draining window does not reset the rate-limit ladder"* — a paced consumer (2 MB/s)
    draining 2 MB of runway against a permanent 509. Fixed: bounded at ≤ 7 boundary attempts,
    every pre-boundary byte served, then a clean −1. Unfixed base: 20 attempts.
- Updated: *"a permanent 509 pays the rate-limit ladder and gives up cleanly"* now expects the
  bounded re-resolve (≥ 1, ≤ 4 source hits) inside the same seven attempts.
- Unchanged and green: the two-attempt lingering-slot cases (503 and 509 keep the pin end to
  end), the hard-500 fallback, `ErrorEndedReconnectTests`, `Issue309SilentTransportDeathTests`
  (including the parked-is-not-stalled regression), the live-window suites, and the detour cap
  unit test.
- Field shape: Apple TV 4K (tvOS 26) against an Xtream aggregator (`max_connections=1`) whose
  edge host expires idle sessions; device retest against that origin planned as soon as a
  release with this lands on the app's pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
