### PR TITLE
A panel parked in HDR is asked again once frames are running (#459)

### DIFF
--- a/Sources/AetherEngine/AetherEngine+Probe.swift
+++ b/Sources/AetherEngine/AetherEngine+Probe.swift
@@ -602,6 +602,25 @@ extension AetherEngine {
         return caps.supportsHDR10 ? .hdr10 : .sdr
     }
 
+    /// The format to publish as `videoFormat`: what the panel is presenting, not what the file carries
+    /// (`sourceVideoFormat` is that). One funnel for both the load-time answer and the late one the #459
+    /// playback probe can produce seconds later, so the two cannot drift apart.
+    ///
+    /// The HDR10+ carry-over exists because the two can arrive in either order. `handleHDR10PlusDetected`
+    /// upgrades a `videoFormat` that already reads `.hdr10`, and on a panel whose answer is still pending
+    /// the label reads `.sdr` when the T.35 payload lands, so the upgrade is skipped and the evidence
+    /// survives in `sourceVideoFormat` alone. Republishing the bare effective format would then relabel a
+    /// proven HDR10+ session "HDR10+ -> HDR10", trading one wrong arrow for a quieter one.
+    nonisolated static func presentedVideoFormat(
+        effectiveFormat: VideoFormat,
+        panelPresentsHDR: Bool,
+        sourceVideoFormat: VideoFormat
+    ) -> VideoFormat {
+        guard effectiveFormat != .sdr, panelPresentsHDR else { return .sdr }
+        if effectiveFormat == .hdr10, sourceVideoFormat == .hdr10Plus { return .hdr10Plus }
+        return effectiveFormat
+    }
+
     private nonisolated static func streamHasDV(stream: UnsafeMutablePointer<AVStream>) -> Bool {
         let nb = Int(stream.pointee.codecpar.pointee.nb_coded_side_data)
         guard nb > 0, let sideData = stream.pointee.codecpar.pointee.coded_side_data else {

--- a/Sources/AetherEngine/AetherEngine.swift
+++ b/Sources/AetherEngine/AetherEngine.swift
@@ -3571,9 +3571,10 @@ public final class AetherEngine: ObservableObject {
         // HDR/DV title as SDR in Stats for Nerds.
         videoFormat = effectiveFormat
         #else
-        videoFormat = (effectiveFormat != .sdr && panelHDRAfterHandshake)
-            ? effectiveFormat
-            : .sdr
+        videoFormat = Self.presentedVideoFormat(
+            effectiveFormat: effectiveFormat,
+            panelPresentsHDR: panelHDRAfterHandshake,
+            sourceVideoFormat: sourceVideoFormat)
         #endif
         // #361: the handshake above is the second stretch a host cannot see, and on a real SDR->HDR
         // switch it is seconds long. Recorded on every branch, including the ones with nothing to
@@ -3828,6 +3829,9 @@ public final class AetherEngine: ObservableObject {
                 startLiveTelemetrySampler()
                 armDisplayModeDiagnostic(gen: gen, backend: "software",
                                          contentRate: detectedRate, requestedRate: snappedRate)
+                armPlaybackPanelProbe(gen: gen, effectiveFormat: effectiveFormat,
+                                      panelPresentedHDRAtLoad: panelHDRAfterHandshake,
+                                      sessionIsPlaying: Self.loadPerformsAutostart(options))
             } else {
                 // Native path: pass the probe Demuxer to loadNative so HLSVideoEngine.start() skips
                 // avformat_open_input + find_stream_info (~1-3 s saved on slow CDN). The cue prewarm
@@ -3915,6 +3919,9 @@ public final class AetherEngine: ObservableObject {
                 startLiveTelemetrySampler()
                 armDisplayModeDiagnostic(gen: gen, backend: "native",
                                          contentRate: detectedRate, requestedRate: snappedRate)
+                armPlaybackPanelProbe(gen: gen, effectiveFormat: effectiveFormat,
+                                      panelPresentedHDRAtLoad: panelHDRAfterHandshake,
+                                      sessionIsPlaying: Self.loadPerformsAutostart(options))
             }
         } catch is CancellationError {
             // Superseded.
@@ -4959,6 +4966,8 @@ public final class AetherEngine: ObservableObject {
 
     private var displayModeDiagnostic: Task<Void, Never>?
 
+    private var playbackPanelProbe: Task<Void, Never>?
+
     /// Sodalite #49: read back what the Match-Frame-Rate switch actually landed on. `preferredDisplayCriteria`
     /// is a hint with no read-back, so a display-link sample once playback is running is the only way to tell
     /// three cases apart for a judder report: the panel ignored the criteria and kept the system rate (50.000
@@ -4987,6 +4996,45 @@ public final class AetherEngine: ObservableObject {
                 + "(nominal \(fmt(sample?.nominal))) player=\(fmt(playerRate.map(Double.init)))fps",
                 category: .engine
             )
+        }
+        #endif
+    }
+
+    /// AE#459: re-ask the panel, once frames are running, whether it is presenting HDR.
+    ///
+    /// Every answer `panelPresentsHDR` gets is sampled around the criteria write, and an Apple TV whose
+    /// output format is fixed to HDR has nothing to say at that moment: there is no dynamic-range
+    /// transition, so the EDR headroom stays 1.00 and `panelProvenToEngageHDR` can never be armed either.
+    /// Such a panel therefore reads SDR forever, which mislabels every HDR/DV session in Stats for Nerds
+    /// and, through the same boolean, serves it media-direct with no HDR signaling.
+    ///
+    /// The probe does not re-route the running session; the proof it latches makes the next load in this
+    /// process route correctly on its own. What it fixes here and now is the label.
+    @MainActor
+    func armPlaybackPanelProbe(gen: UInt64, effectiveFormat: VideoFormat,
+                               panelPresentedHDRAtLoad: Bool, sessionIsPlaying: Bool) {
+        #if os(tvOS)
+        playbackPanelProbe?.cancel()
+        playbackPanelProbe = nil
+        guard DisplayCriteriaController.shouldProbePanelDuringPlayback(
+            effectiveFormat: effectiveFormat,
+            panelPresentedHDRAtLoad: panelPresentedHDRAtLoad,
+            sessionIsPlaying: sessionIsPlaying) else { return }
+        playbackPanelProbe = Task { @MainActor [weak self] in
+            guard let self else { return }
+            let presentsHDR = await self.displayCriteria.probePanelDuringPlayback()
+            guard !Task.isCancelled, self.loadGeneration == gen, presentsHDR else { return }
+            let corrected = Self.presentedVideoFormat(
+                effectiveFormat: effectiveFormat,
+                panelPresentsHDR: true,
+                sourceVideoFormat: self.sourceVideoFormat)
+            guard corrected != self.videoFormat else { return }
+            EngineLog.emit(
+                "[AetherEngine] panel answered HDR during playback, republishing videoFormat "
+                + "\(self.videoFormat) -> \(corrected); the load-time read could not see it and this "
+                + "session was served without HDR signaling (#459)",
+                category: .engine)
+            self.videoFormat = corrected
         }
         #endif
     }
@@ -5639,6 +5687,8 @@ public final class AetherEngine: ObservableObject {
         airPlayProgressWatchdog = nil
         displayModeDiagnostic?.cancel()
         displayModeDiagnostic = nil
+        playbackPanelProbe?.cancel()
+        playbackPanelProbe = nil
         airPlayServedMasterToReceiver = false
         extractorYieldState.deactivate()
         setPendingRecoverySeekTarget(nil)

--- a/Sources/AetherEngine/Display/DisplayCriteriaController.swift
+++ b/Sources/AetherEngine/Display/DisplayCriteriaController.swift
@@ -241,6 +241,42 @@ final class DisplayCriteriaController {
         return lastCriteriaWasHDR ? .engineHDR : .engineRateOnly
     }
 
+    // MARK: - Late panel probe (#459)
+
+    /// How long after the first frames the panel is re-asked whether it is presenting HDR, and how often.
+    ///
+    /// Every reading `panelPresentsHDR` gets today is taken around the criteria write, which is the one
+    /// moment a panel already parked in HDR has nothing to report: no dynamic-range transition, so no raised
+    /// headroom, so no proof, forever (#459). Vincent's 2026-08-09 device trace has the reading this window
+    /// exists to catch, on an Apple TV whose output was fixed to 4K HDR: headroom 1.20 at t+2.5s, back to
+    /// 1.00 by t+20s, against a flat 1.00 for the same title with the output fixed to 4K SDR.
+    ///
+    /// So the window opens wide enough to contain that rise and closes before the value decays into
+    /// meaninglessness. A window that closes with nothing seen is itself the measurement: it says this panel
+    /// never raises the headroom, which is the one thing no log line could say before.
+    nonisolated static let playbackProbeWindowMs = 12_000
+    nonisolated static let playbackProbeIntervalMs = 250
+
+    /// Whether a session's label can still change by asking the panel again once frames are running.
+    ///
+    /// SDR sessions are excluded on both counts: SDR content composites no HDR, so the headroom cannot rise
+    /// for it, and there would be nothing to upgrade the label to if it did. A paused mount (#124) is
+    /// excluded for the first of those reasons alone: no frames, nothing composited, and a window that
+    /// closes on that would report the panel's silence as if it had been asked.
+    nonisolated static func shouldProbePanelDuringPlayback(
+        effectiveFormat: VideoFormat,
+        panelPresentedHDRAtLoad: Bool,
+        sessionIsPlaying: Bool
+    ) -> Bool {
+        effectiveFormat != .sdr && !panelPresentedHDRAtLoad && sessionIsPlaying
+    }
+
+    /// Whether the probe takes another sample. One reading above 1.0 is authoritative and latches the proof
+    /// for good, so the first hit ends the probe.
+    nonisolated static func playbackProbeContinues(elapsedMs: Int, observedHDR: Bool) -> Bool {
+        !observedHDR && elapsedMs < playbackProbeWindowMs
+    }
+
     /// How the gate learned a switch was running. This is the one bit that separates "the panel was already
     /// switching while the AVPlayerItem was built" from "the switch started after the gate opened", the
     /// ordering question Sodalite#49 was filed on and which no log line could answer.
@@ -975,6 +1011,52 @@ final class DisplayCriteriaController {
             attribution: Self.criteriaAttribution(didApply: didApply, lastCriteriaWasHDR: lastCriteriaWasHDR),
             panelProvenToEngageHDR: panelProvenToEngageHDR
         )
+        #else
+        return false
+        #endif
+    }
+
+    /// Re-ask the panel whether it is presenting HDR, now that the session's frames are on screen.
+    ///
+    /// The load-time read cannot answer for a panel already parked in HDR: it is taken around the criteria
+    /// write, and that panel makes no dynamic-range transition to raise the headroom (#459). This one is
+    /// taken while HDR content composites, which is when Vincent's device trace shows the value rising, and
+    /// it goes through `observeHeadroom` so a hit latches the proof for every later load in the process.
+    ///
+    /// Returns whether the panel answered HDR. Bounded by `playbackProbeWindowMs`, and a window that closes
+    /// with nothing seen is logged as the measurement it is.
+    func probePanelDuringPlayback() async -> Bool {
+        #if os(tvOS)
+        guard let window = resolveWindow() else { return false }
+        let started = DispatchTime.now()
+        var samples = 0
+        var maxHeadroom = 0.0
+        var observedHDR = false
+        while !Task.isCancelled,
+              Self.playbackProbeContinues(elapsedMs: Self.elapsedMs(since: started),
+                                          observedHDR: observedHDR) {
+            samples += 1
+            maxHeadroom = max(maxHeadroom, Double(window.screen.currentEDRHeadroom))
+            observedHDR = observeHeadroom(window.screen)
+            if !observedHDR {
+                try? await Task.sleep(for: .milliseconds(Self.playbackProbeIntervalMs))
+            }
+        }
+        guard !Task.isCancelled else { return false }
+        let headroom = String(format: "%.2f", maxHeadroom)
+        if observedHDR {
+            EngineLog.emit(
+                "[DisplayCriteria] playback probe: panel reports HDR after "
+                + "\(Self.elapsedMs(since: started))ms (headroom \(headroom), \(samples) samples)",
+                category: .engine)
+        } else {
+            EngineLog.emit(
+                "[DisplayCriteria] playback probe: no HDR reading in \(Self.elapsedMs(since: started))ms "
+                + "(max headroom \(headroom), \(samples) samples); this panel does not raise the EDR "
+                + "headroom for HDR content, so the session keeps its SDR label",
+                category: .engine)
+        }
+        return observedHDR
         #else
         return false
         #endif

--- a/Tests/AetherEngineTests/Issue459PanelProofDuringPlaybackTests.swift
+++ b/Tests/AetherEngineTests/Issue459PanelProofDuringPlaybackTests.swift
@@ -1,0 +1,135 @@
+import Testing
+@testable import AetherEngine
+
+// AE#459 (DrHurt, Apple TV 4K 2022, tvOS 27 beta): an Apple TV whose output format is fixed to HDR
+// labels every HDR10+/DV session "HDR -> SDR" in Stats for Nerds, and has done for months.
+//
+// `currentPanelIsHDR()` answers from `UIScreen.currentEDRHeadroom`, and on tvOS that value is a
+// TRANSITION artifact: it is raised around a dynamic-range switch and decays back to 1.00 while the
+// panel keeps presenting HDR (see DisplayCriteriaPanelHDRProofTests for the device trace). A panel
+// parked in HDR never transitions, so both terms of `panelPresentsHDR` are dead for it: the live
+// reading is 1.00 at every load-time sample, and `panelProvenToEngageHDR` is only ever armed by such
+// a sample, so the proof can never be earned either. The session is labelled SDR and, because the
+// same boolean is the master-vs-media routing gate, served media-direct.
+//
+// The signal exists, it is just read three seconds too early. Vincent's device measurement of
+// 2026-08-09 (Apple TV 4K 3rd gen, tvOS 26.5, HDR10 panel, one title played twice):
+//
+//     output 4K HDR, t+2.5s:  headroom 1.20
+//     output 4K HDR, t+20s:   headroom 1.00
+//     output 4K SDR, t+2.5s:  headroom 1.00
+//
+// The rise comes with the HDR content reaching the screen, not with an HDMI mode switch, and it
+// separates the two configurations that `eligibleForHDRPlayback` conflates (a panel parked in HDR
+// from a rate-only panel parked in SDR). So the answer has to be sampled again once frames are
+// running, which is what this suite covers.
+@Suite("AE#459 panel-HDR proof during playback")
+struct Issue459PanelProofDuringPlaybackTests {
+
+    // MARK: - Which sessions get a late probe
+
+    @Test("An HDR session the panel read SDR is the one to re-ask")
+    func probesTheClampedHDRSession() {
+        #expect(DisplayCriteriaController.shouldProbePanelDuringPlayback(
+            effectiveFormat: .hdr10, panelPresentedHDRAtLoad: false, sessionIsPlaying: true))
+    }
+
+    @Test("A session the load-time read already answered HDR is not re-asked")
+    func skipsAnsweredSession() {
+        #expect(!DisplayCriteriaController.shouldProbePanelDuringPlayback(
+            effectiveFormat: .hdr10, panelPresentedHDRAtLoad: true, sessionIsPlaying: true))
+    }
+
+    // SDR content composites no HDR, so the headroom cannot rise for it and there is nothing to
+    // upgrade the label to. Sampling would burn a task on every SDR playback for a certain 1.00.
+    @Test("An SDR session is never probed")
+    func skipsSDRSession() {
+        #expect(!DisplayCriteriaController.shouldProbePanelDuringPlayback(
+            effectiveFormat: .sdr, panelPresentedHDRAtLoad: false, sessionIsPlaying: true))
+    }
+
+    @Test("Dolby Vision and HLG sessions are probed like HDR10")
+    func probesEveryHDRFlavor() {
+        #expect(DisplayCriteriaController.shouldProbePanelDuringPlayback(
+            effectiveFormat: .dolbyVision, panelPresentedHDRAtLoad: false, sessionIsPlaying: true))
+        #expect(DisplayCriteriaController.shouldProbePanelDuringPlayback(
+            effectiveFormat: .hlg, panelPresentedHDRAtLoad: false, sessionIsPlaying: true))
+    }
+
+    // #124: a paused mount renders no frames, so nothing composites HDR and the window would close on a
+    // reading that says nothing about the panel. Worse, it would say it in the voice of a measurement.
+    @Test("A paused mount is not probed")
+    func skipsPausedMount() {
+        #expect(!DisplayCriteriaController.shouldProbePanelDuringPlayback(
+            effectiveFormat: .hdr10, panelPresentedHDRAtLoad: false, sessionIsPlaying: false))
+    }
+
+    // MARK: - How long the probe runs
+
+    @Test("The probe stops on the first HDR reading")
+    func stopsOnFirstReading() {
+        #expect(!DisplayCriteriaController.playbackProbeContinues(elapsedMs: 500, observedHDR: true))
+    }
+
+    @Test("The probe keeps sampling while the panel still reads SDR")
+    func continuesWhileSDR() {
+        #expect(DisplayCriteriaController.playbackProbeContinues(elapsedMs: 500, observedHDR: false))
+    }
+
+    // The reading decays, so an unbounded probe would sample a value that can no longer answer
+    // anything. It is also the diagnostic: a window that closes with no reading is the measurement
+    // that says this panel does not raise the headroom at all.
+    @Test("The probe is bounded and stops at the end of its window")
+    func stopsAtWindowEnd() {
+        #expect(!DisplayCriteriaController.playbackProbeContinues(
+            elapsedMs: DisplayCriteriaController.playbackProbeWindowMs, observedHDR: false))
+    }
+
+    // The device trace puts the rise at t+2.5s and the decay at t+20s, so the window has to open
+    // wide enough to contain the rise and close before the value stops meaning anything.
+    @Test("The probe window contains the measured rise and closes before the measured decay")
+    func windowSpansTheMeasuredRise() {
+        #expect(DisplayCriteriaController.playbackProbeWindowMs > 2_500)
+        #expect(DisplayCriteriaController.playbackProbeWindowMs < 20_000)
+    }
+
+    // MARK: - What the late proof publishes
+
+    @Test("A panel that answers HDR publishes the effective format, not SDR")
+    func lateProofPublishesTheEffectiveFormat() {
+        #expect(AetherEngine.presentedVideoFormat(
+            effectiveFormat: .hdr10, panelPresentsHDR: true, sourceVideoFormat: .hdr10) == .hdr10)
+    }
+
+    @Test("A panel that stays SDR keeps the clamped label")
+    func unprovenPanelKeepsSDR() {
+        #expect(AetherEngine.presentedVideoFormat(
+            effectiveFormat: .hdr10, panelPresentsHDR: false, sourceVideoFormat: .hdr10) == .sdr)
+    }
+
+    // SDR content on any panel is SDR content; the panel's mode does not upgrade it.
+    @Test("An SDR source stays SDR on a panel presenting HDR")
+    func sdrSourceStaysSDR() {
+        #expect(AetherEngine.presentedVideoFormat(
+            effectiveFormat: .sdr, panelPresentsHDR: true, sourceVideoFormat: .sdr) == .sdr)
+    }
+
+    // T.35 detection fires early in the session, while the label is still clamped to SDR, and
+    // `handleHDR10PlusDetected` only upgrades a `videoFormat` that already reads `.hdr10`. So by the
+    // time the late proof lands, the HDR10+ evidence lives in `sourceVideoFormat` alone, and
+    // republishing the bare effective format would relabel a proven HDR10+ session "HDR10+ -> HDR10".
+    @Test("An HDR10+ source that was clamped past its T.35 upgrade is republished as HDR10+")
+    func lateProofCarriesTheHDR10PlusUpgrade() {
+        #expect(AetherEngine.presentedVideoFormat(
+            effectiveFormat: .hdr10, panelPresentsHDR: true, sourceVideoFormat: .hdr10Plus)
+            == .hdr10Plus)
+    }
+
+    // The dynamic metadata rides on an HDR10 base layer; it says nothing about a DV or HLG session.
+    @Test("The HDR10+ carry-over applies only to an HDR10 base")
+    func hdr10PlusCarryOverIsScopedToHDR10() {
+        #expect(AetherEngine.presentedVideoFormat(
+            effectiveFormat: .dolbyVision, panelPresentsHDR: true, sourceVideoFormat: .hdr10Plus)
+            == .dolbyVision)
+    }
+}


