### PR TITLE
fix(io): the other two served-from-memory branches charge the ladders too (#380)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,22 @@ the public-API contract.
   "next attempt in Ns" fired as fast as the consumer could read, and the give-up latch was
   erased by the next reconnect from any path. The timestamp is now released by first data or an
   intentional reposition — the two events that genuinely end a faulted lineage.
+- **The other two served-from-memory branches stopped resetting the ladders too (#380
+  follow-up).** The read loop serves without touching the network in three places, and only the
+  window serve was fixed. The retained head/tail spans (#281) run FIRST, before every network
+  path, and their own log line says "no reconnect for it" — yet the parse's return to the head
+  cleared both streaks, and unlike the detour that branch is not taken out of service on a
+  metered origin, so it is the one that reaches the field shape #380 described as "one served
+  byte reset the whole ladder and it started over". The detour cache's resident-block hit (#69)
+  did the same; it now distinguishes a block it fetched from a block it already had, which also
+  replaces the `>2 ms` heuristic the slow-read line used to count detour fetches with the
+  ground truth.
+- **The pinned redirect target is release-visible (#380 follow-up).** Which target is pinned,
+  and when the reader drops it, is half of every field trace about a redirecting origin (#307,
+  #377, #380) — and with the bounded keep-pin grace, dropping it is now a decision the ladder
+  makes rather than a reaction to an expiry status. Both lines were behind `#if DEBUG`, so a
+  rung that only fires in the field was readable only by reporters building the engine
+  themselves. Both are rare by construction: a pin that does not change logs nothing.
 
 ## [6.28.0] - 2026-08-17
 

--- a/Sources/AetherEngine/Demuxer/AVIOReader.swift
+++ b/Sources/AetherEngine/Demuxer/AVIOReader.swift
@@ -87,9 +87,11 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
         defer { resolvedURLLock.unlock() }
         if resolved != url && resolved != _resolvedURL {
             _resolvedURL = resolved
-            #if DEBUG
+            // Release-visible, and rare by construction: only a pin that actually CHANGES logs, so
+            // a healthy session emits this once. Which target is pinned is half of every field
+            // trace about a redirecting origin (#307, #377, #380), and behind `#if DEBUG` it was
+            // readable only by the reporters who happened to build the engine themselves.
             EngineLog.emit("[AVIOReader] Cached resolved URL host=\(resolved.host ?? "?")", category: .demux)
-            #endif
         }
     }
 
@@ -98,9 +100,10 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
         defer { resolvedURLLock.unlock() }
         if _resolvedURL != nil {
             _resolvedURL = nil
-            #if DEBUG
+            // The other half, and the one #380 turned into a decision: dropping the pin is now a
+            // policy the ladder makes (the bounded keep-pin grace), not just a reaction to an
+            // expiry status. A rung the field cannot see is a rung the next trace cannot confirm.
             EngineLog.emit("[AVIOReader] Dropped resolved URL cache (\(reason))", category: .demux)
-            #endif
         }
     }
 
@@ -395,6 +398,15 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
         winCond.lock()
         defer { winCond.unlock() }
         return unproductiveReconnects
+    }
+
+    /// The rate-limit ladder's charge. A test asserting what does and does not count as progress
+    /// against a metered origin (#380) reads this rather than inferring it from request counts,
+    /// which only separate the cases once the ladder has already run to one of its ends.
+    var rateLimitStreakForTesting: Int {
+        winCond.lock()
+        defer { winCond.unlock() }
+        return rateLimitStreak
     }
 
     /// Whether a transfer is still installed. A test that needs a range to have COMPLETED, rather
@@ -1324,8 +1336,11 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
                 if let spanLine { EngineLog.emit(spanLine, category: .demux) }
                 totalRead += n
                 diag.recordDetourServe(ms: 0, fetched: false)
-                unproductiveReconnects = 0
-                rateLimitStreak = 0
+                // No ladder reset. These spans are bytes fetched earlier and kept, and the line
+                // above says so itself: "no reconnect for it". Clearing the streaks here is the
+                // #380 window-serve mistake in the branch that runs FIRST, before every network
+                // path, and unlike the detour it is not taken out of service on a metered origin,
+                // so the parse's return to the head could hold a refusing origin at streak=0.
                 emitNetworkPhase(.flowing)
                 continue
             }
