### PR TITLE
fix(audio): rebuild the resampler when a frame's input format changes mid-stream

### DIFF
--- a/Sources/AetherEngine/Audio/AudioDecoder.swift
+++ b/Sources/AetherEngine/Audio/AudioDecoder.swift
@@ -42,6 +42,14 @@ final class AudioDecoder: @unchecked Sendable {
     private var _loggedZeroConvert = false
     #endif
 
+    /// Input parameters the current `swrContext` was built for (AE#452). `decode()`/`drain()` compare
+    /// each frame against these and rebuild on a mid-stream change: a live splice can swap the
+    /// stream's audio configuration (5.1 <-> stereo at a program boundary), and a context built for
+    /// more input planes than the frame carries reads a NULL plane inside swr_convert.
+    private var configuredInLayout = AVChannelLayout()
+    private var configuredInFormat: Int32 = AV_SAMPLE_FMT_NONE.rawValue
+    private var configuredInRate: Int32 = 0
+
     private(set) var sampleRate: Int32 = 0
     private(set) var channels: Int32 = 0
 
@@ -99,6 +107,9 @@ final class AudioDecoder: @unchecked Sendable {
             // most and recovers immediately.
             if swrContext == nil {
                 if !initResamplerFromFrame(f) { continue }
+            } else if inputFormatChanged(f) {
+                if let sampleBuffer = rebuildResampler(for: f) { results.append(sampleBuffer) }
+                if swrContext == nil { continue }
             }
             appendFrameToPending(f)
             if pendingSampleCount >= Self.minSamplesPerBuffer {
@@ -111,8 +122,41 @@ final class AudioDecoder: @unchecked Sendable {
         return results
     }
 
+    /// True when `frame`'s input parameters no longer match what the resampler was built for (AE#452).
+    /// Layout is compared only when the frame carries a valid one: an UNSPEC frame fell back to the
+    /// synthesised default at init and must not force a rebuild on every frame.
+    private func inputFormatChanged(_ frame: UnsafeMutablePointer<AVFrame>) -> Bool {
+        if frame.pointee.sample_rate > 0, frame.pointee.sample_rate != configuredInRate { return true }
+        if frame.pointee.format != AV_SAMPLE_FMT_NONE.rawValue,
+           frame.pointee.format != configuredInFormat { return true }
+        if frame.pointee.ch_layout.nb_channels > 0,
+           av_channel_layout_compare(&frame.pointee.ch_layout, &configuredInLayout) > 0 { return true }
+        return false
+    }
+
+    /// Tear down and rebuild the resampler for a frame whose input parameters changed mid-stream
+    /// (AE#452). Emits the accumulator first — its bytes are in the OLD output format and must be
+    /// neither dropped nor mixed with the new format's — and returns that buffer, if any. The gapless
+    /// clock's sample count is denominated in the old rate, so it resets and the next buffer
+    /// re-anchors from its own container PTS. On a failed rebuild `swrContext` stays nil and the
+    /// caller skips the frame; the next frame retries, mirroring the lazy-init failure mode.
+    private func rebuildResampler(for frame: UnsafeMutablePointer<AVFrame>) -> CMSampleBuffer? {
+        let flushed = emitPending()
+        EngineLog.emit(
+            "[AudioDecoder] input format changed mid-stream ("
+            + "\(configuredInRate)Hz/\(configuredInLayout.nb_channels)ch/fmt=\(configuredInFormat)"
+            + " -> \(frame.pointee.sample_rate)Hz/\(frame.pointee.ch_layout.nb_channels)ch/fmt=\(frame.pointee.format)"
+            + "); rebuilding resampler",
+            category: .swPlayback)
+        swr_free(&swrContext)
+        clock.reset()
+        _ = initResamplerFromFrame(frame)
+        return flushed
+    }
+
     private func initResamplerFromFrame(_ frame: UnsafeMutablePointer<AVFrame>) -> Bool {
-        // Refresh rate/channels from the frame (codecpar was a hint, the frame is truth). Once per track.
+        // Refresh rate/channels from the frame (codecpar was a hint, the frame is truth). Runs on the
+        // first frame and again after a mid-stream format change tore the context down (AE#452).
         if frame.pointee.sample_rate > 0 { sampleRate = frame.pointee.sample_rate }
         let frameChannels = frame.pointee.ch_layout.nb_channels
         if frameChannels > 0 && frameChannels <= 8 { channels = frameChannels }
@@ -162,6 +206,12 @@ final class AudioDecoder: @unchecked Sendable {
             return false
         }
 
+        // What this context was built for; inputFormatChanged() compares each frame against these (AE#452).
+        av_channel_layout_uninit(&configuredInLayout)
+        av_channel_layout_copy(&configuredInLayout, &inLayout)
+        configuredInFormat = frame.pointee.format
+        configuredInRate = inRate
+
         #if DEBUG
         EngineLog.emit("[AudioDecoder] Resampler ready: \(sampleRate)Hz, \(channels)ch, inFmt=\(inFmt.rawValue)", category: .swPlayback)
         #endif
@@ -200,6 +250,9 @@ final class AudioDecoder: @unchecked Sendable {
             while avcodec_receive_frame(ctx, f) >= 0 {
                 if swrContext == nil {
                     if !initResamplerFromFrame(f) { continue }
+                } else if inputFormatChanged(f) {
+                    if let sampleBuffer = rebuildResampler(for: f) { results.append(sampleBuffer) }
+                    if swrContext == nil { continue }
                 }
                 appendFrameToPending(f)
                 if pendingSampleCount >= Self.minSamplesPerBuffer {
@@ -221,6 +274,8 @@ final class AudioDecoder: @unchecked Sendable {
         if swrContext != nil {
             swr_free(&swrContext)
         }
+        // The stored copy may hold an allocated channel map for custom-order layouts (AE#452).
+        av_channel_layout_uninit(&configuredInLayout)
         codecContext = nil
         swrContext = nil
         audioFormatDescription = nil


### PR DESCRIPTION
Fixes #452.

`AudioDecoder` builds its `SwrContext` lazily from the first decoded frame and never revisits it. A live splice that swaps the stream's audio configuration mid-session (5.1 ↔ stereo at a program boundary is routine on European broadcast TS) leaves the context configured for the first frame's layout; a context built for more input planes than the frame carries reads a NULL plane inside `swr_convert` and crashes the demux thread. Full fault analysis (disassembly, registers, KSCrash capture) is in the issue.

**The fix:** record the input parameters the context was built for (`ch_layout` copy, `format`, rate) and compare each received frame against them in `decode()` and `drain()`. On a change:

1. `emitPending()` first — the accumulator's bytes are in the OLD output format and must be neither dropped nor mixed with the new format's;
2. `swr_free` + re-run the existing `initResamplerFromFrame(_:)`, which also rebuilds the `CMAudioFormatDescription` so the renderer sees the new ASBD on subsequent buffers;
3. reset the gapless `AudioClockAnchor` — its emitted-sample count is denominated in the old rate; the next buffer re-anchors from its own container PTS.

A failed rebuild leaves `swrContext` nil and skips the frame; the next frame retries, mirroring the lazy-init failure mode. The layout compare only runs when the frame carries a valid layout, so an UNSPEC stream that fell back to the synthesised default at init does not rebuild per frame. A rate/format switch that previously resampled garbage silently (an HE-AAC first frame at the core rate, say) now rebuilds too.

**Field-verified on device** (Apple TV 4K 3rd gen, tvOS 26.6, this branch as a local override on 6.56.5): tuned the crashing channel, hit a real on-air AC-3 5.1 → stereo splice two minutes in —

```
21:50:11.110 [AudioDecoder] Resampler ready: 48000Hz, 6ch, inFmt=8
21:51:51.735 [AudioDecoder] input format changed mid-stream (48000Hz/6ch/fmt=8 -> 48000Hz/2ch/fmt=8); rebuilding resampler
21:51:51.735 [AudioDecoder] Resampler ready: 48000Hz, 2ch, inFmt=8
```

One detection, no flapping; the SW diag line holds `dclk=1.00 / status=rendering` straight through the seam, playback continues cleanly. On 6.56.5 this exact moment is the crash from the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HewBbYmNEut2WvoEHmeBRU
