### PR TITLE
The axis a run plays on is the one its segment was advertised at (#418)

### DIFF
--- a/Scripts/timecode-fixture.sh
+++ b/Scripts/timecode-fixture.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# A picture that states its own source frame number, for `aetherctl play --picture-probe` (AE#418).
+#
+# Every axis observable the engine has describes what it WROTE. None of them says where AVPlayer then
+# PUT that segment, and AE#408 shipped an early-opening gate on an assumption about exactly that. With
+# this fixture the question needs no assumption: 12 blocks on one pixel row carry bit k of the frame
+# index, so one row of pixels out of AVPlayer's own video output decodes to a source time.
+#
+# Pair it with Scripts/mkv-cue-fixture.py to get the AE#408 shape (Cues that are not sync samples):
+#
+#   Scripts/timecode-fixture.sh /tmp
+#   python3 Scripts/mkv-cue-fixture.py /tmp/tc-drought.mkv /tmp/tc-cues-lie.mkv \
+#       "$(python3 -c 'print(",".join(str(i) for i in range(1,120)))')"
+#   swift run aetherctl play --seconds 12 --start-position 53 --picture-probe file:///tmp/tc-cues-lie.mkv
+#
+# `tc-drought.mkv` is the control arm (its Cues ARE its sync samples, `axisErr` stays 0 on every
+# tick); `tc-cues-lie.mkv` is the case. A resume at 53 s re-aims the gate three times, opens at
+# 38.417 and reads `axisErr=-13.583`, the whole re-aim, constant for the run.
+set -euo pipefail
+OUT_DIR="${1:?usage: timecode-fixture.sh <out-dir>}"
+DUR=120
+FPS=24
+
+filters=""
+for k in $(seq 0 11); do
+  bit=$((1 << k))
+  x=$((k * 52))
+  [ -n "$filters" ] && filters="${filters},"
+  filters="${filters}drawbox=x=${x}:y=0:w=50:h=50:color=white:t=fill:enable='gt(bitand(n\\,${bit})\\,0)'"
+done
+
+# Sync samples where we ask for them, with a deliberate 12 s drought between 43 s and 55 s: long
+# enough that the gate's 4 / 8 / 16 / 32 s backoff has to escalate to reach a covering sample.
+KEYS="0,1.5,3.2,7.1,10.3,14.9,18.2,22.7,26.1,30.5,34.2,38.4,43.0,55.0,56.5,58.9,61.3,64.8,67.2,71.6,75.1,79.4,83.8,87.2,91.6,95.1,99.5,103.2,107.8,111.4,115.9"
+
+ffmpeg -hide_banner -loglevel error -y \
+  -f lavfi -i "color=c=black:s=640x360:r=${FPS}:d=${DUR}" \
+  -f lavfi -i "sine=frequency=440:duration=${DUR}" \
+  -vf "$filters" \
+  -c:v libx264 -preset ultrafast -pix_fmt yuv420p -g 1000 -sc_threshold 0 \
+  -force_key_frames "$KEYS" -b:v 2M \
+  -c:a aac -b:a 128k -shortest \
+  "$OUT_DIR/tc-drought.mkv"
+echo "wrote $OUT_DIR/tc-drought.mkv (${DUR}s, ${FPS}fps, source time = frame index / ${FPS})"

--- a/Sources/AetherEngine/Video/HLSSegmentProducer.swift
+++ b/Sources/AetherEngine/Video/HLSSegmentProducer.swift
@@ -833,6 +833,20 @@ final class HLSSegmentProducer: @unchecked Sendable {
         return actualItemPts < desiredTfdtPts ? actualItemPts : desiredTfdtPts
     }
 
+    /// AE#418: the offset the HOST folds, which is not the offset the MUXER applies.
+    ///
+    /// Measured with `aetherctl play --picture-probe` against a fixture whose picture states its own
+    /// source time: AVPlayer presents a segment at the position the PLAYLIST gives it, not at the
+    /// tfdt the segment carries. So the axis a consumer reads is the distance between the first
+    /// frame's source time and the segment's ADVERTISED start, whatever the muxer wrote. On a pinned
+    /// (late) gate the pin makes the two identical, which is why publishing the mux shift held until
+    /// the early-opening gate of AE#408 landed; on a re-aimed gate they differ by the whole re-aim,
+    /// and the clock then ran that far ahead of the picture (captions early by the same amount).
+    static func presentedShiftPts(actualFirstDts: Int64, desiredTfdtPts: Int64) -> Int64 {
+        guard actualFirstDts != Int64.min, desiredTfdtPts != Int64.min else { return 0 }
+        return actualFirstDts &- desiredTfdtPts
+    }
+
     /// AE#408: aim the gate below a boundary that cannot be opened on, so the segment covers its own
     /// advertised start. Returns false when there is nothing left to try, in which case the caller
     /// keeps the old behaviour (open at the next random-access point and carry the shift).
@@ -3153,13 +3167,31 @@ final class HLSSegmentProducer: @unchecked Sendable {
                             + (pinnedTfdtPts != desiredFirstVideoTfdtPts
                                 ? "pinnedTo=\(pinnedTfdtPts) " : "")
                             + "shift=\(videoShiftPts) "
+                            + (Self.presentedShiftPts(actualFirstDts: firstActualVideoDts,
+                                                      desiredTfdtPts: desiredFirstVideoTfdtPts) != videoShiftPts
+                                ? "presentedShift=\(Self.presentedShiftPts(actualFirstDts: firstActualVideoDts, desiredTfdtPts: desiredFirstVideoTfdtPts)) " : "")
                             // #133 follow-up diag: PID + reconstruct state per epoch, so retest logs separate a
                             // same-PID mid-stream parameter-set change from a reopen storm (each reopen is a fresh
                             // gate-open here; a same-PID change is NOT, it stays in one epoch and rotates in place).
                             + "videoPID=\(videoStreamIndex) reconstructed=\(pendingJoinVideoConfig != nil)",
                             category: .session
                         )
-                        onVideoShiftKnown?(videoShiftPts, pinnedTfdtPts)
+                        // AE#418: what the HOST folds is not the muxer's shift. Measured with
+                        // `play --picture-probe` against a picture that states its own source time:
+                        // AVPlayer presents a segment at the position the PLAYLIST gives it, not at
+                        // the tfdt the segment carries, so a gate that opened below its boundary has
+                        // its content presented that far late whatever it wrote. The muxer's shift
+                        // stays what it is (it is the source-to-item offset for the bytes), and the
+                        // axis the clock folds with is measured against the ADVERTISED start, which
+                        // is where AVPlayer will put the frame. The two coincide on a pinned (late)
+                        // gate, which is why publishing the mux shift held until the early-opening
+                        // gate landed in 6.40.0. Same reason the seam activates at the advertised
+                        // start: the stretch below it still belongs to the previous epoch on screen.
+                        onVideoShiftKnown?(
+                            Self.presentedShiftPts(
+                                actualFirstDts: firstActualVideoDts,
+                                desiredTfdtPts: desiredFirstVideoTfdtPts),
+                            desiredFirstVideoTfdtPts)
                         // #133 follow-up: the gating IDR's in-band SPS/PPS back this epoch's muxer avcC. Establish
                         // the baseline so a later same-PID parameter-set change (encoder restart / regional splice)
                         // is detected against it. joinConfig is non-nil only in the liveH264AnnexBJoin scope.

--- a/Sources/AetherEngine/Video/HLSVideoEngine.swift
+++ b/Sources/AetherEngine/Video/HLSVideoEngine.swift
@@ -376,6 +376,16 @@ public final class HLSVideoEngine: @unchecked Sendable {
     private func setPlaylistShiftSeconds(_ value: Double) {
         shiftLock.lock(); _playlistShiftSeconds = value; shiftLock.unlock()
     }
+
+    /// AE#418: the segment whose own start establishes the axis of the run AVPlayer is playing, and
+    /// by how much. Only an epoch's FIRST segment can carry a non-zero offset: a gate that had to
+    /// open below its boundary puts that much extra content into that one segment, and every segment
+    /// the epoch cuts after it starts exactly on its boundary. One pair, not a table, because a later
+    /// epoch marching through the same index produces an axis-true segment there and a table would
+    /// keep claiming the old offset for it.
+    private let anchorShiftLock = NSLock()
+    private var anchorShiftIndex: Int = .min
+    private var anchorShiftSeconds: Double = 0
     private let shiftLock = NSLock()
     private var _playlistShiftSeconds: Double = 0
 
@@ -1576,6 +1586,14 @@ public final class HLSVideoEngine: @unchecked Sendable {
 
         // 7. Wire provider, server, and URL.
         let manifestCodecs = audioHLSCodecs.map { "\(primaryCodecs),\($0)" } ?? primaryCodecs
+        // AE#418: where AVPlayer starts a fresh decode run decides the axis it plays on.
+        var coldAnchorHandler: (@Sendable (Int) -> Void)?
+        if !isLiveSession {
+            coldAnchorHandler = { [weak self] idx in
+                guard let self else { return }
+                self.handleColdAnchor(at: idx)
+            }
+        }
         let prov = VideoSegmentProvider(
             cache: segmentCache,
             segments: plan,
@@ -1628,7 +1646,8 @@ public final class HLSVideoEngine: @unchecked Sendable {
             stripASSMarkupInVTT: preserveASSMarkupForSubtitleTap,
             nativeSubtitleDefaultOrdinal: nativeSubtitleDefaultOrdinal,
             nativeSubtitleWholeProgram: nativeSubtitleWholeProgram,
-            currentShiftSeconds: { [weak self] in (self?.playlistShiftSeconds ?? 0) + (self?.subtitleStreamStartSeconds ?? 0) }
+            currentShiftSeconds: { [weak self] in (self?.playlistShiftSeconds ?? 0) + (self?.subtitleStreamStartSeconds ?? 0) },
+            coldAnchorHandler: coldAnchorHandler
         )
         self.provider = prov
         if isLiveSession {
@@ -2208,6 +2227,58 @@ public final class HLSVideoEngine: @unchecked Sendable {
     private func handleVideoShiftKnown(_ shiftPts: Int64, firstItemTfdtPts: Int64) {
         let seconds = shiftPts == Int64.min ? 0 : Double(shiftPts) * sourceVideoTbSeconds
         let seamItemSeconds = Double(firstItemTfdtPts) * sourceVideoTbSeconds
+        // AE#418: record which segment this axis belongs to, so a decode run AVPlayer starts
+        // somewhere else does not inherit it.
+        if !isLiveSession {
+            let index = segmentIndexForPlaylistTime(seamItemSeconds)
+            anchorShiftLock.lock()
+            anchorShiftIndex = index
+            anchorShiftSeconds = seconds
+            anchorShiftLock.unlock()
+        }
+        publishPlaylistShift(seconds, seamItemSeconds: seamItemSeconds)
+    }
+
+    /// AE#418: AVPlayer began a fresh decode run at `index`, so the axis is whatever THAT segment's
+    /// own start is worth, and the previous run's offset stops applying.
+    ///
+    /// Measured with `play --picture-probe` on a fixture whose picture states its own source time: a
+    /// run started on an epoch's overlong first segment carries that segment's offset for as long as
+    /// it plays (across segment boundaries, so it is a property of the run and not of each segment),
+    /// and a seek that leaves the loaded region without provoking a restart lands on a sequentially
+    /// cut, axis-true segment, where the previous offset must not still be folded in. Publishing the
+    /// producer's offset alone got the first case right and the second wrong by the same amount.
+    func handleColdAnchor(at index: Int) {
+        guard !isLiveSession else { return }
+        anchorShiftLock.lock()
+        let shift = Self.axisShiftForRun(
+            beginningAt: index, anchorIndex: anchorShiftIndex, anchorShiftSeconds: anchorShiftSeconds)
+        anchorShiftLock.unlock()
+        guard abs(shift - playlistShiftSeconds) > 0.001 else { return }
+        restartLock.lock()
+        let plannedStart = index >= 0 && index < segmentPlan.count
+            ? segmentPlan[index].startSeconds : nil
+        restartLock.unlock()
+        guard let plannedStart else { return }
+        EngineLog.emit(
+            "[HLSVideoEngine] #418 decode run re-anchored at seg\(index) "
+            + "(advertised \(String(format: "%.3f", plannedStart))s): axis shift "
+            + "\(String(format: "%.3f", playlistShiftSeconds))s -> \(String(format: "%.3f", shift))s",
+            category: .session
+        )
+        publishPlaylistShift(shift, seamItemSeconds: plannedStart)
+    }
+
+    /// AE#418: the axis a decode run beginning at `index` plays on. Only the segment an epoch's gate
+    /// opened into can carry an offset; every other index was cut on its own boundary and is worth
+    /// exactly its advertised position, so a run beginning there must not inherit the previous run's.
+    static func axisShiftForRun(
+        beginningAt index: Int, anchorIndex: Int, anchorShiftSeconds: Double
+    ) -> Double {
+        return index == anchorIndex ? anchorShiftSeconds : 0
+    }
+
+    private func publishPlaylistShift(_ seconds: Double, seamItemSeconds: Double) {
         setPlaylistShiftSeconds(seconds)
         // Refresh every native subtitle store's shift so cuesInWindow stays on the correct AVPlayer
         // axis after a restart (matroska seek can land past the planned keyframe, #55). Snapshot under

--- a/Sources/AetherEngine/Video/VideoSegmentProvider.swift
+++ b/Sources/AetherEngine/Video/VideoSegmentProvider.swift
@@ -212,6 +212,9 @@ final class VideoSegmentProvider: HLSSegmentProvider, @unchecked Sendable {
     /// Current engine playlist shift (AVPlayer clock = source_pts - shift), read at serve time so whole-program
     /// cues land on the same AVPlayer axis as the video even when the shift was not known at load (Sodalite#32).
     private let currentShiftSeconds: @Sendable () -> Double
+    /// AE#418: fired with the index AVPlayer starts a fresh decode run on (a fetch that does not
+    /// follow the previous one). Where that run begins decides the axis for everything it plays.
+    private let coldAnchorHandler: (@Sendable (Int) -> Void)?
     /// Sodalite#32 Phase 2: tap-fed stores can carry raw ASS event lines (the overlay renders the
     /// styling); the WebVTT rendition must serve plain text, so strip at build time.
     private let stripASSMarkupInVTT: Bool
@@ -363,7 +366,8 @@ final class VideoSegmentProvider: HLSSegmentProvider, @unchecked Sendable {
         stripASSMarkupInVTT: Bool = false,
         nativeSubtitleDefaultOrdinal: Int = 0,
         nativeSubtitleWholeProgram: Bool = false,
-        currentShiftSeconds: @escaping @Sendable () -> Double = { 0 }
+        currentShiftSeconds: @escaping @Sendable () -> Double = { 0 },
+        coldAnchorHandler: (@Sendable (Int) -> Void)? = nil
     ) {
         self.cache = cache
         self.segments = segments
@@ -398,6 +402,7 @@ final class VideoSegmentProvider: HLSSegmentProvider, @unchecked Sendable {
         self.nativeSubtitleDefaultOrdinal = nativeSubtitleDefaultOrdinal
         self.nativeSubtitleWholeProgram = nativeSubtitleWholeProgram
         self.currentShiftSeconds = currentShiftSeconds
+        self.coldAnchorHandler = coldAnchorHandler
     }
 
     /// Append a finalized live segment. Index must equal segments.count; out-of-order ignored.
@@ -665,6 +670,15 @@ final class VideoSegmentProvider: HLSSegmentProvider, @unchecked Sendable {
         case fail
     }
 
+    /// AE#418: whether this request is where AVPlayer begins a fresh decode run.
+    ///
+    /// Following its predecessor means the run continues, and a run carries the axis of the segment
+    /// it began on across every boundary it plays through. Asking for the SAME index again is a
+    /// retry, not a new run: treating it as one would republish an axis mid-run.
+    static func beginsFreshDecodeRun(index: Int, previousTarget: Int) -> Bool {
+        return index != previousTarget &+ 1 && index != previousTarget
+    }
+
     static func foldedTargetDecision(folds: Int, alreadyReanchoredHere: Bool) -> FoldedTargetDecision {
         guard folds > 0 else { return .wait }
         if folds >= HLSVideoEngine.foldsProvingUnrecoverableGap { return .fail }
@@ -684,6 +698,15 @@ final class VideoSegmentProvider: HLSSegmentProvider, @unchecked Sendable {
         stateLock.unlock()
         let previousTarget = cache.targetIndex
         cache.declareTarget(index)
+
+        // AE#418: a request that does not follow its predecessor is where AVPlayer begins a fresh
+        // decode run, and a fresh run is anchored at the manifest position of the segment it begins
+        // on (measured with `play --picture-probe`). A re-run of the same index is a retry, not an
+        // anchor. Everything after this fetch is presented continuously from here, so the axis this
+        // segment establishes holds until the next such fetch.
+        if Self.beginsFreshDecodeRun(index: index, previousTarget: previousTarget) {
+            coldAnchorHandler?(index)
+        }
 
         // #358: the consumer is asking for a plan index a pump folded away, because no keyframe
         // reached its boundary. The playlist offers it regardless, so waiting here is waiting for

--- a/Sources/aetherctl/PictureProbe.swift
+++ b/Sources/aetherctl/PictureProbe.swift
@@ -1,0 +1,95 @@
+import AVFoundation
+import CoreMedia
+import CoreVideo
+import Foundation
+
+/// AE#418: which SOURCE frame is AVPlayer presenting at a given item time?
+///
+/// Every axis observable the engine has describes what it WROTE: `MuxedVideoFrameTime` (#260) pairs
+/// the demuxed PTS with the value muxed into the segment, `prodShift` / `hostShift` describe the fold
+/// the clock applies. None of them says where AVPlayer then PUT that segment, and a plan boundary the
+/// producer had to open below is exactly the case where the two can disagree. AE#408 shipped on the
+/// assumption that they cannot, which is what this reads out instead of assuming.
+///
+/// The fixture states its own frame number in the picture (12 white blocks, bit k of the frame index,
+/// `Scripts/timecode-fixture.sh`), so one pixel row decodes to a source time with no OCR and no
+/// tolerance to argue about. `itemTimeForDisplay` is AVPlayer's own label for the frame it handed
+/// over, so the pair is measured at one instant on both axes.
+final class PictureProbe: @unchecked Sendable {
+    struct Sample {
+        /// AVPlayer's item time for the frame it just handed over.
+        let itemTime: Double
+        /// Source time decoded from that frame's own picture.
+        let pictureSourceTime: Double
+        /// What the picture is worth minus where AVPlayer says it sits. 0 on an honest axis.
+        var axisError: Double { pictureSourceTime - itemTime }
+    }
+
+    private let blocks: Int
+    private let blockPitch: Int
+    private let blockCenter: Int
+    private let frameRate: Double
+    private var output: AVPlayerItemVideoOutput?
+    private var attachedItem: AVPlayerItem?
+    private(set) var attachCount = 0
+
+    init(blocks: Int = 12, blockPitch: Int = 52, blockCenter: Int = 25, frameRate: Double = 24) {
+        self.blocks = blocks
+        self.blockPitch = blockPitch
+        self.blockCenter = blockCenter
+        self.frameRate = frameRate
+    }
+
+    /// The item is swapped in place on a reload, and an output belongs to one item, so re-attach on
+    /// identity rather than once.
+    @MainActor
+    func attachIfNeeded(_ item: AVPlayerItem?) {
+        guard let item, item !== attachedItem else { return }
+        let output = AVPlayerItemVideoOutput(pixelBufferAttributes: [
+            kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA
+        ])
+        item.add(output)
+        self.output = output
+        self.attachedItem = item
+        attachCount += 1
+    }
+
+    /// nil when the output has no new frame for this instant, which is a normal read on a stalled or
+    /// pre-roll session and must not be reported as a zero.
+    func sample() -> Sample? {
+        guard let output else { return nil }
+        let hostTime = CACurrentMediaTime()
+        let itemTime = output.itemTime(forHostTime: hostTime)
+        guard itemTime.isNumeric else { return nil }
+        var display = CMTime.zero
+        guard let buffer = output.copyPixelBuffer(forItemTime: itemTime, itemTimeForDisplay: &display),
+              let frameIndex = Self.decodeFrameIndex(
+                  from: buffer, blocks: blocks, pitch: blockPitch, center: blockCenter)
+        else { return nil }
+        return Sample(
+            itemTime: display.isNumeric ? display.seconds : itemTime.seconds,
+            pictureSourceTime: Double(frameIndex) / frameRate)
+    }
+
+    /// The picture carries the frame index as `blocks` white/black cells on one row. A cell is read at
+    /// its centre, so encoder ringing at the edges cannot flip a bit.
+    static func decodeFrameIndex(
+        from buffer: CVPixelBuffer, blocks: Int, pitch: Int, center: Int
+    ) -> Int? {
+        CVPixelBufferLockBaseAddress(buffer, .readOnly)
+        defer { CVPixelBufferUnlockBaseAddress(buffer, .readOnly) }
+        guard let base = CVPixelBufferGetBaseAddress(buffer) else { return nil }
+        let bytesPerRow = CVPixelBufferGetBytesPerRow(buffer)
+        let width = CVPixelBufferGetWidth(buffer)
+        let height = CVPixelBufferGetHeight(buffer)
+        guard height > center, width > (blocks - 1) * pitch + center else { return nil }
+        let row = base.advanced(by: center * bytesPerRow).assumingMemoryBound(to: UInt8.self)
+        var index = 0
+        for bit in 0..<blocks {
+            // BGRA: green is the middle byte and carries the full-resolution luma difference here.
+            let green = row[(bit * pitch + center) * 4 + 1]
+            if green > 128 { index |= (1 << bit) }
+        }
+        return index
+    }
+}

--- a/Sources/aetherctl/PlaybackCmd.swift
+++ b/Sources/aetherctl/PlaybackCmd.swift
@@ -28,7 +28,7 @@ struct TeletextPageSwitchRequest {
 /// and log every overlay cue that arrives. Repro harness for "loads but never
 /// plays" reports and for live teletext end-to-end validation (#107).
 func runPlay(url: URL, seconds: Double, live: Bool, nativeHLS: Bool = false, liveIngest: Bool = false, fastZap: Bool = false, dvrWindow: Double?, subsPick: String?, hostCalls: [String], audioStats: Bool = false, seekEvery: Double? = nil, seekPattern: [Double] = [], seekCount: Int? = nil, startPosition: Double? = nil, mallocCensus: Bool = false, forceSoftware: Bool = false,
-                    censusThresholdMB: Int? = nil, censusHz: Double? = nil, frameTimes: Bool = false,
+                    censusThresholdMB: Int? = nil, censusHz: Double? = nil, frameTimes: Bool = false, pictureProbe: Bool = false,
                     sidecars: [ExternalSubtitleTrack] = [], audioSwitch: AudioSwitchRequest? = nil,
                     teletextPage: Int? = nil, teletextSwitch: TeletextPageSwitchRequest? = nil,
                     sequentialOrigin: Bool = false, maxConcurrentRequests: Int? = nil, declaredDuration: Double? = nil,
@@ -50,7 +50,7 @@ func runPlay(url: URL, seconds: Double, live: Bool, nativeHLS: Bool = false, liv
     // CFRunLoopRun, not a blocking semaphore: AetherEngine is @MainActor, so parking the main thread would deadlock the executor.
     let box = UncheckedBox<Int32?>(nil)
     Task { @MainActor in
-        box.value = await playSmokeTest(url: url, seconds: seconds, live: live, nativeHLS: nativeHLS, liveIngest: liveIngest, fastZap: fastZap, dvrWindow: dvrWindow, subsPick: subsPick, hostCalls: hostCalls, audioStats: audioStats, seekEvery: seekEvery, seekPattern: seekPattern, seekCount: seekCount, startPosition: startPosition, frameTimes: frameTimes, sidecars: sidecars, audioSwitch: audioSwitch, teletextPage: teletextPage, teletextSwitch: teletextSwitch, sequentialOrigin: sequentialOrigin, maxConcurrentRequests: maxConcurrentRequests, declaredDuration: declaredDuration, httpHeaders: httpHeaders)
+        box.value = await playSmokeTest(url: url, seconds: seconds, live: live, nativeHLS: nativeHLS, liveIngest: liveIngest, fastZap: fastZap, dvrWindow: dvrWindow, subsPick: subsPick, hostCalls: hostCalls, audioStats: audioStats, seekEvery: seekEvery, seekPattern: seekPattern, seekCount: seekCount, startPosition: startPosition, frameTimes: frameTimes, pictureProbe: pictureProbe, sidecars: sidecars, audioSwitch: audioSwitch, teletextPage: teletextPage, teletextSwitch: teletextSwitch, sequentialOrigin: sequentialOrigin, maxConcurrentRequests: maxConcurrentRequests, declaredDuration: declaredDuration, httpHeaders: httpHeaders)
         CFRunLoopStop(CFRunLoopGetMain())
     }
     CFRunLoopRun()
@@ -228,7 +228,7 @@ private func seekIntentDrill(
 }
 
 @MainActor
-private func playSmokeTest(url: URL, seconds: Double, live: Bool, nativeHLS: Bool = false, liveIngest: Bool = false, fastZap: Bool = false, dvrWindow: Double?, subsPick: String?, hostCalls: [String], audioStats: Bool, seekEvery: Double? = nil, seekPattern: [Double] = [], seekCount: Int? = nil, startPosition: Double? = nil, frameTimes: Bool = false, sidecars: [ExternalSubtitleTrack] = [], audioSwitch: AudioSwitchRequest? = nil, teletextPage: Int? = nil, teletextSwitch: TeletextPageSwitchRequest? = nil, sequentialOrigin: Bool = false, maxConcurrentRequests: Int? = nil, declaredDuration: Double? = nil, httpHeaders: [String: String] = [:]) async -> Int32 {
+private func playSmokeTest(url: URL, seconds: Double, live: Bool, nativeHLS: Bool = false, liveIngest: Bool = false, fastZap: Bool = false, dvrWindow: Double?, subsPick: String?, hostCalls: [String], audioStats: Bool, seekEvery: Double? = nil, seekPattern: [Double] = [], seekCount: Int? = nil, startPosition: Double? = nil, frameTimes: Bool = false, pictureProbe: Bool = false, sidecars: [ExternalSubtitleTrack] = [], audioSwitch: AudioSwitchRequest? = nil, teletextPage: Int? = nil, teletextSwitch: TeletextPageSwitchRequest? = nil, sequentialOrigin: Bool = false, maxConcurrentRequests: Int? = nil, declaredDuration: Double? = nil, httpHeaders: [String: String] = [:]) async -> Int32 {
     let engine: AetherEngine
     do {
         engine = try AetherEngine()
@@ -308,6 +308,7 @@ private func playSmokeTest(url: URL, seconds: Double, live: Bool, nativeHLS: Boo
     // #311: installed BEFORE the load on purpose. The engine holds it and arms the host it builds,
     // which is the documented usage and the part a host would otherwise have to re-do per load.
     let frameProbe = frameTimes ? FrameTimeProbe() : nil
+    let picture = pictureProbe ? PictureProbe() : nil
     if let frameProbe {
         engine.setSoftwareVideoFrameTimeObserver { [weak frameProbe] frame in
             frameProbe?.record(frame)
@@ -494,6 +495,19 @@ private func playSmokeTest(url: URL, seconds: Double, live: Bool, nativeHLS: Boo
             line += String(format: " alead=%.2f abufs=%d", end - engine.sourceTime, monitor.bufferCount)
         }
         line += networkTelemetryFragment(engine.liveTelemetry)
+        // AE#418: the picture states its own source time, so `axisErr` is what AVPlayer did with the
+        // segment rather than what the producer wrote, and `capErr` is the same error as a host
+        // placing a cue at `sourceTime` would make it.
+        if let picture {
+            picture.attachIfNeeded(engine.currentAVPlayerItem)
+            if let sample = picture.sample() {
+                line += String(format: " pic=%.3f picItem=%.3f axisErr=%+.3f capErr=%+.3f",
+                               sample.pictureSourceTime, sample.itemTime, sample.axisError,
+                               sample.pictureSourceTime - engine.sourceTime)
+            } else {
+                line += " pic=none"
+            }
+        }
         if let frameProbe {
             let tick = frameProbe.drainTick()
             line += " ft=\(tick.frames)"

--- a/Sources/aetherctl/main.swift
+++ b/Sources/aetherctl/main.swift
@@ -518,6 +518,7 @@ if first == "play" {
     // #311: install the software frame-time observer and read the presentation timebase, so the
     // per-frame boundaries and the clock a host would pace an overlay against are both observable.
     let frameTimes = takeFlag("--frame-times", from: &rest)
+    let pictureProbe = takeFlag("--picture-probe", from: &rest)
     // #316: declare sidecar subtitles at load, the LoadOptions.externalSubtitles a host passes.
     // Comma-separated `lang=path-or-url` entries, e.g. --sidecar en=/tmp/en.srt,de=/tmp/de.srt.
     // On the nativeRemoteHLS bypass this is what makes the engine stand up its rewritten master.
@@ -585,7 +586,7 @@ if first == "play" {
         exit(64)
     }
     exit(runPlay(url: parseSourceURL(urlArg), seconds: seconds, live: live, nativeHLS: nativeHLS, liveIngest: liveIngest, fastZap: playFastZap, dvrWindow: dvrWindow, subsPick: subsPick, hostCalls: hostCalls, audioStats: audioStats, seekEvery: seekEvery, seekPattern: seekPattern, seekCount: seekCount, startPosition: playStartPosition, mallocCensus: mallocCensus, forceSoftware: playForceSW,
-                 censusThresholdMB: censusThresholdMB, censusHz: censusHz, frameTimes: frameTimes, sidecars: sidecars,
+                 censusThresholdMB: censusThresholdMB, censusHz: censusHz, frameTimes: frameTimes, pictureProbe: pictureProbe, sidecars: sidecars,
                  audioSwitch: audioSwitch,
                  teletextPage: teletextPage, teletextSwitch: teletextSwitch,
                  sequentialOrigin: sequentialOrigin, maxConcurrentRequests: maxConcurrentRequests,

--- a/Tests/AetherEngineTests/Issue418ReaimedGateAxisTests.swift
+++ b/Tests/AetherEngineTests/Issue418ReaimedGateAxisTests.swift
@@ -1,0 +1,140 @@
+import Testing
+import Foundation
+@testable import AetherEngine
+
+/// AE#418 (rrgomes): after a restart whose gate re-aimed below its boundary, the clock ran ahead of
+/// the picture by the re-aim. Captions about four seconds early on a resume that re-aimed 3.045 s,
+/// about eight after restarts that re-aimed 3.1 and 5.0, and a synced host reports the wrong position
+/// with them. Lip sync survives, because audio and video sit in the same segment.
+///
+/// AE#408 shipped the early-opening gate on the assumption that a segment keeping its own timestamps
+/// leaves the item axis where the plan puts it, so it published no shift for that case. The reporter
+/// measured the opposite from AVPlayer's loaded ranges, and `aetherctl play --picture-probe` measures
+/// it directly: on a fixture whose picture states its own source time in binary, a resume at 53 s
+/// whose gate re-aimed to 38.417 (boundary 52.000) showed source frame 41.250 while AVPlayer reported
+/// item time 54.791, an axis error of exactly the re-aim, constant for the whole run.
+///
+/// **AVPlayer presents a segment at the position the PLAYLIST gives it, not at the tfdt it carries,
+/// and then plays continuously from there.** Two consequences, and the fix needs both:
+///
+/// 1. The offset a consumer must fold is measured against the segment's ADVERTISED start, never
+///    against where the gate actually opened. A pinned (late) gate makes the two identical, which is
+///    why publishing the muxer's shift held until AE#408 added a gate that opens early.
+/// 2. That offset belongs to the decode RUN, not to the timeline. A seek that leaves the loaded
+///    region without provoking a restart lands on a sequentially cut, axis-true segment, and the
+///    previous run's offset must stop applying there. Measured before this half landed: the same
+///    run read `capErr=+0.892` after such a seek, the mirror image of the defect it had just fixed.
+///
+/// Measured on `tc-cues-lie.mkv` (Cues injected at non-sync positions, 12 s keyframe drought at
+/// 43 s), source time decoded from the picture itself:
+///
+/// | arm | gate | published shift | picture vs item axis | picture vs `sourceTime` |
+/// | --- | --- | --- | --- | --- |
+/// | before AE#408 | late, pinned | +3.000 | +3.000 | +0.075 |
+/// | AE#408 as shipped | early, 38.417 | 0.000 | -13.583 | -13.550 |
+/// | with this change | early, 38.417 | -13.583 | -13.583 | -0.009 |
+struct Issue418ReaimedGateAxisTests {
+
+    // The reporter's `#65 ledger`, in the millisecond time base its lines are printed in.
+    // Each row is (advertised boundary, where the gate actually opened, the drift he tabulated).
+    private static let ledger: [(boundary: Int64, gateOpenedAt: Int64, drift: Int64)] = [
+        (352_936, 349_891, -3_045),   // session 1 + 2, the resume at 354.0
+        (676_134, 662_078, -14_056),  // session 1, seek to 682.0, re-aimed 4s, 8s, 16s
+        (972_847, 969_802, -3_045),   // session 1, seek to 992.0
+        (1_084_375, 1_083_332, -1_043), // session 1, seek to 1102.0
+        (512_053, 508_925, -3_128),   // session 2, seek to 519.3
+        (684_809, 679_762, -5_047),   // session 2, seek to 689.3
+        (604_521, 604_896, 375)       // session 2, seek to 609.3: a LATE opening, the pinned case
+    ]
+
+    // MARK: - The offset is measured against the advertised start
+
+    @Test("every re-aimed restart in the report publishes its own drift, not zero")
+    func ledgerRowsPublishTheirDrift() {
+        for row in Self.ledger {
+            let published = HLSSegmentProducer.presentedShiftPts(
+                actualFirstDts: row.gateOpenedAt, desiredTfdtPts: row.boundary)
+            #expect(published == row.drift,
+                    "boundary \(row.boundary) opened at \(row.gateOpenedAt)")
+        }
+    }
+
+    @Test("a gate that opened early publishes a negative shift, which is what was missing")
+    func earlyGatePublishesNegative() {
+        // The harness case: boundary 52.000 s, gate re-aimed three times and opened at 38.417 s.
+        let published = HLSSegmentProducer.presentedShiftPts(
+            actualFirstDts: 38_417, desiredTfdtPts: 52_000)
+        #expect(published == -13_583)
+    }
+
+    @Test("a gate that opened exactly on its boundary publishes nothing")
+    func exactGatePublishesZero() {
+        #expect(HLSSegmentProducer.presentedShiftPts(actualFirstDts: 44_000, desiredTfdtPts: 44_000) == 0)
+    }
+
+    @Test("a late gate is unchanged, because the pin already made the two axes agree")
+    func lateGateUnchanged() {
+        // Pre-AE#408 behaviour on the same fixture: the gate opened at 55.0 for a boundary at 52.0
+        // and the pin moved the first frame down to 52.0, so the content sits 3 s above the axis.
+        #expect(HLSSegmentProducer.presentedShiftPts(actualFirstDts: 55_000, desiredTfdtPts: 52_000) == 3_000)
+    }
+
+    @Test("an unresolved timestamp publishes nothing rather than a garbage offset")
+    func unresolvedPublishesZero() {
+        #expect(HLSSegmentProducer.presentedShiftPts(actualFirstDts: .min, desiredTfdtPts: 52_000) == 0)
+        #expect(HLSSegmentProducer.presentedShiftPts(actualFirstDts: 38_417, desiredTfdtPts: .min) == 0)
+    }
+
+    // MARK: - The offset belongs to the run, not to the timeline
+
+    @Test("a run beginning on the segment the gate opened into carries that offset")
+    func runOnTheAnchorCarriesTheOffset() {
+        let shift = HLSVideoEngine.axisShiftForRun(
+            beginningAt: 13, anchorIndex: 13, anchorShiftSeconds: -13.583)
+        #expect(shift == -13.583)
+    }
+
+    @Test("a run beginning anywhere else is worth its advertised position")
+    func runElsewhereIsAxisTrue() {
+        // The measured case: the seek left the loaded region, no restart followed, and AVPlayer
+        // anchored on seg11, which a previous pump had cut on its own boundary.
+        #expect(HLSVideoEngine.axisShiftForRun(
+            beginningAt: 11, anchorIndex: 2, anchorShiftSeconds: -0.875) == 0)
+        #expect(HLSVideoEngine.axisShiftForRun(
+            beginningAt: 14, anchorIndex: 13, anchorShiftSeconds: -13.583) == 0)
+    }
+
+    @Test("with no epoch on record a run inherits nothing")
+    func noAnchorOnRecord() {
+        #expect(HLSVideoEngine.axisShiftForRun(
+            beginningAt: 0, anchorIndex: .min, anchorShiftSeconds: 0) == 0)
+    }
+
+    // MARK: - What counts as the beginning of a run
+
+    @Test("the next index in sequence continues the run")
+    func sequentialFetchContinuesTheRun() {
+        #expect(!VideoSegmentProvider.beginsFreshDecodeRun(index: 12, previousTarget: 11))
+    }
+
+    @Test("the same index again is a retry, not a new run")
+    func repeatedFetchIsARetry() {
+        // A republished axis mid-run would move the clock under a picture that never changed.
+        #expect(!VideoSegmentProvider.beginsFreshDecodeRun(index: 11, previousTarget: 11))
+    }
+
+    @Test("a jump in either direction begins a run")
+    func jumpBeginsARun() {
+        #expect(VideoSegmentProvider.beginsFreshDecodeRun(index: 40, previousTarget: 11))
+        #expect(VideoSegmentProvider.beginsFreshDecodeRun(index: 3, previousTarget: 11))
+        // One short of contiguous is still a jump: the segment between them was never fetched.
+        #expect(VideoSegmentProvider.beginsFreshDecodeRun(index: 13, previousTarget: 11))
+    }
+
+    @Test("the session's first fetch begins a run")
+    func firstFetchBeginsARun() {
+        // `cache.targetIndex` before any declaration, so the resume segment is an anchor and gets
+        // the epoch's offset published against it.
+        #expect(VideoSegmentProvider.beginsFreshDecodeRun(index: 13, previousTarget: -1))
+    }
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -114,6 +114,19 @@ overlay pipeline stays empty (same as AE#154).
 
 `--sequential-origin` declares `LoadOptions.sequentialOrigin`, the IPTV timeshift / catch-up shape whose `206` answers are fabricated (#346): one long-lived unranged GET, no ranged probes, no tail read, so **seeking is unavailable** in the run. On VOD it needs `--declared-duration S`, which fills `LoadOptions.declaredDurationSeconds`, because the estimate that the tail read would have produced is gone with the tail read.
 
+`--picture-probe` attaches an `AVPlayerItemVideoOutput` to the running item and decodes the source
+time out of the picture itself, which is the one axis question nothing else here can answer: every
+other observable (`#260` frame times, `prodShift` / `hostShift`) describes what the engine WROTE, not
+where AVPlayer then PUT it. Per tick it appends `pic` (source seconds decoded from the frame),
+`picItem` (AVPlayer's own `itemTimeForDisplay` for that frame), `axisErr` (their difference, 0 on an
+honest axis) and `capErr` (the same error as a host placing a cue at `sourceTime` would make it).
+Needs a fixture whose picture states its own frame number, which `Scripts/timecode-fixture.sh`
+writes; against anything else it prints `pic=none` or nonsense. `pic=none` is also the normal read
+before the first frame and during a stall, so it is not reported as a zero. This is what settled
+AE#418: AVPlayer presents a segment at the position the PLAYLIST gives it, not at the tfdt it
+carries, and then plays continuously from there, so a gate that opened below its boundary shifts the
+whole run by the re-aim (`axisErr=-13.583` on a 13.583 s re-aim, constant for the run).
+
 `--start-position S` starts at a resume anchor, the same one `serve` takes. `--sw` forces the software path for a source that would route native, which is how a native-only fixture exercises the SW pipeline.
 
 `--malloc-census` turns on the large-allocation census (`AetherEngine.setLargeAllocationCensusEnabled`) for the run, for tracing a footprint that grows where the segment budget says it should not. Besides the 30 s sample it arms a jump trigger, which exists because the 30 s memprobe cannot catch a failure that completes inside one sample (every kill on #220 was that shape): a counter polled at `--census-hz N` runs the zone walk once it climbs `--census-threshold-mb N` above its running high-water. Both flags are inert without `--malloc-census`.


### PR DESCRIPTION
Fixes the axis error AE#408's early-opening gate introduced, and adds the harness that could have caught it.

## What was measured

`aetherctl play --picture-probe` (first commit) attaches an `AVPlayerItemVideoOutput` to the running item and decodes the source time out of the frame itself, against a fixture whose picture states its own frame number in binary. Every other axis observable describes what the engine WROTE; this one says where AVPlayer PUT it.

The reading: **AVPlayer presents a segment at the position the playlist gives it, not at the tfdt the segment carries, and then plays continuously from there.** AE#408 shipped on the opposite assumption and published no shift for an early-opening gate, so the clock ran ahead of the picture by the whole re-aim.

## The fix

1. The offset a consumer folds is measured against the segment's **advertised** start, never against where the gate opened. A pinned (late) gate makes the two identical, which is why publishing the muxer's shift held until a gate that opens early existed. The muxer's own shift is untouched.
2. That offset belongs to the decode **run**, not to the timeline: a seek that leaves the loaded region without provoking a restart begins a fresh run on an axis-true segment, and the previous run's offset must stop applying there. Without this half the defect is mirrored rather than fixed (`capErr +0.892` where it had been `-0.875`).

## Numbers

`tc-cues-lie.mkv`, Cues at non-sync positions, 12 s keyframe drought at 43 s, resume at 53 s (gate re-aims three times, opens at 38.417):

| arm | published shift | picture vs item axis | picture vs `sourceTime` |
| --- | --- | --- | --- |
| before AE#408 (pinned) | +3.000 | +3.000 | +0.075 |
| AE#408 as shipped | 0.000 | -13.583 | **-13.550** |
| this change | -13.583 | -13.583 | **-0.009** |

Control fixture (Cues ARE sync samples): no re-aim, no seam, `axisErr` 0 on both arms.

2067 tests green, including the fixture-backed restart-continuity suite.

## Not in scope

The re-aim's 4 / 8 / 16 / 32 s backoff opens at the first sync sample above where it landed rather than the nearest one below the boundary, so a resume into a drought lands further back than it needs to (38.417 where 43.0 was available). Visible now that the clock is honest; tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RbWZLwBVLGM1xUVXa9NeJ1