### PR TITLE
fix(muxer): a source container's audio codec_tag never reaches the fMP4 sample entry (#382)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,20 @@ the public-API contract.
 
 ### Fixed
 
+- **E-AC-3 from MPEG-TS stream-copies again, so Atmos (JOC) survives the loopback (#382).** The
+  mpegts demuxer stamps `codec_tag` with the PMT stream type (`0x87`) or the registration
+  descriptor (`EAC3`), and that tag reached the fMP4 muxer, which refuses a tag it does not know
+  for the codec: `Could not find tag for codec eac3 in stream #1`, `-22`. The audio cascade read
+  that as "this source cannot stream-copy" and bridged, re-encoding every Atmos object away and
+  reporting DD+ 5.1 on the receiver. libavformat's own guard would have caught the foreign tag one
+  layer earlier, but only at `FF_COMPLIANCE_NORMAL`; the muxer runs at `-2` so it can write the
+  Dolby Vision atoms. The muxer now drops a source-container audio tag the mp4 muxer rejects (the
+  rule `ffmpeg -c copy` uses), so the canonical `ec-3` sample entry is written and the emitted
+  `dec3` box is byte-identical to the source's, JOC complexity index included. AC-3 and AAC from
+  MPEG-TS fall under the same rule but were measured to escape the defect already (an `AC-3`
+  registration descriptor resolves to `ac-3` case-insensitively, and the ADTS path clears the tag
+  when it synthesises the AudioSpecificConfig), so nothing changes for them. Video was never
+  affected: every route sets its tag explicitly.
 - The forward-only streaming reader hangs up at the response header on anything but a 200/206 and
   fails the open typed with the status, so an origin's error page never reaches the demuxer (#378).
   After a 401/403/404/410 on the open-time data connection the HEAD / `bytes=0-1` size probes are

--- a/Sources/AetherEngine/Video/HLSVideoEngine+AudioRoute.swift
+++ b/Sources/AetherEngine/Video/HLSVideoEngine+AudioRoute.swift
@@ -133,8 +133,10 @@ extension HLSVideoEngine {
                         "[HLSVideoEngine] WARNING: Atmos downgrade, EAC3+JOC stream-copy probe rejected by mp4 muxer (ret=\(probeRet)). "
                         + "Falling back to FLAC bridge: bed channels stay lossless, but object metadata is lost. "
                         + "Source: \(sourceAudioStream?.pointee.codecpar.pointee.profile.description ?? "?") profile, "
-                        + "channels=\(sourceAudioStream?.pointee.codecpar.pointee.ch_layout.nb_channels ?? -1). "
-                        + "If you see this in production, capture the source MKV, dec3 extradata reconstruction can recover Atmos.",
+                        + "channels=\(sourceAudioStream?.pointee.codecpar.pointee.ch_layout.nb_channels ?? -1), "
+                        + "codec_tag=\(MP4SegmentMuxer.fourCCDescription(sourceAudioStream?.pointee.codecpar.pointee.codec_tag ?? 0)). "
+                        + "The source container's codec_tag is already sanitised for the mp4 muxer (AE#382), so the cause "
+                        + "is elsewhere; the muxer's own error line above this one names it.",
                         category: .session
                     )
                 } else {

--- a/Sources/AetherEngine/Video/MP4SegmentMuxer.swift
+++ b/Sources/AetherEngine/Video/MP4SegmentMuxer.swift
@@ -422,6 +422,9 @@ final class MP4SegmentMuxer {
                 throw MuxerError.copyParametersFailed(code: aCopy)
             }
             audioStream.pointee.time_base = audio.timeBase
+            // AE#382: a source-container codec_tag (MPEG-TS stream type / registration descriptor) makes
+            // movenc refuse the header, which the audio cascade reads as "cannot stream-copy" and bridges.
+            Self.dropForeignAudioCodecTag(ctx: ctx, codecpar: audioStream.pointee.codecpar)
             // AE#221: repair a degenerate FLAC STREAMINFO before movenc serialises it into dfLa.
             if let streamInfo = Self.sanitizedFLACExtradata(UnsafePointer(audioStream.pointee.codecpar)) {
                 Self.replaceExtradata(audioStream.pointee.codecpar, with: streamInfo)
@@ -843,6 +846,71 @@ final class MP4SegmentMuxer {
             tag |= UInt32(ascii) << (i * 8)
         }
         return tag
+    }
+
+    /// AE#382: true when the mp4 muxer accepts `tag` for `codecID`, i.e. when the source tag may stay.
+    ///
+    /// The mpegts demuxer stamps `codecpar.codec_tag` with the PMT stream type (`0x87` for E-AC-3, `0x81`
+    /// for AC-3) or, when the PMT carries a registration descriptor, with its fourcc (`EAC3`, `AC-3`).
+    /// `avcodec_parameters_copy` carries that into the output stream, and movenc then looks the (tag, codec)
+    /// pair up in the mp4 tag table, finds nothing, and refuses the whole header: "Could not find tag for
+    /// codec eac3 in stream #1" -> `AVERROR(EINVAL)`. libavformat's own guard in `init_muxer` would have
+    /// caught it one layer earlier, but it only fires at `FF_COMPLIANCE_NORMAL`; we run
+    /// `strict_std_compliance = -2` for the Dolby Vision atoms, and below NORMAL that guard passes a foreign
+    /// tag through untouched. So the tag has to be dropped here.
+    ///
+    /// The rule mirrors `streamcopy_init` in fftools/ffmpeg_mux_init.c, which is why an `ffmpeg -c copy`
+    /// remux of the same source succeeds: keep the tag when the output format has no tag table at all, when
+    /// it maps back to the same codec id (it is already an mp4 tag; `av_codec_get_id` matches
+    /// case-insensitively, exactly like movenc's own validation, so a `AC-3` descriptor is fine), or when
+    /// mp4 knows no tag for this codec whatsoever (nothing better to offer; movenc then fails loudly and the
+    /// audio cascade bridges). Otherwise clear it and let `init_muxer` fill in the canonical tag (`ec-3`).
+    static func mp4AcceptsAudioCodecTag(
+        tags: UnsafePointer<OpaquePointer?>?,
+        codecID: AVCodecID,
+        tag: UInt32
+    ) -> Bool {
+        guard tag != 0 else { return true }
+        guard let tags else { return true }
+        if av_codec_get_id(tags, tag) == codecID { return true }
+        var canonical: UInt32 = 0
+        return av_codec_get_tag2(tags, codecID, &canonical) == 0
+    }
+
+    /// Applies `mp4AcceptsAudioCodecTag` to the muxer's own copy of the audio parameters.
+    ///
+    /// Audio only. The video tag is chosen deliberately by `VideoConfig.codecTagOverride` (every route in
+    /// `CodecRoutePolicy` sets one, which is why a TS video stream never carried its `HEVC`/`H264` tag into
+    /// the header), and the same rule would be actively wrong there: `dvh1` is not in the mp4 table at all
+    /// (mov.c handles it), so a Dolby Vision sample entry would be silently demoted to `hvc1`.
+    private static func dropForeignAudioCodecTag(
+        ctx: UnsafeMutablePointer<AVFormatContext>,
+        codecpar: UnsafeMutablePointer<AVCodecParameters>
+    ) {
+        let tag = codecpar.pointee.codec_tag
+        let codecID = codecpar.pointee.codec_id
+        guard !mp4AcceptsAudioCodecTag(
+            tags: ctx.pointee.oformat?.pointee.codec_tag,
+            codecID: codecID,
+            tag: tag
+        ) else { return }
+        codecpar.pointee.codec_tag = 0
+        EngineLog.emit(
+            "[MP4SegmentMuxer] audio codec_tag \(Self.fourCCDescription(tag)) is a source-container tag the "
+            + "mp4 muxer rejects for \(avcodec_get_name(codecID).map { String(cString: $0) } ?? "?"); "
+            + "cleared so the canonical sample entry is written (stream-copy stays available)",
+            category: .session
+        )
+    }
+
+    /// Printable form of a codec tag: the fourcc when all four bytes are printable ASCII, else hex.
+    /// An MPEG-TS PMT stream type (0x87) is not a fourcc, so printing it as one would be noise.
+    static func fourCCDescription(_ tag: UInt32) -> String {
+        let bytes = [UInt8(tag & 0xFF), UInt8((tag >> 8) & 0xFF), UInt8((tag >> 16) & 0xFF), UInt8((tag >> 24) & 0xFF)]
+        if bytes.allSatisfy({ $0 >= 0x20 && $0 < 0x7F }) {
+            return "'" + String(decoding: bytes, as: UTF8.self) + "'"
+        }
+        return String(format: "0x%08x", tag)
     }
 
     /// Mutate AV_PKT_DATA_DOVI_CONF in-place: dv_profile=8, compat=1 (HDR10), el_present_flag=0.

--- a/Tests/AetherEngineTests/Issue382TSAudioCodecTagTests.swift
+++ b/Tests/AetherEngineTests/Issue382TSAudioCodecTagTests.swift
@@ -1,0 +1,132 @@
+import Testing
+import Foundation
+import Libavformat
+import Libavcodec
+import Libavutil
+@testable import AetherEngine
+
+/// AE#382: E-AC-3 (JOC/Atmos included) from live MPEG-TS never stream-copied into the loopback fMP4. The
+/// muxer header was refused with `Could not find tag for codec eac3 in stream #1` / `-22`, the audio cascade
+/// read that as "this source cannot stream-copy" and bridged, and every Atmos object was re-encoded away.
+///
+/// The tag is the whole story. mpegts sets `codecpar.codec_tag` to the PMT stream type (0x87) or, with a
+/// registration descriptor, to its fourcc (`EAC3`), `avcodec_parameters_copy` carries it into the output
+/// stream, and movenc rejects the (tag, codec) pair because it is not an mp4 tag. `init_muxer` would have
+/// intercepted it, but only at `FF_COMPLIANCE_NORMAL`; the muxer runs at `-2` so the Dolby Vision atoms get
+/// written, and below NORMAL that guard waves a foreign tag through.
+///
+/// Reproduced end to end on a plain file remux of the Dolby JOC kit signal
+/// (`ffmpeg -i ddp-joc.mp4 -c copy -f mpegts`), so it is not live-specific: any MPEG-TS whose audio tag is
+/// not an mp4 tag lost stream-copy, Atmos was only the loudest casualty. AC-3 and AAC from the same remux
+/// were measured NOT to be affected in practice, for two different reasons (a `AC-3` registration descriptor
+/// resolves to `ac-3` case-insensitively; ADTS AAC has its tag cleared by `prepareAACForFMP4` alongside the
+/// synthesised AudioSpecificConfig), which is why E-AC-3 was the one codec the defect was visible on.
+@Suite("AE#382: MPEG-TS audio codec_tag must not reach the fMP4 sample entry")
+struct Issue382TSAudioCodecTagTests {
+
+    // MARK: - Harness
+
+    private static var mp4Tags: UnsafePointer<OpaquePointer?>? {
+        av_guess_format("mp4", nil, nil)?.pointee.codec_tag
+    }
+
+    private static func tag(_ fourCC: String) -> UInt32 {
+        var value: UInt32 = 0
+        for (i, byte) in Array(fourCC.utf8).enumerated() { value |= UInt32(byte) << (i * 8) }
+        return value
+    }
+
+    private static func accepts(_ tag: UInt32, _ codecID: AVCodecID) -> Bool {
+        MP4SegmentMuxer.mp4AcceptsAudioCodecTag(tags: mp4Tags, codecID: codecID, tag: tag)
+    }
+
+    // MARK: - The decision
+
+    @Test("the PMT stream type an MPEG-TS carries is not an mp4 tag")
+    func rejectsMPEGTSStreamType() {
+        #expect(Self.accepts(0x87, AV_CODEC_ID_EAC3) == false)  // E-AC-3 PMT stream type
+        #expect(Self.accepts(0x81, AV_CODEC_ID_AC3) == false)   // AC-3 PMT stream type
+        #expect(Self.accepts(0x0F, AV_CODEC_ID_AAC) == false)   // ADTS AAC PMT stream type
+    }
+
+    @Test("the registration-descriptor fourcc EAC3 is not an mp4 tag either")
+    func rejectsRegistrationDescriptor() {
+        #expect(Self.accepts(Self.tag("EAC3"), AV_CODEC_ID_EAC3) == false)
+    }
+
+    @Test("an mp4 tag survives untouched")
+    func keepsMP4Tags() {
+        #expect(Self.accepts(Self.tag("ec-3"), AV_CODEC_ID_EAC3))
+        #expect(Self.accepts(Self.tag("ac-3"), AV_CODEC_ID_AC3))
+        #expect(Self.accepts(Self.tag("mp4a"), AV_CODEC_ID_AAC))
+        #expect(Self.accepts(0, AV_CODEC_ID_EAC3))  // no tag: init_muxer fills the canonical one
+    }
+
+    /// `AC-3` is what an MPEG-TS registration descriptor carries, and movenc's own validation compares tags
+    /// case-insensitively, so it resolves to `ac-3` and works today. Dropping it would be a needless change
+    /// of behaviour for a source that already plays; the rule must be as permissive as movenc's, not stricter.
+    @Test("a case-variant of an mp4 tag stays, because movenc accepts it")
+    func keepsCaseVariantTag() {
+        #expect(Self.accepts(Self.tag("AC-3"), AV_CODEC_ID_AC3))
+    }
+
+    /// When mp4 has no tag for the codec at all there is nothing better to substitute, so the source tag
+    /// stays and movenc fails loudly, which is what routes the cascade to the bridge. The first expectation
+    /// pins that premise: if a future FFmpeg gains a tag for this codec the test says so instead of quietly
+    /// changing meaning.
+    @Test("a codec mp4 cannot carry keeps its tag")
+    func keepsTagForCodecWithoutMP4Mapping() {
+        var canonical: UInt32 = 0
+        #expect(av_codec_get_tag2(Self.mp4Tags, AV_CODEC_ID_PCM_BLURAY, &canonical) == 0)
+        #expect(Self.accepts(Self.tag("HDMV"), AV_CODEC_ID_PCM_BLURAY))
+    }
+
+    // MARK: - The muxer header
+
+    /// The integration end: a real E-AC-3 codecpar with the tag an MPEG-TS source would carry has to pass
+    /// `probeWriteHeader`, because that probe is what the audio cascade reads as "stream-copy is possible".
+    /// Before the fix this returned -22 and every TS E-AC-3 session bridged.
+    @Test("probeWriteHeader accepts E-AC-3 carrying an MPEG-TS tag")
+    func probeAcceptsTSTaggedEAC3() throws {
+        for sourceTag in [Self.tag("EAC3"), 0x87, 0] {
+            let videoDemuxer = Demuxer()
+            let audioDemuxer = Demuxer()
+            defer { videoDemuxer.close(); audioDemuxer.close() }
+            try videoDemuxer.open(
+                reader: DataIOReader(data: Self.data(AtmosDetectionProbeIntegrationTests.videoOnlyBase64)),
+                formatHint: "mp4"
+            )
+            try audioDemuxer.open(
+                reader: DataIOReader(data: Self.data(AtmosDetectionProbeIntegrationTests.eac3PlainBase64)),
+                formatHint: "mp4"
+            )
+            guard let videoStream = videoDemuxer.stream(at: videoDemuxer.videoStreamIndex),
+                  let audioStream = audioDemuxer.stream(at: audioDemuxer.audioStreamIndex) else {
+                Issue.record("fixtures must expose one video and one audio stream")
+                return
+            }
+            audioStream.pointee.codecpar.pointee.codec_tag = sourceTag
+
+            let ret = MP4SegmentMuxer.probeWriteHeader(
+                video: MP4SegmentMuxer.VideoConfig(
+                    codecpar: UnsafePointer(videoStream.pointee.codecpar),
+                    timeBase: videoStream.pointee.time_base,
+                    codecTagOverride: nil
+                ),
+                audio: MP4SegmentMuxer.AudioConfig(
+                    codecpar: UnsafePointer(audioStream.pointee.codecpar),
+                    timeBase: audioStream.pointee.time_base
+                )
+            )
+            #expect(ret == 0, "source tag \(MP4SegmentMuxer.fourCCDescription(sourceTag)) must not fail the header")
+        }
+    }
+
+    private static func data(_ base64: String) -> Data {
+        guard let d = Data(base64Encoded: base64, options: .ignoreUnknownCharacters) else {
+            Issue.record("failed to decode embedded base64 fixture")
+            return Data()
+        }
+        return d
+    }
+}


### PR DESCRIPTION
E-AC-3 out of an MPEG-TS could not stream-copy into the loopback fMP4, so every such session bridged, and a JOC (Atmos) source lost its objects to the re-encode while the receiver showed DD+ 5.1. Reported in #382 by @Simpendaal, with the correct diagnosis and the correct fix in the report.

## Mechanism

`mpegts` sets `codecpar.codec_tag` to the PMT stream type (`0x87` for E-AC-3) or, when the PMT carries a registration descriptor, to its fourcc (`EAC3`). `avcodec_parameters_copy` carries it into the output stream, movenc looks the (tag, codec) pair up in the mp4 tag table, finds nothing, and refuses the whole header:

```
[mp4] Could not find tag for codec eac3 in stream #1, codec not currently supported in container
```

`probeWriteHeader` reports the `-22` to the audio cascade, which can only read it as "this source cannot stream-copy", and bridges.

libavformat's own guard in `init_muxer` would have caught the foreign tag one layer earlier, but it only fires at `FF_COMPLIANCE_NORMAL`. The muxer runs at `-2` so it can write the Dolby Vision atoms, and below NORMAL that guard passes a foreign tag through untouched.

## Fix

Drop a source-container audio tag the mp4 muxer rejects, which is also where `ffmpeg -c copy` drops it (`fftools/ffmpeg_mux_init.c`, `streamcopy_init`); the rule is copied from there. Keep the tag when the output format has no tag table, when it maps back to the same codec id (already an mp4 tag, matched case-insensitively exactly as movenc validates it), or when mp4 knows no tag for the codec at all (nothing better to offer, movenc then fails loudly and the cascade bridges as before). Otherwise clear it and let `init_muxer` fill in the canonical one.

Audio only, deliberately: the video tag is chosen per route by `VideoConfig.codecTagOverride` (which is why a TS video stream never carried its `HEVC` tag into the header), and the same rule would be actively wrong there, since `dvh1` is not in the mp4 tag table at all and a Dolby Vision sample entry would be silently demoted to `hvc1`.

## Verification

Reproduced without the live path, on a plain remux of the Dolby JOC kit signal (`ffmpeg -i ddp-joc.mp4 -c copy -f mpegts`), which produced the reporter's log lines verbatim. So it was never live-specific.

Before:

```
[HLSVideoEngine] audio: codec=eac3 -> stream-copy as `ec-3` [JOC=Atmos]
[mp4] Could not find tag for codec eac3 in stream #1
[HLSVideoEngine] WARNING: Atmos downgrade, EAC3+JOC stream-copy probe rejected by mp4 muxer (ret=-22)
[AudioBridge] init: mode=surroundCompat ...
```

After:

```
[MP4SegmentMuxer] audio codec_tag 'EAC3' is a source-container tag the mp4 muxer rejects for eac3; cleared ...
[HLSSegmentProducer] init OK ... audio=stream-copy
[HLSVideoEngine] EAC3+JOC Atmos: stream-copy engaged
```

And the delivered init segment's `dec3` box is byte-identical to the source MP4's, `1400200f000110`: 640 kbps, 48 kHz, 5.1, `flag_ec3_extension_type_a = 1`, complexity index 16. The Atmos signalling reaches the sample entry, it is not merely the bitstream being copied.

AC-3 and AAC from the same remux were measured to escape the defect already, for two different reasons (an `AC-3` registration descriptor resolves to `ac-3` case-insensitively; ADTS AAC has its tag cleared by `prepareAACForFMP4` next to the synthesised AudioSpecificConfig), which is why E-AC-3 was the codec it showed on. Both now fall under one rule rather than two accidents.

`Issue382TSAudioCodecTagTests` covers the decision table and the probe. 1918 tests pass.

The Atmos-downgrade warning no longer names dec3 reconstruction from a captured MKV as the remedy: that was a guess, it was wrong for this report, and the tag is now sanitised before the probe runs, so the muxer's own error line above it is what names the cause.

Refs #382 (reporter retest pending on a live channel).