### PR TITLE
fix(io): a redirect chain is one request budget, so a declared ceiling reaches the host that serves (#388)

### DIFF
--- a/Sources/AetherEngine/Demuxer/AVIOReader.swift
+++ b/Sources/AetherEngine/Demuxer/AVIOReader.swift
@@ -83,6 +83,10 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
 
     private func recordResolvedURL(_ resolved: URL?) {
         guard let resolved else { return }
+        // #388: the pinned target is where every later request is keyed, so it has to share the
+        // source's request budget. Idempotent, and stated here as well as at the redirect itself
+        // because a pin is also how a resolve that no delegate of ours followed becomes visible.
+        OriginRequestBudget.shared.noteRedirect(from: url, to: resolved)
         resolvedURLLock.lock()
         defer { resolvedURLLock.unlock() }
         if resolved != url && resolved != _resolvedURL {
@@ -3390,7 +3394,14 @@ private func redirectPreservingHeaders(
     newRequest request: URLRequest,
     extraHeaders: [String: String]
 ) -> URLRequest {
-    RedirectHeaderPolicy.redirectRequest(
+    // #388: this is the moment the request the reader budgeted for stops being answered by the
+    // origin it was budgeted against. Every fetch the reader makes passes through here, so it is
+    // the one place that sees the whole chain, including the hops no response ever pins (a target
+    // that answers the very first request with a 509 is never recorded as resolved).
+    if let from = task.originalRequest?.url, let to = request.url {
+        OriginRequestBudget.shared.noteRedirect(from: from, to: to)
+    }
+    return RedirectHeaderPolicy.redirectRequest(
         request,
         originalURL: task.originalRequest?.url,
         originalRange: task.originalRequest?.value(forHTTPHeaderField: "Range"),

--- a/Sources/AetherEngine/Demuxer/OriginRequestBudget.swift
+++ b/Sources/AetherEngine/Demuxer/OriginRequestBudget.swift
@@ -22,6 +22,12 @@ import Foundation
 /// it had actually reached. There is no automatic increase: an origin that has metered us once is
 /// treated as metering for the rest of the process, which costs some parallelism and no correctness.
 ///
+/// A redirect chain is ONE origin here (#388). A metered source is routinely a portal that 302s to
+/// the host serving the bytes, and the host loading it can only name the portal: keeping a separate
+/// bucket per hop meant the declared ceiling stopped at the proxy, the pump's slot was booked
+/// against an origin it had stopped fetching from, and a detour block opened as a second request
+/// against a host whose books showed nothing in flight. `noteRedirect` folds them.
+///
 /// Deadlock is excluded structurally rather than managed. A reader that already holds a ticket must
 /// never block on a second one, so at `limit == 1` the speculative parallel paths (detour blocks,
 /// the tail prefetch, the staggered probe fan) are switched off instead of queued, and each of them
@@ -43,6 +49,9 @@ final class OriginRequestBudget: @unchecked Sendable {
     /// `deinit`-based guard on purpose: the pump's slot is held across a connection, so its
     /// lifetime is the connection's, not a scope's.
     struct Ticket {
+        /// The origin key the request was made against, NOT the chain it belongs to: a redirect
+        /// folds this origin into a chain after the slot was taken, so the bucket is resolved when
+        /// the ticket is returned rather than when it was handed out (#388).
         let key: String
         let label: String
         /// True when the budget was capped and this ticket waited for room. Diagnostic only.
@@ -78,6 +87,92 @@ final class OriginRequestBudget: @unchecked Sendable {
 
     private let lock = NSLock()
     private var origins: [String: OriginState] = [:]
+    /// #388: member origin key -> the key its chain is kept under. A redirect target is not a
+    /// second origin as far as a request budget is concerned: every request keyed on either end is
+    /// answered by the same server, so both ends share one set of books.
+    private var chainHead: [String: String] = [:]
+
+    /// Resolve an origin key to the key its chain is kept under. Called under `lock`.
+    private func headLocked(_ key: String) -> String {
+        var current = key
+        // Bounded rather than trusting the map to be acyclic: `noteRedirect` never builds a cycle,
+        // and a walk that cannot terminate is not worth the certainty it would need.
+        for _ in 0..<8 {
+            guard let next = chainHead[current], next != current else { return current }
+            current = next
+        }
+        return current
+    }
+
+    // MARK: - Redirect chains
+
+    /// A request against `source` is being answered by `target`, i.e. the reader has just been
+    /// redirected. Fold the two origins into one budget.
+    ///
+    /// The ceiling is the reason this exists. A host that declares
+    /// `LoadOptions.maxConcurrentSourceRequests` knows what its PROVIDER allows and can only name
+    /// the URL it loads; on the shape this comes from (an Xtream portal that 302s to the media host
+    /// that actually counts the connections) that ceiling stopped at the proxy hop, and the host
+    /// cannot route around it - resolving the redirect itself before `load` would spend the one
+    /// connection the panel allows.
+    ///
+    /// Counting is the other half. The pump takes its slot against the URL it asks for, so after a
+    /// 302 it streams from a host whose books show nothing in flight, and the next reader to look
+    /// there sees a free slot that is not free. Folding the chain fixes both without re-keying a
+    /// ticket mid-connection: the slot the pump holds is already the chain's.
+    ///
+    /// Deliberate consequence: a refusal now lowers the whole chain, including the portal. #377
+    /// kept them apart on the reasoning that the proxy did not refuse us, which is true and no
+    /// longer the point - a request to the proxy for this source IS a request to the host that
+    /// refused, because the proxy only ever answers it with a redirect there.
+    ///
+    /// A target that already belongs to a chain keeps it: two portals handing out links on one edge
+    /// host would otherwise let a ceiling declared for one of them spread to the other.
+    func noteRedirect(from source: URL, to target: URL) {
+        guard let sourceKey = Self.originKey(for: source),
+              let targetKey = Self.originKey(for: target) else { return }
+        lock.lock()
+        let head = headLocked(sourceKey)
+        let targetHead = headLocked(targetKey)
+        guard head != targetHead else { lock.unlock(); return }
+        // Already somebody's redirect target: leave it on the chain it joined first.
+        guard targetHead == targetKey else { lock.unlock(); return }
+
+        var merged = origins[head] ?? OriginState()
+        let joining = origins[targetHead]
+        if let joining {
+            merged.inflight += joining.inflight
+            merged.peakInflight = max(max(merged.peakInflight, joining.peakInflight), merged.inflight)
+            merged.refusals += joining.refusals
+            merged.limit = Self.tighter(merged.limit, joining.limit)
+            merged.hostLimit = Self.tighter(merged.hostLimit, joining.hostLimit)
+            if let hostLimit = merged.hostLimit {
+                merged.limit = Self.tighter(merged.limit, hostLimit)
+            }
+            if let theirs = joining.lastRefusalAt {
+                merged.lastRefusalAt = merged.lastRefusalAt.map { max($0, theirs) } ?? theirs
+            }
+            // Their waiters are parked on semaphores this bucket now owns; dropping them would hang
+            // every one of them for its full acquire budget.
+            merged.waiters.append(contentsOf: joining.waiters)
+        }
+        origins[targetHead] = nil
+        chainHead[targetHead] = head
+        origins[head] = merged
+        let limit = merged.limit
+        lock.unlock()
+
+        EngineLog.emit(
+            "[OriginBudget] \(targetKey) is served through \(head); one request budget for both"
+            + (limit.map { " (limit \($0))" } ?? ""),
+            category: .demux)
+    }
+
+    private static func tighter(_ a: Int?, _ b: Int?) -> Int? {
+        guard let a else { return b }
+        guard let b else { return a }
+        return min(a, b)
+    }
 
     // MARK: - Acquire / release
 
@@ -90,17 +185,18 @@ final class OriginRequestBudget: @unchecked Sendable {
     /// else's rate limiter trades a slow session for a dead one. The un-granted case is counted
     /// and logged, because a budget that is being routinely overrun is worth seeing.
     func acquire(for url: URL, label: String, timeout: TimeInterval) -> Ticket? {
-        guard let key = Self.originKey(for: url) else { return nil }
+        guard let raw = Self.originKey(for: url) else { return nil }
 
         let started = DispatchTime.now()
         lock.lock()
+        let key = headLocked(raw)
         var state = origins[key] ?? OriginState()
         if state.limit == nil || state.inflight < (state.limit ?? Int.max) {
             state.inflight += 1
             state.peakInflight = max(state.peakInflight, state.inflight)
             origins[key] = state
             lock.unlock()
-            return Ticket(key: key, label: label, waitedMs: 0, granted: true)
+            return Ticket(key: raw, label: label, waitedMs: 0, granted: true)
         }
         let semaphore = DispatchSemaphore(value: 0)
         state.waiters.append(semaphore)
@@ -112,13 +208,16 @@ final class OriginRequestBudget: @unchecked Sendable {
 
         if signalled {
             // `release` counted us in before signalling, so the slot is already ours.
-            return Ticket(key: key, label: label, waitedMs: waitedMs, granted: true)
+            return Ticket(key: raw, label: label, waitedMs: waitedMs, granted: true)
         }
 
         // Timed out. Drop out of the queue and proceed uncounted-for: a slot handed to us between
         // the timeout and the lock would otherwise be leaked by a waiter that is no longer waiting.
         lock.lock()
-        var timedOut = origins[key] ?? OriginState()
+        // Resolved again: a redirect seen while this caller was parked folds its origin into a
+        // chain, and the bucket it queued on is then kept under the chain's key.
+        let keyNow = headLocked(raw)
+        var timedOut = origins[keyNow] ?? OriginState()
         if let i = timedOut.waiters.firstIndex(where: { $0 === semaphore }) {
             timedOut.waiters.remove(at: i)
             timedOut.inflight += 1   // proceeding anyway; stay honest about what is on the link
@@ -129,14 +228,14 @@ final class OriginRequestBudget: @unchecked Sendable {
         // matching `release` only ever subtracts one.
         timedOut.peakInflight = max(timedOut.peakInflight, timedOut.inflight)
         let limitDesc = timedOut.limit.map(String.init) ?? "none"
-        origins[key] = timedOut
+        origins[keyNow] = timedOut
         lock.unlock()
 
         EngineLog.emit(
             "[OriginBudget] \(label) proceeded without a slot after \(Int(waitedMs))ms "
             + "(limit \(limitDesc))",
             category: .demux, level: .verbose)
-        return Ticket(key: key, label: label, waitedMs: waitedMs, granted: false)
+        return Ticket(key: raw, label: label, waitedMs: waitedMs, granted: false)
     }
 
     /// Take a slot only if one is free right now, never waiting. For SPECULATIVE requests: the tail
@@ -144,8 +243,9 @@ final class OriginRequestBudget: @unchecked Sendable {
     /// given up the only thing it was for and still costs the origin a request. nil means "do not
     /// make this request at all", which is a complete answer for a fetch nobody is waiting on.
     func tryAcquire(for url: URL, label: String) -> Ticket? {
-        guard let key = Self.originKey(for: url) else { return nil }
+        guard let raw = Self.originKey(for: url) else { return nil }
         lock.lock(); defer { lock.unlock() }
+        let key = headLocked(raw)
         var state = origins[key] ?? OriginState()
         guard state.inflight < (state.limit ?? Int.max) else {
             origins[key] = state
@@ -154,13 +254,16 @@ final class OriginRequestBudget: @unchecked Sendable {
         state.inflight += 1
         state.peakInflight = max(state.peakInflight, state.inflight)
         origins[key] = state
-        return Ticket(key: key, label: label, waitedMs: 0, granted: true)
+        return Ticket(key: raw, label: label, waitedMs: 0, granted: true)
     }
 
     func release(_ ticket: Ticket?) {
         guard let ticket else { return }
         lock.lock()
-        guard var state = origins[ticket.key] else { lock.unlock(); return }
+        // Resolved at RELEASE time, not at acquire time: the redirect that folds this request's
+        // origin into a chain arrives after the slot was taken, which is the whole shape of #388.
+        let key = headLocked(ticket.key)
+        guard var state = origins[key] else { lock.unlock(); return }
         state.inflight = max(0, state.inflight - 1)
         // Hand the slot straight to the front of the queue rather than dropping the count and
         // letting whoever locks first take it: without that, a pump reconnecting at a range
@@ -168,12 +271,12 @@ final class OriginRequestBudget: @unchecked Sendable {
         if !state.waiters.isEmpty, state.inflight < (state.limit ?? Int.max) {
             let next = state.waiters.removeFirst()
             state.inflight += 1
-            origins[ticket.key] = state
+            origins[key] = state
             lock.unlock()
             next.signal()
             return
         }
-        origins[ticket.key] = state
+        origins[key] = state
         lock.unlock()
     }
 
@@ -186,10 +289,15 @@ final class OriginRequestBudget: @unchecked Sendable {
     /// said something about four, not about one. Repeated refusals halve again, so an origin that
     /// really allows one connection reaches 1 within a few refusals. A host limit always wins.
     /// Returns the limit now in force, if any.
+    ///
+    /// #388: on a chain the answer is charged to the chain. The host that refused and the host we
+    /// asked are one origin as far as requests are concerned, so halving only the far end would
+    /// leave the near end free to open exactly the request that was just refused.
     @discardableResult
     func noteRefusal(for url: URL, status: Int) -> Int? {
-        guard let key = Self.originKey(for: url) else { return nil }
+        guard let raw = Self.originKey(for: url) else { return nil }
         lock.lock()
+        let key = headLocked(raw)
         var state = origins[key] ?? OriginState()
         state.refusals += 1
         state.lastRefusalAt = DispatchTime.now()
@@ -224,8 +332,9 @@ final class OriginRequestBudget: @unchecked Sendable {
     /// forever: the classification would be built, published, and silently never reached. So the
     /// source URL carries the timestamp too, and only the timestamp.
     func noteRefusalWitnessed(for url: URL) {
-        guard let key = Self.originKey(for: url) else { return }
+        guard let raw = Self.originKey(for: url) else { return }
         lock.lock(); defer { lock.unlock() }
+        let key = headLocked(raw)
         var state = origins[key] ?? OriginState()
         state.lastRefusalAt = DispatchTime.now()
         origins[key] = state
@@ -235,9 +344,9 @@ final class OriginRequestBudget: @unchecked Sendable {
     /// to tell "the source is gone" from "the source is metering us", which the FFmpeg-side error
     /// code (-1) cannot carry.
     func refusedRecently(_ url: URL, within window: TimeInterval) -> Bool {
-        guard let key = Self.originKey(for: url) else { return false }
+        guard let raw = Self.originKey(for: url) else { return false }
         lock.lock(); defer { lock.unlock() }
-        guard let last = origins[key]?.lastRefusalAt else { return false }
+        guard let last = origins[headLocked(raw)]?.lastRefusalAt else { return false }
         let elapsed = Double(DispatchTime.now().uptimeNanoseconds - last.uptimeNanoseconds) / 1_000_000_000
         return elapsed <= window
     }
@@ -246,19 +355,22 @@ final class OriginRequestBudget: @unchecked Sendable {
     /// directions: a host that knows its provider allows one connection should not have to wait
     /// for the engine to be refused a few times to find that out.
     func setHostLimit(_ limit: Int?, for url: URL) {
-        guard let key = Self.originKey(for: url) else { return }
+        guard let raw = Self.originKey(for: url) else { return }
         lock.lock(); defer { lock.unlock() }
+        let key = headLocked(raw)
         var state = origins[key] ?? OriginState()
         state.hostLimit = limit.map { max(1, $0) }
         if let hostLimit = state.hostLimit { state.limit = hostLimit }
         origins[key] = state
     }
 
-    /// The effective ceiling for this origin, or nil while it is uncapped.
+    /// The effective ceiling for this origin, or nil while it is uncapped. On a redirect chain that
+    /// is the chain's ceiling, which is the point of #388: the host names the URL it loads, the
+    /// bytes come from somewhere else, and both answers have to be the same one.
     func limit(for url: URL) -> Int? {
-        guard let key = Self.originKey(for: url) else { return nil }
+        guard let raw = Self.originKey(for: url) else { return nil }
         lock.lock(); defer { lock.unlock() }
-        return origins[key]?.limit
+        return origins[headLocked(raw)]?.limit
     }
 
     /// True when this origin is down to one request at a time. The reader asks this to switch OFF
@@ -272,9 +384,9 @@ final class OriginRequestBudget: @unchecked Sendable {
     }
 
     func snapshot(for url: URL) -> Snapshot? {
-        guard let key = Self.originKey(for: url) else { return nil }
+        guard let raw = Self.originKey(for: url) else { return nil }
         lock.lock(); defer { lock.unlock() }
-        guard let state = origins[key] else { return nil }
+        guard let state = origins[headLocked(raw)] else { return nil }
         let since = state.lastRefusalAt.map {
             Double(DispatchTime.now().uptimeNanoseconds - $0.uptimeNanoseconds) / 1_000_000_000
         }
@@ -289,6 +401,7 @@ final class OriginRequestBudget: @unchecked Sendable {
             for waiter in state.waiters { waiter.signal() }
         }
         origins.removeAll()
+        chainHead.removeAll()
     }
 }
 

--- a/Tests/AetherEngineTests/Issue388RedirectChainBudgetTests.swift
+++ b/Tests/AetherEngineTests/Issue388RedirectChainBudgetTests.swift
@@ -95,10 +95,17 @@ struct Issue388RedirectChainBudgetTests {
         budget.noteRedirect(from: portal, to: mediaHost)
 
         let granted = UnsafeBox()
+        let started = UnsafeBox()
         DispatchQueue.global().async {
+            started.set(true)
             let ticket = budget.acquire(for: self.mediaHostResigned, label: "detour", timeout: 20)
             granted.set(ticket?.granted == true)
         }
+        // Wait for the THREAD before waiting for the park, or the observation window is spent on
+        // libdispatch and a block that never got a thread reports a budget defect nobody measured
+        // (the same trap `cappedSerialises` pays for, and this test hit it on CI first try).
+        #expect(await waitUntil(30) { started.value == true },
+                "the waiter never got a thread; nothing about the budget was measured")
 
         let parked = await waitUntil { budget.snapshot(for: mediaHost)?.waiting == 1 }
         #expect(parked, "the second request went out alongside the pump: \(String(describing: budget.snapshot(for: mediaHost)))")

--- a/Tests/AetherEngineTests/Issue388RedirectChainBudgetTests.swift
+++ b/Tests/AetherEngineTests/Issue388RedirectChainBudgetTests.swift
@@ -1,0 +1,276 @@
+import Testing
+import Foundation
+@testable import AetherEngine
+
+/// #388: `LoadOptions.maxConcurrentSourceRequests` was registered for the origin of the URL the
+/// host loaded, and nothing carried it across the 302 that an Xtream-style panel answers with. The
+/// media host behind the redirect is what counts the provider's connections, and it ran under its
+/// own, uncapped key: the pump streamed from it holding a ticket booked against the portal, and the
+/// first backward read opened a detour block against it as a second request.
+///
+/// The budget now treats an observed redirect chain as ONE origin. That is the only reading that
+/// matches what the bytes do: every request keyed on either end of the chain is answered by the
+/// same server, so a ceiling declared for one of them is a ceiling for both, and a request booked
+/// against one of them is a request the other one sees.
+@Suite("#388 the request ceiling follows the redirect", .serialized)
+struct Issue388RedirectChainBudgetTests {
+
+    /// The portal an Xtream host loads: it mints a signed link and 302s to the media host.
+    private let portal = URL(string: "http://portal.example.com:8080/movie/user/pass/1325105.mkv")!
+    private let mediaHost = URL(string: "https://nexus-128.example.net/signed/1325105.mkv?exp=1&sig=a")!
+    /// Same media host, re-signed by a later resolve. The budget keys on scheme+host+port, so this
+    /// is the same origin and must not start a second, empty bucket.
+    private let mediaHostResigned = URL(string: "https://nexus-128.example.net/signed/1325105.mkv?exp=2&sig=b")!
+    private let secondEdge = URL(string: "https://nexus-175.example.net/signed/1325105.mkv?exp=1&sig=c")!
+
+    /// Wait on a state the budget itself reports rather than on a duration: a sleep long enough to
+    /// "probably" have parked a waiter is a margin against a derived bound, and the first thing a
+    /// loaded machine takes away.
+    private func waitUntil(_ deadlineSeconds: Double = 10, _ condition: () -> Bool) async -> Bool {
+        let deadline = Date().addingTimeInterval(deadlineSeconds)
+        while Date() < deadline {
+            if condition() { return true }
+            try? await Task.sleep(nanoseconds: 2_000_000)
+        }
+        return condition()
+    }
+
+    // MARK: - The ceiling
+
+    @Test("the ceiling declared for the loaded URL binds the host that serves the bytes")
+    func declaredCeilingCrossesTheRedirect() {
+        let budget = OriginRequestBudget()
+        budget.setHostLimit(1, for: portal)
+        #expect(!budget.requiresSerialRequests(mediaHost),
+                "before the 302 has been seen the media host is a stranger, correctly uncapped")
+
+        budget.noteRedirect(from: portal, to: mediaHost)
+
+        #expect(budget.limit(for: mediaHost) == 1)
+        #expect(budget.requiresSerialRequests(mediaHost),
+                "the detour asks this about the PINNED url, which is where the host's ceiling stopped")
+        #expect(budget.requiresSerialRequests(mediaHostResigned),
+                "a re-signed target is the same origin and must not arrive uncapped")
+    }
+
+    @Test("a learned ceiling is not what crosses; it is the chain that is one origin")
+    func aLearnedCeilingStillOnlyDescribesTheHostThatTaughtIt() {
+        // Nothing was declared and no redirect was ever observed: the #377 rule stands, the host
+        // that refused is the only one whose budget comes down.
+        let budget = OriginRequestBudget()
+        let tickets = (0..<4).map { budget.acquire(for: mediaHost, label: "path\($0)", timeout: 0.1) }
+        budget.noteRefusal(for: mediaHost, status: 429)
+        #expect(budget.limit(for: mediaHost) == 2)
+        #expect(budget.limit(for: portal) == nil,
+                "a host we have never been redirected through is not part of anything")
+        tickets.forEach { budget.release($0) }
+    }
+
+    // MARK: - The counting
+
+    @Test("the pump's ticket covers the host it actually streams from")
+    func redirectedPumpCountsAtTheServingHost() {
+        let budget = OriginRequestBudget()
+        budget.setHostLimit(1, for: portal)
+        // The pump takes its slot against the URL it asks for, microseconds before the 302 tells it
+        // where the bytes live.
+        let pump = budget.acquire(for: portal, label: "pump", timeout: 0.1)
+        budget.noteRedirect(from: portal, to: mediaHost)
+
+        #expect(budget.snapshot(for: mediaHost)?.inflight == 1,
+                "the connection streaming from this host has to show up on its books")
+        #expect(budget.tryAcquire(for: mediaHost, label: "tail prefetch") == nil,
+                "a speculative fetch must see the slot as taken, not as free")
+
+        budget.release(pump)
+        #expect(budget.snapshot(for: mediaHost)?.inflight == 0,
+                "a ticket booked on the portal key still frees the chain's slot")
+    }
+
+    @Test("a request against the pinned target waits for the pump instead of joining it")
+    func targetRequestQueuesBehindThePump() async {
+        let budget = OriginRequestBudget()
+        budget.setHostLimit(1, for: portal)
+        let pump = budget.acquire(for: portal, label: "pump", timeout: 0.1)
+        budget.noteRedirect(from: portal, to: mediaHost)
+
+        let granted = UnsafeBox()
+        DispatchQueue.global().async {
+            let ticket = budget.acquire(for: self.mediaHostResigned, label: "detour", timeout: 20)
+            granted.set(ticket?.granted == true)
+        }
+
+        let parked = await waitUntil { budget.snapshot(for: mediaHost)?.waiting == 1 }
+        #expect(parked, "the second request went out alongside the pump: \(String(describing: budget.snapshot(for: mediaHost)))")
+        #expect(granted.value == nil, "nothing may be granted while the pump holds the only slot")
+
+        budget.release(pump)
+        _ = await waitUntil { granted.value != nil }
+        #expect(granted.value == true, "the waiter must be served once the pump's slot comes back")
+    }
+
+    @Test("slots already taken against the target survive the link")
+    func countsTakenBeforeTheLinkAreCarriedOver() {
+        // The link is made when a redirect is seen, which is not necessarily the first request the
+        // target has open: a probe can already be running against a pinned URL from an earlier
+        // generation. Merging must carry that request, or its release decrements a bucket that
+        // never counted it and the chain leaks a slot upward.
+        let budget = OriginRequestBudget()
+        let inFlight = budget.acquire(for: mediaHost, label: "probe", timeout: 0.1)
+        budget.setHostLimit(2, for: portal)
+        budget.noteRedirect(from: portal, to: mediaHost)
+
+        #expect(budget.snapshot(for: portal)?.inflight == 1,
+                "the request already open against the target belongs to the chain")
+        #expect(budget.snapshot(for: portal)?.peakInflight == 1)
+        budget.release(inFlight)
+        #expect(budget.snapshot(for: portal)?.inflight == 0)
+    }
+
+    @Test("a refusal halves from the concurrency the chain actually reached")
+    func refusalHalvesFromTheChainsPeak() {
+        // The report's second half: with the pump counted somewhere else, the halving basis was
+        // whatever the detour alone had reached, so an origin refused with two requests open was
+        // told something about one.
+        let budget = OriginRequestBudget()
+        let pump = budget.acquire(for: portal, label: "pump", timeout: 0.1)
+        budget.noteRedirect(from: portal, to: mediaHost)
+        let others = (0..<3).map { budget.acquire(for: mediaHost, label: "path\($0)", timeout: 0.1) }
+
+        #expect(budget.snapshot(for: mediaHost)?.peakInflight == 4,
+                "the chain saw four requests and every one of them was answered by this host")
+        #expect(budget.noteRefusal(for: mediaHost, status: 509) == 2,
+                "an origin refused with four open has said something about four; counting the pump elsewhere made the basis three and the answer one")
+        #expect(budget.refusedRecently(portal, within: 30),
+                "the revive arm only knows the URL the host loaded")
+
+        budget.release(pump); others.forEach { budget.release($0) }
+    }
+
+    // MARK: - Chains
+
+    @Test("a second hop joins the same chain rather than starting a third bucket")
+    func secondHopJoinsTheChain() {
+        let budget = OriginRequestBudget()
+        budget.setHostLimit(1, for: portal)
+        budget.noteRedirect(from: portal, to: mediaHost)
+        budget.noteRedirect(from: mediaHost, to: secondEdge)
+
+        #expect(budget.limit(for: secondEdge) == 1)
+        let ticket = budget.acquire(for: secondEdge, label: "pump", timeout: 0.1)
+        #expect(budget.snapshot(for: portal)?.inflight == 1, "one chain, one set of books")
+        #expect(budget.tryAcquire(for: portal, label: "tail prefetch") == nil)
+        budget.release(ticket)
+    }
+
+    @Test("a target already on a chain is not re-parented onto a second source")
+    func targetIsNotReparented() {
+        // Two portals that happen to hand out links on the same edge host. The first chain keeps
+        // the target; the second portal keeps its own budget rather than inheriting a ceiling
+        // declared for somebody else.
+        let budget = OriginRequestBudget()
+        let otherPortal = URL(string: "http://other-portal.example.com:8080/movie/u/p/9.mkv")!
+        budget.setHostLimit(1, for: portal)
+        budget.noteRedirect(from: portal, to: mediaHost)
+        budget.noteRedirect(from: otherPortal, to: mediaHost)
+
+        #expect(budget.limit(for: otherPortal) == nil,
+                "a ceiling declared for one portal must not spread to another one")
+        #expect(budget.limit(for: mediaHost) == 1, "the target stays on the chain it joined first")
+    }
+
+    @Test("linking is idempotent")
+    func linkingIsIdempotent() {
+        let budget = OriginRequestBudget()
+        budget.setHostLimit(1, for: portal)
+        let pump = budget.acquire(for: portal, label: "pump", timeout: 0.1)
+        for _ in 0..<5 { budget.noteRedirect(from: portal, to: mediaHost) }
+        #expect(budget.snapshot(for: mediaHost)?.inflight == 1,
+                "re-linking must not re-count what is already in flight")
+        budget.release(pump)
+        #expect(budget.snapshot(for: mediaHost)?.inflight == 0)
+    }
+
+    @Test("an unkeyable end of a redirect links nothing")
+    func unkeyableURLLinksNothing() {
+        let budget = OriginRequestBudget()
+        budget.setHostLimit(1, for: portal)
+        budget.noteRedirect(from: portal, to: URL(fileURLWithPath: "/tmp/local.mkv"))
+        #expect(budget.limit(for: portal) == 1)
+    }
+
+    // MARK: - On the wire
+
+    /// The reporter's repro sketch: a portal that 302s to the media host, a ceiling of one declared
+    /// by the host, and a read that goes backward past the retained head, which is what an MKV with
+    /// cues at the tail, a non-faststart moov or a backward scrub all produce.
+    ///
+    /// What is asserted is what the ENGINE issues, not what the origin counted: a replacement
+    /// connection briefly overlaps the one it replaces at any origin (the teardown window #307/#380
+    /// is about), so a peak of one at the server is not something the reader can promise. Not
+    /// opening a second request on purpose while the pump streams is.
+    @Test("a declared ceiling of one issues no detour block behind the 302", .timeLimit(.minutes(2)))
+    func declaredCeilingIssuesNoSecondRequestOnTheWire() async throws {
+        let total: Int64 = 64 * 1024 * 1024
+        let mediaMaybe = ThrottledOriginServer(totalSize: total, throttleUs: 1000)
+        let media = try #require(mediaMaybe)
+        defer { media.stop() }
+        let mediaPort = media.port
+        let portalMaybe = ThrottledOriginServer(
+            totalSize: total,
+            respond: { _, _, _ in .redirect(to: "http://127.0.0.1:\(mediaPort)/media/movie.bin") }
+        )
+        let portalServer = try #require(portalMaybe)
+        defer { portalServer.stop() }
+
+        let sourceURL = URL(string: "http://127.0.0.1:\(portalServer.port)/movie.bin")!
+        let mediaURL = URL(string: "http://127.0.0.1:\(mediaPort)/media/movie.bin")!
+        // What `AetherEngine.load` does with `LoadOptions(maxConcurrentSourceRequests: 1)`: the
+        // ceiling is registered for the URL the host handed over, and only for that one.
+        OriginRequestBudget.shared.setHostLimit(1, for: sourceURL)
+
+        let reader = AVIOReader(url: sourceURL)
+        defer { reader.markClosed(); reader.close() }
+        try reader.open()
+
+        let chunk = 256 * 1024
+        let buf = UnsafeMutablePointer<UInt8>.allocate(capacity: chunk)
+        defer { buf.deallocate() }
+        var read: Int64 = 0
+        while read < 12 * 1024 * 1024 {
+            let n = reader.read(into: buf, size: Int32(chunk))
+            #expect(n > 0, "forward read failed at \(read)")
+            if n <= 0 { break }
+            read += Int64(n)
+            try? await Task.sleep(nanoseconds: 2_000_000)
+        }
+
+        #expect(OriginRequestBudget.shared.snapshot(for: mediaURL)?.inflight == 1,
+                "the connection streaming from the media host must be on its books while it streams")
+        #expect(OriginRequestBudget.shared.requiresSerialRequests(mediaURL),
+                "the pinned target is where every request after the first is keyed")
+
+        // Backward, past the 4 MB retained head: the read that opens a detour block.
+        #expect(reader.seek(offset: 6 * 1024 * 1024, whence: Int32(SEEK_SET)) == 6 * 1024 * 1024)
+        let served = reader.read(into: buf, size: Int32(chunk))
+        #expect(served > 0, "the backward read must still be served, by repositioning instead")
+
+        // A detour block is a bounded 4 MB range. The pump's own bounded refill is 32 MB and the
+        // tail probe is a suffix at the end of the file, so a small bounded range in the middle can
+        // only be the second request.
+        let blocks = media.requestedRanges.filter {
+            guard let end = $0.end, $0.start < total - 1 * 1024 * 1024 else { return false }
+            return end - $0.start + 1 <= 4 * 1024 * 1024
+        }
+        #expect(blocks.isEmpty,
+                "a detour block went out against the media host while the pump was streaming from it: \(blocks), peak concurrency there \(media.peakConcurrentRequests)")
+    }
+}
+
+/// Cross-thread carrier for the one expectation that is set on another queue.
+private final class UnsafeBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _value: Bool?
+    var value: Bool? { lock.lock(); defer { lock.unlock() }; return _value }
+    func set(_ v: Bool) { lock.lock(); _value = v; lock.unlock() }
+}

--- a/Tests/AetherEngineTests/ThrottledOriginServer.swift
+++ b/Tests/AetherEngineTests/ThrottledOriginServer.swift
@@ -39,6 +39,9 @@ final class ThrottledOriginServer: @unchecked Sendable {
     private let throttleUs: useconds_t
     private let firstByteDelayUs: @Sendable (_ isSuffix: Bool) -> useconds_t
     private let respond: @Sendable (_ requestIndex: Int, _ offset: Int64, _ path: String) -> Directive
+    /// #388: how many requests this origin tolerates at once before it answers 509, the way a
+    /// connection-capped panel does. nil keeps every existing test on the unmetered behaviour.
+    private let refuseAboveConcurrency: Int?
     private let lock = NSLock()
     private var _bytesWritten: Int64 = 0
     private var _connFDs: [Int32] = []
@@ -46,6 +49,23 @@ final class ThrottledOriginServer: @unchecked Sendable {
     private var _requestedRanges: [(start: Int64, end: Int64?)] = []
     private var _requestLog: [(path: String, start: Int64, end: Int64?)] = []
     private var _rangeHeaderPresent: [Bool] = []
+    private var _inflight = 0
+    private var _peakInflight = 0
+    private var _refusedForConcurrency = 0
+
+    /// #388: the most requests this origin ever had open at the same time. The reader's own budget
+    /// counts what it BELIEVES it issued against an origin; this counts what the origin saw, which
+    /// is the only side of the redirect the declared ceiling is supposed to be about.
+    var peakConcurrentRequests: Int {
+        lock.lock(); defer { lock.unlock() }
+        return _peakInflight
+    }
+
+    /// Requests this origin refused because they arrived on top of `refuseAboveConcurrency`.
+    var refusedForConcurrency: Int {
+        lock.lock(); defer { lock.unlock() }
+        return _refusedForConcurrency
+    }
 
     var bytesWritten: Int64 {
         lock.lock(); defer { lock.unlock() }
@@ -89,11 +109,13 @@ final class ThrottledOriginServer: @unchecked Sendable {
     /// that difference is what let the speculative tail fetch pass every test while never once
     /// winning its race in the field. `isSuffix` is true for the `bytes=-n` form.
     init?(totalSize: Int64, chunkBytes: Int = 256 * 1024, throttleUs: useconds_t = 5000,
+          refuseAboveConcurrency: Int? = nil,
           firstByteDelayUs: @escaping @Sendable (_ isSuffix: Bool) -> useconds_t = { _ in 0 },
           respond: @escaping @Sendable (_ requestIndex: Int, _ offset: Int64, _ path: String) -> Directive = { _, _, _ in .serve206 }) {
         self.totalSize = totalSize
         self.chunkBytes = chunkBytes
         self.throttleUs = throttleUs
+        self.refuseAboveConcurrency = refuseAboveConcurrency
         self.firstByteDelayUs = firstByteDelayUs
         self.respond = respond
 
@@ -213,7 +235,28 @@ final class ThrottledOriginServer: @unchecked Sendable {
         _requestLog.append((path, offset, rangeEnd))
         _rangeHeaderPresent.append(hadRangeHeader)
         let requestIndex = _requestLog.count - 1
+        // #388: in flight from the moment this origin has a request to answer until its body is
+        // written. A request parked in `readRequestHeader` on a kept-alive socket is not one.
+        _inflight += 1
+        _peakInflight = max(_peakInflight, _inflight)
+        let concurrent = _inflight
+        let cap = refuseAboveConcurrency
+        if let cap, concurrent > cap { _refusedForConcurrency += 1 }
         lock.unlock()
+        defer {
+            lock.lock()
+            _inflight = max(0, _inflight - 1)
+            lock.unlock()
+        }
+
+        if let cap, concurrent > cap {
+            // What a connection-capped panel answers to the request that arrives on top of the
+            // one it is already serving (#307/#380: 509, not 429).
+            let header = "HTTP/1.1 509 Bandwidth Limit Exceeded\r\n"
+                + "Content-Length: 0\r\n"
+                + "Connection: keep-alive\r\n\r\n"
+            return writeFully(fd, Array(header.utf8))
+        }
 
         var silentAfter: Int64? = nil
         var dropAfter: Int64? = nil


### PR DESCRIPTION
Closes nothing yet: #388 stays open for the reporter's measurement against a real panel.

## What was wrong

`LoadOptions.maxConcurrentSourceRequests` was registered for the origin of the URL the host loaded (`AetherEngine.swift`, `setHostLimit(_:for: url)`) and stopped there. On the shape it exists for, an Xtream portal that 302s to the media host that counts the provider's connections, that is the wrong host:

- the pump takes its slot against the URL it asks for, follows the 302 and streams from the target with its ticket still booked against the portal;
- the 200/206 pins the target, so every later request is keyed there, on an origin with no ceiling and no in-flight count;
- `detourEligible` therefore reads `requiresSerialRequests(pinned) == false` and opens a detour block as a second request while the pump streams from the same server. On a one-slot panel that is the 509, and the halving that follows starts from a peak that never included the pump.

## What this does

Folds an observed redirect into one chain, kept under the source's key. Every request keyed on either end is answered by the same server, so:

- the declared ceiling covers the chain, and `requiresSerialRequests(pinned)` is true from the first byte, so the detour falls back to the reposition path it already has;
- the pump's existing ticket is already the chain's, so nothing has to be re-keyed mid-connection;
- `inflight`/`peakInflight` describe the host the bytes actually come from.

Linked at `redirectPreservingHeaders` (every fetch path funnels through it, including hops no response ever pins) and again when a target is pinned.

Deliberate departure from #377: a refusal now lowers the whole chain, portal included. That rule was per-host on the reasoning that the proxy did not refuse us, which is true and no longer the point, since a request to the proxy for this source IS a request to the host that refused. A target already on a chain keeps it, so two portals on one edge host cannot spread a ceiling declared for one of them to the other.

## Measured

New `Issue388RedirectChainBudgetTests`, including the reporter's repro sketch on loopback (a portal that 302s to a media origin that counts its own concurrency). Before: a bounded 4 MB detour block lands at the media host, peak concurrency 2. After: no second request is issued and the backward read is served by repositioning.

`ThrottledOriginServer` grew a concurrency counter and an optional `refuseAboveConcurrency`, so a test can assert what the ORIGIN saw rather than what the reader believes it issued.

Full suite: 1912 tests, 276 suites, green.

Not claimed: a replacement connection still briefly overlaps the one it replaces (the #307/#380 teardown window), so a peak of one at the server is not something the reader can promise. Not opening a second request on purpose while the pump streams is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E5UztmCZtNYPQpzdmSdmWG