### PR DESCRIPTION
Fixes the mislabelling reported in #459: an Apple TV whose output format is fixed to HDR shows "HDR10+ -> SDR" / "DV -> SDR" in Stats for Nerds, and has for months.

## Root cause

`currentPanelIsHDR()` answers from `UIScreen.currentEDRHeadroom`, and on tvOS that value is a **transition artifact**: it is raised around a dynamic-range switch and decays back to 1.00 while the panel keeps presenting HDR (device trace in `DisplayCriteriaPanelHDRProofTests`). Every reading it gets today is taken around the criteria write, which is the one moment a panel already parked in HDR has nothing to report:

- no dynamic-range transition, so the live reading is 1.00, and
- `panelProvenToEngageHDR` is armed only by such a reading, so the proof can never be earned either.

Both terms of `panelPresentsHDR` are therefore dead for that panel and it reads SDR forever. Since the same boolean is `HLSVideoEngine`'s master-vs-media routing gate (`builtInPanelEngagesOnDemand` is false on tvOS), the session is also served media-direct with no HDR signaling. The label is the visible half.

This is why it does not reproduce on a box set to 4K SDR with Match Dynamic Range on: there a real switch happens and the headroom rises.

## The signal exists, it is read three seconds too early

Vincent's device measurement of 2026-08-09 (Apple TV 4K 3rd gen, tvOS 26.5, HDR10 panel, one title played twice):

