### PR TITLE
diag(video): the #409 verdict line names the cadence it measured

### DIFF
--- a/Sources/AetherEngine/Video/H264CompositionOffsetRepair.swift
+++ b/Sources/AetherEngine/Video/H264CompositionOffsetRepair.swift
@@ -729,8 +729,15 @@ final class H264CompositionOffsetRepairSession {
         )
         switch verdict {
         case .repair(let plan):
+            // The cadence and its phase belong in the line: on a fractional ladder they are the
+            // reading the verdict rests on, and a repair that reports only a rounded step cannot be
+            // told apart from one that measured the ladder wrong.
+            let cadenceDescription = plan.cadence.map {
+                " cadence=\($0.numerator)/\($0.denominator) phase=\(plan.ladderPhase)"
+                    + " ladderAhead=\(plan.ladderOrdinalOffset)"
+            } ?? ""
             verdictDescription = "repair step=\(plan.step) lead=\(plan.decodeLead) "
-                + "shift=\(plan.shift) pocStep=\(plan.pocStep)"
+                + "shift=\(plan.shift) pocStep=\(plan.pocStep)" + cadenceDescription
             phase = .repairing
             var rewriter = H264CompositionOffsetRepair.Rewriter(plan: plan)
             for entry in held where entry.packet.pointee.stream_index == streamIndex {


### PR DESCRIPTION
On a fractional ladder the cadence and its phase are the reading the whole verdict rests on, and a line that reports only a rounded step cannot be told apart from one that measured the ladder wrong. The confirmation line now carries them:

    #409 missing H.264 composition offsets confirmed on stream 0: repair step=40040 lead=80081
    shift=80081 pocStep=2 cadence=200202/5 phase=3 ladderAhead=2 samples=12

A whole-tick ladder logs exactly what it logged before, so the existing vocabulary is unchanged.

`swift test`: 2092 tests in 296 suites, green.