### PR TITLE
fix(routing): let a decode-path correction reach a custom source (#461 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,27 @@ the public-API contract.
 
 ### Fixed
 
+- **A decode-path correction reaches a custom `IOReader` session instead of being quietly dropped
+  (AE#461 follow-up).** `LoadOptions.preferredDecodePath` was read only inside `load`, while the
+  rebuild that keeps a retained reader picks its host from the backend the session was already on.
+  A host correcting a playing custom source onto the software path was therefore told the correction
+  had been applied, and stayed on the native one: accepted, named in the log, ignored, which is the
+  one outcome the reload's own rules forbid. The rebuild now asks the same routing policy `load`
+  asks, seeded with that backend, so the correction lands on both source shapes. Measured on a live
+  spool reader and on a seekable custom VOD source: `backend native -> software`, decoder
+  `libavcodec H264 (SW)`, session preserved at its own playhead, and no reach-back on the live arm.
+  The one-way type is what makes re-routing the reopen safe, since the only flip it can make is
+  native to software.
+
+  What the software path cannot represent is now refused BEFORE any teardown, with two new
+  `SessionReloadRefusal` cases: `.softwarePathCannotRepresentSource` for a source whose only signal
+  is IPT-PQ-c2 (Dolby Vision HEVC Profile 5, AV1 Profile 10.0), and `.demuxedAudioLiveIsNativeOnly`
+  for a live source whose audio is merged on the native path. Inside `load` both guards run after
+  the routing decision, so on a correction they would have failed a session that was already down.
+  Verified on the Dolby browser test kit, which carries its own control: the Profile 5 cut is
+  refused and left playing on VideoToolbox, the Profile 8.1 cut of the same material and grading is
+  honoured and rebuilds in software. Reported by @cmcpherson274.
+
 - **A live custom source is rebuilt where the session left it, not where the host started
   (AE#460 follow-up).** An in-place rebuild on a retained `IOReader` (`reloadAtCurrentPosition`,
   with or without an option correction, plus an audio-track switch, a disc-title switch and a

--- a/Sources/AetherEngine/AetherEngine+Loading.swift
+++ b/Sources/AetherEngine/AetherEngine+Loading.swift
@@ -1943,13 +1943,37 @@ extension AetherEngine {
         let previousAudioIndex = activeAudioTrackIndex
         // Snapshot before stopInternal wipes state. Must reload on the same backend: loadNative on a SW-routed AV1 source throws unsupportedCodec (HLSVideoEngine only accepts HEVC / H.264 / VP9 / probed-AV1).
         let wasOnSoftwarePath = (playbackBackend == .software)
+        // AE#461 follow-up: which host this rebuild hands the source to. This used to be
+        // `wasOnSoftwarePath` alone, which made a `preferredDecodePath` correction on a custom source
+        // accepted, logged as applied and then silently ignored: the option is read only inside
+        // `load`, and a custom source never reaches it. The same pure policy `load` asks decides it
+        // here, seeded with the backend the session is currently on.
+        //
+        // The one-way type is what makes re-routing safe on this path. `DecodePath` has no `.native`,
+        // so the only flip reachable is native -> software, and the software path is the general one;
+        // the reverse (the `unsupportedCodec` case the line above warns about) stays unreachable by
+        // construction. What the software path cannot REPRESENT is refused before any teardown, in
+        // `reloadAtCurrentPosition(applying:)`, because the guards that catch it in `load` run after
+        // the routing decision and would fail a session this rebuild had already stopped.
+        let targetSoftwarePath = VideoRoutingPolicy.usesSoftwarePath(
+            routedSoftware: wasOnSoftwarePath, preferred: loadedOptions.preferredDecodePath)
+        if targetSoftwarePath != wasOnSoftwarePath {
+            EngineLog.emit(
+                "[AetherEngine] #461: reload re-routing this session native -> software on the host's "
+                + "preference (custom source: \(isCustomSource))",
+                category: .engine
+            )
+        }
         // Preserve codec so the decoder label can be reconstructed without re-probing.
         let preservedVideoCodec = lastDetectedVideoCodec
         let reloadStart = DispatchTime.now()
         EngineLog.emit("[AetherEngine] reload: stopInternal start", category: .engine)
         // resetDisplayCriteria: false: video format is unchanged; resetting triggers a full waitForSwitch Stage 2 timeout (5 s at the 2026-05-26 device test, ~2 s cap since #117; Bose SLIII A2DP + 4K HDR10 PQ: each switch added ~12 s black-screen). On the same route a panel SDR drop during the reset window failed the PQ variant with AVFoundationErrorDomain -11868 / CoreMediaErrorDomain -17223.
-        // keepNativeHost: !wasOnSoftwarePath preserves the AVPlayer across the switch (issue #15).
-        stopInternal(resetDisplayCriteria: false, keepNativeHost: !wasOnSoftwarePath, keepCustomReader: true)
+        // keepNativeHost: !targetSoftwarePath preserves the AVPlayer across the switch (issue #15).
+        // It follows the TARGET route, not the previous one: a rebuild that flips to software renders
+        // into its own layer, and a preserved host would leave AVKit bound to a stale player with
+        // audio still flowing into the next load (the release `load()` does by hand on that branch).
+        stopInternal(resetDisplayCriteria: false, keepNativeHost: !targetSoftwarePath, keepCustomReader: true)
         EngineLog.emit("[AetherEngine] reload: stopInternal done (\(elapsedMs(since: reloadStart))ms)", category: .engine)
         let gen = loadGeneration
         loadedURL = url
@@ -2041,7 +2065,7 @@ extension AetherEngine {
 
         do {
             let loadStart = DispatchTime.now()
-            if wasOnSoftwarePath {
+            if targetSoftwarePath {
                 EngineLog.emit("[AetherEngine] reload: loadSoftware enter audio=\(audioStreamIndex.map(String.init) ?? "nil") resumeAt=\(String(format: "%.2f", resumeAt))s", category: .engine)
                 try await loadSoftware(
                     url: url,
@@ -2126,7 +2150,7 @@ extension AetherEngine {
             // fail the reload like a load error instead of leaving the user
             // on an indefinitely frozen frame. Scoped to live reloads on the
             // native path; initial joins and VOD reloads never arm it.
-            if loadedOptions.isLive, !wasOnSoftwarePath {
+            if loadedOptions.isLive, !targetSoftwarePath {
                 armLiveReloadWatchdog(generation: gen)
             }
             EngineLog.emit("[AetherEngine] reload: state=.playing total=\(elapsedMs(since: reloadStart))ms", category: .engine)
@@ -2155,7 +2179,7 @@ extension AetherEngine {
             // A title switch changes the title's stream set. The native path already republished the session's
             // real list via syncPublishedAudioStateFromNativeSession above; only the software path, which does
             // not reconcile tracks post-load, needs the probe-derived lists re-applied here.
-            if wasOnSoftwarePath {
+            if targetSoftwarePath {
                 audioTracks = reopenedAudioTracks
                 applyConfirmedAtmos()   // #214 follow-up: a title switch re-applies probe lists
                 subtitleTracks = reopenedSubtitleTracks

--- a/Sources/AetherEngine/AetherEngine+ReloadWithOptions.swift
+++ b/Sources/AetherEngine/AetherEngine+ReloadWithOptions.swift
@@ -1,4 +1,5 @@
 import Foundation
+import AetherLibavcodec
 
 /// AE#460: a session-preserving reload that changes a `LoadOption`.
 ///
@@ -74,6 +75,27 @@ extension AetherEngine {
             throw AetherEngineError.sessionNotReloadable(refusal)
         }
 
+        // AE#461: the decode-path escape is the one correction that can move the session to a host
+        // that cannot serve this source. `load` catches both such sources, but only after the
+        // routing decision, which on a correction is after the teardown; decide it here instead so
+        // a refused correction still costs nothing (rule 2 above).
+        if let refusal = SessionOptionCorrection.decodePathRefusal(
+            routedSoftware: playbackBackend == .software,
+            preferred: proposed.preferredDecodePath,
+            codecID: lastDetectedVideoCodec,
+            dvProfile: sourceDVProfile,
+            dvBLCompatID: sourceDVBLCompatID,
+            isLive: loadedOptions.isLive,
+            hasCompanionAudioReader: (customReader as? LiveIngestSourceInfo)?.companionAudioReader != nil
+        ) {
+            EngineLog.emit(
+                "[AetherEngine] #461: decode-path correction refused, the software path cannot serve "
+                + "this session: \(refusal.rawValue)",
+                category: .engine
+            )
+            throw AetherEngineError.sessionNotReloadable(refusal)
+        }
+
         // Stating the no-op matters for the same reason #364's teletext switch states it: a host
         // that corrected an option and saw a plain reload cannot otherwise tell "the correction was
         // already in force" from "the correction did not arrive".
@@ -112,11 +134,25 @@ public enum SessionReloadRefusal: String, Sendable, Equatable, CustomStringConve
     /// A custom `IOReader` source that reported itself non-seekable. The rebuild reopens the
     /// retained reader at the current position, which a forward-only origin cannot serve.
     case customSourceNotSeekable
+    /// AE#461: the correction would move the session onto the software path, and this source's only
+    /// signal is IPT-PQ-c2 (HEVC Profile 5, AV1 Profile 10.0), which has no compatible base layer.
+    /// The software decoders hand that signal on as YCbCr, so the picture would render green/purple.
+    /// Reached only from `reloadAtCurrentPosition(applying:)`, and only when the proposal moves a
+    /// native session across; a session already on the software path is not moved by it.
+    case softwarePathCannotRepresentSource
+    /// AE#461: the correction would move a demuxed-audio live session onto the software path. The
+    /// side-audio merge lives in the native path's segment producer, so the session would play
+    /// silent. Same reachability as `softwarePathCannotRepresentSource`.
+    case demuxedAudioLiveIsNativeOnly
 
     public var description: String {
         switch self {
         case .noActiveSession: return "no active session"
         case .customSourceNotSeekable: return "the custom source is not seekable"
+        case .softwarePathCannotRepresentSource:
+            return "the software path cannot represent this source's Dolby Vision signal"
+        case .demuxedAudioLiveIsNativeOnly:
+            return "this live source's audio is delivered separately and merged on the native path only"
         }
     }
 }
@@ -148,6 +184,46 @@ enum SessionOptionCorrection {
         if proposed.nativeRemoteHLS != current.nativeRemoteHLS { refused.append("nativeRemoteHLS") }
         if proposed.sequentialOrigin != current.sequentialOrigin { refused.append("sequentialOrigin") }
         return refused
+    }
+
+    /// AE#461: why a decode-path correction cannot be honoured for this session, or nil when it can.
+    ///
+    /// The escape moves a session onto `SoftwarePlaybackHost`, and two sources cannot be served
+    /// there. `load` fails both of them, but it fails them AFTER the routing decision, which on a
+    /// correction means after `stopInternal` has already taken the session down. #460's second rule
+    /// is that a refusal costs nothing, so the same two facts are decided here, before any teardown,
+    /// off state the session already carries (its codec and Dolby Vision configuration from the
+    /// load-time probe, its live flag, its reader's companion audio reader).
+    ///
+    /// Only a FLIP is refusable. A session already on the software path is not moved by a software
+    /// preference, so it is not asked to represent anything new, and an `.automatic` preference
+    /// moves nothing at all: refusing on the source facts alone would start throwing on every
+    /// ordinary audio-track switch of a Dolby Vision source.
+    static func decodePathRefusal(
+        routedSoftware: Bool,
+        preferred: DecodePath,
+        codecID: AVCodecID,
+        dvProfile: Int?,
+        dvBLCompatID: Int?,
+        isLive: Bool,
+        hasCompanionAudioReader: Bool
+    ) -> SessionReloadRefusal? {
+        let flipsToSoftware = !routedSoftware
+            && VideoRoutingPolicy.usesSoftwarePath(routedSoftware: routedSoftware, preferred: preferred)
+        guard flipsToSoftware else { return nil }
+
+        if VideoRoutingPolicy.softwarePathCannotRepresent(
+            codecID: codecID, dvProfile: dvProfile, dvBlCompatID: dvBLCompatID) {
+            return .softwarePathCannotRepresentSource
+        }
+        // The companion reader exists only for a video-only live variant (the resolver spins one up
+        // for exactly that shape), so this is the demuxed-audio population rather than a superset of
+        // it. `load`'s own guard re-checks that the main container carries no audio; erring towards
+        // the refusal here is the safe direction, because the session it leaves alone is playing.
+        if isLive, hasCompanionAudioReader {
+            return .demuxedAudioLiveIsNativeOnly
+        }
+        return nil
     }
 
     /// Every field the proposal changed, for the log line. Reflection is right here and wrong

--- a/Sources/AetherEngine/AetherEngine.swift
+++ b/Sources/AetherEngine/AetherEngine.swift
@@ -509,6 +509,13 @@ public final class AetherEngine: ObservableObject {
     /// `sourceVideoFormat` for Stats-for-Nerds labels ("Dolby Vision P5"); read from the dvcC record.
     @Published public internal(set) var sourceDVProfile: Int? = nil
 
+    /// AE#461: base-layer signal compatibility ID from the same dvcC/dvvC record as `sourceDVProfile`
+    /// (0 = IPT-only, no compatible base layer). Kept because a decode-path correction has to decide
+    /// whether the software path can represent this source BEFORE it tears the session down, and by
+    /// then the probe stream that carried the record is long gone. Internal: `sourceDVProfile` is the
+    /// label hosts read, this is the term only `softwarePathCannotRepresent` needs.
+    var sourceDVBLCompatID: Int? = nil
+
     /// Nominal source frame rate (fps) from the container's `avg_frame_rate` (falling back to `r_frame_rate`),
     /// or nil when the source has no video or libavformat couldn't derive one. Companion to `sourceVideoFormat`
     /// for Stats-for-Nerds. `LiveTelemetry.observedFps` measures the live rate but is nil on the native AVPlayer
@@ -3250,6 +3257,7 @@ public final class AetherEngine: ObservableObject {
         videoFormat = .sdr
         sourceVideoFormat = .sdr
         sourceDVProfile = nil
+        sourceDVBLCompatID = nil
         sourceVideoFrameRate = nil
         sourceVideoBitrate = 0
         sourceVideoCodecName = nil
@@ -3306,6 +3314,7 @@ public final class AetherEngine: ObservableObject {
         var detectedFormat: VideoFormat = .sdr
         var effectiveFormat: VideoFormat = .sdr
         var detectedDVProfileNum: Int? = nil
+        var detectedDVBLCompatIDNum: Int? = nil
         var detectedRate: Double? = nil
         var detectedVideoBitrate: Int64 = 0
         var detectedDVProfile: Bool = false
@@ -3364,7 +3373,9 @@ public final class AetherEngine: ObservableObject {
                 // DV->HDR10 when the panel can't host it; we don't pre-strip engine-side. Pairs with
                 // always-emit-SUPPLEMENTAL + no-strip in HLSVideoEngine's profile81/profile84 emission.
                 detectedDVProfile = (detectedFormat == .dolbyVision)
-                detectedDVProfileNum = Self.dvProfile(stream: stream)
+                let detectedDVConfig = Self.dvConfig(stream: stream)
+                detectedDVProfileNum = detectedDVConfig?.profile
+                detectedDVBLCompatIDNum = detectedDVConfig?.blCompatID
                 detectedCodecID = stream.pointee.codecpar.pointee.codec_id
                 detectedFieldOrder = stream.pointee.codecpar.pointee.field_order
                 sourceVideoWidth = stream.pointee.codecpar.pointee.width
@@ -3492,6 +3503,7 @@ public final class AetherEngine: ObservableObject {
         // the criteria handshake; see panelHDRAfterHandshake below).
         sourceVideoFormat = detectedFormat
         sourceDVProfile = detectedDVProfileNum
+        sourceDVBLCompatID = detectedDVBLCompatIDNum
         sourceVideoFrameRate = detectedRate
         sourceVideoBitrate = detectedVideoBitrate
         sourceVideoCodecName = detectedCodecID == AV_CODEC_ID_NONE
@@ -5022,6 +5034,7 @@ public final class AetherEngine: ObservableObject {
         videoFormat = .sdr
         sourceVideoFormat = .sdr
         sourceDVProfile = nil
+        sourceDVBLCompatID = nil
         sourceVideoFrameRate = nil
         sourceVideoBitrate = 0
         sourceVideoCodecName = nil

--- a/Sources/aetherctl/CustomIO.swift
+++ b/Sources/aetherctl/CustomIO.swift
@@ -89,7 +89,7 @@ final class FileHandleIOReader: IOReader, @unchecked Sendable {
 }
 
 /// Load media through load(source:) with a custom IOReader and print engine state once a second. Tests both native (seekable) and software (seekable or forward-only) paths.
-func runCustomIO(path: String, inMemory: Bool, forwardOnly: Bool, audioOnly: Bool, reload: Bool, switchAudio: Bool, selectSubs: Bool, extract: Bool, audioIndex: Int32? = nil) -> Int32 {
+func runCustomIO(path: String, inMemory: Bool, forwardOnly: Bool, audioOnly: Bool, reload: Bool, switchAudio: Bool, selectSubs: Bool, extract: Bool, audioIndex: Int32? = nil, reloadDecodePath: DecodePath? = nil) -> Int32 {
     EngineLog.handler = { print($0) }
     var modeDesc: String
     switch (inMemory, forwardOnly) {
@@ -102,7 +102,7 @@ func runCustomIO(path: String, inMemory: Bool, forwardOnly: Bool, audioOnly: Boo
     print("aetherctl customio: \(path) (\(modeDesc))")
     let box = UncheckedBox<Int32?>(nil)
     Task { @MainActor in
-        box.value = await customIOSmokeTest(path: path, inMemory: inMemory, forwardOnly: forwardOnly, audioOnly: audioOnly, reload: reload, switchAudio: switchAudio, selectSubs: selectSubs, extract: extract, audioIndex: audioIndex)
+        box.value = await customIOSmokeTest(path: path, inMemory: inMemory, forwardOnly: forwardOnly, audioOnly: audioOnly, reload: reload, switchAudio: switchAudio, selectSubs: selectSubs, extract: extract, audioIndex: audioIndex, reloadDecodePath: reloadDecodePath)
         CFRunLoopStop(CFRunLoopGetMain())
     }
     CFRunLoopRun()
@@ -110,7 +110,7 @@ func runCustomIO(path: String, inMemory: Bool, forwardOnly: Bool, audioOnly: Boo
 }
 
 @MainActor
-private func customIOSmokeTest(path: String, inMemory: Bool, forwardOnly: Bool, audioOnly: Bool, reload: Bool, switchAudio: Bool, selectSubs: Bool, extract: Bool, audioIndex: Int32? = nil) async -> Int32 {
+private func customIOSmokeTest(path: String, inMemory: Bool, forwardOnly: Bool, audioOnly: Bool, reload: Bool, switchAudio: Bool, selectSubs: Bool, extract: Bool, audioIndex: Int32? = nil, reloadDecodePath: DecodePath? = nil) async -> Int32 {
     let reader: FileHandleIOReader
     do {
         reader = try FileHandleIOReader(path: path, inMemory: inMemory, forwardOnly: forwardOnly)
@@ -190,10 +190,44 @@ private func customIOSmokeTest(path: String, inMemory: Bool, forwardOnly: Bool, 
     }
 
     if reload {
-        do { try await engine.reloadAtCurrentPosition() } catch {
-            print("VERDICT: reload threw: \(error.localizedDescription)"); engine.stop(); return 5
+        // AE#461 follow-up: --reload-decode-path corrects the session onto the software path across
+        // the rebuild that keeps the retained reader, which is the shape where the correction used
+        // to be accepted and then ignored. The backend on both sides is the observable.
+        let beforeBackend = engine.playbackBackend
+        let beforePos = engine.currentTime
+        do {
+            if let reloadDecodePath {
+                print(String(format: "  RELOAD applying preferredDecodePath=%@: playhead=%.2fs backend=%@",
+                             reloadDecodePath.rawValue, beforePos, "\(beforeBackend)"))
+                try await engine.reloadAtCurrentPosition { $0.preferredDecodePath = reloadDecodePath }
+            } else {
+                try await engine.reloadAtCurrentPosition()
+            }
+        } catch {
+            // A refused decode-path correction is a legitimate outcome, and the claim worth
+            // measuring is that it cost the session nothing: the guards it stands in for live after
+            // the routing decision inside `load`, where reaching them means the session is already
+            // torn down. Report the surviving state rather than exiting on the throw.
+            guard reloadDecodePath != nil else {
+                print("VERDICT: reload threw: \(error.localizedDescription)"); engine.stop(); return 5
+            }
+            print("  REFUSED: \(error.localizedDescription)")
+            print(String(format: "  REFUSED state=%@ backend=%@ playhead=%.2fs (was %.2fs) decoder=%@",
+                         "\(engine.state)", "\(engine.playbackBackend)",
+                         engine.currentTime, beforePos, engine.activeVideoDecoder ?? "nil"))
+            if case .playing = engine.state, engine.playbackBackend == beforeBackend {
+                print("VERDICT: correction refused, session untouched and still playing")
+                engine.stop(); return 0
+            }
+            print("VERDICT: correction refused but the session did not survive it"); engine.stop(); return 5
         }
         try? await Task.sleep(nanoseconds: 600_000_000)
+        if reloadDecodePath != nil {
+            print(String(format: "  RELOAD done: playhead %.2fs -> %.2fs, backend %@ -> %@, decoder=%@",
+                         beforePos, engine.currentTime,
+                         "\(beforeBackend)", "\(engine.playbackBackend)",
+                         engine.activeVideoDecoder ?? "nil"))
+        }
         if case .playing = engine.state {
             print("VERDICT: reload OK, still playing")
         } else {

--- a/Sources/aetherctl/LiveSpoolIO.swift
+++ b/Sources/aetherctl/LiveSpoolIO.swift
@@ -257,7 +257,8 @@ final class PacedLiveSpoolIOReader: IOReader, @unchecked Sendable {
 func runCustomLiveSpool(path: String, seconds: Double, rateKbps: Int, dvrWindow: Double?,
                         reportsSize: Bool, wraps: Bool, mallocCensus: Bool,
                         foundationReader: Bool = false, carryTrim: HostCarryTrim = .none,
-                        reloadAt: Double? = nil, cancelLatches: Bool = false) -> Int32 {
+                        reloadAt: Double? = nil, cancelLatches: Bool = false,
+                        reloadDecodePath: DecodePath? = nil) -> Int32 {
     EngineLog.handler = { print($0) }
     if mallocCensus {
         // Uncapped captures: a steady mux-rate climb spends one capture per threshold climbed, so the
@@ -275,7 +276,9 @@ func runCustomLiveSpool(path: String, seconds: Double, rateKbps: Int, dvrWindow:
         box.value = await customLiveSpoolRun(path: path, seconds: seconds, rateKbps: rateKbps,
                                              dvrWindow: dvrWindow, reportsSize: reportsSize, wraps: wraps,
                                              foundationReader: foundationReader, carryTrim: carryTrim,
-                                             reloadAt: reloadAt, cancelLatches: cancelLatches)
+                                             reloadAt: reloadAt,
+                                             reloadDecodePath: reloadDecodePath,
+                                             cancelLatches: cancelLatches)
         CFRunLoopStop(CFRunLoopGetMain())
     }
     CFRunLoopRun()
@@ -286,6 +289,7 @@ func runCustomLiveSpool(path: String, seconds: Double, rateKbps: Int, dvrWindow:
 private func customLiveSpoolRun(path: String, seconds: Double, rateKbps: Int, dvrWindow: Double?,
                                 reportsSize: Bool, wraps: Bool, foundationReader: Bool,
                                 carryTrim: HostCarryTrim, reloadAt: Double? = nil,
+                                reloadDecodePath: DecodePath? = nil,
                                 cancelLatches: Bool = false) async -> Int32 {
     let reader: PacedLiveSpoolIOReader
     do {
@@ -328,11 +332,21 @@ private func customLiveSpoolRun(path: String, seconds: Double, rateKbps: Int, dv
             let beforePos = engine.currentTime
             let beforeCursor = reader.logicalPosition
             let beforeEdge = reader.releasedBytes
-            print(String(format: "  RELOAD at t=%.0fs: playhead=%.2fs cursor=%.1fMB edge=%.1fMB",
+            let beforeBackend = engine.playbackBackend
+            print(String(format: "  RELOAD at t=%.0fs: playhead=%.2fs cursor=%.1fMB edge=%.1fMB backend=%@",
                          reloadAt, beforePos,
-                         Double(beforeCursor) / 1_048_576.0, Double(beforeEdge) / 1_048_576.0))
+                         Double(beforeCursor) / 1_048_576.0, Double(beforeEdge) / 1_048_576.0,
+                         "\(beforeBackend)"))
             do {
-                try await engine.reloadAtCurrentPosition { $0.httpHeaders["X-Aether-Probe"] = "1" }
+                // AE#461 follow-up: with --reload-decode-path the correction is the decode path
+                // itself, which is the field a custom source could not previously be corrected on.
+                // Without it the arm keeps its header probe, which is inert here on purpose and
+                // measures the rebuild rather than any field.
+                if let reloadDecodePath {
+                    try await engine.reloadAtCurrentPosition { $0.preferredDecodePath = reloadDecodePath }
+                } else {
+                    try await engine.reloadAtCurrentPosition { $0.httpHeaders["X-Aether-Probe"] = "1" }
+                }
                 print("  RELOAD returned without throwing, state=\(engine.state)")
             } catch {
                 reloadReport.value = "threw \(error), state=\(engine.state)"
@@ -344,10 +358,11 @@ private func customLiveSpoolRun(path: String, seconds: Double, rateKbps: Int, dv
             let afterCursor = reader.logicalPosition
             let afterEdge = reader.releasedBytes
             reloadReport.value = String(
-                format: "playhead %.2fs -> %.2fs, reader cursor %.1f -> %.1f MB, edge %.1f -> %.1f MB",
+                format: "playhead %.2fs -> %.2fs, reader cursor %.1f -> %.1f MB, edge %.1f -> %.1f MB, backend %@ -> %@",
                 beforePos, afterPos,
                 Double(beforeCursor) / 1_048_576.0, Double(afterCursor) / 1_048_576.0,
-                Double(beforeEdge) / 1_048_576.0, Double(afterEdge) / 1_048_576.0)
+                Double(beforeEdge) / 1_048_576.0, Double(afterEdge) / 1_048_576.0,
+                "\(beforeBackend)", "\(engine.playbackBackend)")
             print("  RELOAD done: \(reloadReport.value ?? "")")
         }
     }

--- a/Sources/aetherctl/main.swift
+++ b/Sources/aetherctl/main.swift
@@ -111,8 +111,8 @@ func printUsage() {
       aetherctl audiotap [--duration S] [--out PATH.wav] [--remote | --software] <url>
                          (#95: decode the loopback audio track to mono 48k WAV, print continuity stats;
                           --software runs a real session through the SW sink, exit 3 if it yields no audible PCM)
-      aetherctl customio [--memory] [--forward-only] [--audio-only] [--reload] [--switch-audio] [--select-subs] [--extract] [--audio-index N] <file>
-      aetherctl customio --live [--rate-kbps N] [--seconds N] [--dvr-window N] [--report-size] [--no-wrap] [--malloc-census] [--foundation-reader] [--host-carry none|removeFirst|subdata] [--reload-at S] [--cancel-latches] <file.ts>
+      aetherctl customio [--memory] [--forward-only] [--audio-only] [--reload] [--switch-audio] [--select-subs] [--extract] [--audio-index N] [--reload-decode-path automatic|software] <file>
+      aetherctl customio --live [--rate-kbps N] [--seconds N] [--dvr-window N] [--report-size] [--no-wrap] [--malloc-census] [--foundation-reader] [--host-carry none|removeFirst|subdata] [--reload-at S] [--cancel-latches] [--reload-decode-path automatic|software] <file.ts>
                          (AE#445: a host-owned live spool behind MediaSource.custom, paced at the mux rate,
                           never EOF, unknown size; prints physFP and its slope against that rate)
       aetherctl live [--seconds N] [--seed <path>] [--dvr-window N] [--serve-only] [--measure-rss] [--report-cache-bytes] [--rewind-test] [--reload-test] [--sw] [--drop-after N] [--discontinuity-at N] [--realtime] [--fast-zap] [--preroll N] [--rewind-hold N] [--gen-highbitrate-seed]
@@ -769,6 +769,16 @@ if ["probe", "serve", "validate", "swdecode", "extract", "audio", "customio"].co
     // reader's in-flight-request cancel becomes. Contract says unblock only; this measures the cost
     // of the other reading rather than leaving it to be discovered on a host.
     let customCancelLatches = takeFlag("--cancel-latches", from: &rest)
+    // AE#461 follow-up: drive the decode-path correction on a CUSTOM source. `--reload-at`'s own
+    // correction (an httpHeaders probe) is inert on this shape by design, so it measures the rebuild
+    // and cannot measure this field; this one is the field.
+    let customReloadDecodePath: DecodePath? = takeStringFlag("--reload-decode-path", from: &rest).flatMap { value in
+        guard let path = DecodePath(rawValue: value) else {
+            print("ERROR: --reload-decode-path takes \(DecodePath.allCases.map(\.rawValue).joined(separator: "|")), got '\(value)'")
+            exit(64)
+        }
+        return path
+    }
     let customHostCarry = takeStringFlag("--host-carry", from: &rest) ?? "none"
     guard let customCarryTrim = HostCarryTrim(rawValue: customHostCarry) else {
         print("ERROR: --host-carry expects none|removeFirst|subdata, got '\(customHostCarry)'")
@@ -831,9 +841,10 @@ if ["probe", "serve", "validate", "swdecode", "extract", "audio", "customio"].co
                                     wraps: !customNoWrap, mallocCensus: customMallocCensus,
                                     foundationReader: customFoundationReader,
                                     carryTrim: customCarryTrim, reloadAt: customReloadAt,
-                                    cancelLatches: customCancelLatches))
+                                    cancelLatches: customCancelLatches,
+                                    reloadDecodePath: customReloadDecodePath))
         }
-        exit(runCustomIO(path: urlArg, inMemory: inMemory, forwardOnly: forwardOnly, audioOnly: audioOnlyFlag, reload: reloadFlag, switchAudio: switchAudioFlag, selectSubs: selectSubsFlag, extract: extractFlag, audioIndex: customAudioIndex))
+        exit(runCustomIO(path: urlArg, inMemory: inMemory, forwardOnly: forwardOnly, audioOnly: audioOnlyFlag, reload: reloadFlag, switchAudio: switchAudioFlag, selectSubs: selectSubsFlag, extract: extractFlag, audioIndex: customAudioIndex, reloadDecodePath: customReloadDecodePath))
     default:
         printUsage()
         exit(64)

--- a/Tests/AetherEngineTests/Issue461CustomSourceDecodePathTests.swift
+++ b/Tests/AetherEngineTests/Issue461CustomSourceDecodePathTests.swift
@@ -1,0 +1,165 @@
+import Foundation
+import Testing
+import AetherLibavcodec
+@testable import AetherEngine
+
+/// AE#461 follow-up: a mid-play decode-path correction has to reach the rebuild that keeps the
+/// retained reader, and be refused before teardown when the software path cannot serve the source.
+///
+/// `preferredDecodePath` was read only inside `load`, while the custom-source rebuild picks its host
+/// from the backend the session was already on. A correction on that shape was therefore accepted,
+/// logged as applied and then ignored, which is the one outcome #460's own rules forbid: a
+/// correction either lands or is refused by name, never three quarters of the way.
+///
+/// The direction is what makes the rebuild safe to re-route at all. `DecodePath` has no `.native`,
+/// so the only flip reachable here is native -> software, and the software path is the general one.
+/// The reverse (`loadNative` on a software-routed AV1 source, `unsupportedCodec`) stays unreachable
+/// by construction rather than by a comment asking the next reader not to write it.
+struct Issue461CustomSourceDecodePathTests {
+
+    // MARK: the rebuild's route
+
+    /// The rebuild must ask the same pure policy `load` asks, seeded with the backend it is on.
+    /// A rebuild that reads `wasOnSoftwarePath` alone cannot honour a correction, which is the bug.
+    @Test("a native session with a software preference rebuilds on software")
+    func nativeSessionFlipsWhenCorrected() {
+        #expect(VideoRoutingPolicy.usesSoftwarePath(routedSoftware: false, preferred: .software))
+    }
+
+    @Test("an uncorrected rebuild stays on the backend it was on")
+    func uncorrectedRebuildIsUnchanged() {
+        #expect(VideoRoutingPolicy.usesSoftwarePath(routedSoftware: false, preferred: .automatic) == false)
+        #expect(VideoRoutingPolicy.usesSoftwarePath(routedSoftware: true, preferred: .automatic))
+    }
+
+    // MARK: the refusal, raised before any teardown
+
+    /// The ordinary case: a native session on a plain codec is exactly the population the escape was
+    /// built for, so the correction is honoured and nothing is refused.
+    @Test("a plain native session accepts the correction")
+    func plainSessionIsNotRefused() {
+        #expect(SessionOptionCorrection.decodePathRefusal(
+            routedSoftware: false,
+            preferred: .software,
+            codecID: AV_CODEC_ID_H264,
+            dvProfile: nil,
+            dvBLCompatID: nil,
+            isLive: false,
+            hasCompanionAudioReader: false) == nil)
+    }
+
+    /// #176's colour guard runs after the routing decision inside `load`, so on the custom rebuild it
+    /// would either be skipped (green/purple picture) or reached after `stopInternal` had already
+    /// taken the session down. Neither is a refusal that costs nothing, so it is decided here.
+    @Test("an IPT-only Dolby Vision source is refused instead of rendered as YCbCr")
+    func iptOnlyDolbyVisionIsRefused() {
+        #expect(SessionOptionCorrection.decodePathRefusal(
+            routedSoftware: false,
+            preferred: .software,
+            codecID: AV_CODEC_ID_HEVC,
+            dvProfile: 5,
+            dvBLCompatID: 0,
+            isLive: false,
+            hasCompanionAudioReader: false) == .softwarePathCannotRepresentSource)
+
+        #expect(SessionOptionCorrection.decodePathRefusal(
+            routedSoftware: false,
+            preferred: .software,
+            codecID: AV_CODEC_ID_AV1,
+            dvProfile: 10,
+            dvBLCompatID: 0,
+            isLive: false,
+            hasCompanionAudioReader: false) == .softwarePathCannotRepresentSource)
+    }
+
+    /// P8.1 and P10.1 carry a decodable base layer, so they are software-eligible and the correction
+    /// is honoured. The refusal has to be narrow or it takes the escape away from the sources that
+    /// can use it.
+    @Test("a Dolby Vision source with a decodable base layer is not refused")
+    func dolbyVisionWithBaseLayerIsAccepted() {
+        #expect(SessionOptionCorrection.decodePathRefusal(
+            routedSoftware: false,
+            preferred: .software,
+            codecID: AV_CODEC_ID_HEVC,
+            dvProfile: 8,
+            dvBLCompatID: 1,
+            isLive: false,
+            hasCompanionAudioReader: false) == nil)
+
+        #expect(SessionOptionCorrection.decodePathRefusal(
+            routedSoftware: false,
+            preferred: .software,
+            codecID: AV_CODEC_ID_AV1,
+            dvProfile: 10,
+            dvBLCompatID: 1,
+            isLive: false,
+            hasCompanionAudioReader: false) == nil)
+    }
+
+    /// The side-audio merge lives in `HLSSegmentProducer`, on the native path. A demuxed-audio live
+    /// source moved onto the software path plays silent, and `load` fails it for that reason; the
+    /// correction is refused for the same reason, one teardown earlier.
+    @Test("a demuxed-audio live source is refused rather than played silent")
+    func demuxedAudioLiveIsRefused() {
+        #expect(SessionOptionCorrection.decodePathRefusal(
+            routedSoftware: false,
+            preferred: .software,
+            codecID: AV_CODEC_ID_H264,
+            dvProfile: nil,
+            dvBLCompatID: nil,
+            isLive: true,
+            hasCompanionAudioReader: true) == .demuxedAudioLiveIsNativeOnly)
+    }
+
+    /// A companion reader on a VOD session is not the demuxed-audio live shape, and live on its own
+    /// is the rung the escape exists for. Neither may borrow the other's refusal.
+    @Test("live alone and a companion reader alone are both accepted")
+    func neitherHalfOfTheLiveGuardRefusesAlone() {
+        #expect(SessionOptionCorrection.decodePathRefusal(
+            routedSoftware: false, preferred: .software, codecID: AV_CODEC_ID_H264,
+            dvProfile: nil, dvBLCompatID: nil,
+            isLive: true, hasCompanionAudioReader: false) == nil)
+
+        #expect(SessionOptionCorrection.decodePathRefusal(
+            routedSoftware: false, preferred: .software, codecID: AV_CODEC_ID_H264,
+            dvProfile: nil, dvBLCompatID: nil,
+            isLive: false, hasCompanionAudioReader: true) == nil)
+    }
+
+    /// A refusal is about the flip, not about the field. A session already on the software path is
+    /// not moved anywhere by a software preference, so there is nothing to refuse: refusing there
+    /// would break the plain reload of every source that legitimately routes software.
+    @Test("a session already on the software path is never refused")
+    func alreadySoftwareIsNeverRefused() {
+        for isLive in [false, true] {
+            #expect(SessionOptionCorrection.decodePathRefusal(
+                routedSoftware: true, preferred: .software, codecID: AV_CODEC_ID_HEVC,
+                dvProfile: 5, dvBLCompatID: 0,
+                isLive: isLive, hasCompanionAudioReader: true) == nil)
+        }
+    }
+
+    /// An uncorrected reload of a native session must not be refused by the source facts either, or
+    /// every audio switch on a Dolby Vision source would start throwing.
+    @Test("an automatic preference is never refused")
+    func automaticIsNeverRefused() {
+        #expect(SessionOptionCorrection.decodePathRefusal(
+            routedSoftware: false, preferred: .automatic, codecID: AV_CODEC_ID_HEVC,
+            dvProfile: 5, dvBLCompatID: 0,
+            isLive: true, hasCompanionAudioReader: true) == nil)
+    }
+
+    /// The refusals say which one they are, in the thrown error and in the log, because a host that
+    /// has to choose between falling back to its own player and leaving the session alone needs the
+    /// difference.
+    @Test("the two refusals are distinguishable and described")
+    func refusalsAreDistinct() {
+        #expect(SessionReloadRefusal.softwarePathCannotRepresentSource
+                != SessionReloadRefusal.demuxedAudioLiveIsNativeOnly)
+        for refusal in [SessionReloadRefusal.softwarePathCannotRepresentSource,
+                        .demuxedAudioLiveIsNativeOnly] {
+            #expect(!refusal.rawValue.isEmpty)
+            #expect(!refusal.description.isEmpty)
+        }
+    }
+}

--- a/docs/api.md
+++ b/docs/api.md
@@ -133,6 +133,8 @@ Two refusals, both raised BEFORE any teardown, so a refused correction leaves th
 | --- | --- |
 | `AetherEngineError.loadIdentityNotCorrectable(fields:)` | the closure changed `isLive`, `audioOnly`, `nativeRemoteHLS` or `sequentialOrigin`. These name the session rather than tune it (each opens the source on a different pipeline, and the engine writes the last two itself), so changing one is a different item, not a correction of this one. Load the source again. |
 | `AetherEngineError.sessionNotReloadable(_:)` | there is no session, or the source is a custom `IOReader` that reported itself non-seekable and cannot be reopened at the current position. It carries a `SessionReloadRefusal` (`.noActiveSession` / `.customSourceNotSeekable`) saying which. |
+| `AetherEngineError.sessionNotReloadable(.softwarePathCannotRepresentSource)` | the correction moves a native session onto the software path, and this source's only signal is IPT-PQ-c2 (Dolby Vision HEVC Profile 5, AV1 Profile 10.0). The software decoders hand that on as YCbCr, so the picture would render green/purple. |
+| `AetherEngineError.sessionNotReloadable(.demuxedAudioLiveIsNativeOnly)` | the correction moves a demuxed-audio live session onto the software path, where the side-audio merge does not exist, so it would play silent. |
 
 Both are all-or-nothing: a correction refused for one field installs none of it.
 
@@ -144,6 +146,15 @@ the four consumed by `load` itself (`preferredAudioLanguages`, `externalSubtitle
 `maxConcurrentSourceRequests`, `autoplay`) are installed and take effect at the next load. The
 custom reload carries the session's explicit audio pick and its own subtitle re-arm, so the two
 language lists have nothing to decide on that path anyway.
+
+`preferredDecodePath` is in the first group and was briefly in neither: the reopen picked its host
+from the backend the session was already on, so a decode-path correction on a custom source was
+accepted, named in the log and then ignored. It now asks the same routing policy `load` asks, seeded
+with that backend, so the correction lands on both source shapes. The direction is what makes that
+safe: `DecodePath` has no `.native`, so the only flip the reopen can make is native to software, and
+the software path is the general one. What the software path cannot REPRESENT is refused before any
+teardown instead (the two rows above), because the guards that catch it inside `load` run after the
+routing decision, and reaching them on a correction would mean failing a session already torn down.
 
 Unlike `reloadAtCurrentPosition()`, which returns silently when there is nothing to rebuild, this one
 throws, because a host correcting a session has to tell "corrected" from "did nothing" to decide
@@ -196,6 +207,13 @@ Three properties worth knowing:
 - **`nativeRemoteHLS` is a different route.** AVPlayer plays the remote playlist and the engine
   demuxes and decodes nothing, so there is no decode path to prefer. The engine logs that it
   ignored the preference rather than letting it look applied.
+- **A mid-play correction lands on both source shapes**, URL and custom `IOReader` alike, and moves
+  the session at its own playhead without a restart. On a source the software path cannot represent
+  the correction is refused before any teardown, with `SessionReloadRefusal`
+  `.softwarePathCannotRepresentSource` or `.demuxedAudioLiveIsNativeOnly`, so the session it refuses
+  is still the session that was playing. Measured on the Dolby browser test kit, which carries the
+  discriminator: the Profile 5 cut of a clip is refused and left playing on VideoToolbox, while the
+  Profile 8.1 cut of the SAME material and grading is honoured and rebuilds on `libavcodec HEVC (SW)`.
 
 ### Reading whether the audio was delivered
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -319,6 +319,39 @@ its base and re-read the whole delivered window. `--cancel-latches` is the other
 control rather than a defect: a reader that treats `cancel()` as terminal cannot serve the rebuild
 that reuses it, so the reopen dies on stream info and the correction throws.
 
+**`--reload-decode-path automatic|software` makes the correction the decode path itself** (AE#461
+follow-up), on `customio` with `--reload` and on `customio --live` with `--reload-at`. The header
+probe those arms apply by default is inert on a custom source on purpose, so it measures the rebuild
+and can never measure this field; the field is what a host actually corrects. Both arms print the
+backend on each side of the rebuild, which is the whole observable:
+
+```
+  RELOAD applying preferredDecodePath=software: playhead=0.00s backend=native
+[AetherEngine] #461: reload re-routing this session native -> software on the host's preference (custom source: true)
+  RELOAD done: playhead 0.00s -> 0.33s, backend native -> software, decoder=libavcodec H264 (SW)
+```
+
+Before the follow-up the same run logged `#460: reload applying preferredDecodePath` and then
+`backend native -> native, decoder=VideoToolbox H264 (HW)`: accepted, named in the log, ignored.
+
+On a source the software path cannot represent the arm measures the OTHER half, that a refusal costs
+nothing, by reporting the state the refusal left behind rather than exiting on the throw. The Dolby
+browser test kit is the fixture, because it carries its own control:
+
+```
+# Profile 5 (IPT-only): refused, and the session is untouched
+  REFUSED state=playing backend=native playhead=0.00s (was 0.00s) decoder=VideoToolbox HEVC (HW)
+VERDICT: correction refused, session untouched and still playing
+# Profile 8.1, same material and grading: honoured
+  RELOAD done: playhead 0.00s -> 0.26s, backend native -> software, decoder=libavcodec HEVC (SW)
+```
+
+**Read the live arm's retention ratio over a long run, not a short one.** The slope anchors at 60 s
+to skip the load step, which is exactly where `--reload-at 60` puts a SECOND step: the software
+pipeline's own baseline. A 100 s run reads ratio 1.31 and means nothing by it; a 260 s run shows
+`physFP` stepping 25 to 66 MB across the switch and then flat at 67 for 140 s, ratio 0.18 and still
+falling, which is a step being amortized rather than a session retaining anything.
+
 **`--host-carry removeFirst|subdata` is the third arm, and it names a cause rather than measuring
 the engine.** Round 3's census on the reporter's device pinned his footprint to ONE `REALLOC`-tagged
 block growing on an exact x1.25 ladder, holding every byte the session had consumed. That factor is


### PR DESCRIPTION
Follow-up to #461, reported by @cmcpherson274 after taking the escape onto his own stack.

## The defect

`LoadOptions.preferredDecodePath` is read at three sites, all inside `public func load(`. The rebuild that keeps a retained `IOReader` picks its host from `wasOnSoftwarePath`, the backend the session was already on, and never reads the option. So a host correcting a playing custom source onto the software path through #460 got the correction written into `loadedOptions`, logged as applied, and then ignored.

Accepted, named in the log, ignored is the one outcome #460's own rules forbid, and it left the escape unreachable for exactly the population it was built for: a spool-backed source with no second engine to hand a struggling stream to.

The docs were worse than silent on it. "Where a correction lands" said the routing fields all apply on the custom path, which is the opposite of what happened.

## The fix

The reopen asks the same routing policy `load` asks, seeded with the backend it is on. `keepNativeHost` and the two post-load fixups (the native-only live watchdog, the software-only track republish) follow the target route rather than the previous one.

The one-way type is what makes re-routing this path safe. `DecodePath` has no `.native`, so the only flip reachable is native to software, and the software path is the general one; `loadNative` on a software-routed AV1 source, which the code comment there warns about, stays unreachable by construction rather than by asking the next reader not to write it.

## The refusal

What the software path cannot REPRESENT is refused before any teardown, with two new `SessionReloadRefusal` cases: `.softwarePathCannotRepresentSource` (IPT-PQ-c2: HEVC P5, AV1 P10.0) and `.demuxedAudioLiveIsNativeOnly`. Inside `load` both guards run AFTER the routing decision, so reaching them on a correction means failing a session that is already down, and a refusal has to cost nothing. Deciding them early needs the base-layer compatibility id to outlive the probe, so it is retained next to `sourceDVProfile`.

This is narrower than the refusal the report offered to consume: only a flip is refusable, and only for a source that genuinely cannot be served, so the sources that CAN use the escape keep it.

## Measured

New `--reload-decode-path` arm on `customio`, because the existing `--reload-at` correction (an `httpHeaders` probe) is inert on a custom source by design and can never measure this field.

Seekable custom VOD source and the live spool reader:

```
  RELOAD applying preferredDecodePath=software: playhead=0.00s backend=native
[AetherEngine] #461: reload re-routing this session native -> software on the host's preference (custom source: true)
  RELOAD done: playhead 0.00s -> 0.33s, backend native -> software, decoder=libavcodec H264 (SW)
```

The same run with the routing change reverted: `backend native -> native, decoder=VideoToolbox H264 (HW)`, under an applied-correction log line.

On live the rebuild keeps #460's reach-back of 0.0 MB. The footprint step across the switch (`physFP` 25 to 66 MB, then flat at 67 for 140 s, ratio 0.18 and still falling) is the software pipeline's own baseline, not retention; a 100 s run reads 1.31 purely because the slope anchor at 60 s lands on the switch.

Refusal arm, on the Dolby browser test kit because it carries its own control:

```
# Profile 5 (IPT-only)
  REFUSED state=playing backend=native playhead=0.00s (was 0.00s) decoder=VideoToolbox HEVC (HW)
VERDICT: correction refused, session untouched and still playing
# Profile 8.1, same material and grading
  RELOAD done: backend native -> software, decoder=libavcodec HEVC (SW)
```

Plain reload arms unchanged, no `#461` line, `backend native -> native`, reach-back 0.0 MB.

10 new unit tests; full suite green on both runners (swift-testing 2595 / 355 suites, XCTest 606 with 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4QpZDsHPJfbz5gkxxPXF7