| output format | t+2.5s | t+20s |
|---|---|---|
| 4K HDR | **1.20** | 1.00 |
| 4K SDR | 1.00 | - |

The rise comes with HDR content reaching the screen, not with an HDMI mode switch, and it separates exactly the two configurations `AVPlayer.eligibleForHDRPlayback` conflates: a panel parked in HDR from a rate-only panel parked in SDR.

## Change

- `DisplayCriteriaController.probePanelDuringPlayback()`: a bounded probe (250 ms, 12 s window) that re-asks the panel once frames are running, through the existing `observeHeadroom` funnel, so one reading latches the proof for every later load in the process. It samples during steady playback rather than across a mode switch, so it is *less* exposed to a switch transient than the current load-time reads are.
- The probe does not re-route the running session. The proof it latches makes the next load route correctly on its own.
- A window that closes with no reading is logged as the measurement it is (`max headroom`, sample count). That is the one thing no log line could say before: whether this panel raises the headroom at all.
- `AetherEngine.presentedVideoFormat` is now the single funnel for the published label, so the load-time answer and the late one cannot drift. It carries the HDR10+ upgrade across: T.35 detection fires while the label still reads SDR, and `handleHDR10PlusDetected` only upgrades an `.hdr10` label, so republishing the bare effective format would have relabelled a proven HDR10+ session "HDR10+ -> HDR10".
- Skipped for SDR sessions (nothing composites HDR, nothing to upgrade to) and for paused mounts (#124: no frames, so the window would report the panel's silence as if it had been asked).

## Not covered

The **first** HDR load of a process on such a panel still routes media-direct, because the proof cannot exist before any playback has happened. The label corrects itself within seconds and every later load in the process is right. Persisting the proof across launches (cleared by a -11848/-11868 display rejection, which is the authoritative negative the latch currently lacks) would close that too and is deliberately left out of this round.

The second half of the report, an "SDR -> HDR" indicator, is not answerable with today's tvOS API and is not attempted here: SDR content composites no HDR so the headroom never rises for it, `isDisplayCriteriaMatchingEnabled` conflates the two matching toggles, and `AVDisplayManager` still exposes no mode read-back (re-checked against the tvOS 26.5 SDK headers).

## Verification

`swift test`: 2459 tests, 333 suites, 0 failures. tvOS build green. New suite `Issue459PanelProofDuringPlaybackTests` (14 tests) pins the decisions.

Device verification by the reporter is open: the probe's own log line is the retest.

Host companion: superuser404notfound/Sodalite#101 removes a second, independent clamp that would have overridden the late correction.