### PR TITLE
diag(live): the first live manifest names the interval it held (#374)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,19 @@ the public-API contract.
 
 ## [Unreleased]
 
-_Nothing yet._
+### Added
+
+- **The first live manifest now reports the interval it was held for.** A loopback live session's whole
+  join latency is one withheld `/media.m3u8` response: the first serve waits until the window carries
+  the live-edge holdback (`3 x TARGETDURATION`, AetherEngine#189) of content behind the edge, while
+  everything else the engine does for that session finishes before the gate is even entered. Only a
+  FAILED gate used to log, so a successful hold of eighteen seconds left no trace and a host had to
+  measure it from the outside. Every exit now names what it held, the window it served and the holdback
+  it was measured against, including the exit where no segment was ever cut, which used to return in
+  silence. The bounded `.fastZap` start reported its grace alone, which is the last leg of the wait
+  rather than the wait: a start measured here at 10.284 s reported itself as 2.000 s. `docs/api.md`
+  gains the paragraph that says where a live start's seconds go, and how `startupProgress` separates
+  this wait from the probe and the display handshake. Raised by ksktech-dev (AetherEngine#374).
 
 ## [6.27.0] - 2026-08-16
 

--- a/Sources/AetherEngine/Video/VideoSegmentProvider.swift
+++ b/Sources/AetherEngine/Video/VideoSegmentProvider.swift
@@ -119,6 +119,31 @@ enum LiveEdgePolicy {
         if segmentCount >= windowSegmentCount { return true }
         return summedDurationSeconds >= holdBackSeconds(targetDuration: targetDuration)
     }
+
+    /// AE#374: the first live manifest's own account of what it cost, for the log.
+    ///
+    /// The loopback's entire live-join latency is this one withheld response: everything the engine does
+    /// for itself is finished before the gate is entered, and the wait that follows is the runway being
+    /// filled at whatever rate the origin hands it over. `.standard` used to log only when the gate
+    /// failed, so a successful hold of eighteen seconds left no trace at all and a downstream host had to
+    /// measure it from the outside. Named here the way the reroute line names the grace it saves (#274).
+    static func firstServeAccount(waitedSeconds: TimeInterval,
+                                  segmentCount: Int,
+                                  summedDurationSeconds: Double,
+                                  targetDuration: Int) -> String {
+        let holdBack = holdBackSeconds(targetDuration: targetDuration)
+        let reached = summedDurationSeconds >= holdBack ? ">=" : "<"
+        return "first live manifest served after \(seconds(waitedSeconds))s: "
+            + "\(segmentCount) segments / \(seconds(summedDurationSeconds))s "
+            + "\(reached) \(seconds(holdBack))s holdback (TARGETDURATION \(targetDuration)s)"
+    }
+
+    /// Millisecond resolution, because the interval this reports spans four orders of magnitude: a
+    /// backlogged origin satisfies the cushion in single-digit milliseconds and a strict-realtime one
+    /// takes the full holdback.
+    static func seconds(_ value: Double) -> String {
+        String(format: "%.3f", value)
+    }
 }
 
 struct LiveTargetDurationSeal {
@@ -155,6 +180,9 @@ final class VideoSegmentProvider: HLSSegmentProvider, @unchecked Sendable {
     private let liveWindowSizing: LiveWindowSizing
     /// Only `.fastZap` sessions may serve a shallow first window after a bounded grace.
     private let allowsBoundedDegradedStart: Bool
+    /// AE#374: whether the first-serve gate has already reported the interval it held. Read and written
+    /// only under `firstSegmentCondition`, inside `waitForFirstLiveSegment` and its two account helpers.
+    private var didAccountForFirstServe = false
     /// Host override for blocking-reload (`LoadOptions.liveBlockingReload`): nil = auto (observed policy for
     /// ingest, on by default for signal-less live), true/false = force. Wins over the policy (#167).
     private let blockingReloadOverride: Bool?
@@ -1170,6 +1198,9 @@ final class VideoSegmentProvider: HLSSegmentProvider, @unchecked Sendable {
     func waitForFirstLiveSegment(timeout: TimeInterval) -> Bool {
         guard isLive else { return true }
         let deadline = Date().addingTimeInterval(timeout)
+        // AE#374: monotonic, because this interval is a measurement and a wall-clock jump would corrupt
+        // it. The deadline above stays on `Date` because `NSCondition.wait(until:)` takes one.
+        let enteredAt = DispatchTime.now()
         let window = liveWindowSizing.windowSegmentCount
         var degradedDeadline: Date?
         var degradedGrace: TimeInterval?
@@ -1183,7 +1214,8 @@ final class VideoSegmentProvider: HLSSegmentProvider, @unchecked Sendable {
                                                        summedDurationSeconds: snap.summed,
                                                        targetDuration: target.value,
                                                        windowSegmentCount: window) {
-                _ = sealLiveTargetDuration(candidate: target.value)
+                let sealed = sealLiveTargetDuration(candidate: target.value)
+                accountForFirstServe(since: enteredAt, snapshot: snap, targetDuration: sealed)
                 return true
             }
             if allowsBoundedDegradedStart,
@@ -1205,20 +1237,20 @@ final class VideoSegmentProvider: HLSSegmentProvider, @unchecked Sendable {
                                                           summedDurationSeconds: after.summed,
                                                           targetDuration: afterTarget.value,
                                                           windowSegmentCount: window) {
-                    _ = sealLiveTargetDuration(candidate: afterTarget.value)
+                    let sealed = sealLiveTargetDuration(candidate: afterTarget.value)
+                    accountForFirstServe(since: enteredAt, snapshot: after, targetDuration: sealed)
                     return true
                 }
                 if let degradedDeadline,
                    Date() >= degradedDeadline,
                    after.count >= LiveEdgePolicy.minStartupSegments {
                     let sealed = sealLiveTargetDuration(candidate: afterTarget.value)
-                    let holdBack = LiveEdgePolicy.holdBackSeconds(targetDuration: sealed)
-                    EngineLog.emit(
-                        "[HLSVideoEngine] fastZap startup degraded, serving first playlist with "
-                        + "\(after.count) segments / \(String(format: "%.3f", after.summed))s "
-                        + "before \(String(format: "%.3f", holdBack))s holdback after "
-                        + "\(String(format: "%.3f", degradedGrace ?? 0))s grace",
-                        category: .session
+                    // AE#374: the grace is the last leg of this wait, not the wait. Reporting it alone
+                    // left a bounded start reading as a half-second one when it had held for twelve.
+                    accountForFirstServe(
+                        since: enteredAt, snapshot: after, targetDuration: sealed,
+                        note: "fastZap bounded start after "
+                            + "\(LiveEdgePolicy.seconds(degradedGrace ?? 0))s grace"
                     )
                     return true
                 }
@@ -1226,24 +1258,66 @@ final class VideoSegmentProvider: HLSSegmentProvider, @unchecked Sendable {
                 // Degraded start: serving before the holdback cushion is built (transcode too slow, or a
                 // strict-realtime origin that has not produced 3 x TD of content within the deadline) makes
                 // a -16832 "restarting from end of live playlist" stall right after startup likely. Observe it.
-                if after.count > 0 && !LiveEdgePolicy.startupCushionSatisfied(segmentCount: after.count,
-                                                                             summedDurationSeconds: after.summed,
-                                                                             targetDuration: afterTarget.value,
-                                                                             windowSegmentCount: window) {
-                    EngineLog.emit(
-                        "[HLSVideoEngine] WARNING: live startup degraded, serving first playlist with "
-                        + "\(after.count) segments / \(String(format: "%.1f", after.summed))s < "
-                        + "\(String(format: "%.1f", LiveEdgePolicy.holdBackSeconds(targetDuration: afterTarget.value)))s holdback "
-                        + "after \(Int(timeout))s timeout (undersized startup cushion)",
-                        category: .session
-                    )
+                guard after.count > 0 else {
+                    // AE#374: nothing was ever cut, so there is no window to account for and no manifest
+                    // worth serving. This exit used to return in silence, which from a host's side is the
+                    // one outcome indistinguishable from a merely slow origin.
+                    accountForUnservedFirstManifest(since: enteredAt)
+                    return false
                 }
-                if after.count > 0 {
-                    _ = sealLiveTargetDuration(candidate: afterTarget.value)
-                }
-                return after.count > 0
+                // The satisfied re-read above has already returned, so reaching the deadline here means the
+                // cushion is undersized by definition.
+                let sealed = sealLiveTargetDuration(candidate: afterTarget.value)
+                accountForFirstServe(
+                    since: enteredAt, snapshot: after, targetDuration: sealed, warning: true,
+                    note: "\(Int(timeout))s timeout (undersized startup cushion)"
+                )
+                return true
             }
         }
+    }
+
+    /// AE#374: one account per live session, emitted at whichever exit ends the first-serve gate.
+    ///
+    /// Every `/media.m3u8` request without an `_HLS_msn` re-enters the gate, so without the latch a
+    /// steady session would repeat the line at its refresh interval. Called with `firstSegmentCondition`
+    /// held, which is what the latch is protected by.
+    private func accountForFirstServe(
+        since entered: DispatchTime,
+        snapshot: (count: Int, summed: Double, maxDuration: Double),
+        targetDuration: Int,
+        warning: Bool = false,
+        note: String? = nil
+    ) {
+        guard !didAccountForFirstServe else { return }
+        didAccountForFirstServe = true
+        let account = LiveEdgePolicy.firstServeAccount(
+            waitedSeconds: Self.secondsSince(entered),
+            segmentCount: snapshot.count,
+            summedDurationSeconds: snapshot.summed,
+            targetDuration: targetDuration
+        )
+        EngineLog.emit(
+            "[HLSVideoEngine] \(warning ? "WARNING: " : "")\(account)"
+            + (note.map { ", \($0)" } ?? ""),
+            category: .session
+        )
+    }
+
+    /// The gate's other ending: the deadline passed and not one segment was ever cut, so there is no
+    /// window to describe and the manifest cannot be served at all.
+    private func accountForUnservedFirstManifest(since entered: DispatchTime) {
+        guard !didAccountForFirstServe else { return }
+        didAccountForFirstServe = true
+        EngineLog.emit(
+            "[HLSVideoEngine] WARNING: first live manifest not served after "
+            + "\(LiveEdgePolicy.seconds(Self.secondsSince(entered)))s: no segment was cut",
+            category: .session
+        )
+    }
+
+    private static func secondsSince(_ start: DispatchTime) -> Double {
+        Double(DispatchTime.now().uptimeNanoseconds &- start.uptimeNanoseconds) / 1_000_000_000
     }
 
     func cancelWaiters() {

--- a/Tests/AetherEngineTests/Issue374FirstServeAccountTests.swift
+++ b/Tests/AetherEngineTests/Issue374FirstServeAccountTests.swift
@@ -1,0 +1,222 @@
+// Tests/AetherEngineTests/Issue374FirstServeAccountTests.swift
+// AE#374: the loopback's entire live-join cost is one withheld `/media.m3u8` response, and `.standard`
+// used to log only when the gate FAILED. Measured on 6.27.0 against a paced raw-MPEG-TS origin, first
+// readyToPlay landed at 18.66s / 12.70s / 6.75s / 0.43s for 0 / 6 / 12 / 30s of origin backlog, while the
+// engine's own work was finished at +0.19s in every one of them. A downstream host could see the wait in
+// `startupProgress` (it stalls at `sessionConstructed`) but nowhere in the log, so the interval had to be
+// measured from the outside. These tests pin that every exit from the gate now names the interval it held.
+import XCTest
+@testable import AetherEngine
+
+private final class Issue374WaitResult: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _value: Bool?
+
+    var value: Bool? {
+        lock.lock()
+        defer { lock.unlock() }
+        return _value
+    }
+
+    func store(_ value: Bool) {
+        lock.lock()
+        _value = value
+        lock.unlock()
+    }
+}
+
+/// Captures `EngineLog` lines for the duration of one test. The handler is global, so it is restored in
+/// every path rather than at the end of the happy one.
+private final class Issue374LogTap: @unchecked Sendable {
+    private let lock = NSLock()
+    private var lines: [String] = []
+    private let previous: ((String) -> Void)?
+
+    init() {
+        previous = EngineLog.handler
+        let sink = { [self] (line: String) in
+            lock.lock()
+            lines.append(line)
+            lock.unlock()
+        }
+        EngineLog.handler = sink
+    }
+
+    func restore() { EngineLog.handler = previous }
+
+    func matching(_ needle: String) -> [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        return lines.filter { $0.contains(needle) }
+    }
+}
+
+final class Issue374FirstServeAccountTests: XCTestCase {
+
+    // MARK: The account line
+
+    func testAccountNamesTheIntervalTheGateHeld() {
+        let line = LiveEdgePolicy.firstServeAccount(
+            waitedSeconds: 18.463,
+            segmentCount: 6,
+            summedDurationSeconds: 18.400,
+            targetDuration: 6
+        )
+        XCTAssertTrue(line.contains("after 18.463s"), line)
+    }
+
+    func testAccountDerivesTheHoldbackFromTargetDurationRatherThanTakingItOnTrust() {
+        let line = LiveEdgePolicy.firstServeAccount(
+            waitedSeconds: 1.0,
+            segmentCount: 6,
+            summedDurationSeconds: 18.4,
+            targetDuration: 6
+        )
+        XCTAssertTrue(line.contains("18.000s holdback"), line)
+        XCTAssertTrue(line.contains("TARGETDURATION 6s"), line)
+    }
+
+    func testAccountReportsWhetherTheWindowReachedTheHoldback() {
+        let satisfied = LiveEdgePolicy.firstServeAccount(
+            waitedSeconds: 0,
+            segmentCount: 6,
+            summedDurationSeconds: 18.0,
+            targetDuration: 6
+        )
+        XCTAssertTrue(satisfied.contains("18.000s >= 18.000s holdback"), satisfied)
+
+        let short = LiveEdgePolicy.firstServeAccount(
+            waitedSeconds: 0,
+            segmentCount: 2,
+            summedDurationSeconds: 10.0,
+            targetDuration: 5
+        )
+        XCTAssertTrue(short.contains("10.000s < 15.000s holdback"), short)
+    }
+
+    /// The free-runway case is the one a host most needs to be able to tell apart from "not logged":
+    /// an origin with a deep backlog satisfies the cushion at I/O speed, and that is a measurement.
+    func testAFreeRunwayStillGetsItsOwnLine() {
+        let line = LiveEdgePolicy.firstServeAccount(
+            waitedSeconds: 0.004,
+            segmentCount: 30,
+            summedDurationSeconds: 30.0,
+            targetDuration: 1
+        )
+        XCTAssertTrue(line.contains("after 0.004s"), line)
+        XCTAssertTrue(line.contains("30 segments"), line)
+    }
+
+    // MARK: The gate
+
+    private func makeProvider(
+        allowsBoundedDegradedStart: Bool
+    ) -> (VideoSegmentProvider, SegmentCache) {
+        let cache = SegmentCache(forwardWindow: 10, backwardWindow: 10)
+        let provider = VideoSegmentProvider(
+            cache: cache,
+            segments: [],
+            codecsString: "hvc1.2.4.L150,mp4a.40.2",
+            supplementalCodecs: nil,
+            resolution: (3840, 2160),
+            videoRange: .pq,
+            frameRate: 50,
+            hdcpLevel: "TYPE-1",
+            sourceBitrate: 20_000_000,
+            isLive: true,
+            liveWindowSizing: LiveWindowSizing(
+                targetSegmentDurationSeconds: 0.5,
+                dvrWindowSeconds: nil
+            ),
+            allowsBoundedDegradedStart: allowsBoundedDegradedStart
+        )
+        return (provider, cache)
+    }
+
+    private func append(
+        _ provider: VideoSegmentProvider,
+        index: Int,
+        duration: Double = 0.2
+    ) {
+        provider.appendLiveSegment(
+            index: index,
+            startSeconds: Double(index) * duration,
+            durationSeconds: duration
+        )
+    }
+
+    func testSatisfiedGateAccountsForItsWaitExactlyOnceAcrossRepeatedRequests() {
+        let (provider, cache) = makeProvider(allowsBoundedDegradedStart: false)
+        defer { cache.close() }
+        let tap = Issue374LogTap()
+        defer { tap.restore() }
+
+        for index in 0..<15 {
+            append(provider, index: index)
+        }
+        XCTAssertTrue(provider.waitForFirstLiveSegment(timeout: 2))
+        // Every /media.m3u8 request without an _HLS_msn re-enters the gate; only the first is a first serve.
+        XCTAssertTrue(provider.waitForFirstLiveSegment(timeout: 2))
+        XCTAssertTrue(provider.waitForFirstLiveSegment(timeout: 2))
+
+        let accounted = tap.matching("first live manifest")
+        XCTAssertEqual(accounted.count, 1, accounted.joined(separator: " | "))
+        guard let line = accounted.first else { return XCTFail("no account emitted") }
+        XCTAssertTrue(line.contains("15 segments"), line)
+    }
+
+    func testBoundedFastZapStartNamesTheWholeWaitAndNotOnlyItsGrace() {
+        let (provider, cache) = makeProvider(allowsBoundedDegradedStart: true)
+        defer { cache.close() }
+        let tap = Issue374LogTap()
+        defer { tap.restore() }
+
+        let result = Issue374WaitResult()
+        let finished = expectation(description: "startup waiter finished")
+        DispatchQueue.global().async {
+            result.store(provider.waitForFirstLiveSegment(timeout: 3))
+            finished.fulfill()
+        }
+        Thread.sleep(forTimeInterval: 0.3)
+        append(provider, index: 0)
+        append(provider, index: 1)
+
+        wait(for: [finished], timeout: 2)
+        XCTAssertEqual(result.value, true)
+
+        let accounted = tap.matching("first live manifest")
+        XCTAssertEqual(accounted.count, 1, accounted.joined(separator: " | "))
+        guard let line = accounted.first else { return XCTFail("no account emitted") }
+        // The bounded path used to report its 0.5s grace and nothing else, which is the last leg of the
+        // wait rather than the wait: the total is what a host budgets against.
+        XCTAssertTrue(line.contains("bounded start"), line)
+        XCTAssertTrue(line.contains("grace"), line)
+        guard let held = Self.heldSeconds(in: line) else {
+            return XCTFail("no interval in \(line)")
+        }
+        XCTAssertGreaterThan(held, 0.3)
+    }
+
+    func testAGateThatNeverCutASegmentSaysSoRatherThanReturningInSilence() {
+        let (provider, cache) = makeProvider(allowsBoundedDegradedStart: false)
+        defer { cache.close() }
+        let tap = Issue374LogTap()
+        defer { tap.restore() }
+
+        XCTAssertFalse(provider.waitForFirstLiveSegment(timeout: 0.2))
+
+        let accounted = tap.matching("first live manifest")
+        XCTAssertEqual(accounted.count, 1, accounted.joined(separator: " | "))
+        guard let line = accounted.first else { return XCTFail("no account emitted") }
+        XCTAssertTrue(line.contains("no segment"), line)
+    }
+
+    /// Pulls the `after <x>s` interval back out of the line, so the assertion is about the number the
+    /// engine reported rather than about the sentence around it.
+    private static func heldSeconds(in line: String) -> Double? {
+        guard let range = line.range(of: "after ") else { return nil }
+        let tail = line[range.upperBound...]
+        guard let end = tail.firstIndex(of: "s") else { return nil }
+        return Double(tail[tail.startIndex..<end])
+    }
+}

--- a/docs/api.md
+++ b/docs/api.md
@@ -266,6 +266,28 @@ Time lives on `player.clock`, a separate `ObservableObject`, so ~10 Hz ticks nev
 | `$playlistShiftSeconds` | Seconds the producer subtracted from source PTS. Published values already fold it back; exposed for hosts pairing their own samples against AVPlayer's raw clock. |
 | `HLSLiveIngestReader(playlistURL:)`, `HLSLiveIngestReader(playlistURL:httpHeaders:)` | The ready-made `IOReader` for ingesting an upstream HLS playlist directly, with AES-128 clear-key and SSAI handling. The headers ride the playlist, every segment and every AES key, which is what a tokenized IPTV origin enforces per request. Unsupported shapes surface a typed `HLSIngestError`. |
 
+### Where a live start's seconds go
+
+On the loopback live path (a raw stream, or an HLS source the engine ingests itself) the join cost is
+not probe or decode work, it is one withheld response. The engine serves AVPlayer a playlist of its own,
+and AVPlayer starts a live session at the edge minus a holdback of `3 x TARGETDURATION`, the RFC 8216bis
+floor that the served playlist advertises. So the first `/media.m3u8` is held until the window carries
+that much content behind the edge: serving earlier puts AVPlayer's opening seek inside its own
+stall-danger zone, where it restarts in a loop instead of playing (#189). An origin that hands over a
+backlog satisfies it at I/O speed, and a strict-realtime origin pays it in wall clock. The native bypass
+has no such gate, which is why a host measuring both sees it only on the paths that ingest.
+
+Two things report it, and both are worth reading before a slow live start is treated as a decode
+problem. `startupProgress` stalls at `sessionConstructed` for the whole wait, so the checkpoint at the
+slow moment tells this apart from the demux probe (`streamsProbed`) and the display handshake
+(`routed`). And the first serve logs the interval it held, the window it served, and the holdback it was
+measured against, whether it waited or was satisfied immediately.
+
+`LoadOptions.liveJoinProfile` is the lever. `.fastZap` collapses `TARGETDURATION` to the source keyframe
+cadence and the holdback follows it down, so the win belongs to the source GOP rather than to the flag:
+`TARGETDURATION` can never fall below `ceil(max EXTINF)`, and a long-GOP source therefore keeps most of
+its runway under either profile.
+
 ## Picture, layers and PiP
 
 | Symbol | Notes |


### PR DESCRIPTION
A loopback live session's entire join latency is one withheld `/media.m3u8` response, and until now only a **failed** gate said so.

## What the gate does

The first serve holds until the window carries the live-edge holdback (`3 x TARGETDURATION`, #189) of content behind the edge, because serving earlier puts AVPlayer's opening seek inside its own stall-danger zone and it restarts in a loop instead of playing. Everything else the engine does for that session finishes before the gate is entered.

Measured on 6.27.0 with `aetherctl live` against a paced raw-MPEG-TS origin, same machine and fixture, varying only the backlog the origin holds at join:

| backlog at join | first `readyToPlay` |
|---|---|
| 0 s (strict realtime) | 18.66 s |
| 6 s | 12.70 s |
| 12 s | 6.75 s |
| 30 s | 0.43 s |

The startup ladder reached `sessionConstructed` at +0.19 s in every one of them. The wait is the runway being filled at whatever rate the origin hands it over, and nothing else.

## What changes

Every exit from the gate now names what it held, the window it served and the holdback it was measured against:

```
[HLSVideoEngine] first live manifest served after 18.154s: 5 segments / 20.000s >= 18.000s holdback (TARGETDURATION 6s)
[HLSVideoEngine] first live manifest served after 0.088s: 5 segments / 20.000s >= 18.000s holdback (TARGETDURATION 6s)
[HLSVideoEngine] first live manifest served after 10.284s: 2 segments / 10.000s < 15.000s holdback (TARGETDURATION 5s), fastZap bounded start after 2.000s grace
```

Two exits change more than their wording:

- **The bounded `.fastZap` start reported its grace alone**, which is the last leg of the wait rather than the wait. The third line above described itself as `2.000s` before this change, having held for `10.284s`.
- **The exit where no segment was ever cut returned in silence**, which from a host's side is the one outcome indistinguishable from a merely slow origin. It now says so.

The interval is monotonic, because it is a measurement; the deadline stays on `Date` because `NSCondition.wait(until:)` takes one. One account per session, latched under `firstSegmentCondition`, since every `/media.m3u8` without an `_HLS_msn` re-enters the gate.

`docs/api.md` gains **Where a live start's seconds go**: the mechanism, the fact that `startupProgress` stalls at `sessionConstructed` for the whole wait (which separates it from `streamsProbed` and `routed`), and `liveJoinProfile` as the lever with the honest caveat that the win belongs to the source GOP rather than to the flag.

## Test plan

- `Issue374FirstServeAccountTests`, 7 tests, all seen red first: four pin the account line (interval, holdback derived from TD rather than taken on trust, the `>=` / `<` verdict, and that a free runway still gets a line), three drive the gate itself (exactly one account across repeated requests, the bounded start naming the whole wait, the never-cut exit speaking).
- Full suite green: 529 XCTest (1 skipped) + 1865 swift-testing in 270 suites.
- tvOS simulator: `** BUILD SUCCEEDED **`.
- End to end on macOS with `aetherctl live`, all three shapes above, against the paced fixture origin at `--preroll 0` and `--preroll 30` plus a long-GOP seed under `--fast-zap`.

Raised by @ksktech-dev while measuring AetherEngine against libVLC across their device matrix (#374).
