### PR TITLE
An origin that refuses is asked less often, not just less concurrently (#465, round 2)

### DIFF
--- a/Sources/AetherEngine/AetherEngine+Subtitles.swift
+++ b/Sources/AetherEngine/AetherEngine+Subtitles.swift
@@ -13,6 +13,15 @@ public enum SubtitleChannel: Sendable {
     case secondary
 }
 
+extension SubtitleForwardPrefetcher {
+    /// #151: on the 6.60.0-atlas.1 device run, refusals fell from roughly 150 to 21, but every 429
+    /// after the pump went quiet came from this best-effort reader reopening every 4 to 10 seconds.
+    /// A paced or single-slot origin keeps the pump's tap-fed subtitles and yields the speculative
+    /// far-ahead window, the same trade already documented for serial source requests.
+    static func shouldHold(originPaced: Bool, originSerial: Bool) -> Bool {
+        originPaced || originSerial
+    }
+}
 
 extension AetherEngine {
 
@@ -643,7 +652,29 @@ extension AetherEngine {
                 maxRestarts: AetherEngine.subtitleForwardPrefetchMaxRestarts,
                 backoffNanoseconds: AetherEngine.subtitleForwardPrefetchRestartBackoffNanoseconds)
             var resumeAt = anchor
+            var holdingForMeteredOrigin = false
             while !Task.isCancelled {
+                let originPaced = OriginRequestBudget.shared.isPaced(url)
+                let originSerial = OriginRequestBudget.shared.requiresSerialRequests(url)
+                if SubtitleForwardPrefetcher.shouldHold(
+                    originPaced: originPaced, originSerial: originSerial
+                ) {
+                    if !holdingForMeteredOrigin {
+                        EngineLog.emit(
+                            "[AetherEngine] #151 forward prefetch holding: origin is metered "
+                            + "(paced=\(originPaced) serial=\(originSerial))",
+                            category: .engine)
+                        holdingForMeteredOrigin = true
+                    }
+                    do { try await Task.sleep(for: .seconds(2)) } catch { return }
+                    continue
+                }
+                if holdingForMeteredOrigin {
+                    EngineLog.emit(
+                        "[AetherEngine] #151 forward prefetch resuming: origin is no longer metered",
+                        category: .engine)
+                    holdingForMeteredOrigin = false
+                }
                 // A custom source needs its own independent reader per attempt: the previous one
                 // is closed by the session that failed.
                 var attemptReader: IOReader? = nil

--- a/Sources/AetherEngine/Demuxer/AVIOReader.swift
+++ b/Sources/AetherEngine/Demuxer/AVIOReader.swift
@@ -52,6 +52,56 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
     /// deadlocks this one. See `makeSessionConfig`.
     static let longLivedConnectionsPerHost = 64
 
+    struct HopTiming {
+        let host: String
+        let port: Int
+        let status: Int?
+        let ttfbMs: Double
+        let totalMs: Double
+    }
+
+    /// #377 follow-up: 32 MB at 100 Mbps takes about 3 seconds after a healthy first byte, while
+    /// measured stalls waited 5.3 and 9.5 seconds before one; trigger on summed redirect-hop TTFB.
+    static func slowFirstByteLine(taskSeconds: TimeInterval, hops: [HopTiming]) -> String? {
+        let firstByteMs = hops.reduce(0) { $0 + $1.ttfbMs }
+        guard firstByteMs > 1_000 else { return nil }
+        let taskMs = Int((taskSeconds * 1_000).rounded())
+        let summary = hops.map { hop in
+            var fields = ["\(hop.host):\(hop.port)"]
+            if let status = hop.status { fields.append("status=\(status)") }
+            fields.append("ttfb=\(Int(hop.ttfbMs.rounded()))ms")
+            fields.append("total=\(Int(hop.totalMs.rounded()))ms")
+            return fields.joined(separator: " ")
+        }.joined(separator: " -> ")
+        return "[AVIOReader] slow first byte: task=\(taskMs)ms over \(hops.count) hops: \(summary)"
+    }
+
+    /// Signed redirect paths and queries carry tokens, so only host and port cross this adapter.
+    static func hopTiming(_ transaction: URLSessionTaskTransactionMetrics) -> HopTiming? {
+        guard let url = transaction.request.url,
+              let host = url.host,
+              let fetchStart = transaction.fetchStartDate,
+              let responseStart = transaction.responseStartDate,
+              let responseEnd = transaction.responseEndDate else { return nil }
+        let port: Int
+        if let explicitPort = url.port {
+            port = explicitPort
+        } else if url.scheme?.lowercased() == "https" {
+            port = 443
+        } else if url.scheme?.lowercased() == "http" {
+            port = 80
+        } else {
+            return nil
+        }
+        return HopTiming(
+            host: host,
+            port: port,
+            status: (transaction.response as? HTTPURLResponse)?.statusCode,
+            ttfbMs: responseStart.timeIntervalSince(fetchStart) * 1_000,
+            totalMs: responseEnd.timeIntervalSince(fetchStart) * 1_000
+        )
+    }
+
     /// Session config factory. Short-lived probes/chunks get a 60s resource timeout;
     /// long-lived persistent/streaming connections omit it (fires mid-stream, NSURLError
     /// -1001; stall detection is handled by `connStallTimeout`). `urlCache = nil` avoids
@@ -345,9 +395,10 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
     /// refusal on an edge target. Keying off `requestURL()` there names the source in the books for
     /// an answer it never gave. The chain folding (#388) lands both keys in one bucket either way,
     /// so this is about which host the books name, not about which budget moves.
-    private func noteOriginRefusal(status: Int, respondedBy: URL? = nil) {
+    private func noteOriginRefusal(status: Int, retryAfter: TimeInterval? = nil,
+                                   respondedBy: URL? = nil) {
         let refusing = respondedBy ?? requestURL()
-        OriginRequestBudget.shared.noteRefusal(for: refusing, status: status)
+        OriginRequestBudget.shared.noteRefusal(for: refusing, status: status, retryAfter: retryAfter)
         // The refusal usually comes back from the post-redirect CDN, while the engine's revive arm
         // only knows the URL the host loaded. Where those differ (a proxy that 302s to a signed CDN
         // target, the shape in the #377 report) the verdict would never be found on the key the
@@ -2212,12 +2263,15 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
     /// Single Range fetch for a detour block over the pooled chunkSession. Surfaces rate limiting with
     /// its Retry-After so the caller can back off in place rather than churn the connection (#71).
     private func detourFetchBlock(from offset: Int64, size: Int) -> DetourFetch {
+        let budget = Self.effectiveDetourBudget(chunkRequestTimeout: chunkRequestTimeout)
+        let ticket = OriginRequestBudget.shared.acquire(
+            for: requestURL(), label: "\(label) detour", timeout: budget)
+        defer { OriginRequestBudget.shared.release(ticket) }
         let rangeEnd = offset + Int64(size) - 1
         var request = URLRequest(url: requestURL())
         request.setValue("bytes=\(offset)-\(rangeEnd)", forHTTPHeaderField: "Range")
         // #93/#96: a starved backward-scrub detour fetch must abort fast (the rescue reconnect serves
         // instantly), so this path uses the tight interactive budget, not the full chunk timeout.
-        let budget = Self.effectiveDetourBudget(chunkRequestTimeout: chunkRequestTimeout)
         request.timeoutInterval = budget
         applyExtraHeaders(&request)
         do {
@@ -2225,8 +2279,10 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
             if let http = response as? HTTPURLResponse {
                 let status = http.statusCode
                 if Self.isRateLimitStatus(status) {
-                    noteOriginRefusal(status: status, respondedBy: http.url)
-                    return .rateLimited(Self.parseRetryAfter(http))
+                    let retryAfter = Self.parseRetryAfter(http)
+                    noteOriginRefusal(status: status, retryAfter: retryAfter > 0 ? retryAfter : nil,
+                                      respondedBy: http.url)
+                    return .rateLimited(retryAfter)
                 }
                 if status != 200 && status != 206 {
                     if Self.isResolvedExpiryStatus(status) { invalidateResolvedURL() }
@@ -2865,7 +2921,8 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
         var retryAfter: TimeInterval = 0
         if Self.isRateLimitStatus(status) {
             retryAfter = Self.parseRetryAfter(http)
-            noteOriginRefusal(status: status, respondedBy: respondedBy)
+            noteOriginRefusal(status: status, retryAfter: retryAfter > 0 ? retryAfter : nil,
+                              respondedBy: respondedBy)
         }
         var headerMs: Double? = nil
         winCond.lock()
@@ -3822,6 +3879,13 @@ private final class PersistentReadDelegate: NSObject, URLSessionDataDelegate, @u
         didFinishCollecting metrics: URLSessionTaskMetrics
     ) {
         ReaderTransportLog.note(metrics, for: originURL)
+        let hops = metrics.transactionMetrics.compactMap(AVIOReader.hopTiming)
+        if let line = AVIOReader.slowFirstByteLine(
+            taskSeconds: metrics.taskInterval.duration,
+            hops: hops
+        ) {
+            EngineLog.emit(line, category: .engine)
+        }
     }
 }
 

--- a/Sources/AetherEngine/Demuxer/OriginRequestBudget.swift
+++ b/Sources/AetherEngine/Demuxer/OriginRequestBudget.swift
@@ -51,6 +51,18 @@ final class OriginRequestBudget: @unchecked Sendable {
     private static let firstQuietPeriod: TimeInterval = 2
     private static let maximumQuietPeriod: TimeInterval = 15
     private static let quietSecondsToDisarm: TimeInterval = 60
+    /// Longest single wait a paced caller takes before re-reading the books. Only an injected clock
+    /// needs this to be shorter than the whole debt: a clock that moves without the wall clock
+    /// cannot shorten a wait that has already been entered.
+    private static let pacerWaitSliceSeconds: TimeInterval = 0.25
+
+    /// Test seam: caps the quiet period a refusal arms on THIS budget, and **zero leaves the pacer
+    /// unarmed entirely**. The ladder is wall-clock by design, so a suite whose subject is the
+    /// concurrency ceiling or the resolved-URL ladder would otherwise block a thread for 2 to 15 s
+    /// per refusal on a rule it is not testing, and five such tests were enough to starve unrelated
+    /// suites of threads on a CI runner. Pinned on `.shared` by those suites; the pacer's own tests
+    /// build their own instances and keep the shipped ladder.
+    var quietPeriodCapForTesting: TimeInterval?
 
     /// Scheme + host + port, matching `SuffixRangeSupport.originKey`. Deliberately NOT the full
     /// URL: a metered CDN hands out signed URLs with a rotating token, so a per-URL budget would
@@ -266,14 +278,18 @@ final class OriginRequestBudget: @unchecked Sendable {
         state.lastRefillAt = instant
     }
 
-    /// The caller already owns a concurrency slot. Hold it while the pacer waits: taking the slot
-    /// first keeps the two admission rules in one order, so two callers cannot each hold one gate
-    /// while waiting for the other. Polling is bounded and intentionally short so an injected test
-    /// clock can advance without making the test spend the production quiet period on wall time.
-    private func ticketAfterPacing(raw: String, label: String, started: DispatchTime,
-                                   timeout: TimeInterval, slotWaitedMs: Double) -> Ticket {
+    /// Wait until this origin's pacer allows one more request. Returns the milliseconds spent
+    /// waiting, or nil when `timeout` measured from `started` ran out first.
+    ///
+    /// **Nothing is held while this waits.** A pacer token is consumed, not held, so a caller
+    /// parked here occupies no slot. Waiting for the token INSIDE a slot (the shape this replaces)
+    /// turned a rate rule into a concurrency rule: on a single-slot origin one paced request parked
+    /// every other path behind it for the whole quiet period, and a suite full of readers doing that
+    /// blocked enough threads that unrelated tests could not get one.
+    private func waitForPacerToken(raw: String, label: String, started: DispatchTime,
+                                   timeout: TimeInterval) -> Double? {
         var pacingStarted: DispatchTime?
-        let poller = DispatchSemaphore(value: 0)
+        let sleeper = DispatchSemaphore(value: 0)
         while true {
             let instant = now()
             lock.lock()
@@ -284,11 +300,7 @@ final class OriginRequestBudget: @unchecked Sendable {
             guard let quietUntil = state.quietUntil else {
                 origins[key] = state
                 lock.unlock()
-                let waitedMs = slotWaitedMs > 0
-                    ? Double(DispatchTime.now().uptimeNanoseconds - started.uptimeNanoseconds)
-                        / 1_000_000
-                    : 0
-                return Ticket(key: raw, label: label, waitedMs: waitedMs, granted: true)
+                return pacedMilliseconds(since: pacingStarted, label: label, spent: false)
             }
 
             let waitNeeded: TimeInterval
@@ -300,42 +312,37 @@ final class OriginRequestBudget: @unchecked Sendable {
                     state.tokens -= 1
                     origins[key] = state
                     lock.unlock()
-                    let waitedMs = slotWaitedMs > 0 || pacingStarted != nil
-                        ? Double(DispatchTime.now().uptimeNanoseconds - started.uptimeNanoseconds)
-                            / 1_000_000
-                        : 0
-                    if let pacingStarted {
-                        let pacedMs = Self.elapsedSeconds(from: pacingStarted, to: DispatchTime.now())
-                            * 1_000
-                        EngineLog.emit(
-                            "[OriginBudget] \(label) paced \(Int(pacedMs))ms",
-                            category: .demux, level: .verbose)
-                    }
-                    return Ticket(key: raw, label: label, waitedMs: waitedMs, granted: true)
+                    return pacedMilliseconds(since: pacingStarted, label: label, spent: false)
                 }
                 waitNeeded = (1 - state.tokens) / Self.pacerRefillPerSecond
             }
             origins[key] = state
             lock.unlock()
 
-            let elapsed = Self.elapsedSeconds(from: started, to: DispatchTime.now())
-            let remaining = timeout - elapsed
+            let remaining = timeout - Self.elapsedSeconds(from: started, to: DispatchTime.now())
             guard remaining > 0 else {
-                let waitedMs = elapsed * 1_000
-                if let pacingStarted {
-                    let pacedMs = Self.elapsedSeconds(from: pacingStarted, to: DispatchTime.now())
-                        * 1_000
-                    EngineLog.emit(
-                        "[OriginBudget] \(label) paced \(Int(pacedMs))ms",
-                        category: .demux, level: .verbose)
-                }
-                return Ticket(key: raw, label: label, waitedMs: waitedMs, granted: false)
+                _ = pacedMilliseconds(since: pacingStarted, label: label, spent: true)
+                return nil
             }
 
-            let poll = min(remaining, max(0.001, min(waitNeeded, 0.01)))
             if pacingStarted == nil { pacingStarted = DispatchTime.now() }
-            _ = poller.wait(timeout: .now() + poll)
+            // One wait for as long as the pacer actually owes, rather than a 10 ms poll: the old
+            // shape woke a blocked thread up to a hundred times a second for a quiet period that
+            // reaches 15 s. The slice cap is what an injected test clock needs, since a clock that
+            // moves without the wall clock cannot shorten a wait already entered.
+            let slice = min(remaining, max(0.001, min(waitNeeded, Self.pacerWaitSliceSeconds)))
+            _ = sleeper.wait(timeout: .now() + slice)
         }
+    }
+
+    private func pacedMilliseconds(since pacingStarted: DispatchTime?, label: String,
+                                   spent: Bool) -> Double {
+        guard let pacingStarted else { return 0 }
+        let ms = Self.elapsedSeconds(from: pacingStarted, to: DispatchTime.now()) * 1_000
+        EngineLog.emit(
+            "[OriginBudget] \(label) paced \(Int(ms))ms" + (spent ? ", budget spent" : ""),
+            category: .demux, level: .verbose)
+        return ms
     }
 
     /// Take a slot for one request against `url`, waiting up to `timeout` when the origin is
@@ -350,6 +357,26 @@ final class OriginRequestBudget: @unchecked Sendable {
         guard let raw = Self.originKey(for: url) else { return nil }
 
         let started = DispatchTime.now()
+        // Rate before concurrency. The two rules bind different things and only this order lets a
+        // caller wait for the rate rule without holding the concurrency one.
+        guard let pacedMs = waitForPacerToken(raw: raw, label: label, started: started,
+                                              timeout: timeout) else {
+            // The pacer alone spent the caller's budget. Proceed uncounted-for, the same answer the
+            // slot timeout below gives, and stay honest about being on the link.
+            lock.lock()
+            let spentKey = headLocked(raw)
+            var spent = origins[spentKey] ?? OriginState()
+            spent.inflight += 1
+            spent.peakInflight = max(spent.peakInflight, spent.inflight)
+            origins[spentKey] = spent
+            lock.unlock()
+            let waitedMs = Self.elapsedSeconds(from: started, to: DispatchTime.now()) * 1_000
+            EngineLog.emit(
+                "[OriginBudget] \(label) proceeded without waiting the pacer out after "
+                + "\(Int(waitedMs))ms", category: .demux)
+            return Ticket(key: raw, label: label, waitedMs: waitedMs, granted: false)
+        }
+
         lock.lock()
         let key = headLocked(raw)
         var state = origins[key] ?? OriginState()
@@ -358,21 +385,22 @@ final class OriginRequestBudget: @unchecked Sendable {
             state.peakInflight = max(state.peakInflight, state.inflight)
             origins[key] = state
             lock.unlock()
-            return ticketAfterPacing(raw: raw, label: label, started: started,
-                                     timeout: timeout, slotWaitedMs: 0)
+            return Ticket(key: raw, label: label, waitedMs: pacedMs, granted: true)
         }
         let semaphore = DispatchSemaphore(value: 0)
         state.waiters.append(semaphore)
         origins[key] = state
         lock.unlock()
 
-        let signalled = semaphore.wait(timeout: .now() + timeout) == .success
+        // What the pacer already spent comes off the slot's budget, so the caller's total wait is
+        // the one figure it asked for rather than that figure per gate.
+        let slotBudget = max(0, timeout - Self.elapsedSeconds(from: started, to: DispatchTime.now()))
+        let signalled = semaphore.wait(timeout: .now() + slotBudget) == .success
         let waitedMs = Double(DispatchTime.now().uptimeNanoseconds - started.uptimeNanoseconds) / 1_000_000
 
         if signalled {
             // `release` counted us in before signalling, so the slot is already ours.
-            return ticketAfterPacing(raw: raw, label: label, started: started,
-                                     timeout: timeout, slotWaitedMs: waitedMs)
+            return Ticket(key: raw, label: label, waitedMs: waitedMs, granted: true)
         }
 
         // Timed out. Drop out of the queue and proceed uncounted-for: a slot handed to us between
@@ -483,14 +511,18 @@ final class OriginRequestBudget: @unchecked Sendable {
         state.refusals += 1
         state.lastRefusalAt = instant
         state.refusalStreak += 1
-        state.tokens = 0
-        state.lastRefillAt = instant
-        let exponent = min(state.refusalStreak - 1, 3)
-        let exponentialQuiet = min(
-            Self.maximumQuietPeriod,
-            Self.firstQuietPeriod * pow(2, Double(exponent)))
-        let quiet = retryAfter.map { max(0, $0) } ?? exponentialQuiet
-        state.quietUntil = instant + quiet
+        // A cap of zero means "do not arm at all", not "arm with a zero quiet period": arming empties
+        // the bucket, and an empty bucket alone still costs two seconds a request at the refill rate.
+        if quietPeriodCapForTesting != 0 {
+            state.tokens = 0
+            state.lastRefillAt = instant
+            let exponent = min(state.refusalStreak - 1, 3)
+            let exponentialQuiet = min(
+                Self.maximumQuietPeriod,
+                Self.firstQuietPeriod * pow(2, Double(exponent)))
+            let asked = retryAfter.map { max(0, $0) } ?? exponentialQuiet
+            state.quietUntil = instant + (quietPeriodCapForTesting.map { min(asked, $0) } ?? asked)
+        }
         let previous = state.limit
         if let hostLimit = state.hostLimit {
             state.limit = hostLimit

--- a/Sources/AetherEngine/Demuxer/OriginRequestBudget.swift
+++ b/Sources/AetherEngine/Demuxer/OriginRequestBudget.swift
@@ -21,6 +21,11 @@ import Foundation
 /// or the origin does, by answering 429/503/509, after which the budget halves from the concurrency
 /// it had actually reached. There is no automatic increase: an origin that has metered us once is
 /// treated as metering for the rest of the process, which costs some parallelism and no correctness.
+/// A refusal also arms a request-rate pacer for that origin. It is deliberately learned rather than
+/// host-configured: the measured CDN served eight parallel 32 MB reads but first refused a run of
+/// 256 KB reads after 36 requests in 10 seconds, so concurrency and request rate are separate limits.
+/// Sixty seconds without another refusal disarms pacing; the learned concurrency ceiling remains
+/// because its recovery policy belongs to the existing budget.
 ///
 /// A redirect chain is ONE origin here (#388). A metered source is routinely a portal that 302s to
 /// the host serving the bytes, and the host loading it can only name the portal: keeping a separate
@@ -38,6 +43,15 @@ final class OriginRequestBudget: @unchecked Sendable {
 
     static let shared = OriginRequestBudget()
 
+    /// The cold probe first refused 36 requests in 10 seconds, but the atlas.2 device run refused
+    /// the third pump request in 2.1 seconds 45 seconds after the prior refusal, stalling for 35
+    /// seconds. A two-request bucket refilling one every two seconds keeps the warm link quieter.
+    static let pacerCapacity = 2.0
+    static let pacerRefillPerSecond = 0.5
+    private static let firstQuietPeriod: TimeInterval = 2
+    private static let maximumQuietPeriod: TimeInterval = 15
+    private static let quietSecondsToDisarm: TimeInterval = 60
+
     /// Scheme + host + port, matching `SuffixRangeSupport.originKey`. Deliberately NOT the full
     /// URL: a metered CDN hands out signed URLs with a rotating token, so a per-URL budget would
     /// start at zero on every refresh and cap nothing. What meters us is the host.
@@ -54,7 +68,7 @@ final class OriginRequestBudget: @unchecked Sendable {
         /// the ticket is returned rather than when it was handed out (#388).
         let key: String
         let label: String
-        /// True when the budget was capped and this ticket waited for room. Diagnostic only.
+        /// Time spent waiting for a concurrency slot or the refusal pacer. Diagnostic only.
         let waitedMs: Double
         /// False when no room came free within the caller's budget and it proceeded anyway.
         let granted: Bool
@@ -64,6 +78,7 @@ final class OriginRequestBudget: @unchecked Sendable {
         var inflight: Int
         var peakInflight: Int
         var limit: Int?
+        var paced: Bool
         var refusals: Int
         var secondsSinceLastRefusal: Double?
         /// How many callers are parked waiting for a slot right now. Reported so a test can wait on
@@ -80,6 +95,12 @@ final class OriginRequestBudget: @unchecked Sendable {
         var hostLimit: Int?
         var refusals = 0
         var lastRefusalAt: DispatchTime?
+        /// nil `quietUntil` means the request-rate pacer is inert. The bucket remains untouched
+        /// until the first refusal so an unmetered origin keeps its old request shape exactly.
+        var tokens = 0.0
+        var lastRefillAt: DispatchTime?
+        var quietUntil: DispatchTime?
+        var refusalStreak = 0
         /// FIFO of waiters. Front is served first, so the pump cannot re-take the slot it just
         /// released ahead of a detour that has been waiting.
         var waiters: [DispatchSemaphore] = []
@@ -101,6 +122,11 @@ final class OriginRequestBudget: @unchecked Sendable {
     /// second origin as far as a request budget is concerned: every request keyed on either end is
     /// answered by the same server, so both ends share one set of books.
     private var chainHead: [String: String] = [:]
+    private let now: () -> DispatchTime
+
+    init(now: @escaping () -> DispatchTime = { .now() }) {
+        self.now = now
+    }
 
     /// Resolve an origin key to the key its chain is kept under. Called under `lock`.
     private func headLocked(_ key: String) -> String {
@@ -162,6 +188,22 @@ final class OriginRequestBudget: @unchecked Sendable {
             if let theirs = joining.lastRefusalAt {
                 merged.lastRefusalAt = merged.lastRefusalAt.map { max($0, theirs) } ?? theirs
             }
+            if let theirQuiet = joining.quietUntil {
+                if let ourQuiet = merged.quietUntil {
+                    merged.tokens = min(merged.tokens, joining.tokens)
+                    if let theirRefill = joining.lastRefillAt {
+                        merged.lastRefillAt = merged.lastRefillAt.map { max($0, theirRefill) }
+                            ?? theirRefill
+                    }
+                    merged.quietUntil = max(ourQuiet, theirQuiet)
+                    merged.refusalStreak = max(merged.refusalStreak, joining.refusalStreak)
+                } else {
+                    merged.tokens = joining.tokens
+                    merged.lastRefillAt = joining.lastRefillAt
+                    merged.quietUntil = theirQuiet
+                    merged.refusalStreak = joining.refusalStreak
+                }
+            }
             merged.droppedTargets.formUnion(joining.droppedTargets)
             // Their waiters are parked on semaphores this bucket now owns; dropping them would hang
             // every one of them for its full acquire budget.
@@ -194,8 +236,110 @@ final class OriginRequestBudget: @unchecked Sendable {
 
     // MARK: - Acquire / release
 
+    private static func elapsedSeconds(from earlier: DispatchTime, to later: DispatchTime) -> Double {
+        guard later.uptimeNanoseconds >= earlier.uptimeNanoseconds else { return 0 }
+        return Double(later.uptimeNanoseconds - earlier.uptimeNanoseconds) / 1_000_000_000
+    }
+
+    private func disarmPacerLocked(_ state: inout OriginState) {
+        state.tokens = 0
+        state.lastRefillAt = nil
+        state.quietUntil = nil
+        state.refusalStreak = 0
+    }
+
+    private func disarmPacerIfQuietLocked(_ state: inout OriginState, at instant: DispatchTime) {
+        guard state.quietUntil != nil, let refusedAt = state.lastRefusalAt,
+              Self.elapsedSeconds(from: refusedAt, to: instant) >= Self.quietSecondsToDisarm
+        else { return }
+        disarmPacerLocked(&state)
+    }
+
+    private func refillPacerLocked(_ state: inout OriginState, at instant: DispatchTime) {
+        guard let lastRefillAt = state.lastRefillAt else {
+            state.lastRefillAt = instant
+            return
+        }
+        let elapsed = Self.elapsedSeconds(from: lastRefillAt, to: instant)
+        state.tokens = min(Self.pacerCapacity,
+                           state.tokens + elapsed * Self.pacerRefillPerSecond)
+        state.lastRefillAt = instant
+    }
+
+    /// The caller already owns a concurrency slot. Hold it while the pacer waits: taking the slot
+    /// first keeps the two admission rules in one order, so two callers cannot each hold one gate
+    /// while waiting for the other. Polling is bounded and intentionally short so an injected test
+    /// clock can advance without making the test spend the production quiet period on wall time.
+    private func ticketAfterPacing(raw: String, label: String, started: DispatchTime,
+                                   timeout: TimeInterval, slotWaitedMs: Double) -> Ticket {
+        var pacingStarted: DispatchTime?
+        let poller = DispatchSemaphore(value: 0)
+        while true {
+            let instant = now()
+            lock.lock()
+            let key = headLocked(raw)
+            var state = origins[key] ?? OriginState()
+            disarmPacerIfQuietLocked(&state, at: instant)
+
+            guard let quietUntil = state.quietUntil else {
+                origins[key] = state
+                lock.unlock()
+                let waitedMs = slotWaitedMs > 0
+                    ? Double(DispatchTime.now().uptimeNanoseconds - started.uptimeNanoseconds)
+                        / 1_000_000
+                    : 0
+                return Ticket(key: raw, label: label, waitedMs: waitedMs, granted: true)
+            }
+
+            let waitNeeded: TimeInterval
+            if instant < quietUntil {
+                waitNeeded = Self.elapsedSeconds(from: instant, to: quietUntil)
+            } else {
+                refillPacerLocked(&state, at: instant)
+                if state.tokens >= 1 {
+                    state.tokens -= 1
+                    origins[key] = state
+                    lock.unlock()
+                    let waitedMs = slotWaitedMs > 0 || pacingStarted != nil
+                        ? Double(DispatchTime.now().uptimeNanoseconds - started.uptimeNanoseconds)
+                            / 1_000_000
+                        : 0
+                    if let pacingStarted {
+                        let pacedMs = Self.elapsedSeconds(from: pacingStarted, to: DispatchTime.now())
+                            * 1_000
+                        EngineLog.emit(
+                            "[OriginBudget] \(label) paced \(Int(pacedMs))ms",
+                            category: .demux, level: .verbose)
+                    }
+                    return Ticket(key: raw, label: label, waitedMs: waitedMs, granted: true)
+                }
+                waitNeeded = (1 - state.tokens) / Self.pacerRefillPerSecond
+            }
+            origins[key] = state
+            lock.unlock()
+
+            let elapsed = Self.elapsedSeconds(from: started, to: DispatchTime.now())
+            let remaining = timeout - elapsed
+            guard remaining > 0 else {
+                let waitedMs = elapsed * 1_000
+                if let pacingStarted {
+                    let pacedMs = Self.elapsedSeconds(from: pacingStarted, to: DispatchTime.now())
+                        * 1_000
+                    EngineLog.emit(
+                        "[OriginBudget] \(label) paced \(Int(pacedMs))ms",
+                        category: .demux, level: .verbose)
+                }
+                return Ticket(key: raw, label: label, waitedMs: waitedMs, granted: false)
+            }
+
+            let poll = min(remaining, max(0.001, min(waitNeeded, 0.01)))
+            if pacingStarted == nil { pacingStarted = DispatchTime.now() }
+            _ = poller.wait(timeout: .now() + poll)
+        }
+    }
+
     /// Take a slot for one request against `url`, waiting up to `timeout` when the origin is
-    /// capped and full.
+    /// capped and full, or after a refusal while its request-rate pacer has no token.
     ///
     /// Always returns a ticket. A caller that could not be given room within its budget gets one
     /// with `granted == false` and proceeds: the budget is a throttle over an origin's tolerance,
@@ -214,7 +358,8 @@ final class OriginRequestBudget: @unchecked Sendable {
             state.peakInflight = max(state.peakInflight, state.inflight)
             origins[key] = state
             lock.unlock()
-            return Ticket(key: raw, label: label, waitedMs: 0, granted: true)
+            return ticketAfterPacing(raw: raw, label: label, started: started,
+                                     timeout: timeout, slotWaitedMs: 0)
         }
         let semaphore = DispatchSemaphore(value: 0)
         state.waiters.append(semaphore)
@@ -226,7 +371,8 @@ final class OriginRequestBudget: @unchecked Sendable {
 
         if signalled {
             // `release` counted us in before signalling, so the slot is already ours.
-            return Ticket(key: raw, label: label, waitedMs: waitedMs, granted: true)
+            return ticketAfterPacing(raw: raw, label: label, started: started,
+                                     timeout: timeout, slotWaitedMs: waitedMs)
         }
 
         // Timed out. Drop out of the queue and proceed uncounted-for: a slot handed to us between
@@ -265,9 +411,23 @@ final class OriginRequestBudget: @unchecked Sendable {
         lock.lock(); defer { lock.unlock() }
         let key = headLocked(raw)
         var state = origins[key] ?? OriginState()
+        let instant = now()
+        disarmPacerIfQuietLocked(&state, at: instant)
         guard state.inflight < (state.limit ?? Int.max) else {
             origins[key] = state
             return nil
+        }
+        if let quietUntil = state.quietUntil {
+            guard instant >= quietUntil else {
+                origins[key] = state
+                return nil
+            }
+            refillPacerLocked(&state, at: instant)
+            guard state.tokens >= 1 else {
+                origins[key] = state
+                return nil
+            }
+            state.tokens -= 1
         }
         state.inflight += 1
         state.peakInflight = max(state.peakInflight, state.inflight)
@@ -300,7 +460,8 @@ final class OriginRequestBudget: @unchecked Sendable {
 
     // MARK: - Learning the limit
 
-    /// The origin answered 429/503/509. Halve the concurrency it was actually given, floor 1.
+    /// The origin answered 429/503/509. Halve the concurrency it was actually given, floor 1,
+    /// and arm its request-rate pacer.
     ///
     /// Halving from the observed peak rather than dropping straight to 1 keeps the answer
     /// proportionate to what we were doing: an origin refused while four requests were open has
@@ -312,13 +473,24 @@ final class OriginRequestBudget: @unchecked Sendable {
     /// asked are one origin as far as requests are concerned, so halving only the far end would
     /// leave the near end free to open exactly the request that was just refused.
     @discardableResult
-    func noteRefusal(for url: URL, status: Int) -> Int? {
+    func noteRefusal(for url: URL, status: Int, retryAfter: TimeInterval? = nil) -> Int? {
         guard let raw = Self.originKey(for: url) else { return nil }
+        let instant = now()
         lock.lock()
         let key = headLocked(raw)
         var state = origins[key] ?? OriginState()
+        disarmPacerIfQuietLocked(&state, at: instant)
         state.refusals += 1
-        state.lastRefusalAt = DispatchTime.now()
+        state.lastRefusalAt = instant
+        state.refusalStreak += 1
+        state.tokens = 0
+        state.lastRefillAt = instant
+        let exponent = min(state.refusalStreak - 1, 3)
+        let exponentialQuiet = min(
+            Self.maximumQuietPeriod,
+            Self.firstQuietPeriod * pow(2, Double(exponent)))
+        let quiet = retryAfter.map { max(0, $0) } ?? exponentialQuiet
+        state.quietUntil = instant + quiet
         let previous = state.limit
         if let hostLimit = state.hostLimit {
             state.limit = hostLimit
@@ -326,18 +498,18 @@ final class OriginRequestBudget: @unchecked Sendable {
             let basis = state.limit ?? max(1, state.peakInflight)
             state.limit = max(1, basis / 2)
         }
-        let now = state.limit
+        let limitNow = state.limit
         let peak = state.peakInflight
         origins[key] = state
         lock.unlock()
 
-        if previous != now, let now {
+        if previous != limitNow, let limitNow {
             EngineLog.emit(
                 "[OriginBudget] \(key) answered \(status); concurrency budget "
-                + "\(previous.map(String.init) ?? "uncapped") -> \(now) (peak was \(peak))",
+                + "\(previous.map(String.init) ?? "uncapped") -> \(limitNow) (peak was \(peak))",
                 category: .demux)
         }
-        return now
+        return limitNow
     }
 
     /// Record that a refusal happened while fetching this source, WITHOUT touching the concurrency
@@ -351,10 +523,11 @@ final class OriginRequestBudget: @unchecked Sendable {
     /// source URL carries the timestamp too, and only the timestamp.
     func noteRefusalWitnessed(for url: URL) {
         guard let raw = Self.originKey(for: url) else { return }
+        let instant = now()
         lock.lock(); defer { lock.unlock() }
         let key = headLocked(raw)
         var state = origins[key] ?? OriginState()
-        state.lastRefusalAt = DispatchTime.now()
+        state.lastRefusalAt = instant
         origins[key] = state
     }
 
@@ -365,7 +538,7 @@ final class OriginRequestBudget: @unchecked Sendable {
         guard let raw = Self.originKey(for: url) else { return false }
         lock.lock(); defer { lock.unlock() }
         guard let last = origins[headLocked(raw)]?.lastRefusalAt else { return false }
-        let elapsed = Double(DispatchTime.now().uptimeNanoseconds - last.uptimeNanoseconds) / 1_000_000_000
+        let elapsed = Self.elapsedSeconds(from: last, to: now())
         return elapsed <= window
     }
 
@@ -468,15 +641,33 @@ final class OriginRequestBudget: @unchecked Sendable {
         limit(for: url) == 1
     }
 
+    /// True while this origin's learned request-rate pacer remains armed. Resolve through the
+    /// redirect chain so the relay URL a host loaded reports the CDN's pacing state (#388), and
+    /// apply the same 60-second quiet disarm every other pacer query uses.
+    func isPaced(_ url: URL) -> Bool {
+        guard let raw = Self.originKey(for: url) else { return false }
+        lock.lock(); defer { lock.unlock() }
+        let key = headLocked(raw)
+        guard var state = origins[key] else { return false }
+        disarmPacerIfQuietLocked(&state, at: now())
+        origins[key] = state
+        return state.quietUntil != nil
+    }
+
     func snapshot(for url: URL) -> Snapshot? {
         guard let raw = Self.originKey(for: url) else { return nil }
         lock.lock(); defer { lock.unlock() }
-        guard let state = origins[headLocked(raw)] else { return nil }
+        let key = headLocked(raw)
+        guard var state = origins[key] else { return nil }
+        let instant = now()
+        disarmPacerIfQuietLocked(&state, at: instant)
+        origins[key] = state
         let since = state.lastRefusalAt.map {
-            Double(DispatchTime.now().uptimeNanoseconds - $0.uptimeNanoseconds) / 1_000_000_000
+            Self.elapsedSeconds(from: $0, to: instant)
         }
         return Snapshot(inflight: state.inflight, peakInflight: state.peakInflight,
-                        limit: state.limit, refusals: state.refusals,
+                        limit: state.limit, paced: state.quietUntil != nil,
+                        refusals: state.refusals,
                         secondsSinceLastRefusal: since, waiting: state.waiters.count)
     }
 

--- a/Tests/AetherEngineTests/AVIOReaderTaskMetricsTests.swift
+++ b/Tests/AetherEngineTests/AVIOReaderTaskMetricsTests.swift
@@ -1,0 +1,61 @@
+import Testing
+@testable import AetherEngine
+
+@Suite("AVIOReader slow first-byte task metrics")
+struct AVIOReaderTaskMetricsTests {
+
+    @Test("a slow task lists host-only hops in order and rounds milliseconds")
+    func slowTaskListsOrderedHostOnlyHops() {
+        let hops = [
+            AVIOReader.HopTiming(
+                host: "remux.atlasvideoplayer.com", port: 443, status: 302,
+                ttfbMs: 9_011.6, totalMs: 9_013.6),
+            AVIOReader.HopTiming(
+                host: "addon.debridio.com", port: 443, status: 302,
+                ttfbMs: 209.6, totalMs: 210.6),
+            AVIOReader.HopTiming(
+                host: "store-076.wnam.tb-cdn.io", port: 443, status: 206,
+                ttfbMs: 179.6, totalMs: 261.6),
+        ]
+
+        let line = AVIOReader.slowFirstByteLine(taskSeconds: 9.4866, hops: hops)
+
+        #expect(line == "[AVIOReader] slow first byte: task=9487ms over 3 hops: "
+            + "remux.atlasvideoplayer.com:443 status=302 ttfb=9012ms total=9014ms -> "
+            + "addon.debridio.com:443 status=302 ttfb=210ms total=211ms -> "
+            + "store-076.wnam.tb-cdn.io:443 status=206 ttfb=180ms total=262ms")
+        #expect(line?.contains("/") == false)
+        #expect(line?.contains("?") == false)
+    }
+
+    @Test("a hop without an HTTP response omits status")
+    func missingStatusIsOmitted() {
+        let line = AVIOReader.slowFirstByteLine(
+            taskSeconds: 1.5,
+            hops: [AVIOReader.HopTiming(
+                host: "cdn.example.com", port: 8443, status: nil,
+                ttfbMs: 1_100.4, totalMs: 1_499.6)]
+        )
+
+        #expect(line == "[AVIOReader] slow first byte: task=1500ms over 1 hops: "
+            + "cdn.example.com:8443 ttfb=1100ms total=1500ms")
+        #expect(line?.contains("status=") == false)
+    }
+
+    @Test("summed first-byte wait controls the strict one-second threshold")
+    func thresholdUsesSummedFirstByteWait() {
+        let fastHop = AVIOReader.HopTiming(
+            host: "cdn.example.com", port: 443, status: 200,
+            ttfbMs: 200, totalMs: 3_000)
+        let boundaryHop = AVIOReader.HopTiming(
+            host: "cdn.example.com", port: 443, status: 200,
+            ttfbMs: 1_000, totalMs: 3_000)
+        let slowHop = AVIOReader.HopTiming(
+            host: "cdn.example.com", port: 443, status: 200,
+            ttfbMs: 1_200, totalMs: 3_000)
+
+        #expect(AVIOReader.slowFirstByteLine(taskSeconds: 3, hops: [fastHop]) == nil)
+        #expect(AVIOReader.slowFirstByteLine(taskSeconds: 3, hops: [boundaryHop]) == nil)
+        #expect(AVIOReader.slowFirstByteLine(taskSeconds: 3, hops: [slowHop]) != nil)
+    }
+}

--- a/Tests/AetherEngineTests/Issue151SubtitleForwardPrefetchTests.swift
+++ b/Tests/AetherEngineTests/Issue151SubtitleForwardPrefetchTests.swift
@@ -146,6 +146,18 @@ struct Issue151SubtitleForwardPrefetchTests {
             isLive: false, hasEmbeddedDrainTargets: true, hasSource: false))
     }
 
+    @Test("prefetch holds whenever its origin is paced or serial")
+    func meteredOriginHoldTruthTable() {
+        #expect(!SubtitleForwardPrefetcher.shouldHold(
+            originPaced: false, originSerial: false))
+        #expect(SubtitleForwardPrefetcher.shouldHold(
+            originPaced: true, originSerial: false))
+        #expect(SubtitleForwardPrefetcher.shouldHold(
+            originPaced: false, originSerial: true))
+        #expect(SubtitleForwardPrefetcher.shouldHold(
+            originPaced: true, originSerial: true))
+    }
+
     /// A drain-tick jump (seek) re-anchors the prefetcher; a fresh selection (no cursor yet) does
     /// not, because the selection path starts it itself; steady decode ticks never restart it.
     @Test("re-anchor fires on a jump with an existing cursor only")

--- a/Tests/AetherEngineTests/Issue410SourceStallVisibilityTests.swift
+++ b/Tests/AetherEngineTests/Issue410SourceStallVisibilityTests.swift
@@ -12,6 +12,11 @@ import Foundation
 @Suite("Source-stall visibility (#410)", .serialized)
 struct Issue410SourceStallVisibilityTests {
 
+    /// The refusal these tests stage arms the request-rate pacer's wall-clock quiet ladder, which
+    /// added 54 s to `bytes handed back out of memory do not clear the stall` and blocked a reader
+    /// thread throughout. The subject here is stall visibility, so the ladder is pinned away.
+    init() { OriginRequestBudget.shared.quietPeriodCapForTesting = 0 }
+
     private final class PhaseLog: @unchecked Sendable {
         private let lock = NSLock()
         private var phases: [ReaderNetworkPhase] = []

--- a/Tests/AetherEngineTests/OriginRequestBudgetTests.swift
+++ b/Tests/AetherEngineTests/OriginRequestBudgetTests.swift
@@ -15,8 +15,8 @@ struct OriginRequestBudgetTests {
     private let sameOriginRotatedToken = URL(string: "https://cdn.example.com:443/signed/movie.mkv?token=b")!
     private let otherOrigin = URL(string: "https://other.example.com:443/movie.mkv")!
 
-    private func freshBudget() -> OriginRequestBudget {
-        let budget = OriginRequestBudget()
+    private func freshBudget(now: @escaping () -> DispatchTime = { .now() }) -> OriginRequestBudget {
+        let budget = OriginRequestBudget(now: now)
         return budget
     }
 
@@ -159,6 +159,246 @@ struct OriginRequestBudgetTests {
         #expect(budget.snapshot(for: url)?.refusals == 3)
 
         tickets.forEach { budget.release($0) }
+    }
+
+    @Test("an unrefused origin never arms the request-rate pacer")
+    func unrefusedOriginIsNeverPaced() {
+        let clock = ManualDispatchClock()
+        let budget = freshBudget(now: clock.now)
+
+        #expect(!budget.isPaced(url))
+        let first = budget.tryAcquire(for: url, label: "tail prefetch")
+        #expect(first?.granted == true)
+        #expect(budget.snapshot(for: url)?.paced == false)
+        budget.release(first)
+
+        clock.advance(by: 600)
+        let later = budget.tryAcquire(for: url, label: "tail prefetch")
+        #expect(later?.granted == true, "time alone must not arm an origin that never refused")
+        #expect(budget.snapshot(for: url)?.paced == false)
+        budget.release(later)
+    }
+
+    @Test("isPaced follows the pacer's armed, draining, and disarmed states")
+    func isPacedReportsThePacerLifetime() {
+        let clock = ManualDispatchClock()
+        let budget = freshBudget(now: clock.now)
+
+        #expect(!budget.isPaced(url))
+        budget.noteRefusal(for: url, status: 429)
+        #expect(budget.isPaced(url), "the first refusal arms pacing inside its quiet period")
+
+        clock.advance(by: 4)
+        for _ in 0..<2 {
+            let ticket = budget.tryAcquire(for: url, label: "pump")
+            #expect(ticket?.granted == true)
+            budget.release(ticket)
+        }
+        #expect(budget.isPaced(url),
+                "an empty bucket remains paced after the quiet period while tokens refill")
+
+        clock.advance(by: 60.1)
+        #expect(!budget.isPaced(url), "sixty seconds without a refusal disarms pacing")
+    }
+
+    @Test("isPaced answers for a relay URL through the redirect chain head")
+    func isPacedCrossesTheRedirectChain() {
+        let clock = ManualDispatchClock()
+        let budget = freshBudget(now: clock.now)
+        let relay = URL(string: "https://relay.example.com/link/movie")!
+        let cdn = URL(string: "https://edge.example.net/signed/movie?token=one")!
+
+        budget.noteRedirect(from: relay, to: cdn)
+        budget.noteRefusal(for: cdn, status: 429)
+
+        #expect(budget.isPaced(cdn))
+        #expect(budget.isPaced(relay),
+                "the host-loaded relay must report pacing learned from its folded CDN")
+    }
+
+    @Test("the first refusal arms a two-second quiet period with an empty bucket")
+    func firstRefusalArmsThePacer() {
+        let clock = ManualDispatchClock()
+        let budget = freshBudget(now: clock.now)
+
+        budget.noteRefusal(for: url, status: 429)
+        #expect(budget.snapshot(for: url)?.paced == true)
+        #expect(budget.tryAcquire(for: url, label: "tail prefetch") == nil)
+
+        clock.advance(by: 1.99)
+        #expect(budget.tryAcquire(for: url, label: "tail prefetch") == nil,
+                "the quiet period, not token refill, is the first gate")
+        clock.advance(by: 0.02)
+        let ticket = budget.tryAcquire(for: url, label: "tail prefetch")
+        #expect(ticket?.granted == true)
+        budget.release(ticket)
+    }
+
+    @Test("Retry-After overrides the learned quiet period")
+    func retryAfterOverridesQuietPeriod() {
+        let clock = ManualDispatchClock()
+        let budget = freshBudget(now: clock.now)
+
+        budget.noteRefusal(for: url, status: 429, retryAfter: 6)
+        clock.advance(by: 5.99)
+        #expect(budget.tryAcquire(for: url, label: "tail prefetch") == nil)
+        clock.advance(by: 0.02)
+        let ticket = budget.tryAcquire(for: url, label: "tail prefetch")
+        #expect(ticket?.granted == true)
+        budget.release(ticket)
+    }
+
+    @Test("refusals in one streak double the quiet period and cap it at fifteen seconds")
+    func refusalQuietPeriodDoublesAndCaps() {
+        let clock = ManualDispatchClock()
+        let budget = freshBudget(now: clock.now)
+
+        budget.noteRefusal(for: url, status: 429)
+        budget.noteRefusal(for: url, status: 429)
+        clock.advance(by: 3.99)
+        #expect(budget.tryAcquire(for: url, label: "tail prefetch") == nil)
+        clock.advance(by: 0.02)
+        let afterFour = budget.tryAcquire(for: url, label: "tail prefetch")
+        #expect(afterFour?.granted == true, "the second refusal in the streak waits four seconds")
+        budget.release(afterFour)
+
+        budget.noteRefusal(for: url, status: 429)
+        budget.noteRefusal(for: url, status: 429)
+        clock.advance(by: 14.99)
+        #expect(budget.tryAcquire(for: url, label: "tail prefetch") == nil)
+        clock.advance(by: 0.02)
+        let afterCap = budget.tryAcquire(for: url, label: "tail prefetch")
+        #expect(afterCap?.granted == true, "the fourth refusal caps at fifteen seconds, not sixteen")
+        budget.release(afterCap)
+    }
+
+    @Test("an acquire inside the quiet period waits and proceeds when the injected clock advances")
+    func acquireWaitsForThePacer() async {
+        let clock = ManualDispatchClock()
+        let budget = freshBudget(now: clock.now)
+        budget.noteRefusal(for: url, status: 429)
+
+        let started = UnsafeFlag()
+        let granted = UnsafeFlag()
+        DispatchQueue.global().async {
+            started.set(true)
+            let ticket = budget.acquire(for: self.url, label: "pump", timeout: 1)
+            granted.set(ticket?.granted == true)
+            budget.release(ticket)
+        }
+
+        #expect(await waitUntil { started.value == true })
+        #expect(await waitUntil { budget.snapshot(for: url)?.inflight == 1 },
+                "the request owns its concurrency slot while the pacer holds it")
+        #expect(granted.value == nil, "the request must remain parked inside the quiet period")
+
+        clock.advance(by: 2)
+        #expect(await waitUntil { granted.value == true },
+                "advancing the injected clock must release the request without a two-second sleep")
+    }
+
+    @Test("a paced acquire that exhausts its caller budget proceeds ungranted")
+    func pacedAcquireRespectsTimeout() {
+        let clock = ManualDispatchClock()
+        let budget = freshBudget(now: clock.now)
+        budget.noteRefusal(for: url, status: 429)
+
+        let ticket = budget.acquire(for: url, label: "pump", timeout: 0)
+        #expect(ticket?.granted == false,
+                "request pacing is a throttle, not a correctness barrier")
+        #expect(budget.snapshot(for: url)?.inflight == 1,
+                "an over-budget request still counts as present on the link")
+        budget.release(ticket)
+        #expect(budget.snapshot(for: url)?.inflight == 0)
+    }
+
+    @Test("tokens refill at one every two seconds and cap at two")
+    func tokensRefillAndCap() {
+        let clock = ManualDispatchClock()
+        let budget = freshBudget(now: clock.now)
+        budget.noteRefusal(for: url, status: 429)
+        clock.advance(by: 4)
+
+        for _ in 0..<2 {
+            let ticket = budget.tryAcquire(for: url, label: "tail prefetch")
+            #expect(ticket?.granted == true)
+            budget.release(ticket)
+        }
+        #expect(budget.tryAcquire(for: url, label: "tail prefetch") == nil,
+                "the burst capacity is two")
+
+        clock.advance(by: 1.99)
+        #expect(budget.tryAcquire(for: url, label: "tail prefetch") == nil,
+                "less than two seconds does not refill one token")
+        clock.advance(by: 0.02)
+        let refilled = budget.tryAcquire(for: url, label: "tail prefetch")
+        #expect(refilled?.granted == true, "two seconds refill one token")
+        budget.release(refilled)
+        #expect(budget.tryAcquire(for: url, label: "tail prefetch") == nil)
+
+        clock.advance(by: 10)
+        for _ in 0..<2 {
+            let ticket = budget.tryAcquire(for: url, label: "tail prefetch")
+            #expect(ticket?.granted == true)
+            budget.release(ticket)
+        }
+        #expect(budget.tryAcquire(for: url, label: "tail prefetch") == nil,
+                "a long refill must still cap the bucket at two")
+    }
+
+    @Test("twenty clean grants do not disarm pacing before sixty quiet seconds")
+    func cleanGrantsDoNotDisarmPacing() {
+        let clock = ManualDispatchClock()
+        let budget = freshBudget(now: clock.now)
+        budget.noteRefusal(for: url, status: 429)
+        clock.advance(by: 2)
+
+        for grant in 0..<20 {
+            let ticket = budget.tryAcquire(for: url, label: "tail prefetch")
+            #expect(ticket?.granted == true)
+            budget.release(ticket)
+            if grant < 19 {
+                clock.advance(by: 2)
+            }
+        }
+        #expect(budget.isPaced(url), "clean grants cannot disarm a recently refused warm link")
+        #expect(budget.snapshot(for: url)?.paced == true)
+        #expect(budget.limit(for: url) == 1,
+                "clean grants must not undo upstream's learned concurrency limit")
+
+        clock.advance(by: 20.1)
+        #expect(!budget.isPaced(url), "the sixty-second quiet rule still disarms pacing")
+    }
+
+    @Test("sixty seconds without a refusal disarms pacing")
+    func quietOriginDisarmsPacing() {
+        let clock = ManualDispatchClock()
+        let budget = freshBudget(now: clock.now)
+        budget.noteRefusal(for: url, status: 429)
+
+        clock.advance(by: 59.9)
+        #expect(budget.snapshot(for: url)?.paced == true)
+        clock.advance(by: 0.2)
+        #expect(budget.snapshot(for: url)?.paced == false)
+        let ticket = budget.tryAcquire(for: url, label: "tail prefetch")
+        #expect(ticket?.granted == true, "the bucket is irrelevant after the quiet disarm")
+        budget.release(ticket)
+    }
+
+    @Test("a host concurrency limit still wins while request pacing is armed")
+    func hostLimitStillWinsWithPacing() {
+        let clock = ManualDispatchClock()
+        let budget = freshBudget(now: clock.now)
+        budget.setHostLimit(1, for: url)
+        budget.noteRefusal(for: url, status: 429)
+        clock.advance(by: 2)
+
+        let held = budget.tryAcquire(for: url, label: "pump")
+        #expect(held?.granted == true)
+        #expect(budget.tryAcquire(for: url, label: "tail prefetch") == nil,
+                "available tokens do not override a full host concurrency budget")
+        #expect(budget.limit(for: url) == 1)
+        budget.release(held)
     }
 
     @Test("a host limit wins over anything learned, in both directions")
@@ -361,4 +601,22 @@ private final class UnsafeOrder: @unchecked Sendable {
     private var items: [String] = []
     var first: String? { lock.lock(); defer { lock.unlock() }; return items.first }
     func append(_ s: String) { lock.lock(); items.append(s); lock.unlock() }
+}
+
+/// Monotonic test clock for the refusal pacer. The production wait polls this clock, so advancing
+/// it releases a paced request without making the suite spend the CDN's two-to-fifteen-second
+/// quiet periods on wall time.
+private final class ManualDispatchClock: @unchecked Sendable {
+    private let lock = NSLock()
+    private var nanoseconds: UInt64 = 1_000_000_000
+
+    func now() -> DispatchTime {
+        lock.lock(); defer { lock.unlock() }
+        return DispatchTime(uptimeNanoseconds: nanoseconds)
+    }
+
+    func advance(by seconds: TimeInterval) {
+        lock.lock(); defer { lock.unlock() }
+        nanoseconds += UInt64((seconds * 1_000_000_000).rounded())
+    }
 }

--- a/Tests/AetherEngineTests/OriginRequestBudgetTests.swift
+++ b/Tests/AetherEngineTests/OriginRequestBudgetTests.swift
@@ -179,6 +179,39 @@ struct OriginRequestBudgetTests {
         budget.release(later)
     }
 
+    /// AE#465 round 2. The case the reversed invariant above is actually FOR: at a ceiling of one,
+    /// a paced caller must leave the single slot available, or the rate rule has silently become a
+    /// concurrency outage for every other path against that origin.
+    @Test("a paced caller leaves a single-slot origin's slot available")
+    func pacedCallerLeavesTheSlotFree() async {
+        let clock = ManualDispatchClock()
+        let budget = freshBudget(now: clock.now)
+        budget.setHostLimit(1, for: url)
+        budget.noteRefusal(for: url, status: 429)
+
+        let granted = UnsafeFlag()
+        let started = UnsafeFlag()
+        DispatchQueue.global().async {
+            started.set(true)
+            let ticket = budget.acquire(for: self.url, label: "pump", timeout: 30)
+            granted.set(ticket?.granted == true)
+            budget.release(ticket)
+        }
+        #expect(await waitUntil(30) { started.value == true },
+                "the caller never got a thread; nothing about the budget was measured")
+
+        #expect(await waitUntil { budget.snapshot(for: url)?.paced == true })
+        #expect(budget.snapshot(for: url)?.inflight == 0,
+                "the one slot must stay free while its only caller waits on the rate rule")
+        #expect(granted.value == nil, "the pacer's quiet period has not elapsed yet")
+
+        clock.advance(by: 4)
+        #expect(await waitUntil { granted.value == true },
+                "the pacer must hand the caller through once the quiet period is paid")
+        _ = await waitUntil { budget.snapshot(for: url)?.inflight == 0 }
+        #expect(budget.snapshot(for: url)?.inflight == 0, "the granted ticket returns its slot")
+    }
+
     @Test("isPaced follows the pacer's armed, draining, and disarmed states")
     func isPacedReportsThePacerLifetime() {
         let clock = ManualDispatchClock()
@@ -282,14 +315,23 @@ struct OriginRequestBudgetTests {
         let granted = UnsafeFlag()
         DispatchQueue.global().async {
             started.set(true)
-            let ticket = budget.acquire(for: self.url, label: "pump", timeout: 1)
+            // Generous on purpose: the injected clock decides when this is released, so a real
+            // budget short enough for a loaded machine to spend first would make the wall clock the
+            // subject instead.
+            let ticket = budget.acquire(for: self.url, label: "pump", timeout: 30)
             granted.set(ticket?.granted == true)
             budget.release(ticket)
         }
 
         #expect(await waitUntil { started.value == true })
-        #expect(await waitUntil { budget.snapshot(for: url)?.inflight == 1 },
-                "the request owns its concurrency slot while the pacer holds it")
+        // AE#465 round 2 reverses what this used to assert. Owning the slot while the pacer holds
+        // you turns a rate rule into a concurrency rule: on a single-slot origin one paced request
+        // then parks every other path for the whole quiet period, and a suite of readers doing that
+        // blocked enough threads that unrelated CI tests could not get one. A token is consumed,
+        // not held, so nothing is owed to the books until it is granted.
+        #expect(await waitUntil { budget.snapshot(for: url)?.paced == true })
+        #expect(budget.snapshot(for: url)?.inflight == 0,
+                "a request waiting on the rate rule must not be occupying a concurrency slot")
         #expect(granted.value == nil, "the request must remain parked inside the quiet period")
 
         clock.advance(by: 2)

--- a/Tests/AetherEngineTests/ResolvedURLInvalidationTests.swift
+++ b/Tests/AetherEngineTests/ResolvedURLInvalidationTests.swift
@@ -12,6 +12,12 @@ import Foundation
 @Suite("Resolved-URL invalidation on hard server errors", .serialized)
 struct ResolvedURLInvalidationTests {
 
+    /// These tests drive real 429 and 509 answers, and each one arms the request-rate pacer's
+    /// wall-clock quiet ladder. Their subject is the resolved-URL verdict, not that ladder, so it is
+    /// pinned away: unpinned it added 44 s to a single test here and blocked a reader thread for all
+    /// of it. `.serialized` above already declares this suite a mutator of process-wide test hooks.
+    init() { OriginRequestBudget.shared.quietPeriodCapForTesting = 0 }
+
     private final class AttemptCounter: @unchecked Sendable {
         private let lock = NSLock()
         private var counts: [Int64: Int] = [:]


### PR DESCRIPTION
Round 2 of @sitepilotusa's request-rate pacer from PR #465. Round 1 merged on a green local run, failed CI in four unrelated tests, and was reverted (`ef108d28`). This restores it with the cause fixed, and goes through a pull request so CI runs before it lands.

## What CI said

Nine issues in four tests, none in the pacer's own coverage: two waiters reported `the waiter never got a thread; nothing about the budget was measured`, a HEAD size probe never ran, and a served-from-memory count came back one high.

## Cause

`acquire` took the concurrency slot first and waited for a rate token inside it. On an origin capped at one request the paced caller then parked every other path for the whole quiet period, up to fifteen seconds. Five tests drive real refusals and paid that ladder in wall time (6 to 55 s each, against under two before), and with 352 suites in parallel enough threads sat in a blocked `acquire` that unrelated suites could not get one.

## Change

- The rate token is taken **before** any slot. A token is consumed, not held, so a caller waiting on the rate rule occupies nothing.
- One timed wait in 250 ms slices instead of a 10 ms poll. The slice exists only for an injected clock; the shipped path wakes a blocked thread a handful of times over a quiet period rather than up to fifteen hundred.
- What the pacer spent comes off the slot's budget, so `timeout` is the caller's total rather than that figure per gate.
- A caller whose slot wait timed out used to skip the pacer entirely. With the token first there is no path around it.
- `quietPeriodCapForTesting` pins the ladder for the two suites that measurably pay it and do not test it. A cap of zero leaves the pacer unarmed rather than arming it with a zero quiet period, because arming also empties the token bucket and that alone still costs two seconds a request.

## One assertion of yours is reversed

`the request owns its concurrency slot while the pacer holds it` is exactly the behaviour that broke CI, so it now asserts the opposite, plus the ceiling-of-one case it exists for. That test's one-second budget is raised to thirty so the injected clock decides when it is released, not the wall clock on a loaded machine.

## Verification

`swift test`: 606 XCTest cases, 1 skipped, 0 failures; 2567 swift-testing cases in 352 suites passed in 14 s. The five ladder payers go from 54.9, 44.9, 44.6, 14.0 and 6.0 seconds to under 1.1 each. Run locally with `SubtitleOCRTests` skipped, whose Vision request wedges the main thread on this machine reproducibly with no engine frame on any thread; CI covers that suite.