@@ -1414,14 +1429,19 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
                     switch serveFromDetour(into: buf.advanced(by: totalRead),
                                            maxLen: requestSize - totalRead,
                                            at: curPosition, allowFetch: true) {
-                    case .served(let n):
-                        // A resident-block hit is a pure memcpy (sub-ms); anything slower crossed the network.
-                        let detourMs = msSince(detourStart)
-                        diag.recordDetourServe(ms: detourMs, fetched: detourMs > 2)
+                    case .served(let n, let fetched):
+                        diag.recordDetourServe(ms: msSince(detourStart), fetched: fetched)
                         winCond.lock(); position = curPosition + Int64(n); winCond.broadcast(); winCond.unlock()
                         totalRead += n
-                        unproductiveReconnects = 0
-                        rateLimitStreak = 0
+                        // Only a serve that crossed the network is progress against the origin. The
+                        // resident-block hit is the detour twin of the window serve #380 fixed: it
+                        // hands back read-ahead already paid for, so resetting the ladders on it lets
+                        // a parser ping-ponging through a cached region hold a refusing origin at
+                        // streak=0 for as long as the blocks last.
+                        if fetched {
+                            unproductiveReconnects = 0
+                            rateLimitStreak = 0
+                        }
                         emitNetworkPhase(.flowing)   // detour cache served: not stalled (#85)
                         detourTrackSequential(at: curPosition, length: n)
                         continue
@@ -1540,12 +1560,12 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
                     switch serveFromDetour(into: buf.advanced(by: totalRead),
                                            maxLen: requestSize - totalRead,
                                            at: curPosition, allowFetch: false) {
-                    case .served(let n):
+                    case .served(let n, _):
                         diag.recordDetourServe(ms: 0, fetched: false)   // resident-only path
                         winCond.lock(); position = curPosition + Int64(n); winCond.broadcast(); winCond.unlock()
                         totalRead += n
-                        unproductiveReconnects = 0
-                        rateLimitStreak = 0
+                        // No ladder reset: `allowFetch: false` cannot have crossed the network, so
+                        // this serve says nothing about an origin that is refusing (#380).
                         emitNetworkPhase(.flowing)   // detour cache served: not stalled (#85)
                         detourTrackSequential(at: curPosition, length: n)
                         continue
@@ -1808,7 +1828,10 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
 
     // MARK: - Detour Block Cache (AetherEngine#69)
 
-    private enum DetourServe { case served(Int); case rateLimited(TimeInterval); case miss }
+    /// `fetched` says whether the served bytes crossed the network. The callers charge the
+    /// reconnect ladders on it: a resident-block hit is a memcpy out of read-ahead already paid
+    /// for, so it is no more "progress" against a refusing origin than a window serve is (#380).
+    private enum DetourServe { case served(Int, fetched: Bool); case rateLimited(TimeInterval); case miss }
     private enum DetourFetch { case ok(Data); case rateLimited(TimeInterval); case failed }
 
     /// Serve `[offset, offset+maxLen)` (clamped to one 4 MB block) from the detour cache,
@@ -1821,7 +1844,7 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
 
         // Resident-block hit: pure copy, no network.
         if let n = detourCache.serveCached(into: dst, maxLen: maxLen, at: offset) {
-            return .served(n)
+            return .served(n, fetched: false)
         }
         guard allowFetch else { return .miss }
 
@@ -1855,7 +1878,7 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
                 dst.update(from: base.advanced(by: inBlock).assumingMemoryBound(to: UInt8.self), count: n)
             }
         }
-        return .served(n)
+        return .served(n, fetched: true)
     }
 
     /// Single Range fetch for a detour block over the pooled chunkSession. Surfaces rate limiting with

