### PR TITLE
fix(audio): count the silent-bridge gate in encoder frames, not source packets (#474)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,25 @@ the public-API contract.
 
 ### Fixed
 
+- **The silent-bridge ERROR no longer announces a failure during a healthy start-up (AE#474).**
+  `AudioBridge`'s AE#396 detector was counted in source packets (64) while the thing that bounds
+  it is one encoder frame: `drainFIFOIntoEncoder(requireFull:)` cannot encode below `frame_size`,
+  so no output is POSSIBLE until that many samples have been enqueued. Its threshold was derived
+  from the lossy pair alone (an E-AC-3 frame of 1536 against a DTS packet of 512), and the FLAC arm
+  breaks both constants: a FLAC frame is 4608 samples and a TrueHD access unit is 40, so the first
+  output needs 116 packets and the line fired at 64. Every TrueHD session therefore printed
+  `the bridge has produced no encoded audio at all ... enqueued=2560 emitted=0` and then played to
+  the end, and not only under the opt-in `.lossless` mode: `.surroundCompat` encodes any source of
+  two channels or fewer to FLAC, so a stereo TrueHD file reproduces it on the default setting. The
+  gate now counts each arm in the unit that bounds it, the encoder's own `frame_size` where PCM
+  reached the FIFO and packets only where the FIFO never moved, and the latter counts from the last
+  accepted sample rather than from the start, so a decoder that answers for a while and then stops
+  is caught by the same arm. The line arrives sooner than it used to on the arm it was written for
+  (about 128 ms of source audio on E-AC-3 against 64 packets), and it now names the encoder it is
+  talking about and the frame boundary it judged. Nothing else read the old threshold: both
+  decision sites that classify a silent bridge are gated on an actual failure, and `$audioDelivery`
+  is derived independently and read `bridged` correctly throughout. Reported by @cmcpherson274.
+
 - **A decode-path correction reaches a custom `IOReader` session instead of being quietly dropped
   (AE#461 follow-up).** `LoadOptions.preferredDecodePath` was read only inside `load`, while the
   rebuild that keeps a retained reader picks its host from the backend the session was already on.

--- a/Sources/AetherEngine/Audio/AudioBridge.swift
+++ b/Sources/AetherEngine/Audio/AudioBridge.swift
@@ -478,6 +478,11 @@ final class AudioBridge: @unchecked Sendable {
         /// produced nothing.
         var framesDroppedBeforeFIFO = 0
         var samplesEnqueued: Int64 = 0
+        /// Source packets fed since the FIFO last accepted a sample, reset by every accepted write.
+        /// The decoder arm of `silenceIsStructural` is counted on this rather than on `packetsFed`,
+        /// so a decoder that answers for a while and then stops is the same shape as one that never
+        /// answered at all, and neither has to be told apart from a bridge that is merely young.
+        var packetsFedSinceLastEnqueue = 0
         var packetsEmitted = 0
         /// `avcodec_receive_packet` answers that were neither a packet nor EAGAIN/EOF.
         var encodeErrors = 0
@@ -519,12 +524,29 @@ final class AudioBridge: @unchecked Sendable {
     var feedStats: FeedStats { stats }
 
     /// One-shot: a bridge that stays silent for an hour costs one line, not one per packet.
-    private var silentFeedReported = false
+    private(set) var silentFeedReported = false
 
-    /// Enough source that no start-up latency explains the silence. The largest encoder frame the
-    /// bridge builds is 1536 samples (E-AC-3) and the smallest source packet it is fed is 512 (DTS),
-    /// so three packets is the honest worst case before the first output and 64 is two orders past it.
+    /// AE#474: the DECODER arm's unit, and only its unit. Source went in and the FIFO got nothing
+    /// back, so there is no sample count to bound anything with and packets are all there is.
     private static let silentFeedPacketThreshold = 64
+
+    /// AE#474: the ENCODER arm's unit. `drainFIFOIntoEncoder(requireFull: true)` cannot encode below
+    /// `frame_size`, so nothing can be emitted until that many samples have been enqueued, and the
+    /// figure is not a constant of the bridge: 1536 on E-AC-3, 4608 on FLAC. A source packet is not
+    /// a constant either, 1536 samples on E-AC-3 down to 40 on a TrueHD access unit, so the ratio
+    /// between the two spans a factor of 100 across arms this bridge already builds and no packet
+    /// count can express one encoder frame. The old 64-packet threshold was derived from the lossy
+    /// pair alone (1536 against 512) and fired at 2560 of FLAC's 4608 samples on TrueHD, announcing
+    /// a failure on sessions that then played to the end. Four frames rather than one: the first is
+    /// when output becomes POSSIBLE, the second covers an encoder that holds it, and four is still
+    /// inside the first half second of source audio on every arm (128 ms on E-AC-3, 384 ms on FLAC
+    /// at 48 kHz), which is sooner in wall-clock than the packet threshold it replaces.
+    private static let silentFeedEncoderFrameMultiple: Int64 = 4
+
+    /// What to assume for `frame_size` before the encoder has resolved one. Shared with
+    /// `drainFIFOIntoEncoder`, which chunks the FIFO by the same figure: a gate that used a
+    /// different fallback than the drain it is judging would be judging a boundary nobody uses.
+    private static let assumedEncoderFrameSize: Int32 = 4096
 
     /// Snapshot of bytes live in the bridge's growable buffers, for the engine memory probe. Both fields grow on
     /// the FFmpeg side (FIFO reallocs upward, swr delay buffer reallocates on rate/layout shift), so a
@@ -755,6 +777,7 @@ final class AudioBridge: @unchecked Sendable {
         }
 
         stats.packetsFed += 1
+        stats.packetsFedSinceLastEnqueue += 1
 
         var results: [UnsafeMutablePointer<AVPacket>] = []
 
@@ -839,24 +862,42 @@ final class AudioBridge: @unchecked Sendable {
             throw error
         }
 
-        noteSilentFeedIfNeeded()
+        noteSilentFeedIfNeeded(encoderFrameSize: enc.pointee.frame_size)
         return results
     }
 
-    /// AE#396: say it once, the moment enough source has gone in for the silence to be structural
-    /// rather than start-up latency. Without this the only downstream evidence is movenc's -22 on a
-    /// moov it cannot build, which names the muxer and the source and never the bridge. `EngineLog`
-    /// has no error level, so the `ERROR:` prefix carries it, as in the #165 cascade line.
-    private func noteSilentFeedIfNeeded() {
+    /// AE#396 / AE#474: is this silence structural, or has the bridge simply not been asked yet?
+    /// The two ways a bridge stays quiet end at different subsystems and are bounded by different
+    /// quantities, so each arm is counted in the unit that actually bounds it and neither is
+    /// expressed in the other's (see `silentFeedPacketThreshold` and the frame multiple above).
+    ///
+    /// Pure and static so the boundary can be pinned against the frame sizes this bridge really
+    /// opens instead of against whichever one the fixtures happen to reach.
+    static func silenceIsStructural(stats: FeedStats, encoderFrameSize: Int32) -> Bool {
+        guard stats.isSilent else { return false }
+        let frame = Int64(encoderFrameSize > 0 ? encoderFrameSize : assumedEncoderFrameSize)
+        // The encoder arm: enough PCM to build several frames went in and none came back.
+        if stats.samplesEnqueued >= frame * silentFeedEncoderFrameMultiple { return true }
+        // The decoder arm: the FIFO has stood still for longer than any source explains.
+        return stats.packetsFedSinceLastEnqueue >= silentFeedPacketThreshold
+    }
+
+    /// AE#396: say it once, the moment the silence is structural. Without this the only downstream
+    /// evidence is movenc's -22 on a moov it cannot build, which names the muxer and the source and
+    /// never the bridge. `EngineLog` has no error level, so the `ERROR:` prefix carries it, as in
+    /// the #165 cascade line.
+    private func noteSilentFeedIfNeeded(encoderFrameSize: Int32) {
         guard !silentFeedReported,
-              stats.isSilent,
-              stats.packetsFed >= Self.silentFeedPacketThreshold else { return }
+              Self.silenceIsStructural(stats: stats, encoderFrameSize: encoderFrameSize)
+        else { return }
         silentFeedReported = true
+        let encoder = avcodec_get_name(outputCodecID).map { String(cString: $0) } ?? "the encoder"
+        let frame = encoderFrameSize > 0 ? encoderFrameSize : Self.assumedEncoderFrameSize
         EngineLog.emit(
             "[AudioBridge] ERROR: AE#396 the bridge has produced no encoded audio at all "
-            + "(mode=\(mode.rawValue)): \(stats.summary). The mp4 muxer can only build an "
-            + "AC-3/E-AC-3 sample entry from a packet that was written, so this session will fail "
-            + "its first segment cut unless output starts.",
+            + "(mode=\(mode.rawValue), encoder=\(encoder), frame=\(frame)): \(stats.summary). "
+            + "The mp4 muxer can only build a \(encoder) sample entry from a packet that was "
+            + "written, so this session will fail its first segment cut unless output starts.",
             category: .session
         )
     }
@@ -998,7 +1039,10 @@ final class AudioBridge: @unchecked Sendable {
                 av_audio_fifo_write(fifo, rebound, producedSamples)
             }
         }
-        if written > 0 { stats.samplesEnqueued += Int64(written) }
+        if written > 0 {
+            stats.samplesEnqueued += Int64(written)
+            stats.packetsFedSinceLastEnqueue = 0
+        }
     }
 
     /// Pull frame_size chunks from the FIFO and encode each. requireFull true stops below frame_size (streaming);
@@ -1009,7 +1053,7 @@ final class AudioBridge: @unchecked Sendable {
         requireFull: Bool,
         results: inout [UnsafeMutablePointer<AVPacket>]
     ) throws {
-        let frameSize = enc.pointee.frame_size > 0 ? enc.pointee.frame_size : 4096
+        let frameSize = enc.pointee.frame_size > 0 ? enc.pointee.frame_size : Self.assumedEncoderFrameSize
         let nChannels = enc.pointee.ch_layout.nb_channels
 
         while true {

--- a/Tests/AetherEngineTests/Issue396SilentAudioBridgeTests.swift
+++ b/Tests/AetherEngineTests/Issue396SilentAudioBridgeTests.swift
@@ -223,4 +223,159 @@ struct Issue396SilentAudioBridgeTests {
                 "a bridge that produced audio is not the reason the moov could not be written")
         #expect(surfaced.snapshot?.reason == "Source audio cannot be muxed")
     }
+
+    // MARK: - AE#474: the gate's unit
+
+    /// Raw stereo PCM at 48 kHz. `.surroundCompat` encodes 2 channels or fewer to FLAC, so this is
+    /// the FLAC arm on the DEFAULT mode, and raw PCM lets a packet carry any number of samples.
+    private func makePCMCodecpar() -> UnsafeMutablePointer<AVCodecParameters> {
+        let par = avcodec_parameters_alloc()!
+        par.pointee.codec_type = AVMEDIA_TYPE_AUDIO
+        par.pointee.codec_id = AV_CODEC_ID_PCM_S16LE
+        par.pointee.sample_rate = 48_000
+        par.pointee.format = AV_SAMPLE_FMT_S16.rawValue
+        par.pointee.bits_per_coded_sample = 16
+        par.pointee.block_align = 4
+        av_channel_layout_default(&par.pointee.ch_layout, 2)
+        return par
+    }
+
+    /// One packet per TrueHD access unit: 40 samples at 48 kHz, the smallest source packet the bridge
+    /// is fed anywhere. 64 of them are 2560 samples, which is what the reporter's device log carried.
+    private func makeTrueHDShapedPCMPackets(count: Int, samplesPerPacket: Int = 40)
+        -> [UnsafeMutablePointer<AVPacket>] {
+        (0..<count).compactMap { i in
+            guard let pkt = trackedPacketAlloc() else { return nil }
+            let bytes = samplesPerPacket * 2 * 2
+            guard av_new_packet(pkt, Int32(bytes)) >= 0 else { return nil }
+            for n in 0..<samplesPerPacket {
+                let global = i * samplesPerPacket + n
+                let v = Int16(9000 * sin(2 * .pi * 440 * Double(global) / 48_000)).littleEndian
+                for ch in 0..<2 {
+                    let off = (n * 2 + ch) * 2
+                    withUnsafeBytes(of: v) { raw in
+                        pkt.pointee.data!.advanced(by: off).update(from: raw.baseAddress!
+                            .assumingMemoryBound(to: UInt8.self), count: 2)
+                    }
+                }
+            }
+            pkt.pointee.pts = Int64(i * samplesPerPacket)
+            pkt.pointee.dts = pkt.pointee.pts
+            return pkt
+        }
+    }
+
+    @Test("start-up on the FLAC arm is not silence: 64 small packets are half of one encoder frame")
+    func flacArmStartUpIsNotReportedAsSilence() throws {
+        let codecpar = makePCMCodecpar()
+        defer {
+            var p: UnsafeMutablePointer<AVCodecParameters>? = codecpar
+            avcodec_parameters_free(&p)
+        }
+        let bridge = try AudioBridge(srcCodecpar: codecpar,
+                                     srcTimeBase: AVRational(num: 1, den: 48_000),
+                                     mode: .surroundCompat)
+        defer { bridge.close() }
+        #expect(bridge.outputCodecID == AV_CODEC_ID_FLAC,
+                "precondition: the default mode encodes a stereo source to FLAC")
+
+        var packets = makeTrueHDShapedPCMPackets(count: 64)
+        defer { freeAll(&packets) }
+        var outputs: [UnsafeMutablePointer<AVPacket>] = []
+        defer { freeAll(&outputs) }
+        for p in packets { outputs.append(contentsOf: try bridge.feed(packet: p)) }
+
+        let stats = bridge.feedStats
+        #expect(stats.packetsFed == 64)
+        #expect(stats.samplesEnqueued == 2560, "the reporter's own counters, reproduced")
+        #expect(stats.packetsEmitted == 0,
+                "requireFull declines below frame_size, so no output is POSSIBLE yet")
+        #expect(stats.isSilent, "silent in the counter's sense, which is not the same as structural")
+        #expect(!bridge.silentFeedReported,
+                "AE#474: 2560 samples is short of FLAC's 4608, so nothing could have been emitted")
+    }
+
+    @Test("the same feed continued past the encoder's frame produces audio and still reports nothing")
+    func flacArmProducesOnceTheFrameIsFull() throws {
+        let codecpar = makePCMCodecpar()
+        defer {
+            var p: UnsafeMutablePointer<AVCodecParameters>? = codecpar
+            avcodec_parameters_free(&p)
+        }
+        let bridge = try AudioBridge(srcCodecpar: codecpar,
+                                     srcTimeBase: AVRational(num: 1, den: 48_000),
+                                     mode: .surroundCompat)
+        defer { bridge.close() }
+
+        var packets = makeTrueHDShapedPCMPackets(count: 400)
+        defer { freeAll(&packets) }
+        var outputs: [UnsafeMutablePointer<AVPacket>] = []
+        defer { freeAll(&outputs) }
+        for p in packets { outputs.append(contentsOf: try bridge.feed(packet: p)) }
+
+        #expect(bridge.feedStats.packetsEmitted > 0)
+        #expect(!bridge.silentFeedReported,
+                "a bridge that went on to produce audio must never have announced a failure")
+    }
+
+    @Test("a source the decoder rejects still names itself, from the packet arm")
+    func decoderArmStillReports() throws {
+        let codecpar = makeMP3Codecpar()
+        defer {
+            var p: UnsafeMutablePointer<AVCodecParameters>? = codecpar
+            avcodec_parameters_free(&p)
+        }
+        let bridge = try AudioBridge(srcCodecpar: codecpar,
+                                     srcTimeBase: AVRational(num: 1, den: 1000),
+                                     mode: .surroundCompat)
+        defer { bridge.close() }
+
+        var packets = makeUndecodablePackets(count: 80)
+        defer { freeAll(&packets) }
+        for p in packets { _ = try? bridge.feed(packet: p) }
+
+        #expect(bridge.feedStats.samplesEnqueued == 0)
+        #expect(bridge.silentFeedReported,
+                "nothing ever reached the FIFO, which is the arm packets are the only unit for")
+    }
+
+    // MARK: - The gate itself
+
+    @Test("the encoder's frame is the bound on the encoder arm, not a packet count")
+    func structuralSilenceIsBoundedByTheEncoderFrame() {
+        var startUp = AudioBridge.FeedStats()
+        startUp.packetsFed = 64
+        startUp.framesDecoded = 64
+        startUp.samplesEnqueued = 2560
+        startUp.packetsFedSinceLastEnqueue = 0
+        #expect(!AudioBridge.silenceIsStructural(stats: startUp, encoderFrameSize: 4608),
+                "AE#474: below one FLAC frame the encoder has not been asked yet")
+        #expect(AudioBridge.silenceIsStructural(stats: startUp, encoderFrameSize: 512),
+                "the same counters ARE structural against an encoder whose frame they cleared")
+
+        var fed = startUp
+        fed.samplesEnqueued = 4608 * 4
+        #expect(AudioBridge.silenceIsStructural(stats: fed, encoderFrameSize: 4608))
+
+        var healthy = fed
+        healthy.packetsEmitted = 1
+        #expect(!AudioBridge.silenceIsStructural(stats: healthy, encoderFrameSize: 4608),
+                "a bridge that emitted anything is never silent")
+    }
+
+    @Test("a decoder that stops answering is caught by the packet arm, from where it stopped")
+    func decoderThatStopsAnsweringIsStillCaught() {
+        var trickle = AudioBridge.FeedStats()
+        trickle.packetsFed = 900
+        trickle.framesDecoded = 3
+        trickle.samplesEnqueued = 120
+        trickle.packetsFedSinceLastEnqueue = 897
+        #expect(AudioBridge.silenceIsStructural(stats: trickle, encoderFrameSize: 4608),
+                "120 samples will never reach a FLAC frame, and the FIFO stopped moving 897 packets ago")
+
+        var stillFilling = trickle
+        stillFilling.packetsFedSinceLastEnqueue = 1
+        #expect(!AudioBridge.silenceIsStructural(stats: stillFilling, encoderFrameSize: 4608),
+                "a FIFO that is still accepting samples is a bridge that has not been asked yet")
+    }
 }


