### PR TITLE
fix(video): move AV1 planar conversion onto Metal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,19 @@ the public-API contract.
 
 ## [Unreleased]
 
-_Nothing yet._
+### Fixed
+
+- **4K AV1 software playback no longer spends CPU converting every decoded frame to NV12/P010.**
+  On Apple TV, dav1d outputs planar 4:2:0 and the software decoder previously followed it with a
+  full-frame `sws_scale` conversion before enqueueing the frame. A 3840x2160/23.976 source measured
+  roughly 464% process CPU and could not maintain a display cushion, while a native-Metal player
+  handled the same file. AV1 `YUV420P`, `YUVJ420P`, and `YUV420P10LE` frames now upload their planes
+  to reused Metal textures and write NV12/P010 directly into the existing IOSurface-backed pixel
+  buffer pool. The sample-buffer renderer, subtitles, seeking, PiP, colour/SAR attachments, and
+  frame pacing are unchanged. Missing Metal, unsupported layouts, invalid strides, texture/shader
+  failures, or GPU command failures disable the fast path for that session and fall back to
+  `sws_scale`. Exact GPU readback tests cover NV12, low-aligned 10-bit to high-aligned P010 packing,
+  and the negative-stride fallback; pure range tests cover the P010 full-range mapping.
 
 ## [6.57.1] - 2026-08-31
 

