### PR TITLE
Expose the source sample aspect ratio and flag natively rendered subtitle tracks

### DIFF
--- a/Sources/AetherEngine/AetherEngine.swift
+++ b/Sources/AetherEngine/AetherEngine.swift
@@ -1468,6 +1468,10 @@ public final class AetherEngine: ObservableObject {
     /// is parsed. 0 before load or when source has no video (AetherEngine#28). Also available in SourceProbe.
     public private(set) var sourceVideoWidth: Int32 = 0
     public private(set) var sourceVideoHeight: Int32 = 0
+    /// Display-width multiplier for non-square source pixels. Hosts use this with
+    /// the coded dimensions when positioning their own overlays over anamorphic
+    /// video; the coded size alone is not the shape the picture ends up.
+    public private(set) var sourceVideoPixelAspectRatio: Double = 1
 
     /// MKV font attachments from the probe. Hosts write these to disk for ASS renderer font config (AetherEngine#30).
     /// Not @Published and not in SourceProbe: payloads are 10-30 MB and only playback hosts need them.
@@ -2789,6 +2793,7 @@ public final class AetherEngine: ObservableObject {
         sourceVideoBitrate = 0
         sourceVideoWidth = 0
         sourceVideoHeight = 0
+        sourceVideoPixelAspectRatio = 1
 
         // #114: guarantee the AVAudioSession category is declared (off-main, from init) before any branch
         // below can activate the session: AVKit on the native/remote-HLS paths, activateRendererAudioSession()
@@ -2890,6 +2895,12 @@ public final class AetherEngine: ObservableObject {
                 detectedFieldOrder = stream.pointee.codecpar.pointee.field_order
                 sourceVideoWidth = stream.pointee.codecpar.pointee.width
                 sourceVideoHeight = stream.pointee.codecpar.pointee.height
+                let streamSAR = stream.pointee.sample_aspect_ratio
+                let codecSAR = stream.pointee.codecpar.pointee.sample_aspect_ratio
+                let sar = (streamSAR.num > 0 && streamSAR.den > 0) ? streamSAR : codecSAR
+                if sar.num > 0, sar.den > 0 {
+                    sourceVideoPixelAspectRatio = Double(sar.num) / Double(sar.den)
+                }
                 detectedVideoBitrate = probe.declaredBitrate(stream: stream)
                 lastDetectedVideoCodec = detectedCodecID
             }
@@ -4380,6 +4391,7 @@ public final class AetherEngine: ObservableObject {
         sourceVideoBitrate = 0
         sourceVideoWidth = 0
         sourceVideoHeight = 0
+        sourceVideoPixelAspectRatio = 1
         pendingExternalMetadata = []
         #if os(tvOS) || os(iOS)
         // Same lifetime as pendingExternalMetadata: session identity the host staged, cleared when the

--- a/Sources/AetherEngine/Native/RemoteHLSMediaSelection.swift
+++ b/Sources/AetherEngine/Native/RemoteHLSMediaSelection.swift
@@ -113,7 +113,8 @@ enum RemoteHLSMediaSelection {
                 language: option.extendedLanguageTag,
                 isDefault: option.isDefault,
                 isForced: option.isForced,
-                isHearingImpaired: option.isSDH
+                isHearingImpaired: option.isSDH,
+                isNativelyRenderedSubtitle: true
             )
         }
     }

--- a/Sources/AetherEngine/PlayerState.swift
+++ b/Sources/AetherEngine/PlayerState.swift
@@ -595,8 +595,11 @@ public struct TrackInfo: Identifiable, Sendable, Equatable {
     /// True for host-registered external subtitle tracks (AetherEngine#88); their `id` is synthetic
     /// (`AetherEngine.externalSubtitleTrackIDBase` + ordinal), not an AVStream index.
     public let isExternal: Bool
+    /// True when the playback backend, rather than `subtitleCues`, renders this
+    /// track. Hosts can avoid presenting overlay controls that cannot affect it.
+    public let isNativelyRenderedSubtitle: Bool
 
-    public init(id: Int, name: String, codec: String, language: String?, channels: Int = 0, bitrate: Int64 = 0, isDefault: Bool, isForced: Bool = false, isHearingImpaired: Bool = false, isCommentary: Bool = false, isAtmos: Bool = false, assHeader: String? = nil, isExternal: Bool = false) {
+    public init(id: Int, name: String, codec: String, language: String?, channels: Int = 0, bitrate: Int64 = 0, isDefault: Bool, isForced: Bool = false, isHearingImpaired: Bool = false, isCommentary: Bool = false, isAtmos: Bool = false, assHeader: String? = nil, isExternal: Bool = false, isNativelyRenderedSubtitle: Bool = false) {
         self.id = id
         self.name = name
         self.codec = codec
@@ -610,6 +613,7 @@ public struct TrackInfo: Identifiable, Sendable, Equatable {
         self.isAtmos = isAtmos
         self.assHeader = assHeader
         self.isExternal = isExternal
+        self.isNativelyRenderedSubtitle = isNativelyRenderedSubtitle
     }
 }
 


### PR DESCRIPTION
Two small additive properties, both from data the engine already reads and then drops.

`sourceVideoWidth` and `sourceVideoHeight` are the coded dimensions, so on anamorphic video they aren't the shape the picture actually is. I use them to work out a natural size for positioning my own overlays and there's nothing to correct with, and AVAsset track properties don't help on the loopback path since the item there is the engine's own HLS rather than the source. The probe already reads the stream, so this is one more field off the same `AVStream`. Stream SAR wins over codecpar SAR when both are set, stays 1 when neither is.

The other one is for the remote-HLS path, where the backend renders WebVTT itself and no cue ever reaches `subtitleCues`. From outside those tracks look identical to any other, so my subtitle picker was offering position and delay controls that can't affect them. Selecting one now goes down a different path entirely, which needs to know which tracks they are. Set only in `RemoteHLSMediaSelection` where the distinction is already known, defaults to false everywhere else.

I've been carrying both as local patches on a vendored copy and reapplying them by hand on every update. Would rather not keep doing that.

`swift build` and `swift test` clean, 1865 tests, same as without the changes.
