### PR TITLE
Cache-backed scrub stills decode on VideoToolbox (#465)

### DIFF
--- a/Sources/AetherEngine/AetherEngine+ScrubThumbnail.swift
+++ b/Sources/AetherEngine/AetherEngine+ScrubThumbnail.swift
@@ -3,6 +3,11 @@ import CoreGraphics
 
 extension AetherEngine {
 
+    /// The 2026-09-02 Whole Title trace opened 30 software decoders in 20 seconds while
+    /// scrubbing three resident 100 MB segments and back. Six keeps that small working set
+    /// warm; the segment bytes are already disk-backed and the bound remains fixed.
+    nonisolated static let scrubThumbnailExtractorLimit = 6
+
     /// Cache-backed scrub still for the active native session (live or VOD). Decodes from
     /// already-produced SegmentCache bytes, so it never opens a second connection and works
     /// on single-connection sources (debrid/torrent HTTP links, #106) where the
@@ -42,12 +47,18 @@ extension AetherEngine {
         } else {
             extractor = FrameExtractor(reader: DataIOReader(data: source.data), formatHint: "mp4")
             scrubThumbnailExtractors.append((source.segmentIndex, extractor))
-            while scrubThumbnailExtractors.count > 2 {
-                let evicted = scrubThumbnailExtractors.removeFirst()
-                Task { await evicted.extractor.shutdown() }
-            }
+            trimScrubThumbnailExtractors()
         }
         return await extractor.thumbnail(at: 0, maxWidth: maxWidth)
+    }
+
+    /// Enforce the cache-backed still LRU after a miss. Kept internal so the exact six-entry
+    /// eviction boundary can be pinned without opening a playback session.
+    func trimScrubThumbnailExtractors() {
+        while scrubThumbnailExtractors.count > Self.scrubThumbnailExtractorLimit {
+            let evicted = scrubThumbnailExtractors.removeFirst()
+            Task { await evicted.extractor.shutdown() }
+        }
     }
 
     /// True when a native session (live or VOD) is active, so `scrubThumbnail` can serve

--- a/Sources/AetherEngine/FrameExtractor/FrameDecodeContext.swift
+++ b/Sources/AetherEngine/FrameExtractor/FrameDecodeContext.swift
@@ -7,7 +7,7 @@ import AetherLibavutil
 import AetherLibswscale
 
 /// Isolated, single-threaded FFmpeg decode context for still-image extraction.
-/// Owns its own Demuxer, AVCodecContext (forced software), and SwsContext, separate
+/// Owns its own Demuxer, AVCodecContext, and SwsContext, separate
 /// from playback. Lazy: ensureOpen() opens on first use, close() is idempotent.
 /// NOT thread-safe; FrameExtractor serializes all access on its decode queue.
 final class FrameDecodeContext: @unchecked Sendable {
@@ -18,6 +18,9 @@ final class FrameDecodeContext: @unchecked Sendable {
     /// idle-reopen path can rebuild over the still-alive reader).
     private let reader: IOReader?
     private let formatHint: String?
+    /// Cache-backed stills run beside native AVPlayer playback, so they may use VideoToolbox.
+    /// Every existing standalone/network extractor keeps the software default from issue #27.
+    private let allowsHardwareDecode: Bool
     /// For a disc image (Blu-ray / DVD ISO) URL, the title to extract stills from. nil = the default
     /// (main) title. Threaded into `Demuxer.open` so a still follows the currently-selected disc title
     /// instead of always decoding the default one (AE#105).
@@ -25,6 +28,9 @@ final class FrameDecodeContext: @unchecked Sendable {
 
     private var demuxer: Demuxer?
     private var codecContext: UnsafeMutablePointer<AVCodecContext>?
+    private var hardwareDeviceContext: UnsafeMutablePointer<AVBufferRef>?
+    private var hardwareDecodeDisabled = false
+    private var loggedHardwareFallback = false
     private var swsContext: UnsafeMutablePointer<SwsContext>?
     private var videoStreamIndex: Int32 = -1
     private var timeBase = AVRational(num: 1, den: 90000)
@@ -37,6 +43,8 @@ final class FrameDecodeContext: @unchecked Sendable {
     /// True for Dolby Vision Profile 5 / Profile 10.0 (no base layer): the decoded planes are
     /// IPT-PQ-C2, not standard YCbCr, so they route through DolbyVisionStillConverter (#103).
     private(set) var isDolbyVisionNoBaseLayer = false
+    /// Diagnostic/test seam for the decoder selected after the first frame.
+    private(set) var hardwareDecoderName: String?
 
     /// Cumulative bytes this context's demuxer pulled from the source (decode-queue only).
     /// Diagnostic: quantifies the extractor's share of link bandwidth per extraction.
@@ -96,21 +104,28 @@ final class FrameDecodeContext: @unchecked Sendable {
         return max(0, duration - clampBackoffSeconds)
     }
 
-    init(url: URL, httpHeaders: [String: String], selectTitleID: Int? = nil) {
+    init(url: URL, httpHeaders: [String: String], selectTitleID: Int? = nil,
+         allowsHardwareDecode: Bool = false) {
         self.url = url
         self.httpHeaders = httpHeaders
         self.reader = nil
         self.formatHint = nil
         self.selectTitleID = selectTitleID
+        self.allowsHardwareDecode = allowsHardwareDecode
     }
 
-    init(reader: IOReader, formatHint: String?) {
+    init(reader: IOReader, formatHint: String?, allowsHardwareDecode: Bool = false) {
         // Placeholder; unused when reader != nil (openInternal opens the reader).
         self.url = URL(string: "aether-custom://frame-extractor")!
         self.httpHeaders = [:]
         self.reader = reader
         self.formatHint = formatHint
         self.selectTitleID = nil
+        // DataIOReader is internal and exists for the native segment-cache still path. Recognizing
+        // it here keeps both VOD and live FrameExtractor call sites byte-identical and leaves every
+        // public custom-reader/network caller on the issue #27 software default. The 2026-09-02
+        // device trace measured 30 software context opens in 20 seconds over resident H.264 bytes.
+        self.allowsHardwareDecode = allowsHardwareDecode || reader is DataIOReader
     }
 
     deinit {
@@ -136,6 +151,10 @@ final class FrameDecodeContext: @unchecked Sendable {
             avcodec_free_context(&codecContext)
         }
         codecContext = nil
+        if hardwareDeviceContext != nil {
+            av_buffer_unref(&hardwareDeviceContext)
+        }
+        hardwareDeviceContext = nil
         if swsContext != nil {
             sws_freeContext(swsContext)
             swsContext = nil
@@ -145,6 +164,7 @@ final class FrameDecodeContext: @unchecked Sendable {
         videoStreamIndex = -1
         isHDR = false
         isDolbyVisionNoBaseLayer = false
+        hardwareDecoderName = nil
         isOpen = false
     }
 
@@ -186,21 +206,71 @@ final class FrameDecodeContext: @unchecked Sendable {
         guard let codec = avcodec_find_decoder(codecpar.pointee.codec_id) else {
             throw FrameDecodeError.unsupportedCodec
         }
+        var openedWithHardware = false
+        if allowsHardwareDecode, !hardwareDecodeDisabled {
+            let deviceResult = av_hwdevice_ctx_create(
+                &hardwareDeviceContext, AV_HWDEVICE_TYPE_VIDEOTOOLBOX, nil, nil, 0)
+            if deviceResult >= 0, hardwareDeviceContext != nil {
+                do {
+                    codecContext = try makeCodecContext(
+                        codecpar: codecpar, codec: codec, useHardware: true)
+                    openedWithHardware = true
+                } catch {
+                    disableHardwareDecode("decoder open failed")
+                }
+            } else {
+                disableHardwareDecode("device creation failed ret=\(deviceResult)")
+            }
+        }
+
+        if !openedWithHardware {
+            if hardwareDeviceContext != nil {
+                av_buffer_unref(&hardwareDeviceContext)
+            }
+            hardwareDeviceContext = nil
+            codecContext = try makeCodecContext(
+                codecpar: codecpar, codec: codec, useHardware: false)
+            logOpened(codecpar: codecpar, codec: codec, hardware: "none")
+        }
+    }
+
+    private func makeCodecContext(
+        codecpar: UnsafeMutablePointer<AVCodecParameters>,
+        codec: UnsafePointer<AVCodec>,
+        useHardware: Bool
+    ) throws -> UnsafeMutablePointer<AVCodecContext> {
         guard let ctx = avcodec_alloc_context3(codec) else {
             throw FrameDecodeError.allocationFailed
         }
-        codecContext = ctx
         guard avcodec_parameters_to_context(ctx, codecpar) >= 0 else {
+            var doomed: UnsafeMutablePointer<AVCodecContext>? = ctx
+            avcodec_free_context(&doomed)
             throw FrameDecodeError.noCodecParameters
         }
-        ctx.pointee.get_format = { _, fmts in
-            guard let fmts = fmts else { return AV_PIX_FMT_NONE }
-            var i = 0
-            while fmts[i] != AV_PIX_FMT_NONE {
-                if fmts[i] != AV_PIX_FMT_VIDEOTOOLBOX { return fmts[i] }
-                i += 1
+
+        if useHardware, let hardwareDeviceContext {
+            ctx.pointee.hw_device_ctx = av_buffer_ref(hardwareDeviceContext)
+            ctx.pointee.get_format = { _, fmts in
+                guard let fmts else { return AV_PIX_FMT_NONE }
+                var fallback = AV_PIX_FMT_NONE
+                var i = 0
+                while fmts[i] != AV_PIX_FMT_NONE {
+                    if fmts[i] == AV_PIX_FMT_VIDEOTOOLBOX { return fmts[i] }
+                    if fallback == AV_PIX_FMT_NONE { fallback = fmts[i] }
+                    i += 1
+                }
+                return fallback
             }
-            return AV_PIX_FMT_YUV420P
+        } else {
+            ctx.pointee.get_format = { _, fmts in
+                guard let fmts = fmts else { return AV_PIX_FMT_NONE }
+                var i = 0
+                while fmts[i] != AV_PIX_FMT_NONE {
+                    if fmts[i] != AV_PIX_FMT_VIDEOTOOLBOX { return fmts[i] }
+                    i += 1
+                }
+                return AV_PIX_FMT_YUV420P
+            }
         }
         ctx.pointee.thread_count = Int32(Self.stillExtractionThreadCount(
             activeProcessorCount: ProcessInfo.processInfo.activeProcessorCount))
@@ -214,16 +284,71 @@ final class FrameDecodeContext: @unchecked Sendable {
         ctx.pointee.flags2 |= AV_CODEC_FLAG2_FAST_VALUE
 
         var opts: OpaquePointer?
-        // SW decode is forced by the get_format callback above (rejects VIDEOTOOLBOX).
-        // The "hwaccel" entry is a no-op at avcodec_open2, kept for parity with SoftwareVideoDecoder.
-        av_dict_set(&opts, "hwaccel", "none", 0)
-        guard avcodec_open2(ctx, codec, &opts) >= 0 else {
-            av_dict_free(&opts)
+        if !useHardware {
+            // Belt-and-suspenders with the software get_format callback above.
+            av_dict_set(&opts, "hwaccel", "none", 0)
+        }
+        let openResult = avcodec_open2(ctx, codec, &opts)
+        av_dict_free(&opts)
+        guard openResult >= 0 else {
+            var doomed: UnsafeMutablePointer<AVCodecContext>? = ctx
+            avcodec_free_context(&doomed)
             throw FrameDecodeError.decoderOpenFailed
         }
-        av_dict_free(&opts)
+        return ctx
+    }
 
-        EngineLog.emit("[FrameDecode] Opened \(codecpar.pointee.width)x\(codecpar.pointee.height) codec=\(String(cString: codec.pointee.name)) threads=\(ctx.pointee.thread_count)", category: .swPlayback)
+    private func disableHardwareDecode(_ reason: String) {
+        hardwareDecodeDisabled = true
+        if !loggedHardwareFallback {
+            loggedHardwareFallback = true
+            EngineLog.emit(
+                "[FrameDecode] VideoToolbox unavailable; using software (\(reason))",
+                category: .swPlayback)
+        }
+    }
+
+    private func logOpened(
+        codecpar: UnsafeMutablePointer<AVCodecParameters>,
+        codec: UnsafePointer<AVCodec>,
+        hardware: String
+    ) {
+        hardwareDecoderName = hardware
+        guard let ctx = codecContext else { return }
+        EngineLog.emit(
+            "[FrameDecode] Opened \(codecpar.pointee.width)x\(codecpar.pointee.height) "
+            + "codec=\(String(cString: codec.pointee.name)) threads=\(ctx.pointee.thread_count) "
+            + "hw=\(hardware)",
+            category: .swPlayback)
+    }
+
+    private func replaceHardwareDecoderWithSoftware(reason: String) -> Bool {
+        disableHardwareDecode(reason)
+        if codecContext != nil {
+            avcodec_free_context(&codecContext)
+        }
+        codecContext = nil
+        if hardwareDeviceContext != nil {
+            av_buffer_unref(&hardwareDeviceContext)
+        }
+        hardwareDeviceContext = nil
+        hardwareDecoderName = nil
+
+        guard let stream = demuxer?.stream(at: videoStreamIndex),
+              let codecpar = stream.pointee.codecpar,
+              let codec = avcodec_find_decoder(codecpar.pointee.codec_id) else {
+            isOpen = false
+            return false
+        }
+        do {
+            codecContext = try makeCodecContext(
+                codecpar: codecpar, codec: codec, useHardware: false)
+            logOpened(codecpar: codecpar, codec: codec, hardware: "none")
+            return true
+        } catch {
+            isOpen = false
+            return false
+        }
     }
 
     // MARK: - Decode
@@ -279,7 +404,46 @@ final class FrameDecodeContext: @unchecked Sendable {
         guard frame != nil else { return nil }
         defer { av_frame_free(&frame) }
 
-        func makeImage(_ f: UnsafeMutablePointer<AVFrame>) -> CGImage? {
+        var hardwareTransferFailure: Int32?
+        func makeImage(_ decodedFrame: UnsafeMutablePointer<AVFrame>) -> CGImage? {
+            var transferredFrame: UnsafeMutablePointer<AVFrame>?
+            let f: UnsafeMutablePointer<AVFrame>
+            if decodedFrame.pointee.format == AV_PIX_FMT_VIDEOTOOLBOX.rawValue {
+                transferredFrame = av_frame_alloc()
+                guard let transferTarget = transferredFrame else { return nil }
+                let transferResult = av_hwframe_transfer_data(transferTarget, decodedFrame, 0)
+                guard transferResult >= 0 else {
+                    hardwareTransferFailure = transferResult
+                    av_frame_free(&transferredFrame)
+                    return nil
+                }
+                let propertyResult = av_frame_copy_props(transferTarget, decodedFrame)
+                guard propertyResult >= 0 else {
+                    hardwareTransferFailure = propertyResult
+                    av_frame_free(&transferredFrame)
+                    return nil
+                }
+                f = transferTarget
+                if hardwareDecoderName == nil,
+                   let stream = demuxer.stream(at: videoStreamIndex),
+                   let codecpar = stream.pointee.codecpar,
+                   let codec = avcodec_find_decoder(codecpar.pointee.codec_id) {
+                    logOpened(codecpar: codecpar, codec: codec, hardware: "videotoolbox")
+                }
+            } else {
+                f = decodedFrame
+                if hardwareDecoderName == nil,
+                   let stream = demuxer.stream(at: videoStreamIndex),
+                   let codecpar = stream.pointee.codecpar,
+                   let codec = avcodec_find_decoder(codecpar.pointee.codec_id) {
+                    logOpened(codecpar: codecpar, codec: codec, hardware: "none")
+                }
+            }
+            defer {
+                if transferredFrame != nil {
+                    av_frame_free(&transferredFrame)
+                }
+            }
             let width = mode == .thumbnail
                 ? targetWidth
                 : Self.clampedWidth(frame: f, maxSize: maxSize)
@@ -355,7 +519,20 @@ final class FrameDecodeContext: @unchecked Sendable {
                 }
 
                 if isCancelled() { return nil }
-                return makeImage(f)
+                let image = makeImage(f)
+                if let hardwareTransferFailure {
+                    guard replaceHardwareDecoderWithSoftware(
+                        reason: "frame transfer failed ret=\(hardwareTransferFailure)") else {
+                        return nil
+                    }
+                    return decodeFrame(
+                        at: seconds,
+                        mode: mode,
+                        targetWidth: targetWidth,
+                        maxSize: maxSize,
+                        isCancelled: isCancelled)
+                }
+                return image
             }
         }
     }

--- a/Tests/AetherEngineTests/FrameDecodeContextHardwareTests.swift
+++ b/Tests/AetherEngineTests/FrameDecodeContextHardwareTests.swift
@@ -1,0 +1,53 @@
+import Foundation
+import Testing
+@testable import AetherEngine
+
+/// Cache-backed stills are the one extraction path allowed to ask for VideoToolbox: native
+/// playback is already on the hardware path, so issue #27's software-playback starvation does
+/// not apply. A codec VideoToolbox declines must remain a successful software still, not a miss.
+struct FrameDecodeContextHardwareTests {
+
+    @Test("hardware-allowed still falls back for an MPEG-4 Part 2 fixture")
+    func declinedCodecStillDecodes() throws {
+        let data = try #require(Data(
+            base64Encoded: Self.mpeg4FixtureBase64,
+            options: .ignoreUnknownCharacters))
+        let context = FrameDecodeContext(
+            reader: DataIOReader(data: data),
+            formatHint: "mp4",
+            allowsHardwareDecode: true)
+        defer { context.close() }
+
+        try context.ensureOpen()
+        let image = context.decodeFrame(
+            at: 0,
+            mode: .thumbnail,
+            targetWidth: 64,
+            maxSize: nil,
+            isCancelled: { false })
+
+        #expect(image != nil)
+        #expect(context.hardwareDecoderName == "none")
+    }
+
+    /// One 64x64 MPEG-4 Part 2 frame. VideoToolbox does not offer that legacy codec, while
+    /// FFmpeg's software decoder does; this is the deterministic decline/fallback witness.
+    /// Regenerate with:
+    /// `ffmpeg -f lavfi -i color=c=red:s=64x64:r=1:d=1 -c:v mpeg4 -q:v 5 -pix_fmt yuv420p -movflags +faststart vt-decline.mp4`
+    private static let mpeg4FixtureBase64 = """
+        AAAAHGZ0eXBpc29tAAACAGlzb21pc28ybXA0MQAAA0Ftb292AAAAbG12aGQAAAAAAAAAAAAAAAAAAAPoAAAD6AABAAABAAAA
+        AAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC
+        AAACa3RyYWsAAABcdGtoZAAAAAMAAAAAAAAAAAAAAAEAAAAAAAAD6AAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAA
+        AAEAAAAAAAAAAAAAAAAAAEAAAAAAQAAAAEAAAAAAACRlZHRzAAAAHGVsc3QAAAAAAAAAAQAAA+gAAAAAAAEAAAAAAeNtZGlh
+        AAAAIG1kaGQAAAAAAAAAAAAAAAAAAEAAAABAAFXEAAAAAAAtaGRscgAAAAAAAAAAdmlkZQAAAAAAAAAAAAAAAFZpZGVvSGFu
+        ZGxlcgAAAAGObWluZgAAABR2bWhkAAAAAQAAAAAAAAAAAAAAJGRpbmYAAAAcZHJlZgAAAAAAAAABAAAADHVybCAAAAABAAAB
+        TnN0YmwAAADqc3RzZAAAAAAAAAABAAAA2m1wNHYAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAQABAAEgAAABIAAAAAAAAAAET
+        TGF2YzYyLjI4LjEwMCBtcGVnNAAAAAAAAAAAAAAAAAAY//8AAABgZXNkcwAAAAADgICATwABAASAgIBBIBEAAAAAAw1AAAAC
+        qAWAgIAvAAABsAEAAAG1iRMAAAEAAAABIADEjYgADQIECBRDAAABskxhdmM2Mi4yOC4xMDAGgICAAQIAAAAQcGFzcAAAAAEA
+        AAABAAAAFGJ0cnQAAAAAAAMNQAAAAqgAAAAYc3R0cwAAAAAAAAABAAAAAQAAQAAAAAAcc3RzYwAAAAAAAAABAAAAAQAAAAEA
+        AAABAAAAFHN0c3oAAAAAAAAAVQAAAAEAAAAUc3RjbwAAAAAAAAABAAADbQAAAGJ1ZHRhAAAAWm1ldGEAAAAAAAAAIWhkbHIA
+        AAAAAAAAAG1kaXJhcHBsAAAAAAAAAAAAAAAALWlsc3QAAAAlqXRvbwAAAB1kYXRhAAAAAQAAAABMYXZmNjIuMTIuMTAwAAAA
+        CGZyZWUAAABdbWRhdAAAAbMAEAcAAAG2FgsYWm2C6Bxxtt/G238bbfsAAKFRhabYLoHHG238bbfxtt+/AADBUYWm2C6Bxxtt
+        /G238bbfvwAA4VGFptgugccbbfxtt/G2378=
+        """
+}

--- a/Tests/AetherEngineTests/ScrubThumbnailExtractorLRUTests.swift
+++ b/Tests/AetherEngineTests/ScrubThumbnailExtractorLRUTests.swift
@@ -1,0 +1,32 @@
+import Foundation
+import Testing
+@testable import AetherEngine
+
+struct ScrubThumbnailExtractorLRUTests {
+
+    @Test("cache-backed still LRU retains the six newest segment contexts")
+    @MainActor
+    func retainsSixNewestContexts() async throws {
+        let engine = try AetherEngine()
+        for segmentIndex in 0..<6 {
+            engine.scrubThumbnailExtractors.append((
+                segmentIndex,
+                FrameExtractor(reader: DataIOReader(data: Data()), formatHint: "mp4")))
+        }
+
+        engine.trimScrubThumbnailExtractors()
+        #expect(engine.scrubThumbnailExtractors.map { $0.segmentIndex } == Array(0..<6))
+
+        engine.scrubThumbnailExtractors.append((
+            6,
+            FrameExtractor(reader: DataIOReader(data: Data()), formatHint: "mp4")))
+        engine.trimScrubThumbnailExtractors()
+        #expect(engine.scrubThumbnailExtractors.map { $0.segmentIndex } == Array(1...6))
+
+        let retained = engine.scrubThumbnailExtractors.map { $0.extractor }
+        engine.scrubThumbnailExtractors.removeAll()
+        for extractor in retained {
+            await extractor.shutdown()
+        }
+    }
+}


### PR DESCRIPTION
One commit from @sitepilotusa's PR #465, taken on its own because it is independent of that pull request's request-rate work.

A device trace on 2026-09-02 opened 30 software decoders in 20 seconds while scrubbing three resident 100 MB segments and back. Cache-backed stills run beside native AVPlayer playback, so they may use VideoToolbox: the decode context now opens with a hardware device when its reader is the internal `DataIOReader` the segment-cache still path uses, transfers the frame back with `av_hwframe_transfer_data`, and falls back to software on device-creation, open, or transfer failure, latching so it cannot retry per frame. Every public custom-reader and network caller keeps the software default from issue #27. The still extractor's LRU goes from 2 to 6 so a small scrub working set stays warm.

Opened as a pull request rather than merged directly so CI runs before it lands.

Left out of this pick and still on the `atlas` branch: the request-rate pacer (merged and reverted, see below), the delivery-rate range sizing, the far backward-seek re-anchor, and the resident-ranges commit, which landed as #468 in a form that branch predates.