--- a/Package.swift
+++ b/Package.swift
@@ -67,6 +67,7 @@ let package = Package(
                 .linkedFramework("CoreVideo"),
                 .linkedFramework("VideoToolbox"),
                 .linkedFramework("AudioToolbox"),
+                .linkedFramework("Metal"),
             ]
         ),
         .target(

--- a/Sources/AetherEngine/Decoder/MetalYUVConverter.swift
+++ b/Sources/AetherEngine/Decoder/MetalYUVConverter.swift
@@ -1,0 +1,339 @@
+import Foundation
+import CoreVideo
+import AetherLibavcodec
+import AetherLibavutil
+
+#if canImport(Metal)
+import Metal
+
+/// Small, session-scoped YUV420P/YUV420P10LE -> NV12/P010 converter.
+///
+/// The source planes are uploaded into three reused shared textures and the destination
+/// textures are views of the decoder's IOSurface-backed CVPixelBuffer.  The command buffer is
+/// waited on before returning: callers may immediately enqueue the sample and the pool may
+/// recycle the buffer without racing the compute pass.
+final class MetalYUVConverter {
+    enum Result: Equatable {
+        case converted
+        case unavailable(String)
+        case failed(String)
+    }
+
+    /// This is deliberately a format policy, independent of device availability, so routing can
+    /// be tested on CI machines without a Metal device.
+    static func supports(codecID: AVCodecID, pixelFormat: AVPixelFormat) -> Bool {
+        guard codecID == AV_CODEC_ID_AV1 else { return false }
+        return pixelFormat == AV_PIX_FMT_YUV420P
+            || pixelFormat == AV_PIX_FMT_YUVJ420P
+            || pixelFormat == AV_PIX_FMT_YUV420P10LE
+    }
+
+    /// Convert FFmpeg's low-aligned 10-bit code value to the high-aligned P010 word. Kept as a
+    /// small pure seam for exactness tests; the Metal kernel mirrors this integer arithmetic.
+    static func p010Code(value: UInt16, fullRange: Bool, chroma: Bool = false) -> UInt16 {
+        let input = UInt32(min(value, 1023))
+        let code: UInt32
+        if fullRange {
+            let span: UInt32 = chroma ? 896 : 876
+            let offset: UInt32 = 64
+            code = offset + (input * span + 511) / 1023
+        } else {
+            let low: UInt32 = 64
+            let high: UInt32 = chroma ? 960 : 940
+            code = min(max(input, low), high)
+        }
+        return UInt16(min(code, 1023) << 6)
+    }
+
+    private struct Parameters {
+        var fullRange: UInt32
+    }
+
+    private let device: MTLDevice?
+    private let commandQueue: MTLCommandQueue?
+    private let textureCache: CVMetalTextureCache?
+    private var pipeline8: MTLComputePipelineState?
+    private var pipeline10: MTLComputePipelineState?
+    private var sourceY: MTLTexture?
+    private var sourceU: MTLTexture?
+    private var sourceV: MTLTexture?
+    private var sourceWidth = 0
+    private var sourceHeight = 0
+    private var source10Bit = false
+    private var initializationFailure: String?
+
+    init() {
+        guard let device = MTLCreateSystemDefaultDevice() else {
+            self.device = nil
+            self.commandQueue = nil
+            self.textureCache = nil
+            initializationFailure = "no Metal device"
+            return
+        }
+        self.device = device
+        guard let queue = device.makeCommandQueue() else {
+            self.commandQueue = nil
+            self.textureCache = nil
+            initializationFailure = "command queue creation failed"
+            return
+        }
+        commandQueue = queue
+        // CVMetalTextureCache defaults to shader-read textures. Declare both usages up front so
+        // plane views created for our destination IOSurfaces are legal compute write targets on
+        // tvOS as well as macOS. The per-texture attributes below repeat this contract for cache
+        // implementations that do not inherit all cache attributes.
+        let usage = NSNumber(value: MTLTextureUsage.shaderRead.union(.shaderWrite).rawValue)
+        let cacheAttributes: NSDictionary = [kCVMetalTextureUsage: usage]
+        var cache: CVMetalTextureCache?
+        guard CVMetalTextureCacheCreate(
+            kCFAllocatorDefault, cacheAttributes, device, nil, &cache
+        ) == kCVReturnSuccess,
+              let cache else {
+            textureCache = nil
+            initializationFailure = "texture cache creation failed"
+            return
+        }
+        textureCache = cache
+
+        do {
+            let library = try device.makeLibrary(source: Self.shaderSource, options: nil)
+            guard let fn8 = library.makeFunction(name: "yuv420_to_nv12"),
+                  let fn10 = library.makeFunction(name: "yuv420p10_to_p010") else {
+                initializationFailure = "conversion shader function missing"
+                return
+            }
+            pipeline8 = try device.makeComputePipelineState(function: fn8)
+            pipeline10 = try device.makeComputePipelineState(function: fn10)
+        } catch {
+            initializationFailure = "conversion shader compilation failed: \(error)"
+        }
+    }
+
+    func convert(
+        frame: UnsafeMutablePointer<AVFrame>,
+        destination: CVPixelBuffer,
+        pixelFormat: AVPixelFormat,
+        fullRange: Bool
+    ) -> Result {
+        guard Self.supports(codecID: AV_CODEC_ID_AV1, pixelFormat: pixelFormat) else {
+            return .unavailable("unsupported pixel format \(pixelFormat.rawValue)")
+        }
+        let is10Bit = pixelFormat == AV_PIX_FMT_YUV420P10LE
+        guard let device, let commandQueue, let textureCache,
+              let pipeline = is10Bit ? pipeline10 : pipeline8 else {
+            return .unavailable(initializationFailure ?? "Metal conversion unavailable")
+        }
+
+        let width = Int(frame.pointee.width)
+        let height = Int(frame.pointee.height)
+        let chromaWidth = (width + 1) / 2
+        guard width > 0, height > 0,
+              let y = frame.pointee.data.0,
+              let u = frame.pointee.data.1,
+              let v = frame.pointee.data.2,
+              frame.pointee.linesize.0 > 0,
+              frame.pointee.linesize.1 > 0,
+              frame.pointee.linesize.2 > 0,
+              Int(frame.pointee.linesize.0) >= width * (is10Bit ? 2 : 1),
+              Int(frame.pointee.linesize.1) >= chromaWidth * (is10Bit ? 2 : 1),
+              Int(frame.pointee.linesize.2) >= chromaWidth * (is10Bit ? 2 : 1) else {
+            return .failed("frame has no complete YUV420 planes")
+        }
+
+        if !ensureSourceTextures(device: device, width: width, height: height, is10Bit: is10Bit) {
+            return .failed("source texture allocation failed")
+        }
+        let chromaHeight = (height + 1) / 2
+        let regionY = MTLRegionMake2D(0, 0, width, height)
+        let regionUV = MTLRegionMake2D(0, 0, chromaWidth, chromaHeight)
+        sourceY?.replace(region: regionY, mipmapLevel: 0, withBytes: y,
+                         bytesPerRow: Int(frame.pointee.linesize.0))
+        sourceU?.replace(region: regionUV, mipmapLevel: 0, withBytes: u,
+                         bytesPerRow: Int(frame.pointee.linesize.1))
+        sourceV?.replace(region: regionUV, mipmapLevel: 0, withBytes: v,
+                         bytesPerRow: Int(frame.pointee.linesize.2))
+
+        let yWidth = CVPixelBufferGetWidthOfPlane(destination, 0)
+        let yHeight = CVPixelBufferGetHeightOfPlane(destination, 0)
+        let uvWidth = CVPixelBufferGetWidthOfPlane(destination, 1)
+        let uvHeight = CVPixelBufferGetHeightOfPlane(destination, 1)
+        // CVPixelBuffer's bi-planar formats are exposed by CVMetalTextureCache as normalized
+        // textures on Apple platforms (r8/rg8 and r16/rg16), not integer views. The kernels
+        // write normalized values while retaining exact 8-bit and high-aligned 10-bit samples.
+        let yFormat: MTLPixelFormat = is10Bit ? .r16Unorm : .r8Unorm
+        let uvFormat: MTLPixelFormat = is10Bit ? .rg16Unorm : .rg8Unorm
+        let usageAttributes: NSDictionary = [
+            kCVMetalTextureUsage: NSNumber(value: MTLTextureUsage.shaderRead.union(.shaderWrite).rawValue)
+        ]
+        var yTexture: CVMetalTexture?
+        var uvTexture: CVMetalTexture?
+        guard CVMetalTextureCacheCreateTextureFromImage(
+            kCFAllocatorDefault, textureCache, destination, usageAttributes, yFormat,
+            yWidth, yHeight, 0, &yTexture
+        ) == kCVReturnSuccess,
+        CVMetalTextureCacheCreateTextureFromImage(
+            kCFAllocatorDefault, textureCache, destination, usageAttributes, uvFormat,
+            uvWidth, uvHeight, 1, &uvTexture
+        ) == kCVReturnSuccess,
+        let yOut = yTexture.flatMap(CVMetalTextureGetTexture),
+        let uvOut = uvTexture.flatMap(CVMetalTextureGetTexture),
+        let sourceY, let sourceU, let sourceV,
+        let commandBuffer = commandQueue.makeCommandBuffer(),
+        let encoder = commandBuffer.makeComputeCommandEncoder() else {
+            return .failed("destination texture or command buffer creation failed")
+        }
+
+        var params = Parameters(fullRange: fullRange ? 1 : 0)
+        encoder.setComputePipelineState(pipeline)
+        encoder.setTexture(sourceY, index: 0)
+        encoder.setTexture(sourceU, index: 1)
+        encoder.setTexture(sourceV, index: 2)
+        encoder.setTexture(yOut, index: 3)
+        encoder.setTexture(uvOut, index: 4)
+        encoder.setBytes(&params, length: MemoryLayout<Parameters>.stride, index: 0)
+        let threads = MTLSize(width: width, height: height, depth: 1)
+        let w = max(1, min(pipeline.threadExecutionWidth, width))
+        let h = max(1, min(pipeline.maxTotalThreadsPerThreadgroup / w, height))
+        encoder.dispatchThreads(threads, threadsPerThreadgroup: MTLSize(width: w, height: h, depth: 1))
+        encoder.endEncoding()
+        commandBuffer.commit()
+        commandBuffer.waitUntilCompleted()
+        guard commandBuffer.status == .completed else {
+            return .failed("GPU command buffer status \(commandBuffer.status.rawValue)")
+        }
+        return .converted
+    }
+
+    private func ensureSourceTextures(device: MTLDevice, width: Int, height: Int, is10Bit: Bool) -> Bool {
+        guard sourceY == nil || sourceWidth != width || sourceHeight != height || source10Bit != is10Bit else {
+            return true
+        }
+        let chromaWidth = (width + 1) / 2
+        let chromaHeight = (height + 1) / 2
+        // Metal color textures use normalized float channels. We upload the FFmpeg words
+        // unchanged and quantize the normalized readback in the kernel; integer texture channel
+        // types are not valid for texture2d on current Apple GPU compilers.
+        let format: MTLPixelFormat = is10Bit ? .r16Unorm : .r8Unorm
+        func makeTexture(width: Int, height: Int) -> MTLTexture? {
+            let descriptor = MTLTextureDescriptor.texture2DDescriptor(
+                pixelFormat: format, width: width, height: height, mipmapped: false
+            )
+            descriptor.storageMode = .shared
+            descriptor.usage = [.shaderRead]
+            return device.makeTexture(descriptor: descriptor)
+        }
+        guard let y = makeTexture(width: width, height: height),
+              let u = makeTexture(width: chromaWidth, height: chromaHeight),
+              let v = makeTexture(width: chromaWidth, height: chromaHeight) else {
+            sourceY = nil
+            sourceU = nil
+            sourceV = nil
+            return false
+        }
+        sourceY = y
+        sourceU = u
+        sourceV = v
+        sourceWidth = width
+        sourceHeight = height
+        source10Bit = is10Bit
+        return true
+    }
+
+    private static let shaderSource = #"""
+    #include <metal_stdlib>
+    using namespace metal;
+
+    struct Parameters { uint fullRange; };
+
+    inline uchar limitedY8(uchar x, bool full) {
+        uint v = full ? ((uint(x) * 219u + 127u) / 255u + 16u) : uint(x);
+        return uchar(clamp(v, 16u, 235u));
+    }
+    inline uchar limitedUV8(uchar x, bool full) {
+        uint v = full ? ((uint(x) * 224u + 127u) / 255u + 16u) : uint(x);
+        return uchar(clamp(v, 16u, 240u));
+    }
+    inline uchar sample8(float4 x) {
+        return uchar(round(clamp(x.r, 0.0f, 1.0f) * 255.0f));
+    }
+    inline ushort sample10(float4 x) {
+        return ushort(round(clamp(x.r, 0.0f, 1.0f) * 65535.0f));
+    }
+    inline float limitedY10(ushort x, bool full) {
+        uint v = uint(x);
+        v = full ? ((v * 876u + 511u) / 1023u + 64u) : clamp(v, 64u, 940u);
+        return float(clamp(v, 64u, 940u) << 6) / 65535.0f;
+    }
+    inline float limitedUV10(ushort x, bool full) {
+        uint v = uint(x);
+        v = full ? ((v * 896u + 511u) / 1023u + 64u) : clamp(v, 64u, 960u);
+        return float(clamp(v, 64u, 960u) << 6) / 65535.0f;
+    }
+
+    kernel void yuv420_to_nv12(
+        texture2d<float, access::read> y,
+        texture2d<float, access::read> u,
+        texture2d<float, access::read> v,
+        texture2d<float, access::write> outY,
+        texture2d<float, access::write> outUV,
+        constant Parameters& p,
+        uint2 gid [[thread_position_in_grid]]) {
+        if (gid.x >= outY.get_width() || gid.y >= outY.get_height()) return;
+        bool full = p.fullRange != 0;
+        outY.write(float4(float(limitedY8(sample8(y.read(gid)), full)) / 255.0f, 0, 0, 1), gid);
+        if ((gid.x & 1u) == 0u && (gid.y & 1u) == 0u) {
+            uint2 c = gid / 2u;
+            outUV.write(float4(float(limitedUV8(sample8(u.read(c)), full)) / 255.0f,
+                               float(limitedUV8(sample8(v.read(c)), full)) / 255.0f, 0, 1), c);
+        }
+    }
+
+    kernel void yuv420p10_to_p010(
+        texture2d<float, access::read> y,
+        texture2d<float, access::read> u,
+        texture2d<float, access::read> v,
+        texture2d<float, access::write> outY,
+        texture2d<float, access::write> outUV,
+        constant Parameters& p,
+        uint2 gid [[thread_position_in_grid]]) {
+        if (gid.x >= outY.get_width() || gid.y >= outY.get_height()) return;
+        bool full = p.fullRange != 0;
+        outY.write(float4(limitedY10(sample10(y.read(gid)), full), 0, 0, 1), gid);
+        if ((gid.x & 1u) == 0u && (gid.y & 1u) == 0u) {
+            uint2 c = gid / 2u;
+            outUV.write(float4(limitedUV10(sample10(u.read(c)), full),
+                               limitedUV10(sample10(v.read(c)), full), 0, 1), c);
+        }
+    }
+    """#
+}
+
+#else
+
+/// Linux/non-Metal build seam. AetherEngine's supported playback platforms have Metal, but the
+/// decoder still compiles for tooling and tests and will use its swscale fallback there.
+final class MetalYUVConverter {
+    enum Result: Equatable { case converted, unavailable(String), failed(String) }
+
+    static func supports(codecID: AVCodecID, pixelFormat: AVPixelFormat) -> Bool {
+        guard codecID == AV_CODEC_ID_AV1 else { return false }
+        return pixelFormat == AV_PIX_FMT_YUV420P
+            || pixelFormat == AV_PIX_FMT_YUVJ420P
+            || pixelFormat == AV_PIX_FMT_YUV420P10LE
+    }
+
+    static func p010Code(value: UInt16, fullRange: Bool, chroma: Bool = false) -> UInt16 {
+        let input = UInt32(min(value, 1023))
+        let code: UInt32
+        if fullRange {
+            let span: UInt32 = chroma ? 896 : 876
+            code = 64 + (input * span + 511) / 1023
+        } else {
+            let high: UInt32 = chroma ? 960 : 940
+            code = min(max(input, 64), high)
+        }
+        return UInt16(min(code, 1023) << 6)
+    }
+}
+
+#endif

--- a/Sources/AetherEngine/Decoder/SoftwareVideoDecoder.swift
+++ b/Sources/AetherEngine/Decoder/SoftwareVideoDecoder.swift
@@ -8,10 +8,13 @@ import AetherLibavutil
 import AetherLibswscale
 
 /// libavcodec software video decoder for codecs without VideoToolbox support (e.g. AV1/dav1d on Apple TV).
-/// Uses sws_scale (SIMD/NEON-optimized) for YUV→NV12/P010 conversion; required to hit 24fps at 1080p for AV1.
+/// AV1's common planar output uses the Metal YUV converter when available; sws_scale remains the
+/// failure-safe conversion path for every other codec, format, or runtime configuration.
 final class SoftwareVideoDecoder: VideoDecodingPipeline, @unchecked Sendable {
 
     private var codecContext: UnsafeMutablePointer<AVCodecContext>?
+    /// Latched at open so the AV1-only Metal policy cannot accidentally affect another codec.
+    private var codecID: AVCodecID = AV_CODEC_ID_NONE
     // FFmpeg 8.x exposes SwsContext as a real struct (7.x was OpaquePointer); pointer type must match or call sites miscompile.
     private var swsContext: UnsafeMutablePointer<SwsContext>?
     private var timeBase: AVRational = AVRational(num: 1, den: 90000)
@@ -41,6 +44,14 @@ final class SoftwareVideoDecoder: VideoDecodingPipeline, @unchecked Sendable {
     private var pixelBufferPool: CVPixelBufferPool?
     private var poolWidth = 0
     private var poolHeight = 0
+    private var poolIs10Bit = false
+
+    /// A converter and its diagnostics live for one decoder session. A failed command/pipeline
+    /// disables further attempts for that session, preventing a per-frame fallback storm.
+    private var metalConverter: MetalYUVConverter?
+    private var metalDisabledForSession = false
+    private var loggedMetalPath = false
+    private var loggedMetalFallback = false
 
     /// Skip pre-seek frames; decoded for reference but not converted.
     /// Guarded by `skipLock` not `lock`: emit() runs with `lock` held, so a same-lock accessor would deadlock.
@@ -98,6 +109,7 @@ final class SoftwareVideoDecoder: VideoDecodingPipeline, @unchecked Sendable {
         }
 
         timeBase = stream.pointee.time_base
+        codecID = codecpar.pointee.codec_id
 
         // Container SAR fallback; see streamSAR. Frames usually carry their own (MPEG-2 seq header, from frame 1).
         //
@@ -155,6 +167,10 @@ final class SoftwareVideoDecoder: VideoDecodingPipeline, @unchecked Sendable {
         let bitsPerSample = codecpar.pointee.bits_per_raw_sample
         let isHDRTransfer = ColorAttachments.isHDRTransfer(codecpar.pointee.color_trc)
         use10Bit = bitsPerSample > 8 || isHDRTransfer
+        metalConverter = codecID == AV_CODEC_ID_AV1 ? MetalYUVConverter() : nil
+        metalDisabledForSession = false
+        loggedMetalPath = false
+        loggedMetalFallback = false
 
         // Release-visible log (no #if DEBUG): needed for TestFlight users and DrHurt #4 black-screen reports.
         EngineLog.emit("[SWDecoder] Opened: \(codecpar.pointee.width)x\(codecpar.pointee.height), codec=\(String(cString: codec.pointee.name)), threads=\(ctx.pointee.thread_count), \(use10Bit ? "10-bit" : "8-bit")", category: .swPlayback)
@@ -448,6 +464,9 @@ final class SoftwareVideoDecoder: VideoDecodingPipeline, @unchecked Sendable {
         pixelBufferPool = nil
         poolWidth = 0
         poolHeight = 0
+        poolIs10Bit = false
+        metalConverter = nil
+        metalDisabledForSession = false
         if let session = transferSession {
             VTPixelTransferSessionInvalidate(session)
             transferSession = nil
@@ -471,7 +490,7 @@ final class SoftwareVideoDecoder: VideoDecodingPipeline, @unchecked Sendable {
             ? kCVPixelFormatType_420YpCbCr10BiPlanarVideoRange
             : kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange
 
-        if pixelBufferPool == nil || poolWidth != width || poolHeight != height {
+        if pixelBufferPool == nil || poolWidth != width || poolHeight != height || poolIs10Bit != use10Bit {
             pixelBufferPool = nil
             let poolAttrs: NSDictionary = [kCVPixelBufferPoolMinimumBufferCountKey: 6]
             let pbAttrs: NSDictionary = [
@@ -484,6 +503,7 @@ final class SoftwareVideoDecoder: VideoDecodingPipeline, @unchecked Sendable {
             CVPixelBufferPoolCreate(kCFAllocatorDefault, poolAttrs, pbAttrs, &pixelBufferPool)
             poolWidth = width
             poolHeight = height
+            poolIs10Bit = use10Bit
         }
         return pixelBufferPool
     }
@@ -519,6 +539,13 @@ final class SoftwareVideoDecoder: VideoDecodingPipeline, @unchecked Sendable {
 
         let srcFmt = AVPixelFormat(rawValue: frame.pointee.format)
 
+        // A decoder can report 10-bit output through the frame even when codecpar did not carry
+        // bits_per_raw_sample. Latch the destination format before obtaining the first pool
+        // buffer, otherwise a valid P010 frame would be silently truncated to NV12.
+        if srcFmt == AV_PIX_FMT_YUV420P10LE {
+            use10Bit = true
+        }
+
         let dstFmt = use10Bit ? AV_PIX_FMT_P010LE : AV_PIX_FMT_NV12
 
         swsContext = sws_getCachedContext(
@@ -538,6 +565,43 @@ final class SoftwareVideoDecoder: VideoDecodingPipeline, @unchecked Sendable {
 
         attachColorSpace(from: frame, to: pb)
         attachPixelAspectRatio(from: frame, to: pb)
+
+        let metalFormatSupported = MetalYUVConverter.supports(codecID: codecID, pixelFormat: srcFmt)
+        let metalBitDepthMatchesPool = (srcFmt == AV_PIX_FMT_YUV420P10LE) == use10Bit
+        if !metalDisabledForSession,
+           codecID == AV_CODEC_ID_AV1,
+           metalFormatSupported,
+           metalBitDepthMatchesPool,
+           let converter = metalConverter {
+            let fullRange = srcFmt == AV_PIX_FMT_YUVJ420P || frame.pointee.color_range == AVCOL_RANGE_JPEG
+            switch converter.convert(
+                frame: frame, destination: pb, pixelFormat: srcFmt, fullRange: fullRange
+            ) {
+            case .converted:
+                if !loggedMetalPath {
+                    loggedMetalPath = true
+                    EngineLog.emit("[SWDecoder] AV1 Metal YUV conversion enabled (GPU-complete)", category: .swPlayback)
+                }
+                return pb
+            case let .unavailable(reason), let .failed(reason):
+                metalDisabledForSession = true
+                if !loggedMetalFallback {
+                    loggedMetalFallback = true
+                    EngineLog.emit(
+                        "[SWDecoder] AV1 Metal YUV conversion unavailable (\(reason)); falling back to sws_scale",
+                        category: .swPlayback
+                    )
+                }
+            }
+        } else if codecID == AV_CODEC_ID_AV1,
+                  (!metalFormatSupported || !metalBitDepthMatchesPool || metalConverter == nil),
+                  !loggedMetalFallback {
+            loggedMetalFallback = true
+            EngineLog.emit(
+                "[SWDecoder] AV1 Metal YUV conversion unsupported for pixel format/bit depth (format=\(srcFmt.rawValue), pool10=\(use10Bit)); falling back to sws_scale",
+                category: .swPlayback
+            )
+        }
 
         CVPixelBufferLockBaseAddress(pb, [])
         defer { CVPixelBufferUnlockBaseAddress(pb, []) }

--- a/Tests/AetherEngineTests/MetalYUVConversionPolicyTests.swift
+++ b/Tests/AetherEngineTests/MetalYUVConversionPolicyTests.swift
@@ -1,0 +1,141 @@
+import Testing
+import CoreVideo
+import AetherLibavcodec
+import AetherLibavutil
+@testable import AetherEngine
+
+#if canImport(Metal)
+import Metal
+#endif
+
+@Suite("AV1 Metal YUV conversion policy")
+struct MetalYUVConversionPolicyTests {
+    @Test("the fast path is limited to AV1 YUV420 planar formats")
+    func supportedFormats() {
+        #expect(MetalYUVConverter.supports(codecID: AV_CODEC_ID_AV1, pixelFormat: AV_PIX_FMT_YUV420P))
+        #expect(MetalYUVConverter.supports(codecID: AV_CODEC_ID_AV1, pixelFormat: AV_PIX_FMT_YUVJ420P))
+        #expect(MetalYUVConverter.supports(codecID: AV_CODEC_ID_AV1, pixelFormat: AV_PIX_FMT_YUV420P10LE))
+    }
+
+    @Test("other codecs and layouts always use swscale")
+    func unsupportedRoutesToFallback() {
+        #expect(!MetalYUVConverter.supports(codecID: AV_CODEC_ID_HEVC, pixelFormat: AV_PIX_FMT_YUV420P))
+        #expect(!MetalYUVConverter.supports(codecID: AV_CODEC_ID_AV1, pixelFormat: AV_PIX_FMT_NV12))
+        #expect(!MetalYUVConverter.supports(codecID: AV_CODEC_ID_AV1, pixelFormat: AV_PIX_FMT_YUV444P))
+    }
+
+    @Test("10-bit FFmpeg samples are low-aligned and become high-aligned P010")
+    func p010PackingAndRange() {
+        #expect(MetalYUVConverter.p010Code(value: 64, fullRange: false) == UInt16(64 << 6))
+        #expect(MetalYUVConverter.p010Code(value: 0, fullRange: false) == UInt16(64 << 6))
+        #expect(MetalYUVConverter.p010Code(value: 1023, fullRange: false) == UInt16(940 << 6))
+        #expect(MetalYUVConverter.p010Code(value: 0, fullRange: true) == UInt16(64 << 6))
+        #expect(MetalYUVConverter.p010Code(value: 1023, fullRange: true) == UInt16(940 << 6))
+        #expect(MetalYUVConverter.p010Code(value: 0, fullRange: true, chroma: true) == UInt16(64 << 6))
+        #expect(MetalYUVConverter.p010Code(value: 1023, fullRange: true, chroma: true) == UInt16(960 << 6))
+    }
+
+#if canImport(Metal)
+    @Test("Metal converts a small NV12 frame and preserves video-range samples")
+    func gpuNV12Smoke() throws {
+        // A machine without a Metal device is an expected CI configuration. Once a device is
+        // present, conversion failures are assertions rather than skips.
+        guard MTLCreateSystemDefaultDevice() != nil else { return }
+        let converter = MetalYUVConverter()
+        let frame = try makeFrame(format: AV_PIX_FMT_YUV420P)
+        defer { var owned: UnsafeMutablePointer<AVFrame>? = frame; av_frame_free(&owned) }
+        let y = frame.pointee.data.0!
+        let u = frame.pointee.data.1!
+        let v = frame.pointee.data.2!
+        y[0] = 16; y[1] = 235
+        y[Int(frame.pointee.linesize.0)] = 81; y[Int(frame.pointee.linesize.0) + 1] = 145
+        u[0] = 128; v[0] = 129
+
+        let destination = try makePixelBuffer(format: kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange)
+        let result = converter.convert(
+            frame: frame, destination: destination, pixelFormat: AV_PIX_FMT_YUV420P, fullRange: false
+        )
+        #expect(result == .converted)
+        CVPixelBufferLockBaseAddress(destination, [.readOnly])
+        defer { CVPixelBufferUnlockBaseAddress(destination, [.readOnly]) }
+        let yOut = CVPixelBufferGetBaseAddressOfPlane(destination, 0)!.assumingMemoryBound(to: UInt8.self)
+        let uvOut = CVPixelBufferGetBaseAddressOfPlane(destination, 1)!.assumingMemoryBound(to: UInt8.self)
+        #expect(yOut[0] == 16 && yOut[1] == 235)
+        #expect(yOut[CVPixelBufferGetBytesPerRowOfPlane(destination, 0)] == 81)
+        #expect(uvOut[0] == 128 && uvOut[1] == 129)
+    }
+
+    @Test("Metal converts low-aligned 10-bit samples to high-aligned P010")
+    func gpuP010Smoke() throws {
+        guard MTLCreateSystemDefaultDevice() != nil else { return }
+        let converter = MetalYUVConverter()
+        let frame = try makeFrame(format: AV_PIX_FMT_YUV420P10LE)
+        defer { var owned: UnsafeMutablePointer<AVFrame>? = frame; av_frame_free(&owned) }
+        let y = UnsafeMutableRawPointer(frame.pointee.data.0!).assumingMemoryBound(to: UInt16.self)
+        let u = UnsafeMutableRawPointer(frame.pointee.data.1!).assumingMemoryBound(to: UInt16.self)
+        let v = UnsafeMutableRawPointer(frame.pointee.data.2!).assumingMemoryBound(to: UInt16.self)
+        let yStride = Int(frame.pointee.linesize.0) / MemoryLayout<UInt16>.stride
+        y[0] = 64; y[1] = 940
+        y[yStride] = 640; y[yStride + 1] = 512
+        u[0] = 940; v[0] = 64
+
+        let destination = try makePixelBuffer(format: kCVPixelFormatType_420YpCbCr10BiPlanarVideoRange)
+        let result = converter.convert(
+            frame: frame, destination: destination, pixelFormat: AV_PIX_FMT_YUV420P10LE, fullRange: false
+        )
+        #expect(result == .converted)
+        CVPixelBufferLockBaseAddress(destination, [.readOnly])
+        defer { CVPixelBufferUnlockBaseAddress(destination, [.readOnly]) }
+        let yOut = CVPixelBufferGetBaseAddressOfPlane(destination, 0)!.assumingMemoryBound(to: UInt16.self)
+        let uvOut = CVPixelBufferGetBaseAddressOfPlane(destination, 1)!.assumingMemoryBound(to: UInt16.self)
+        let outStride = CVPixelBufferGetBytesPerRowOfPlane(destination, 0) / MemoryLayout<UInt16>.stride
+        #expect(yOut[0] == UInt16(64 << 6) && yOut[1] == UInt16(940 << 6))
+        #expect(yOut[outStride] == UInt16(640 << 6))
+        #expect(uvOut[0] == UInt16(940 << 6) && uvOut[1] == UInt16(64 << 6))
+    }
+
+    @Test("negative FFmpeg plane strides use the conversion fallback result")
+    func negativeStrideIsRejected() throws {
+        guard MTLCreateSystemDefaultDevice() != nil else { return }
+        let converter = MetalYUVConverter()
+        let frame = try makeFrame(format: AV_PIX_FMT_YUV420P)
+        defer { var owned: UnsafeMutablePointer<AVFrame>? = frame; av_frame_free(&owned) }
+        frame.pointee.linesize.0 = -frame.pointee.linesize.0
+        let destination = try makePixelBuffer(format: kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange)
+        let result = converter.convert(
+            frame: frame, destination: destination, pixelFormat: AV_PIX_FMT_YUV420P, fullRange: false
+        )
+        if case .failed = result {
+            // Expected: the caller's swscale path owns the negative-stride fallback.
+        } else {
+            Issue.record("negative stride must not be submitted to the Metal texture upload")
+        }
+    }
+
+    private func makeFrame(format: AVPixelFormat) throws -> UnsafeMutablePointer<AVFrame> {
+        let frame = try #require(av_frame_alloc())
+        frame.pointee.width = 2
+        frame.pointee.height = 2
+        frame.pointee.format = format.rawValue
+        guard av_frame_get_buffer(frame, 0) >= 0 else {
+            var owned: UnsafeMutablePointer<AVFrame>? = frame
+            av_frame_free(&owned)
+            throw NSError(domain: "MetalYUVConversionTests", code: 1)
+        }
+        return frame
+    }
+
+    private func makePixelBuffer(format: OSType) throws -> CVPixelBuffer {
+        var pixelBuffer: CVPixelBuffer?
+        let attributes: NSDictionary = [
+            kCVPixelBufferMetalCompatibilityKey: true,
+            kCVPixelBufferIOSurfacePropertiesKey: NSDictionary(),
+        ]
+        let status = CVPixelBufferCreate(
+            kCFAllocatorDefault, 2, 2, format, attributes, &pixelBuffer
+        )
+        #expect(status == kCVReturnSuccess)
+        return try #require(pixelBuffer)
+    }
+#endif
+}

--- a/docs/formats.md
+++ b/docs/formats.md
@@ -13,6 +13,11 @@ That list is the supported set, not the compiled set. The FFmpeg build also carr
 **Software decode** (`SoftwareVideoDecoder` + `AVSampleBufferDisplayLayer`):
 
 - AV1 (libavcodec / dav1d) on devices without HW AV1 (currently all Apple TVs, M1 / M2 Macs, pre-A17-Pro iPhones).
+
+  For AV1's common planar 4:2:0 outputs, the software decoder uses Metal to write NV12/P010 into
+  the existing CVPixelBuffer pool instead of performing a second full-frame CPU conversion after
+  dav1d. Unsupported pixel layouts and any Metal failure fall back to `sws_scale`; hosts keep the
+  same sample-buffer rendering, subtitle, seek, and PiP contracts on either path.
 - VP9 and VP8 (libavcodec native) unconditionally, since AVPlayer's HLS pipeline rejects the `vp09` / `vp08` CODECS attributes even where VideoToolbox can HW-decode them.
 - MPEG-4 Part 2 (XVID / DIVX / SP / ASP), MPEG-2 video, and VC-1, none of which AVPlayer's HLS-fMP4 pipeline accepts; libavcodec ships native decoders for all three.
 - The legacy Microsoft tail (FFmpegBuild 2.4.3): MS-MPEG4 v1 / v2 / v3, the DivX 3.x that pre-2005 AVI rips carry, and WMV1 / WMV2 / WMV3 (WMV9). The routing was already correct before that release, so these reached `SoftwareVideoDecoder` and failed the load with `unsupportedCodec` for want of a compiled-in decoder. WMV3 covers WMV9 inside Matroska and MPEG-TS, where the container's own demuxer supplies the stream; a native `.wmv` / `.asf` file still fails at `avformat_open_input`, because the `asf` demuxer and the WMA decoders such a file also needs stay out of the build deliberately (with the demuxer but no WMA decoder, `AudioCodecCompat` maps the unrecognised id to `.unsupported` and the session drops to video-only, so the file would play silently, which is a worse failure than an honest one). None of the six supports frame threading, so they decode single-threaded; the content that carries them is SD. Reported by cmcpherson274 (FFmpegBuild#3).


### PR DESCRIPTION
## Summary

Moves AetherEngine's common AV1 planar 4:2:0 conversion from CPU `sws_scale` to a small Metal compute path while preserving the existing CVPixelBuffer and `SampleBufferRenderer` pipeline.

This was found through [NuvioTVOS #40](https://github.com/bobsupra/NuvioTVOS/issues/40). On an Apple TV 4K running tvOS 26.6, a 3840x2160 23.976 fps AV1 MKV with TrueHD 5.1 routed through dav1d software decode, measured about 464% process CPU, and held a 0.0 s display cushion. The same source played smoothly in Stremio's KSPlayer pipeline. Aether's software decoder was performing a second full-frame planar YUV -> NV12/P010 CPU conversion after dav1d.

## Implementation

- Adds a session-scoped `MetalYUVConverter` for AV1 `YUV420P`, `YUVJ420P`, and `YUV420P10LE`.
- Uploads the three source planes into reused Metal textures.
- Writes NV12/P010 into the existing IOSurface-backed CVPixelBuffer pool.
- Preserves color/SAR attachments, sample-buffer rendering, subtitles, seeking, PiP, and frame pacing.
- Handles FFmpeg's low-aligned 10-bit samples and writes high-aligned P010 values.
- Falls back to `sws_scale` for unsupported layouts, invalid/negative strides, missing Metal, texture/shader failures, or GPU command failures.
- Disables a failed Metal path for the remainder of the session to avoid retrying every frame.

## Tests

- `swift test --filter MetalYUVConversionPolicyTests`
  - Real Metal NV12 conversion with byte readback.
  - Real Metal P010 conversion with byte readback and alignment checks.
  - Format-routing and negative-stride fallback coverage.
- Full `swift test`: **2,415 tests in 329 suites passed**.
- Nuvio host builds passed for generic tvOS Simulator and generic physical tvOS destinations.

## Device verification status

The original high-CPU failure was captured on Apple TV 4K / tvOS 26.6. The converter and exact output were exercised on a macOS Metal device, and the tvOS targets compile and link, but the affected source still needs a post-change physical Apple TV performance retest. Opening as draft for that device validation and maintainer feedback.