### PR DESCRIPTION
Fixes the start-up false positive reported by @cmcpherson274 in #462, filed as #474.

## What was wrong

`AudioBridge.noteSilentFeedIfNeeded` (AE#396) fired at **64 source packets**, but the quantity that bounds its encoder arm is **one encoder frame**: `drainFIFOIntoEncoder(requireFull: true)` cannot encode below `frame_size`, so no output is possible until that many samples have been enqueued.

The threshold's own comment named the two constants it was derived from, and the FLAC arm breaks both:

| | encoder frame | source packet | packets before the first output is possible |
|---|---|---|---|
| E-AC-3 arm | 1536 | 512 (DTS) … 1536 | 3 |
| FLAC arm | **4608** | **40** (TrueHD access unit) | **116** |

The `enqueued=2560` in the reporter's line is the proof: short of 4608, so the drain had correctly declined to encode and nothing could have been emitted. The FLAC mode has been in the same file since `ec4723dc` (2026-05-22) and predates the gate (`9870892c`, 2026-08-18).

It is not confined to the opt-in `.lossless` mode: `.surroundCompat` encodes any source of two channels or fewer to FLAC, so a stereo TrueHD file reproduces it on the default setting.

## The fix

Each arm is counted in the unit that bounds it:

- **Encoder arm**: `samplesEnqueued >= frame_size * 4`. Four frames because the first is when output becomes *possible* and the second covers an encoder that holds it; four is still inside the first half second of source audio on every arm (128 ms on E-AC-3, 384 ms on FLAC at 48 kHz), which is **sooner in wall clock** than the packet threshold it replaces.
- **Decoder arm**: packets, because where the FIFO never moved there is no sample count to bound anything with. Counted from the **last accepted sample** rather than from the start, so a decoder that answers for a while and then stops is the same shape as one that never answered, which the old gate could not express at all.

`silenceIsStructural(stats:encoderFrameSize:)` is pure and static so the boundary is pinned against the frame sizes the bridge really opens rather than whichever one a fixture happens to reach. The ERROR line now also names the encoder it is talking about (it said "AC-3/E-AC-3 sample entry" on a FLAC session) and the frame boundary it judged.

## Measured

Fixture, reproducible from scratch:

```bash
ffmpeg -f lavfi -i testsrc=size=1280x720:rate=25:duration=90 -f lavfi -i sine=frequency=440:duration=90 \
  -map 0:v -map 1:a -c:v libx264 -preset ultrafast -g 50 -pix_fmt yuv420p \
  -c:a truehd -strict -2 -ac 2 -ar 48000 truehd2.mkv
aetherctl play --seconds 20 file://$PWD/truehd2.mkv
```

**before**

```
[AudioBridge] init: mode=surroundCompat encoder=flac srcCodec=86060 sampleRate=48000 sourceChannels=2 …
[AudioBridge] ERROR: AE#396 the bridge has produced no encoded audio at all (mode=surroundCompat):
              fed=64 decoded=64 enqueued=2560 emitted=0. …
[AetherEngine] AE#462: audio delivery = bridged
[NativeAVPlayerHost] #1 item.audioTrack codec='flac' enabled=true sr=48000 ch=2 (readyToPlay)
final t=20.20s state=playing cues=0
```

**after**: same session, same counters reached, no ERROR line, `final t=20.30s state=playing`.

The counters in the before arm are identical to the reporter's device log, on the default mode.

## Tests

Four new tests in `Issue396SilentAudioBridgeTests`, all four failing against the old rule and passing against the new one, with the four pre-existing tests passing in both arms:

- 64 raw-PCM packets of 40 samples each through the FLAC arm reproduce `enqueued=2560 emitted=0` and must not report
- the same feed continued past the frame produces audio and still reports nothing
- 80 undecodable MP3 packets still report, from the packet arm
- the gate itself, against 4608 and against 512 with the same counters, plus the trickle shape the old gate could not express

Full suite green on both runners: XCTest 606 executed / 0 failures, swift-testing 2600 tests in 355 suites.

## Limit

The encoder arm is measured on media. The **decoder** arm is pinned through the real bridge in tests rather than in a session, because no corruption that could be built here (`noise` bsf at every byte, on MP3, AC-3 and TrueHD) makes libavcodec stop producing frames for a whole session; each of those sources decoded and played.

## Blast radius

None beyond the line. Both sites that classify a silent bridge are gated on an actual failure (`HLSVideoEngine+LiveReopen.swift:206` on a pump death with `muxerFailed`, `:632` on the exhausted revive), so a healthy start-up never reached them, and `$audioDelivery` (#462) is derived independently and read `bridged` correctly throughout.