### PR TITLE
A wedge on a stored segment is the consumer's, so nudge it first (#421)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ the public-API contract.
 
 ### Fixed
 
+- **A wedge whose target was already on disk spent six seconds re-anchoring the producer before
+  nudging the consumer that was actually stuck (AE#421).** The wedge itself is an AVPlayer state
+  (#65 / #93: zero GETs while the item never fails), and the ladder had one repair for it: move the
+  producer, then, if the consumer is still silent after the grace window, ask the host to nudge it.
+  Two field logs say the first half could not work in their case. On an Apple TV the pump had
+  marched to segment 15 and was sent back to segment 3, the consumer fetched nothing for the whole
+  six seconds, and the nudge that followed landed the seek in 240 ms; the Mac run has the same
+  shape with a 44 MB segment already served. A re-anchor is the repair for a consumer STARVED of
+  content nobody is producing, so it is now chosen on that question: if the segment the consumer is
+  silent about is already stored, the nudge goes first and the re-anchor stays as the fallback for
+  a nudge that does not take. The `WEDGE BROKEN` line carries `consumerTargetStored=` and
+  `highStored=` so a report can say which of the two a wedge called for, which previously had to be
+  inferred. The 5 s park detection is deliberately unchanged.
+
 - **After a restart whose gate re-aimed below its boundary, the clock ran ahead of the picture by
   the re-aim (AE#418).** Captions early by the same amount, and a synced host's reported position
   with them; lip sync survived because audio and video sit in the same segment. AE#408's

--- a/Sources/AetherEngine/Video/HLSSegmentProducer.swift
+++ b/Sources/AetherEngine/Video/HLSSegmentProducer.swift
@@ -1551,7 +1551,14 @@ final class HLSSegmentProducer: @unchecked Sendable {
                 markBackpressureWedgeBroken()
                 EngineLog.emit(
                     "[HLSSegmentProducer] #65 backpressure WEDGE BROKEN (\(context)) head=\(head) "
-                    + "target=\(target) cacheTarget=\(cacheTarget) parked=\(parked)s"
+                    + "target=\(target) cacheTarget=\(cacheTarget) parked=\(parked)s "
+                    // AE#421: the line has to say which repair the wedge calls for, and that is
+                    // decided by whether the consumer's own target is already on disk. Without it a
+                    // report can show the wedge and the recovery but not whether re-anchoring the
+                    // producer could have helped at all, which is exactly what had to be inferred
+                    // from two field logs.
+                    + "consumerTargetStored=\(cache.peekURL(index: cacheTarget) != nil ? "y" : "n") "
+                    + "highStored=\(cache.highestStoredIndex) cached=\(cache.count)"
                     + (wedgeDetector.lastTripFast ? " (fast path: fetch target + rendered clock both frozen)" : "")
                     + "; exiting pump for host re-anchor on AVPlayer position",
                     category: .session

--- a/Sources/AetherEngine/Video/HLSVideoEngine+LiveReopen.swift
+++ b/Sources/AetherEngine/Video/HLSVideoEngine+LiveReopen.swift
@@ -800,6 +800,36 @@ extension HLSVideoEngine {
             + " (attempt \(attempts)/\(Self.maxConsecutiveWedgeReanchors))",
             category: .session
         )
+        // AE#421: the two repairs are not interchangeable, and which one goes first is decided by
+        // whether the consumer could have the content it is silent about. Measured twice by the
+        // reporter, on an Apple TV and on a Mac: the producer had already served, the re-anchor
+        // changed nothing for the whole six-second grace (zero fetches), and the nudge that followed
+        // landed the seek in 240 ms. A re-anchor is the repair for a consumer STARVED of content
+        // nobody is producing. A consumer silent on a segment that is already on disk is not
+        // starved, and re-anchoring there throws the pump's forward work away to rebuild what it
+        // already has (the reporting run put it back from seg15 to seg3).
+        if Self.wedgeRepair(targetStored: provider?.hasStoredSegment(at: idx) ?? false) == .nudgeConsumerFirst {
+            EngineLog.emit(
+                "[HLSVideoEngine] #421 backpressure wedge with seg\(idx) already stored: the consumer "
+                + "is silent on content it can have, so nudging it before touching the producer "
+                + "(pos=\(String(format: "%.2f", anchor))s, attempt \(attempts)/\(Self.maxConsecutiveWedgeReanchors))",
+                category: .session
+            )
+            onConsumerReengageNeeded?(anchor)
+            // The nudge is cheap and reversible, but it is not guaranteed: if the consumer is still
+            // silent after the grace, fall back to the re-anchor rather than leaving it wedged.
+            afterGraceIfConsumerStaysSilent(capturedPosition: pos) { [weak self] _ in
+                guard let self else { return }
+                EngineLog.emit(
+                    "[HLSVideoEngine] #421 nudge did not re-engage the consumer within "
+                    + "\(Int(Self.consumerReengageGraceSeconds))s; re-anchoring producer to seg\(idx) after all",
+                    category: .session
+                )
+                self.requestRestart(at: idx, authoritative: true)
+            }
+            return
+        }
+
         // #79: re-anchor authoritatively. The anchor is where recovery must aim (pending seek target,
         // else AVPlayer's real position), so it must win the coalescer's pending slot over any stale
         // in-flight scrub target (else the producer settles at the scrub target and AVPlayer stays starved).
@@ -809,18 +839,8 @@ extension HLSVideoEngine {
         // never resumes REQUESTING (zero GETs, waitingToMinimizeStalls forever, item never fails).
         // Watch the provider's fetch counter through a grace window; if the consumer stays silent
         // while it still wants to play, ask the host for a re-engage nudge.
-        let fetchesAtReanchor = provider?.mediaFetchCount ?? 0
-        let epoch = sessionEpochSnapshot()
-        Task.detached(priority: .userInitiated) { [weak self] in
-            try? await Task.sleep(nanoseconds: UInt64(Self.consumerReengageGraceSeconds * 1_000_000_000))
-            guard let self, self.isSessionEpochCurrent(epoch) else { return }
-            let fetchesNow = self.provider?.mediaFetchCount ?? 0
-            guard fetchesNow == fetchesAtReanchor,
-                  self.playIntentProvider?() == true else { return }
-            // #115: re-read the position at nudge time. On VOD the consumer keeps rendering
-            // buffered segments through the grace window, so the wedge-trip capture is behind
-            // the on-screen frame and a zero-tolerance nudge to it replays visibly.
-            let freshPos = self.currentPlaybackPositionProvider?() ?? pos
+        afterGraceIfConsumerStaysSilent(capturedPosition: pos) { [weak self] freshPos in
+            guard let self else { return }
             EngineLog.emit(
                 "[HLSVideoEngine] #65 consumer re-engage: no segment fetch for "
                 + "\(Int(Self.consumerReengageGraceSeconds))s after wedge re-anchor "
@@ -830,6 +850,37 @@ extension HLSVideoEngine {
                 category: .session
             )
             self.onConsumerReengageNeeded?(freshPos)
+        }
+    }
+
+    /// AE#421: which repair a wedge calls for.
+    enum WedgeRepair: Equatable {
+        /// The target is not produced: the consumer has nothing to fetch, so move the producer.
+        case reanchorProducer
+        /// The target is on disk: the consumer is silent about content it can have, so move IT.
+        case nudgeConsumerFirst
+    }
+
+    static func wedgeRepair(targetStored: Bool) -> WedgeRepair {
+        return targetStored ? .nudgeConsumerFirst : .reanchorProducer
+    }
+
+    /// Run `follow` once the grace window has passed WITHOUT the consumer fetching anything, so a
+    /// repair that took effect is never followed by a second one. `follow` receives the position
+    /// re-read at that moment (#115: on VOD the consumer keeps rendering buffered segments through
+    /// the window, so the trip capture is behind the on-screen frame and acting on it replays
+    /// visibly).
+    private func afterGraceIfConsumerStaysSilent(
+        capturedPosition: Double, _ follow: @escaping @Sendable (Double) -> Void
+    ) {
+        let fetchesBefore = provider?.mediaFetchCount ?? 0
+        let epoch = sessionEpochSnapshot()
+        Task.detached(priority: .userInitiated) { [weak self] in
+            try? await Task.sleep(nanoseconds: UInt64(Self.consumerReengageGraceSeconds * 1_000_000_000))
+            guard let self, self.isSessionEpochCurrent(epoch) else { return }
+            guard (self.provider?.mediaFetchCount ?? 0) == fetchesBefore,
+                  self.playIntentProvider?() == true else { return }
+            follow(self.currentPlaybackPositionProvider?() ?? capturedPosition)
         }
     }
 

--- a/Sources/AetherEngine/Video/VideoSegmentProvider.swift
+++ b/Sources/AetherEngine/Video/VideoSegmentProvider.swift
@@ -657,6 +657,16 @@ final class VideoSegmentProvider: HLSSegmentProvider, @unchecked Sendable {
         return (index, cache.foldCount(index))
     }
 
+    /// AE#421: whether the segment for `index` is already on disk, answered without reading it.
+    ///
+    /// This is what separates the two repairs for a wedge. A producer re-anchor is the fix for a
+    /// consumer STARVED of content nobody is producing; a consumer silent on a segment that is
+    /// already stored is not starved, and re-anchoring throws away the pump's forward work to
+    /// rebuild what it already has.
+    func hasStoredSegment(at index: Int) -> Bool {
+        return cache.peekURL(index: index) != nil
+    }
+
     /// What to do with a request for a non-resident index, given how often pumps have folded it (#358).
     enum FoldedTargetDecision: Equatable {
         /// Nobody has folded this index: it is ordinary read-ahead, wait for the producer.

--- a/Tests/AetherEngineTests/Issue421WedgeRepairOrderTests.swift
+++ b/Tests/AetherEngineTests/Issue421WedgeRepairOrderTests.swift
@@ -1,0 +1,55 @@
+import Testing
+import Foundation
+@testable import AetherEngine
+
+/// AE#421 (rrgomes): after a restart, a landing waited out 5 s of park detection plus 6 s of
+/// re-engage grace, so a seek took 11.94 s on an Apple TV and 15.75 s on a Mac while the producer
+/// had already served its first segment about two seconds in.
+///
+/// The wedge itself is an AVPlayer state (#65 / #93: zero GETs, `waitingToMinimizeStalls` forever,
+/// the item never fails) and is not reproducible here; a seek burst under a 120 kbit/s throttle on
+/// the loopback path lands every seek. What IS ours is the repair, and both field logs say the same
+/// thing about it:
+///
+/// ```
+/// 21:08:52.498 #65 backpressure WEDGE BROKEN head=15 target=5 cacheTarget=4 parked=5s
+/// 21:08:52.503 #65 backpressure wedge: re-anchoring producer to 15.00s -> seg3
+/// 21:08:58.508 #65 consumer re-engage: no segment fetch for 6s after wedge re-anchor
+/// 21:08:58.748 seek#1 programmatic landed rendered=15.00 target=15.00
+/// ```
+///
+/// The producer was at segment 15 and was sent back to segment 3. Through the whole grace window
+/// the consumer fetched nothing, so the re-anchor demonstrably changed nothing; the nudge that
+/// followed it landed the seek in 240 ms. Same shape on the Mac (`seg35: served ... restarted=true`
+/// at +1.9 s, no further GET, nudge at +15.5 s, landed at +15.75 s).
+///
+/// So the order was wrong, not the repairs. A re-anchor is the fix for a consumer STARVED of
+/// content nobody is producing. A consumer silent about a segment that is already on disk is not
+/// starved, and re-anchoring throws the pump's forward work away to rebuild what it already has.
+/// The nudge goes first in that case, with the re-anchor kept as the fallback if the nudge does not
+/// take within the same grace window.
+///
+/// Deliberately unchanged: the 5 s park detection. Shortening it needs a measurement of what an
+/// honest early signal looks like, and a frozen clock is also what a normal seek landing looks like
+/// for a moment. What this removes is the 6 s that were being spent on the repair that could not
+/// work, which is the half the logs actually indict.
+struct Issue421WedgeRepairOrderTests {
+
+    @Test("a consumer silent about a stored segment gets the nudge, not a producer re-anchor")
+    func storedTargetNudgesConsumer() {
+        // The reporting case: seg3 was long since produced (the pump had marched to seg15).
+        #expect(HLSVideoEngine.wedgeRepair(targetStored: true) == .nudgeConsumerFirst)
+    }
+
+    @Test("a consumer starved of an unproduced segment still moves the producer")
+    func unstoredTargetReanchorsProducer() {
+        // The case #65 was opened for: the pump parked ten segments ahead and the target sat
+        // outside the producible window, so nothing the consumer does can fetch it.
+        #expect(HLSVideoEngine.wedgeRepair(targetStored: false) == .reanchorProducer)
+    }
+
+    @Test("the two repairs are distinct, so a log can name which one ran")
+    func repairsAreDistinguishable() {
+        #expect(HLSVideoEngine.WedgeRepair.nudgeConsumerFirst != HLSVideoEngine.WedgeRepair.reanchorProducer)
+    }
+}


### PR DESCRIPTION
The 11 to 15 s landings @rrgomes measured after a re-aimed restart, addressed where the evidence points: at the ORDER of the repair, not at its parts.

## What the field logs say

The wedge itself is an AVPlayer state (#65 / #93: zero GETs, `waitingToMinimizeStalls` forever, the item never fails) and does not reproduce here. A 12-seek burst under a 120 kbit/s throttle on the loopback path lands every seek, with and without this change.

What both logs do settle is that the first repair could not have worked in their case:

```
21:08:52.498 #65 backpressure WEDGE BROKEN head=15 target=5 cacheTarget=4 parked=5s
21:08:52.503 #65 backpressure wedge: re-anchoring producer to 15.00s -> seg3
21:08:58.508 #65 consumer re-engage: no segment fetch for 6s after wedge re-anchor
21:08:58.748 seek#1 programmatic landed rendered=15.00 target=15.00
```

The pump had marched to segment 15 and was sent back to segment 3. Through the whole grace window the consumer fetched nothing, so the re-anchor demonstrably changed nothing, and the nudge that followed landed the seek in 240 ms. Same shape on the Mac: `seg35: served 44291341 B (restarted=true)` at +1.9 s, no further GET, nudge at +15.5 s, landed at +15.75 s.

## The change

A re-anchor is the repair for a consumer **starved** of content nobody is producing. A consumer silent about a segment that is already on disk is not starved. So the repair is chosen on that question:

- target stored → nudge the consumer first, keep the re-anchor as the fallback if the nudge does not take within the same grace window
- target not stored → unchanged (#65's original case: the pump parked ahead of a target outside the producible window)

`WEDGE BROKEN` now carries `consumerTargetStored=` and `highStored=`, so a report can say which repair a wedge called for. That is the discriminator the issue asks for first, and it had to be inferred from logs that do not state it.

## Deliberately unchanged

The 5 s park detection. Shortening it needs a measurement of what an honest early signal looks like, and a frozen clock is also what a normal seek landing looks like for a moment. This removes the 6 s spent on the repair that could not work, which is the half the logs indict.

## Verification

2070 tests green. `seektest` reports the same 0 wedge breaks / 0 producer re-anchors as before the change, so the new branch raises no false alarm on a healthy run. The effect on a real wedge can only be confirmed on the reporting setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RbWZLwBVLGM1xUVXa9NeJ1