--- a/Tests/AetherEngineTests/OriginRequestBudgetTests.swift
+++ b/Tests/AetherEngineTests/OriginRequestBudgetTests.swift
@@ -75,11 +75,19 @@ struct OriginRequestBudgetTests {
         #expect(first?.granted == true)
 
         let secondGranted = UnsafeFlag()
+        let secondStarted = UnsafeFlag()
         DispatchQueue.global().async {
+            secondStarted.set(true)
             let second = budget.acquire(for: url, label: "detour", timeout: 20)
             secondGranted.set(second?.granted == true)
             budget.release(second)
         }
+        // Waiting for the park without first waiting for the THREAD spends the observation window
+        // on libdispatch. A green run and a run where the block never got a thread then look
+        // identical, and the second one reports a budget defect that was never measured. Seen on
+        // CI: `parked` false with `secondGranted` still nil, i.e. the acquire had not happened.
+        #expect(await waitUntil(30) { secondStarted.value == true },
+                "the waiter never got a thread; nothing about the budget was measured")
         let parked = await waitUntil { budget.snapshot(for: url)?.waiting == 1 }
         #expect(parked, "the second acquire must park rather than proceed")
         #expect(secondGranted.value == nil, "the second request must not proceed while the slot is held")

--- a/Tests/AetherEngineTests/ServedFromMemoryProgressTests.swift
+++ b/Tests/AetherEngineTests/ServedFromMemoryProgressTests.swift
@@ -1,0 +1,115 @@
+import Testing
+import Foundation
+@testable import AetherEngine
+
+/// #380 follow-up. The report named ONE branch: the window serve, where draining read-ahead reset
+/// the reconnect ladders and so held a refusing origin at streak=1 for as long as the runway
+/// lasted. The read loop serves from memory in three places, and the other two were charging the
+/// ladders the same way:
+///
+/// - the retained head/tail spans (#281), which run FIRST, before every network path, and whose
+///   own log line says "no reconnect for it";
+/// - the detour cache's resident-block hit (#69), the parse ping-pong's cheap path.
+///
+/// The span serve is the one that reaches a metered origin: a rate-limit status hands the origin
+/// to the #377 budget, which caps it to one request and takes the detour out of service
+/// (`originRequiresSerialRequests`), while the spans keep serving. That is the field shape #380
+/// described as "one served byte reset the whole ladder and it started over".
+struct ServedFromMemoryProgressTests {
+
+    /// The frontier refill is only requested once the initial range has COMPLETED (`activeTask`
+    /// cleared by the completion callback), so the test waits on that state rather than on a
+    /// sleep long enough to probably work.
+    private static func awaitRangeDelivered(_ reader: AVIOReader) -> Bool {
+        let deadline = Date().addingTimeInterval(20)
+        while Date() < deadline {
+            if !reader.hasLiveConnectionForTesting { return true }
+            Thread.sleep(forTimeInterval: 0.01)
+        }
+        return false
+    }
+
+    @discardableResult
+    private static func readOnce(_ reader: AVIOReader, at offset: Int64, bytes: Int) -> Int32 {
+        #expect(reader.seek(offset: offset, whence: SEEK_SET) == offset)
+        let buf = UnsafeMutablePointer<UInt8>.allocate(capacity: bytes)
+        defer { buf.deallocate() }
+        return reader.read(into: buf, size: Int32(bytes))
+    }
+
+    /// Sequential reads from the current position, which is what walks the window forward and
+    /// trims it, so a later read at 0 is genuinely below `winStart`. Returns the bytes served.
+    private static func readForward(_ reader: AVIOReader, bytes: Int) -> Int {
+        let slice = 128 * 1024
+        let buf = UnsafeMutablePointer<UInt8>.allocate(capacity: slice)
+        defer { buf.deallocate() }
+        var got = 0
+        while got < bytes {
+            let n = reader.read(into: buf, size: Int32(min(slice, bytes - got)))
+            if n <= 0 { break }
+            got += Int(n)
+        }
+        return got
+    }
+
+    /// Serves from inside the resident window until the refused frontier has charged the ladder.
+    /// The charge is paced (`nextFaultedRefillAt`), so this re-reads rather than sleeping once and
+    /// hoping the ladder ran; each iteration's read is itself the thing that can charge it.
+    private static func chargeLadderFromWindow(_ reader: AVIOReader, near offset: Int64) -> Int {
+        for step in 0..<200 {
+            readOnce(reader, at: offset + Int64(step % 8) * 64 * 1024, bytes: 32 * 1024)
+            if reader.rateLimitStreakForTesting > 0 { return reader.rateLimitStreakForTesting }
+            Thread.sleep(forTimeInterval: 0.01)
+        }
+        return reader.rateLimitStreakForTesting
+    }
+
+    /// A metered origin refusing the frontier while the parser returns to the retained head: the
+    /// serve costs no request, so it says nothing about the origin and must leave the ladder's
+    /// charge standing. Before this held, the return to the head reset the streak on every read,
+    /// and both the bounded give-up and #380's re-resolve rung stayed out of reach.
+    @Test("a retained-span serve is not progress against a metered origin",
+          .timeLimit(.minutes(2)))
+    func retainedSpanServeDoesNotClearTheLadder() async throws {
+        AetherEngine.reconnectBackoffScaleForTesting = 0.02
+        defer { AetherEngine.reconnectBackoffScaleForTesting = 1.0 }
+
+        // The first range ends here and every refill at the frontier is refused: the shape of an
+        // origin that answers the range boundary and meters everything past it.
+        let frontier: Int64 = 8 * 1024 * 1024
+        let serverMaybe = ThrottledOriginServer(
+            totalSize: 64 * 1024 * 1024,
+            respond: { _, offset, _ in offset == frontier ? .status(509) : .serve206 }
+        )
+        let server = try #require(serverMaybe)
+        defer { server.stop() }
+
+        let reader = AVIOReader(url: URL(string: "http://127.0.0.1:\(server.port)/movie.bin")!,
+                                boundedInitialFetch: frontier)
+        defer { reader.markClosed(); reader.close() }
+        try reader.open()
+
+        #expect(Self.readOnce(reader, at: 0, bytes: 64 * 1024) > 0)
+        #expect(Self.awaitRangeDelivered(reader), "the bounded initial range never completed")
+
+        // Past winLookback (2 MB) + winTrimBatch (4 MB), so the window has trimmed and a read at 0
+        // can no longer be served from it.
+        let walked = Self.readForward(reader, bytes: 6 * 1024 * 1024 + 512 * 1024)
+        #expect(walked == 6 * 1024 * 1024 + 512 * 1024,
+                "need a trimmed window for the read at 0 to reach the head span (read \(walked))")
+
+        let charged = Self.chargeLadderFromWindow(reader, near: 6 * 1024 * 1024)
+        #expect(charged > 0, "the refused frontier must have charged the rate-limit ladder")
+
+        // The parse's return to the head, repeatedly. Every one of these is a memcpy out of bytes
+        // fetched during open.
+        let requestsBefore = server.requestLog.count
+        for step in 0..<16 {
+            #expect(Self.readOnce(reader, at: Int64(step) * 64 * 1024, bytes: 32 * 1024) > 0)
+        }
+        #expect(server.requestLog.count == requestsBefore,
+                "the run must come out of the retained head: \(server.requestLog.suffix(4))")
+        #expect(reader.rateLimitStreakForTesting >= charged,
+                "a span serve costs no request and must not clear the ladder")
+    }
+}


