### PR TITLE
Recovery paths must not read AVPlayer on the main actor (#422)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,24 @@ the public-API contract.
 
 ### Fixed
 
+- **Recovery and deadline paths read AVPlayer synchronously on the main actor, where a busy media
+  server blocks the whole app (AE#422).** These getters are sync XPC round trips to mediaserverd;
+  `AVFoundationOffMain` has said so since #134 ("past the watchdog threshold, a process kill") but
+  only the 30 s memory probe used it. The reporter measured `AVPlayerItem.currentTime()` from a
+  host's main actor not returning for 13.3 s during a consumer wedge, coming back 30 ms after the
+  re-engage watchdog fired, with the app frozen throughout. Every path that runs while the server is
+  the thing not answering now reads off-main or from a mirror: the seek-deadline loop took four
+  round trips per pass (one island, three `bufferedEnd`) and now takes one batched
+  `seekBufferSnapshot`; the stall nudge and the item reload read the rendered-position mirror; the
+  VOD shift-publish line awaits its buffer figure; and the #287 premature-end recovery batches its
+  three witnesses. For the recovery anchors the mirror is also the correct VALUE rather than merely
+  the cheap one: `recoveryAnchorPosition(currentRendered:)` exists to keep the anchor off a frame
+  the viewer has already passed (#115), and `currentTime()` is the clock, which diverges from the
+  rendered frame during exactly the landing those paths run in (#123). The wedge path was already
+  passing the mirror; the stall watchdog next to it was not. Reads inside `load` and the seek
+  completion are deliberately left synchronous: both run at a moment where AVPlayer has just
+  answered.
+
 - **A wedge whose target was already on disk spent six seconds re-anchoring the producer before
   nudging the consumer that was actually stuck (AE#421).** The wedge itself is an AVPlayer state
   (#65 / #93: zero GETs while the item never fails), and the ladder had one repair for it: move the

--- a/Sources/AetherEngine/AetherEngine+Diagnostics.swift
+++ b/Sources/AetherEngine/AetherEngine+Diagnostics.swift
@@ -34,17 +34,23 @@ extension AetherEngine {
 
     /// Seconds of AVPlayer buffer ahead of the current playhead (sum of loadedTimeRanges beyond now). 0 on SW path / pre-start.
     /// Surfaced in the 30 s memprobe and the #65 VOD shift-publish diagnostic so a stale cross-epoch buffer is visible.
-    func avPlayerBufferAheadSeconds() -> Double {
+    ///
+    /// AE#422: async, because it hops off the main actor. Its one caller emits from inside a producer
+    /// restart, which is a state where the media server may not answer, and a figure that only ever
+    /// appears in a log line must not be able to block the app to produce itself.
+    func avPlayerBufferAheadSeconds() async -> Double {
         guard let avPlayer = currentAVPlayer, let item = avPlayer.currentItem else { return 0 }
-        let now = item.currentTime().seconds
-        var ahead = 0.0
-        for value in item.loadedTimeRanges {
-            let range = value.timeRangeValue
-            let start = range.start.seconds
-            let end = (range.start + range.duration).seconds
-            if end > now { ahead += end - max(start, now) }
+        return await AVFoundationOffMain.read(item, on: NativeAVPlayerHost.offMainReadQueue) { item in
+            let now = item.currentTime().seconds
+            var ahead = 0.0
+            for value in item.loadedTimeRanges {
+                let range = value.timeRangeValue
+                let start = range.start.seconds
+                let end = (range.start + range.duration).seconds
+                if end > now { ahead += end - max(start, now) }
+            }
+            return ahead
         }
-        return ahead
     }
 
     // MARK: - Memory diagnostic

--- a/Sources/AetherEngine/AetherEngine+Loading.swift
+++ b/Sources/AetherEngine/AetherEngine+Loading.swift
@@ -657,6 +657,8 @@ extension AetherEngine {
                 // is still on screen those differ, and the picture is what the clock has to describe.
                 let activeShift = self.presentationAxis.shiftSeconds(atItemSeconds: self.nativeClockSeconds) ?? seconds
                 self.playlistShiftSeconds = activeShift
+                // AE#422: read off-main before building the line (see `avPlayerBufferAheadSeconds`).
+                let avBufAhead = await self.avPlayerBufferAheadSeconds()
                 // Re-fold immediately so currentTime doesn't lag the next periodic tick (origin-corrected).
                 self.clock.currentTime = PresentationAxis.display(
                     sourcePTS: self.nativeClockSeconds + activeShift,
@@ -671,7 +673,7 @@ extension AetherEngine {
                     + "foldShift=\(String(format: "%.3f", activeShift))s "
                     + "presentationOrigin=\(String(format: "%.3f", self.sourcePresentationOrigin))s "
                     + "rawClock=\(String(format: "%.2f", self.nativeClockSeconds))s "
-                    + "avBufAhead=\(String(format: "%.2f", self.avPlayerBufferAheadSeconds()))s",
+                    + "avBufAhead=\(String(format: "%.2f", avBufAhead))s",
                     category: .session
                 )
             }
@@ -732,7 +734,8 @@ extension AetherEngine {
                           player.currentItem?.status != .failed else { return }
                     // #115: read the position at reload time, same as the stall watchdog's
                     // stage 2; the wedge-trip capture is two grace windows stale by now.
-                    self.reloadStalledConsumerItem(position: player.currentTime().seconds)
+                    // AE#422: the mirror, not a sync XPC read on the main actor from inside a stall.
+                    self.reloadStalledConsumerItem(position: self.renderedPositionMirror.get())
                 }
             }
         }
@@ -1203,8 +1206,10 @@ extension AetherEngine {
                           let player = self.currentAVPlayer else { return }
                     // Stage 1: nudge seek. Device-proven to reach AVPlayer (rate re-asserts)
                     // but NOT always to revive its loader; stage 2 covers that.
+                    // AE#422: same read the wedge path already takes from the mirror. This one was
+                    // the sync XPC round trip the reporter caught blocking the app for 13.3 s.
                     self.reengageStalledConsumer(
-                        position: player.currentTime().seconds,
+                        position: self.renderedPositionMirror.get(),
                         trigger: "stall + \(Int(Self.stallReengageGraceSeconds))s without fetches")
                     // Stage 2: the -15628 loader poison ignores seeks; only a fresh item resets
                     // it. Escalate when the consumer stays silent through a second grace window.

--- a/Sources/AetherEngine/AetherEngine.swift
+++ b/Sources/AetherEngine/AetherEngine.swift
@@ -1828,9 +1828,17 @@ public final class AetherEngine: ObservableObject {
         guard let host = nativeHost, let player = currentAVPlayer,
               let item = player.currentItem else { return }
         guard player.timeControlStatus != .paused else { return }
+        // AE#422: the rendered position comes from the mirror, not from `player.currentTime()`.
+        // Two reasons, and either one is enough. It is the right VALUE: this parameter exists to keep
+        // the anchor from sitting below the frame on screen (#115), and `currentTime()` is the clock,
+        // which diverges from the rendered frame during exactly the landing this runs in (#123).
+        // And it is the right THREAD: `currentTime()` is a sync XPC round trip to mediaserverd, and
+        // this line runs on the main actor in the one state where that server is not answering. The
+        // reporter measured 13.3 s of fully blocked app on such a read, returning 30 ms after the
+        // watchdog fired. The mirror is written by the periodic observer and costs a lock.
         let anchor = Self.recoveryAnchorPosition(
             frozenPosition: position, pendingSeekTarget: pendingRecoverySeekClockTarget,
-            currentRendered: player.currentTime().seconds)
+            currentRendered: renderedPositionMirror.get())
         stallRecoveryWindowUntil = Date().addingTimeInterval(Self.stallRecoveryWindowSeconds)
         EngineLog.emit(
             "[AetherEngine] #65 re-engaging stalled AVPlayer (\(trigger)): nudge seek to "
@@ -2070,9 +2078,11 @@ public final class AetherEngine: ObservableObject {
         guard Self.stalledConsumerRecoveryAllowed(
             consumerIsPaused: player.timeControlStatus == .paused,
             allowPausedConsumer: allowPausedConsumer) else { return }
+        // AE#422: mirror, not `currentTime()`. See `reengageStalledConsumer`; this path runs one
+        // grace window deeper into the same stall.
         let anchor = Self.recoveryAnchorPosition(
             frozenPosition: position, pendingSeekTarget: pendingRecoverySeekClockTarget,
-            currentRendered: player.currentTime().seconds)
+            currentRendered: renderedPositionMirror.get())
         stallRecoveryWindowUntil = Date().addingTimeInterval(Self.stallRecoveryWindowSeconds)
         EngineLog.emit(
             "[AetherEngine] #65 nudge did not revive the consumer; reloading item at "
@@ -4082,8 +4092,12 @@ public final class AetherEngine: ObservableObject {
                 // window is only wide enough to keep a FAR backward target clear of it, and a near one
                 // (less than the window back) would otherwise read the old, full buffer as progress at the
                 // target and earn an extension the producer never served.
-                let targetIsland = host.bufferedSecondsAtTarget(
-                    clockTarget, excludeAtOrAbove: seekIsForward ? nil : avpReal)
+                // AE#422: one off-main reading for both figures. This loop runs while a seek is not
+                // landing, so every synchronous read here is taken in the state where the media
+                // server is least likely to answer, and it was doing four of them per pass.
+                let bufferSnapshot = await host.seekBufferSnapshot(
+                    target: clockTarget, excludeAtOrAbove: seekIsForward ? nil : avpReal)
+                let targetIsland = bufferSnapshot.targetIsland
                 if Self.shouldExtendSeekDeadlineForProgress(
                     targetIslandSeconds: targetIsland,
                     previousIslandSeconds: lastTargetIslandSeconds,
@@ -4106,7 +4120,7 @@ public final class AetherEngine: ObservableObject {
                         "[AetherEngine] seek slow but producer serving target "
                         + "(island=\(String(format: "%.2f", targetIsland))s at target, "
                         + "rendered=\(String(format: "%.2f", avpReal))s "
-                        + "buffered=\(String(format: "%.2f", host.bufferedEnd))s); extending budget "
+                        + "buffered=\(String(format: "%.2f", bufferSnapshot.bufferedEnd))s); extending budget "
                         + "\(deadlineExtensionsUsed)/\(Self.nativeSeekMaxDeadlineExtensions)",
                         category: .engine
                     )
@@ -4130,7 +4144,7 @@ public final class AetherEngine: ObservableObject {
                 // the re-anchored region, and wait for it to land -- reconciling FORWARD to the target,
                 // never back to the rendered position.
                 let wasStarved = seekIsWedged(
-                    renderedTime: avpReal, bufferedEnd: host.bufferedEnd)
+                    renderedTime: avpReal, bufferedEnd: bufferSnapshot.bufferedEnd)
                 // `targetBeyondCoverage` (AE#141) was computed above, before the extend branch, so it
                 // gates both the extension and this re-anchor decision.
                 let reason = wasStarved
@@ -4162,7 +4176,7 @@ public final class AetherEngine: ObservableObject {
                         + "\(reason), "
                         + "island=\(String(format: "%.2f", targetIsland))s at target, "
                         + "rendered=\(String(format: "%.2f", avpReal))s "
-                        + "buffered=\(String(format: "%.2f", host.bufferedEnd))s); holding clock at target "
+                        + "buffered=\(String(format: "%.2f", bufferSnapshot.bufferedEnd))s); holding clock at target "
                         + "\(String(format: "%.2f", target))s"
                         + (didReanchor
                             ? " and re-anchored producer at \(String(format: "%.2f", recoveryAnchor))s, re-seeking"

--- a/Sources/AetherEngine/Native/NativeAVPlayerHost.swift
+++ b/Sources/AetherEngine/Native/NativeAVPlayerHost.swift
@@ -10,6 +10,21 @@ import MediaPlayer
 /// tvOS exposes the HDMI DV/HDR handshake only through AVPlayer-rooted playback, not AVSampleBufferDisplayLayer.
 /// Covers HEVC, H.264, and HW-AV1; SW fallback (AV1/VP9) lives in SoftwarePlaybackHost.
 /// DisplayCriteriaController writes preferredDisplayCriteria before item load so the handshake is in flight first.
+/// AE#422: what the seek-deadline loop needs from AVPlayer, as one off-main reading.
+/// AE#422 / AE#287: what the premature-end recovery needs from AVPlayer, as one off-main reading.
+struct PrematureEndReading: Sendable {
+    let playhead: Double
+    let seekableEnd: Double?
+    let loadedEnd: Double?
+}
+
+struct SeekBufferSnapshot: Sendable {
+    /// End of the contiguous buffered span covering the playhead.
+    let bufferedEnd: Double
+    /// Loaded seconds measured AT the pending seek target, not at the playhead.
+    let targetIsland: Double
+}
+
 @MainActor
 final class NativeAVPlayerHost {
 
@@ -843,22 +858,46 @@ final class NativeAVPlayerHost {
         return end.isFinite ? end : 0
     }
 
-    /// End of the contiguous buffered span covering the playhead (AetherEngine#54); disjoint ranges ahead of a gap are ignored.
-    var bufferedEnd: Double {
-        guard let item = avPlayer.currentItem else { return 0 }
-        let now = item.currentTime().seconds
+    /// End of the contiguous buffered span covering the playhead (AetherEngine#54); disjoint ranges
+    /// ahead of a gap are ignored. Pure, so the reading can be taken off the main actor (AE#422).
+    nonisolated static func contiguousBufferedEnd(ranges: [(Double, Double)], now: Double) -> Double {
         guard now.isFinite else { return 0 }
         var end = now
-        for value in item.loadedTimeRanges {
-            let r = value.timeRangeValue
-            let s = r.start.seconds
-            let e = (r.start + r.duration).seconds
-            guard s.isFinite, e.isFinite else { continue }
+        for (start, endpoint) in ranges {
+            guard start.isFinite, endpoint.isFinite else { continue }
             // Contiguous with the playhead (small tolerance for the gap
             // between the rendered frame and the range's reported start).
-            if s <= now + 1.0 && e >= now { end = max(end, e) }
+            if start <= now + 1.0 && endpoint >= now { end = max(end, endpoint) }
         }
         return end
+    }
+
+    /// AE#422: the queue every figplayer-backed read hops onto. A stalled reply parks a GCD thread
+    /// rather than the main thread, which past the watchdog threshold is a process kill.
+    nonisolated static let offMainReadQueue = DispatchQueue(
+        label: "engine.avplayerhost.avfread", qos: .userInitiated)
+
+    /// AE#422: everything the seek-deadline loop measures, read ONCE and off the main actor.
+    ///
+    /// That loop runs precisely while a seek is not landing, which is the state in which the media
+    /// server is least likely to answer, and it was taking four synchronous XPC round trips per pass
+    /// on the main actor (one island, three `bufferedEnd`). The reporter measured 13.3 s of fully
+    /// blocked app on one such read, returning 30 ms after the re-engage watchdog fired. Batching
+    /// also makes the two figures one consistent reading rather than four moments.
+    func seekBufferSnapshot(target: Double, excludeAtOrAbove: Double?) async -> SeekBufferSnapshot {
+        guard let item = avPlayer.currentItem else { return SeekBufferSnapshot(bufferedEnd: 0, targetIsland: 0) }
+        return await AVFoundationOffMain.read(item, on: Self.offMainReadQueue) { item in
+            let now = item.currentTime().seconds
+            let ranges = item.loadedTimeRanges.map { value -> (Double, Double) in
+                let r = value.timeRangeValue
+                return (r.start.seconds, (r.start + r.duration).seconds)
+            }
+            return SeekBufferSnapshot(
+                bufferedEnd: NativeAVPlayerHost.contiguousBufferedEnd(ranges: ranges, now: now),
+                targetIsland: NativeAVPlayerHost.bufferedSecondsInWindow(
+                    ranges: ranges, target: target, tolerance: 1.0, window: 30.0,
+                    excludeAtOrAbove: excludeAtOrAbove))
+        }
     }
 
     /// Seconds of media buffered *at the pending seek target*, i.e. how much the producer has actually
@@ -880,23 +919,8 @@ final class NativeAVPlayerHost {
     /// measurement origin: the reason this function ignores the playhead is that a figure measured *from*
     /// one is meaningless while `currentTime()` and `renderedTime` diverge, and clamping a range does not
     /// reintroduce that.
-    func bufferedSecondsAtTarget(
-        _ target: Double,
-        tolerance: Double = 1.0,
-        window: Double = 30.0,
-        excludeAtOrAbove: Double? = nil
-    ) -> Double {
-        guard let item = avPlayer.currentItem else { return 0 }
-        return Self.bufferedSecondsInWindow(
-            ranges: item.loadedTimeRanges.map {
-                let r = $0.timeRangeValue
-                return (r.start.seconds, (r.start + r.duration).seconds)
-            },
-            target: target,
-            tolerance: tolerance,
-            window: window,
-            excludeAtOrAbove: excludeAtOrAbove)
-    }
+    // AE#422: the main-actor reader that used to sit here is gone; `seekBufferSnapshot` is the only
+    // way in, so a stall-adjacent caller cannot accidentally take the blocking route again.
 
     /// Pure part of `bufferedSecondsAtTarget(_:tolerance:window:excludeAtOrAbove:)`: total loaded seconds
     /// intersecting the target window, with the optional exclusion bound applied.
@@ -978,8 +1002,13 @@ final class NativeAVPlayerHost {
         // Only resume what the viewer was playing: an item that ends while the transport is parked
         // must stay parked.
         guard playIntent, !didReachEnd else { return false }
-        let playhead = avPlayer.currentTime().seconds
-        let seekEnd = seekableRangeEndSeconds
+        // AE#422: one batched off-main reading. A premature end IS a state where the media server is
+        // misreporting, so "one read at a rare event" (the note that used to stand on
+        // `seekableRangeEndSeconds`) is not the cheap thing it looks like: the reporter measured a
+        // single such read holding the main thread for 13.3 s.
+        let reading = await prematureEndReading()
+        let playhead = reading.playhead
+        let seekEnd = reading.seekableEnd
         guard AetherEngine.prematureEndRecoveryQualifies(
             isLive: isLiveSession,
             duration: duration,
@@ -996,7 +1025,7 @@ final class NativeAVPlayerHost {
             "[NativeAVPlayerHost] #\(sessionID) AE#287 premature end: playhead="
             + "\(String(format: "%.3f", playhead))s duration=\(String(format: "%.3f", duration))s "
             + "seekableEnd=\(String(format: "%.3f", seekEnd ?? -1))s "
-            + "loadedEnd=\(String(format: "%.3f", loadedRangeEndSeconds ?? -1))s; "
+            + "loadedEnd=\(String(format: "%.3f", reading.loadedEnd ?? -1))s; "
             + "\(String(format: "%.1f", duration - playhead))s of the presentation lies past the end "
             + "AVPlayer reported, re-seeking in place (attempt \(prematureEndRecoveryAttempts))",
             category: .engine)
@@ -1004,30 +1033,37 @@ final class NativeAVPlayerHost {
         avPlayer.play()
         prematureEndRecoveryInFlight = false
         timeControlStatus = avPlayer.timeControlStatus
+        let resumedAt = await prematureEndReading().playhead
         EngineLog.emit(
             "[NativeAVPlayerHost] #\(sessionID) AE#287 resumed: rate=\(avPlayer.rate) "
-            + "t=\(String(format: "%.3f", avPlayer.currentTime().seconds))s",
+            + "t=\(String(format: "%.3f", resumedAt))s",
             category: .engine)
         return true
     }
 
-    /// End of AVPlayer's last seekable time range, in item seconds: the extent of the presentation it
-    /// parsed from the playlist. Read from the item rather than the `seekableEnd` KVO mirror, which
-    /// exists to keep the LIVE edge off a tick-cadence read (#134); this is one read at a rare event.
-    private var seekableRangeEndSeconds: Double? {
-        guard let last = playerItem?.seekableTimeRanges.last?.timeRangeValue else { return nil }
-        let end = CMTimeGetSeconds(CMTimeAdd(last.start, last.duration))
-        return end.isFinite ? end : nil
+    /// AE#422: the three figures the #287 recovery needs, read once and off the main actor.
+    private func prematureEndReading() async -> PrematureEndReading {
+        guard let item = playerItem else {
+            return PrematureEndReading(playhead: 0, seekableEnd: nil, loadedEnd: nil)
+        }
+        return await AVFoundationOffMain.read(item, on: Self.offMainReadQueue) { item in
+            func endOf(_ ranges: [NSValue]) -> Double? {
+                guard let last = ranges.last?.timeRangeValue else { return nil }
+                let end = CMTimeGetSeconds(CMTimeAdd(last.start, last.duration))
+                return end.isFinite ? end : nil
+            }
+            return PrematureEndReading(
+                playhead: item.currentTime().seconds,
+                seekableEnd: endOf(item.seekableTimeRanges),
+                loadedEnd: endOf(item.loadedTimeRanges))
+        }
     }
 
-    /// Raw end of AVPlayer's last loaded time range, in item seconds; diagnostics only. It is NOT the
-    /// #287 witness: measured at a premature end, AVPlayer has already trimmed this range back to the
-    /// exhaustion point, so it corroborates the mistake instead of refuting it.
-    private var loadedRangeEndSeconds: Double? {
-        guard let last = playerItem?.loadedTimeRanges.last?.timeRangeValue else { return nil }
-        let end = CMTimeGetSeconds(CMTimeAdd(last.start, last.duration))
-        return end.isFinite ? end : nil
-    }
+    /// AE#287 witnesses, now read through `prematureEndReading()`. `seekableEnd` is the extent of the
+    /// presentation AVPlayer parsed from the playlist, read from the item rather than the KVO mirror
+    /// (which exists to keep the LIVE edge off a tick-cadence read, #134). `loadedEnd` is diagnostics
+    /// only and is NOT the witness: measured at a premature end, AVPlayer has already trimmed that
+    /// range back to the exhaustion point, so it corroborates the mistake instead of refuting it.
 
     /// Resolve only when the seek physically lands (loopback source lands seeks seconds after the call; issue #37).
     /// seekInFlight suppresses the periodic observer across the wait; only the latest seekGeneration clears it.

--- a/Tests/AetherEngineTests/Issue422OffMainPlayerReadsTests.swift
+++ b/Tests/AetherEngineTests/Issue422OffMainPlayerReadsTests.swift
@@ -1,0 +1,91 @@
+import Testing
+import Foundation
+@testable import AetherEngine
+
+/// AE#422 (rrgomes): on macOS, an `AVPlayerItem.currentTime()` made from the host's main actor did
+/// not return for 13.3 s while AVPlayer was wedged, blocking the whole app; it came back 30 ms after
+/// the re-engage watchdog fired. The engine read the same property from the same place.
+///
+/// `AVFoundationOffMain` already carried the reason ("a momentarily busy media server turns any of
+/// them into a fully blocked main thread and, past the watchdog threshold, a process kill"), but only
+/// the 30 s memory probe used it. The paths that run precisely while the server is not answering did
+/// not:
+///
+/// | path | reads per pass | now |
+/// | --- | --- | --- |
+/// | seek-deadline loop | 1 island + 3 `bufferedEnd` | one batched `seekBufferSnapshot` off-main |
+/// | stall nudge / reload | `currentTime()` at the call site and again inside | `renderedPositionMirror` |
+/// | VOD shift-publish line | `avPlayerBufferAheadSeconds()` | off-main, awaited before the line |
+/// | premature-end recovery (#287) | playhead + seekable + loaded | one batched reading off-main |
+///
+/// The mirror is not just the non-blocking choice for the recovery anchors, it is the correct value:
+/// `recoveryAnchorPosition(currentRendered:)` exists to keep the anchor from sitting below the frame
+/// on screen (#115), and `currentTime()` is the clock, which diverges from the rendered frame during
+/// exactly the landing these run in (#123). The wedge path was already passing the mirror.
+///
+/// What is verified here is the logic that came out of the main actor with the reads. `bufferedEnd`
+/// used to be a `@MainActor` property wrapped around a blocking round trip, so its rule (the span
+/// CONTIGUOUS with the playhead, disjoint islands ahead of a gap ignored) had no test at all.
+struct Issue422OffMainPlayerReadsTests {
+
+    private static func end(_ ranges: [(Double, Double)], now: Double) -> Double {
+        NativeAVPlayerHost.contiguousBufferedEnd(ranges: ranges, now: now)
+    }
+
+    @Test("an empty buffer ends at the playhead, not at zero")
+    func emptyBufferEndsAtPlayhead() {
+        // The #65 reporter signature: `loaded=[]` with the clock frozen, which `seekIsWedged` reads
+        // as starved precisely because bufferedEnd equals renderedTime.
+        #expect(Self.end([], now: 149.9) == 149.9)
+    }
+
+    @Test("the range covering the playhead sets the end")
+    func coveringRangeSetsEnd() {
+        #expect(Self.end([(100.0, 158.0)], now: 149.9) == 158.0)
+    }
+
+    @Test("an island beyond a gap does not count")
+    func disjointIslandIgnored() {
+        // A far-forward seek's target island is real buffer, but it is not contiguous with the
+        // playhead, so it must not read as "this consumer is fed" (AE#141).
+        #expect(Self.end([(100.0, 150.5), (300.0, 330.0)], now: 149.9) == 150.5)
+    }
+
+    @Test("a range starting within a second of the playhead still counts as contiguous")
+    func toleranceAtTheHead() {
+        // The gap between the rendered frame and the range's reported start is normal.
+        #expect(Self.end([(150.5, 160.0)], now: 149.9) == 160.0)
+        // Past the tolerance it is a hole, and the buffer ends at the playhead.
+        #expect(Self.end([(151.5, 160.0)], now: 149.9) == 149.9)
+    }
+
+    @Test("a range wholly behind the playhead does not extend the end")
+    func behindRangeIgnored() {
+        #expect(Self.end([(100.0, 140.0)], now: 149.9) == 149.9)
+    }
+
+    @Test("adjacent ranges are not chained: only a range touching the playhead counts")
+    func adjacentRangesAreNotChained() {
+        // Behaviour as it has stood since AetherEngine#54, recorded rather than changed: each range
+        // is judged against the PLAYHEAD, not against the running end, so `[100, 152]` counts and the
+        // `[152, 170]` that continues it does not. AVFoundation normally reports a contiguous span as
+        // one range, so this rarely bites, but where it does the figure understates the buffer, and
+        // `seekIsWedged` reads an understated buffer as starvation. Worth its own measurement before
+        // anyone changes it; this test exists so the change would be visible.
+        #expect(Self.end([(100.0, 152.0), (152.0, 170.0)], now: 149.9) == 152.0)
+        // A single range covering the same span reads the full extent.
+        #expect(Self.end([(100.0, 170.0)], now: 149.9) == 170.0)
+    }
+
+    @Test("a non-finite playhead reads as no buffer rather than as NaN")
+    func nonFinitePlayhead() {
+        // `currentTime()` is indefinite before the first sample, and a NaN escaping here would
+        // silently poison `seekIsWedged`.
+        #expect(Self.end([(100.0, 158.0)], now: .nan) == 0)
+    }
+
+    @Test("a non-finite range is skipped rather than poisoning the result")
+    func nonFiniteRangeSkipped() {
+        #expect(Self.end([(Double.nan, 158.0), (100.0, 152.0)], now: 149.9) == 152.0)
+    }
+}


### PR DESCRIPTION
The 13.3 s main-thread block @rrgomes measured, and the audit it prompted.

## The rule that existed but was not applied

`AVFoundationOffMain` has carried the reason since #134: these getters are synchronous XPC round trips to mediaserverd, and "on the main actor a momentarily busy media server turns any of them into a fully blocked main thread and, past the watchdog threshold, a process kill". Only the 30 s memory probe used it. The paths that run precisely BECAUSE the server is not answering read the player directly.

| path | reads per pass | now |
| --- | --- | --- |
| seek-deadline loop | 1 island + 3 `bufferedEnd` | one batched `seekBufferSnapshot`, off-main |
| stall nudge / item reload | `currentTime()` at the call site and again inside | `renderedPositionMirror` |
| VOD shift-publish line | `avPlayerBufferAheadSeconds()` | awaited off-main |
| premature-end recovery (#287) | playhead + seekable + loaded | one batched reading |

The seek-deadline loop is the sharpest of these: it runs while a seek is not landing, which is exactly the state the block was measured in, and it was taking four round trips per pass.

## The mirror is also the right value

`recoveryAnchorPosition(currentRendered:)` exists to keep a recovery anchor from sitting below the frame already on screen (#115). `currentTime()` is the clock, and the clock diverges from the rendered frame during exactly the landing these paths run in (#123). The wedge path was already passing the mirror; the stall watchdog beside it was reading the player. So this is a correctness fix as much as a threading one.

## Left alone on purpose

The reads inside `load()` and the seek completion. Both run at a moment where AVPlayer has just answered.

## A property nobody had written down

Taking the reads off the main actor took the logic out with them: `bufferedEnd` was a `@MainActor` property wrapped around a blocking round trip, so its rule had no test at all. `contiguousBufferedEnd` is pure now and has eight. One of them records something the old shape hid: ranges are judged against the playhead rather than against the running end, so `[100,152]` and `[152,170]` do not chain and the figure understates the buffer. Recorded rather than changed, because `seekIsWedged` reads an understated buffer as starvation, and that deserves its own measurement.

## Verification

2078 tests green. `seektest` reports the same tallies and the same `settleError` as before the change, and a `--picture-probe` run is unchanged. The block itself needs a wedged media server and can only be confirmed on the reporting setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RbWZLwBVLGM1xUVXa9NeJ1