### PR DESCRIPTION
Follow-up to #381, found while reviewing it against main.

#381 fixed the window serve: draining read-ahead is not network progress, so it must not reset the reconnect streaks. The read loop serves from memory in **three** places and the other two were still clearing them.

**The retained head/tail spans (#281) are the reachable one.** They run FIRST, before every network path, their own log line says "no reconnect for it", and unlike the detour they are not taken out of service on a metered origin (a refusal caps the origin to one request via the #377 budget, which disables the detour but not the spans). So the parse returning to the head is exactly the "one served byte reset the whole ladder and it started over" that #380 described, and it survived the fix written for it.

**The detour cache's resident-block hit (#69) is the second.** `DetourServe.served` now carries whether the bytes crossed the network, so a block the reader fetched counts and a block it already had does not. That also replaces the `>2 ms` heuristic the slow-read line used to count detour fetches with the ground truth.

**Both pin lines lose their `#if DEBUG`.** Which target is pinned, and when the reader drops it, is half of every field trace about a redirecting origin (#307, #377, #380) — and with #381's bounded keep-pin grace the drop is a decision the ladder makes, not a reaction to an expiry status. A rung that only fires in the field is worth nothing if the field cannot see it. Rare by construction: a pin that does not change logs nothing.

## Test

`ServedFromMemoryProgressTests` drives a real loopback origin that refuses the frontier with 509 while the consumer returns to the retained head. It passes here and fails on the pre-fix branch (`rateLimitStreak` 1 -> 0).

Full suite: 1886 tests / 273 suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E5UztmCZtNYPQpzdmSdmWG