### PR TITLE
fix(engine): a session-preserving reload preserves the transport and the playhead (AE#464 round 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,35 @@ the public-API contract.
 
 ### Fixed
 
+- **A session-preserving reload preserves the transport, and keeps the playhead when one is stacked
+  behind another (AE#464 round 2, reported and measured by @cmcpherson274).** `reloadAtCurrentPosition`
+  replayed `LoadOptions.autoplay` verbatim, and that flag describes the FIRST mount rather than the
+  session. A host that owns transport and mounts with `autoplay = false` therefore got a frozen picture
+  and no error out of every rebuild the engine raises on its own (the AirPlay LAN swap, a #460
+  correction, an audio-delay nudge): the rebuilt host settled `paused`, the producer parked on a
+  consumer that would never ask for a segment, and the host went on reporting progress. The rebuild now
+  comes back in the state the session is in, read from the native host's durable #122 intent where there
+  is one, so it survives a rebuild raised mid-scrub. A resume after a background teardown has no
+  transport left to read and is still the host's call, so that path is unchanged. Second half: the
+  reload's position snapshot read `currentTime`, which `load` zeroes at its start, so a reload raised
+  while another was still in flight rebuilt the session at its head. The position each load was handed
+  is parked across that window instead. Measured on a 300 s H.264 + AAC fixture: before, item #2 settled
+  `timeControlStatus=paused t+0.00s` and never left it, and three stepper presses in one runloop turn
+  came back `startPos=nil` cutting `seg0+` on a session 14.90 s in; after, `playing t+0.06s` and
+  `startPos=14.90s` cutting `seg3+`. `autoplay` is consequently not correctable through
+  `reloadAtCurrentPosition(applying:)`; call `play()` / `pause()` instead.
+
+- **The audio-delay re-anchor gate reads the field that carries the distinction, and states what it
+  actually did (AE#464 round 2).** The gate asked `liveWindow != nil`, which is true for every live
+  session (`load` builds one for each), so its own documented branch, that a live source without a DVR
+  window keeps the value for the next seam rather than paying a rebuild, was unreachable: a live-only
+  `.loopback` session took a reload that rejoins at the edge, and a live-only `.software` session issued
+  a seek the engine then refused as `liveWithoutDVR`. `windowSeconds` is what carries it, exactly as the
+  seek path reads it, and the gate takes the window itself now so there is no derivation left at a call
+  site to get wrong. The loopback re-anchor also ran under `try?` beneath a line that had already
+  announced the re-cut; it asks `sessionReloadRefusal` before the teardown and names the outcome after
+  it, so a re-cut that could not happen no longer reads as one that did.
+
 - **The live axis diagnostic names the term it was missing, and the reading it was published with is
   corrected (AE#446).** The line that reports what the replaced reconstruction WOULD have said takes
   its "nothing to say yet" exit on two separate signals, the item not having reported a seekable

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ try await player.load(url: videoURL, options: .init(
     httpHeaders: headers,              // attached to every demux + segment fetch
     matchContentEnabled: matchContent  // tvOS Match Content master toggle
 ))
-try await player.reloadAtCurrentPosition()                      // background reopen, preserves options
+try await player.reloadAtCurrentPosition()                      // background reopen, preserves options + transport
 try await player.load(url: trackURL, options: .init(audioOnly: true))   // lean audio path
 
 // Transport

--- a/Sources/AetherEngine/AetherEngine+AudioDelay.swift
+++ b/Sources/AetherEngine/AetherEngine+AudioDelay.swift
@@ -94,11 +94,39 @@ extension AetherEngine {
             // makes the next producer the session builds for its own reasons cut with the new value.
             nativeVideoSession?.audioDelaySeconds = clamped
             EngineLog.emit(
-                "[AetherEngine] AE#464: audio delay = \(Self.ms(clamped)) on the loopback path, "
-                + "re-cutting from the playhead",
+                "[AetherEngine] AE#464: audio delay = \(Self.ms(clamped)) on the loopback path",
                 category: .engine
             )
-            reanchorForAudioDelay(clamped) { _ in try? await self.reloadAtCurrentPosition() }
+            reanchorForAudioDelay(clamped) { _ in
+                // Round 2 (cmcpherson274): this was `try? await reloadAtCurrentPosition()`, under a
+                // line that had already announced the re-cut. Two claims, one of them unverified: a
+                // rebuild the session cannot make is not a rebuild, and a rebuild that threw is not
+                // one either, so both used to read as a re-cut that happened. The refusal is asked
+                // for BEFORE the rebuild, where it still costs nothing (#460 rule 2).
+                if let refusal = self.sessionReloadRefusal {
+                    EngineLog.emit(
+                        "[AetherEngine] AE#464: audio delay = \(Self.ms(clamped)) stands, but this "
+                        + "session cannot be rebuilt in place (\(refusal.rawValue)); it arrives at "
+                        + "the next seam the session makes on its own",
+                        category: .engine
+                    )
+                    return
+                }
+                do {
+                    try await self.reloadAtCurrentPosition()
+                    EngineLog.emit(
+                        "[AetherEngine] AE#464: re-cut at the playhead with audio delay "
+                        + "\(Self.ms(clamped))",
+                        category: .engine
+                    )
+                } catch {
+                    EngineLog.emit(
+                        "[AetherEngine] AE#464: the re-cut at the playhead failed (\(error)); the "
+                        + "audio delay \(Self.ms(clamped)) stands and arrives at the next seam",
+                        category: .engine
+                    )
+                }
+            }
         }
     }
 
@@ -113,7 +141,7 @@ extension AetherEngine {
     /// second seek ticket aimed at the re-cut segment's START and left it stalled for the rest of the
     /// session, with `phase` stuck at `seeking`.
     private func reanchorForAudioDelay(_ delay: Double, _ reanchor: @escaping (Double) async -> Void) {
-        guard Self.audioDelayRecutIsPossible(state: state, isLive: isLive, hasLiveWindow: liveWindow != nil) else {
+        guard Self.audioDelayRecutIsPossible(state: state, isLive: isLive, liveWindow: liveWindow) else {
             EngineLog.emit(
                 "[AetherEngine] AE#464: audio delay = \(Self.ms(delay)) stands, but this session cannot "
                 + "re-anchor at the playhead (state=\(state), live=\(isLive)); it arrives at the next seam",
@@ -130,12 +158,23 @@ extension AetherEngine {
     /// Whether the session has a playhead to come back to. Pure so the rule is testable without a
     /// session: the states that carry no position are the same ones `seek` refuses, and a live source
     /// without a DVR window has no seekable range at all.
-    static func audioDelayRecutIsPossible(state: PlaybackState, isLive: Bool, hasLiveWindow: Bool) -> Bool {
+    ///
+    /// Round 2 (cmcpherson274): this used to take the answer as a `Bool` and the call site derived it
+    /// as `liveWindow != nil`, which is true for EVERY live session (`load` builds one for each; the
+    /// engine's own field comment says so) and made the live-only branch above unreachable. The
+    /// distinction is carried by `windowSeconds`, exactly as `liveSeekRefusedWithoutDVR` reads it. It
+    /// takes the window itself now, so there is no derivation left at the call site to get wrong: a
+    /// pure gate can only be as right as its arguments, and this one was tested only through its
+    /// parameters.
+    static func audioDelayRecutIsPossible(state: PlaybackState, isLive: Bool, liveWindow: LiveWindow?) -> Bool {
         switch state {
         case .idle, .loading, .ended, .error: return false
         default: break
         }
-        return !isLive || hasLiveWindow
+        // Live-only (`windowSeconds == nil`): no rewind range, so no position to come back to. The
+        // software route's `seek(origin: .host)` would be refused as `liveWithoutDVR` and the loopback
+        // route's reload would rejoin at the edge, which throws the viewer's place away to move audio.
+        return !isLive || liveWindow?.windowSeconds != nil
     }
 
     /// Milliseconds, for log lines. The unit the correction is actually reasoned about in.

--- a/Sources/AetherEngine/AetherEngine+Loading.swift
+++ b/Sources/AetherEngine/AetherEngine+Loading.swift
@@ -1901,7 +1901,9 @@ extension AetherEngine {
         // already playing so an audio switch / background-resume doesn't silently revert to the main title (#67).
         let titleToReopen = discTitleIDOverride ?? activeDiscTitleID
         // resumeOverride 0 restarts a title switch at the new title's head; nil keeps the current playhead.
-        let resumeAt = resumeOverride ?? currentTime
+        // AE#464 round 2: "the current playhead" is not `currentTime` while another load is in flight,
+        // which has already zeroed that clock. See `AetherEngine.rebuildPosition`.
+        let resumeAt = resumeOverride ?? positionForSessionRebuild
         let embeddedStreamToResume: Int32 = activeEmbeddedSubtitleStreamIndex
         let sidecarToResume: URL? = isSubtitleActive && activeEmbeddedSubtitleStreamIndex < 0
             ? loadedSidecarURL
@@ -1940,6 +1942,9 @@ extension AetherEngine {
         )
 
         state = .loading
+        // AE#464 round 2: this branch reaches `loadSoftware` / `loadNative` rather than `load`, so it
+        // parks its own rebuild position for anything that stacks behind it.
+        positionUnderReconstruction = resumeAt
         let previousAudioIndex = activeAudioTrackIndex
         // Snapshot before stopInternal wipes state. Must reload on the same backend: loadNative on a SW-routed AV1 source throws unsupportedCodec (HLSVideoEngine only accepts HEVC / H.264 / VP9 / probed-AV1).
         let wasOnSoftwarePath = (playbackBackend == .software)

--- a/Sources/AetherEngine/AetherEngine.swift
+++ b/Sources/AetherEngine/AetherEngine.swift
@@ -1682,6 +1682,13 @@ public final class AetherEngine: ObservableObject {
     /// would be lost at the next audio-track switch or background return.
     func setLoadedAudioDelay(_ seconds: Double) { loadedOptions.audioDelaySeconds = seconds }
 
+    /// AE#464 round 2: the fourth narrow write, and the one that makes a session-preserving reload
+    /// preserve the session's transport. `autoplay` describes a MOUNT, and a rebuild is not a mount;
+    /// writing the session's own transport state here is what both reload branches then replay,
+    /// without either of them having to learn about it (the URL branch copies this struct into
+    /// `load`, the custom-source branch reads these fields one by one). See `rebuildResumesPlaying`.
+    func setLoadedAutoplay(_ autoplay: Bool) { loadedOptions.autoplay = autoplay }
+
     /// AE#460: the second narrow write into `loadedOptions` outside a load, for a host correction
     /// that a session-preserving reload is about to rebuild on. Installed before the rebuild rather
     /// than carried through it, because only the URL branch passes a struct into `load`: the
@@ -2158,6 +2165,46 @@ public final class AetherEngine: ObservableObject {
     /// site cannot silently bypass the flag.
     nonisolated static func loadPerformsAutostart(_ options: LoadOptions) -> Bool {
         options.autoplay
+    }
+
+    /// AE#464 round 2: whether a session-preserving rebuild comes back PLAYING.
+    ///
+    /// `reloadAtCurrentPosition` replayed `LoadOptions.autoplay` verbatim, and that flag describes the
+    /// FIRST mount, not the session. A host that owns transport itself and mounts with
+    /// `autoplay = false` therefore got a frozen picture and no error out of every rebuild the engine
+    /// makes on its own (the AirPlay LAN swap, a #460 correction, the #464 nudge): the rebuilt host
+    /// settled `paused`, the producer parked on a consumer that would never ask for a segment, and
+    /// nothing was left to call `play()` because the load was the engine's, not the host's. The rate a
+    /// host set already survives these rebuilds (#436); the play/pause did not.
+    ///
+    /// `nativeTransportIntent` is the native host's durable #122 intent, which is what the session is
+    /// DOING rather than what its player momentarily reads: it survives a scrub, so a rebuild raised
+    /// mid-seek comes back playing instead of paused. nil where there is no native host to ask (the
+    /// software and audio routes have no competing transport owner, so `state` is authoritative there,
+    /// which is the same split `togglePlayPause` makes).
+    nonisolated static func rebuildResumesPlaying(state: PlaybackState, nativeTransportIntent: Bool?) -> Bool {
+        if let nativeTransportIntent { return nativeTransportIntent }
+        switch state {
+        case .playing, .seeking: return true
+        case .idle, .loading, .paused, .ended, .error: return false
+        }
+    }
+
+    /// AE#464 round 2: the playhead a session-preserving rebuild has to come back to.
+    ///
+    /// `load()` zeroes the clock at its start, before the session it is building has anything to put
+    /// there, so a reload raised while another load is still in flight snapshotted that zero and
+    /// rebuilt the session at its head. Measured by the reporter: three stepper presses inside one
+    /// runloop turn stacked three reloads, two were superseded by generation, and the one that
+    /// survived cut `seg0+` on a title 15 s in. While a load is in flight the position that describes
+    /// the session is the one THAT load was handed, which it received before the clock was cleared.
+    ///
+    /// `.loading` is the whole of that window and nothing else: the only other writer of it holds it
+    /// through startup before the first roll (`host.$timeControlStatus`, which cannot reach it once
+    /// the session has played), so the parked value can never be read after the load it belongs to.
+    nonisolated static func rebuildPosition(state: PlaybackState, clock: Double, underReconstruction: Double?) -> Double {
+        guard state == .loading, let parked = underReconstruction else { return clock }
+        return parked
     }
 
     /// #35 cold-DV-master startup-readiness gate. A DV master (P7->P8.1, or any HDR master)
@@ -2810,6 +2857,28 @@ public final class AetherEngine: ObservableObject {
     /// misread as deselect) and applied by `restoreSubtitleSelection`.
     var sessionPreservingReloadInFlight = false
     var pendingNativeRenderingRequest: Bool? = nil
+
+    /// AE#464 round 2: the position the load currently in flight was handed, parked across the window
+    /// in which `load` has already zeroed the clock but the rebuilt session has not reached it yet.
+    /// Written at the two sites that raise `state = .loading` for a load; read only through
+    /// `positionForSessionRebuild`, which is what makes a reload stacked behind another one rebuild at
+    /// the playhead instead of at the head.
+    var positionUnderReconstruction: Double?
+
+    /// The playhead a rebuild of this session has to come back to (#464 round 2).
+    var positionForSessionRebuild: Double {
+        Self.rebuildPosition(state: state, clock: currentTime, underReconstruction: positionUnderReconstruction)
+    }
+
+    /// The transport state a rebuild of this session has to come back in (#464 round 2). Asks the
+    /// native host for its durable intent where there is one to ask, exactly as `togglePlayPause`
+    /// does, and falls back to `state` on the routes that have no competing transport owner.
+    var sessionRebuildResumesPlaying: Bool {
+        let nativeIntent = (nativeHost != nil && !audioAVPlayerActive && audioHost == nil && softwareHost == nil)
+            ? nativeHost?.transportIntentIsPlaying
+            : nil
+        return Self.rebuildResumesPlaying(state: state, nativeTransportIntent: nativeIntent)
+    }
     /// #357: selection parked by a background teardown for the foreground reload, because on that
     /// path the two are minutes apart and `stopInternal` has wiped the state the reload snapshots
     /// itself. Claimed by `consumeReloadSelection`, dropped by any other `load()` and by `stop()`.
@@ -3197,6 +3266,10 @@ public final class AetherEngine: ObservableObject {
             ? LiveWindow(windowSeconds: options.nativeRemoteHLS ? .greatestFiniteMagnitude : options.dvrWindowSeconds)
             : nil
         state = .loading
+        // AE#464 round 2: park the position THIS load is rebuilding toward before the clock that held
+        // it is cleared below, so a reload raised while this one is still in flight has something
+        // truer than the zero to snapshot. See `rebuildPosition`.
+        positionUnderReconstruction = startPosition ?? 0
         isBuffering = false
         residentPlaylistRanges = []
         residentRanges = []
@@ -4230,6 +4303,12 @@ public final class AetherEngine: ObservableObject {
         // nothing was parked this is exactly the pre-#357 live read.
         let resumesTornDownSession = backgroundTeardownSelection != nil
         let selection = consumeReloadSelection()
+        // AE#464 round 2: come back in the transport state the session is IN, not the one its first
+        // mount was given. Written before the branch because only the URL branch below carries a
+        // struct into `load`; the custom-source branch reads `loadedOptions` field by field.
+        // A torn-down session (#357 background teardown) has no transport left to read and its
+        // resume is the host's call, so that path keeps replaying the mount flag exactly as before.
+        if !resumesTornDownSession { setLoadedAutoplay(sessionRebuildResumesPlaying) }
         if isCustomSource {
             // Rebuild on retained reader (seekable only); no URL to reopen.
             guard customSourceIsSeekable, let placeholderURL = loadedURL else { return }
@@ -4254,7 +4333,9 @@ public final class AetherEngine: ObservableObject {
             return
         }
         guard let url = loadedURL else { return }
-        let pos = currentTime
+        // AE#464 round 2: not `currentTime`. A reload stacked behind one still in flight reads a clock
+        // that load already zeroed, and rebuilds the session at its head. See `rebuildPosition`.
+        let pos = positionForSessionRebuild
         // Snapshot the disc title before load()'s stopInternal wipes it, so a background-resumed disc image
         // keeps the title the user selected instead of reverting to the main title (#67).
         let titleID = selection.discTitleID

--- a/Sources/aetherctl/PlaybackCmd.swift
+++ b/Sources/aetherctl/PlaybackCmd.swift
@@ -80,7 +80,8 @@ func runPlay(url: URL, seconds: Double, live: Bool, nativeHLS: Bool = false, liv
                     censusThresholdMB: Int? = nil, censusHz: Double? = nil, frameTimes: Bool = false, pictureProbe: Bool = false,
                     sidecars: [ExternalSubtitleTrack] = [], audioSwitch: AudioSwitchRequest? = nil,
                     teletextPage: Int? = nil, teletextSwitch: TeletextPageSwitchRequest? = nil,
-                    audioDelayMs: Int = 0, audioDelaySwitch: AudioDelaySwitchRequest? = nil,
+                    audioDelayMs: Int = 0, audioDelaySwitches: [AudioDelaySwitchRequest] = [],
+                    pausedMount: Bool = false,
                     optionCorrection: LoadOptionCorrectionRequest? = nil,
                     sequentialOrigin: Bool = false, maxConcurrentRequests: Int? = nil, declaredDuration: Double? = nil,
                     httpHeaders: [String: String] = [:]) -> Int32 {
@@ -104,7 +105,7 @@ func runPlay(url: URL, seconds: Double, live: Bool, nativeHLS: Bool = false, liv
     // CFRunLoopRun, not a blocking semaphore: AetherEngine is @MainActor, so parking the main thread would deadlock the executor.
     let box = UncheckedBox<Int32?>(nil)
     Task { @MainActor in
-        box.value = await playSmokeTest(url: url, seconds: seconds, live: live, forceSoftware: forceSoftware, nativeHLS: nativeHLS, liveIngest: liveIngest, fastZap: fastZap, liveStartImmediately: liveStartImmediately, dvrWindow: dvrWindow, subsPick: subsPick, hostCalls: hostCalls, audioStats: audioStats, seekEvery: seekEvery, seekPattern: seekPattern, seekCount: seekCount, startPosition: startPosition, frameTimes: frameTimes, pictureProbe: pictureProbe, sidecars: sidecars, audioSwitch: audioSwitch, teletextPage: teletextPage, teletextSwitch: teletextSwitch, audioDelayMs: audioDelayMs, audioDelaySwitch: audioDelaySwitch, optionCorrection: optionCorrection, sequentialOrigin: sequentialOrigin, maxConcurrentRequests: maxConcurrentRequests, declaredDuration: declaredDuration, httpHeaders: httpHeaders)
+        box.value = await playSmokeTest(url: url, seconds: seconds, live: live, forceSoftware: forceSoftware, nativeHLS: nativeHLS, liveIngest: liveIngest, fastZap: fastZap, liveStartImmediately: liveStartImmediately, dvrWindow: dvrWindow, subsPick: subsPick, hostCalls: hostCalls, audioStats: audioStats, seekEvery: seekEvery, seekPattern: seekPattern, seekCount: seekCount, startPosition: startPosition, frameTimes: frameTimes, pictureProbe: pictureProbe, sidecars: sidecars, audioSwitch: audioSwitch, teletextPage: teletextPage, teletextSwitch: teletextSwitch, audioDelayMs: audioDelayMs, audioDelaySwitches: audioDelaySwitches, pausedMount: pausedMount, optionCorrection: optionCorrection, sequentialOrigin: sequentialOrigin, maxConcurrentRequests: maxConcurrentRequests, declaredDuration: declaredDuration, httpHeaders: httpHeaders)
         CFRunLoopStop(CFRunLoopGetMain())
     }
     CFRunLoopRun()
@@ -289,7 +290,7 @@ private func seekIntentDrill(
 }
 
 @MainActor
-private func playSmokeTest(url: URL, seconds: Double, live: Bool, forceSoftware: Bool = false, nativeHLS: Bool = false, liveIngest: Bool = false, fastZap: Bool = false, liveStartImmediately: Bool = true, dvrWindow: Double?, subsPick: String?, hostCalls: [String], audioStats: Bool, seekEvery: Double? = nil, seekPattern: [Double] = [], seekCount: Int? = nil, startPosition: Double? = nil, frameTimes: Bool = false, pictureProbe: Bool = false, sidecars: [ExternalSubtitleTrack] = [], audioSwitch: AudioSwitchRequest? = nil, teletextPage: Int? = nil, teletextSwitch: TeletextPageSwitchRequest? = nil, audioDelayMs: Int = 0, audioDelaySwitch: AudioDelaySwitchRequest? = nil, optionCorrection: LoadOptionCorrectionRequest? = nil, sequentialOrigin: Bool = false, maxConcurrentRequests: Int? = nil, declaredDuration: Double? = nil, httpHeaders: [String: String] = [:]) async -> Int32 {
+private func playSmokeTest(url: URL, seconds: Double, live: Bool, forceSoftware: Bool = false, nativeHLS: Bool = false, liveIngest: Bool = false, fastZap: Bool = false, liveStartImmediately: Bool = true, dvrWindow: Double?, subsPick: String?, hostCalls: [String], audioStats: Bool, seekEvery: Double? = nil, seekPattern: [Double] = [], seekCount: Int? = nil, startPosition: Double? = nil, frameTimes: Bool = false, pictureProbe: Bool = false, sidecars: [ExternalSubtitleTrack] = [], audioSwitch: AudioSwitchRequest? = nil, teletextPage: Int? = nil, teletextSwitch: TeletextPageSwitchRequest? = nil, audioDelayMs: Int = 0, audioDelaySwitches: [AudioDelaySwitchRequest] = [], pausedMount: Bool = false, optionCorrection: LoadOptionCorrectionRequest? = nil, sequentialOrigin: Bool = false, maxConcurrentRequests: Int? = nil, declaredDuration: Double? = nil, httpHeaders: [String: String] = [:]) async -> Int32 {
     let engine: AetherEngine
     do {
         engine = try AetherEngine()
@@ -377,6 +378,10 @@ private func playSmokeTest(url: URL, seconds: Double, live: Bool, forceSoftware:
         maxConcurrentSourceRequests: maxConcurrentRequests,
         declaredDurationSeconds: declaredDuration,
         externalSubtitles: sidecars,
+        // AE#464 round 2: the reporter's mount. A host that drives transport itself loads with
+        // autoplay off and calls play() next to its own load; a rebuild the ENGINE raises has no
+        // such caller, which is what made a mid-play nudge settle paused and stay there.
+        autoplay: !pausedMount,
         teletextPage: teletextPage,
         audioDelaySeconds: Double(audioDelayMs) / 1000.0,   // AE#464
         preferredDecodePath: forceSoftware ? .software : .automatic
@@ -488,7 +493,9 @@ private func playSmokeTest(url: URL, seconds: Double, live: Bool, forceSoftware:
     // shape as the audio switch below, for the same reason: the delay has to be elapsed time next to
     // a running session, and here it also has to outlast the subtitle selection, or the run measures
     // the load option it was already able to measure before.
-    if let audioDelaySwitch {
+    // AE#464 round 2: repeatable, because a stepper press is repeatable. Three of them inside
+    // one runloop turn is the leg that stacked three reloads and lost the playhead.
+    for audioDelaySwitch in audioDelaySwitches {
         Task { @MainActor in
             try? await Task.sleep(nanoseconds: UInt64(max(0, audioDelaySwitch.delayMilliseconds)) * 1_000_000)
             print("  HOSTCALL setAudioDelay(\(audioDelaySwitch.milliseconds) ms) at "

--- a/Sources/aetherctl/main.swift
+++ b/Sources/aetherctl/main.swift
@@ -73,7 +73,7 @@ func printUsage() {
       aetherctl play [--seconds N] [--live] [--fast-zap] [--live-start-immediately] [--dvr-window N] [--subs <codec-or-lang>]
                  [--start-position S] [--switch-audio <index>[@ms]]
                  [--teletext-page N] [--switch-teletext-page <page|auto>[@ms]]
-                 [--audio-delay <ms>] [--switch-audio-delay <ms>[@ms]]
+                 [--audio-delay <ms>] [--switch-audio-delay <ms>[@ms]]... [--paused]
                  [--reload-applying <key>=<value>]... [--reload-applying-at <ms>]
                  [--drop-audio]
                  [--sequential-origin] [--declared-duration S]
@@ -645,15 +645,21 @@ if first == "play" {
     // runtime setter. Same 20 s default as the teletext switch and for the same reason: it has to
     // land on a session that is playing, or it only re-proves the load option.
     let audioDelayMs = takeIntFlag("--audio-delay", from: &rest) ?? 0
-    let audioDelaySwitch: AudioDelaySwitchRequest? = takeStringFlag("--switch-audio-delay", from: &rest).flatMap { spec in
+    // Round 2: repeatable, so a run can press the stepper more than once. The `@ms` suffixes are
+    // what put two presses inside one runloop turn.
+    var audioDelaySwitches: [AudioDelaySwitchRequest] = []
+    while let spec = takeStringFlag("--switch-audio-delay", from: &rest) {
         let parts = spec.split(separator: "@", maxSplits: 1).map(String.init)
         guard let ms = Int(parts[0]) else {
             print("ERROR: --switch-audio-delay takes <ms>[@ms], got '\(spec)'")
             exit(64)
         }
-        return AudioDelaySwitchRequest(milliseconds: ms,
-                                       delayMilliseconds: parts.count == 2 ? (Int(parts[1]) ?? 20_000) : 20_000)
+        audioDelaySwitches.append(AudioDelaySwitchRequest(
+            milliseconds: ms,
+            delayMilliseconds: parts.count == 2 ? (Int(parts[1]) ?? 20_000) : 20_000))
     }
+    // AE#464 round 2: mount with `autoplay = false`, the shape of a host that owns transport.
+    let pausedMount = takeFlag("--paused", from: &rest)
     // #460: `--reload-applying <key>=<value>`, repeatable, with one shared delay. The delay is a
     // separate flag rather than teletext's `@ms` suffix because a header value can carry an `@`.
     // Default +20 s for the same reason the teletext switch uses it: the correction has to land on
@@ -725,7 +731,8 @@ if first == "play" {
                  censusThresholdMB: censusThresholdMB, censusHz: censusHz, frameTimes: frameTimes, pictureProbe: pictureProbe, sidecars: sidecars,
                  audioSwitch: audioSwitch,
                  teletextPage: teletextPage, teletextSwitch: teletextSwitch,
-                 audioDelayMs: audioDelayMs, audioDelaySwitch: audioDelaySwitch,
+                 audioDelayMs: audioDelayMs, audioDelaySwitches: audioDelaySwitches,
+                 pausedMount: pausedMount,
                  optionCorrection: optionCorrection,
                  sequentialOrigin: sequentialOrigin, maxConcurrentRequests: maxConcurrentRequests,
                  declaredDuration: declaredDuration,

--- a/Tests/AetherEngineTests/Issue464AudioDelayTests.swift
+++ b/Tests/AetherEngineTests/Issue464AudioDelayTests.swift
@@ -204,20 +204,41 @@ struct Issue464RecutEligibilityTests {
 
     @Test("a session with a playhead re-anchors; one without keeps the value for the next seam")
     func stateMatrix() {
-        #expect(AetherEngine.audioDelayRecutIsPossible(state: .playing, isLive: false, hasLiveWindow: false))
-        #expect(AetherEngine.audioDelayRecutIsPossible(state: .paused, isLive: false, hasLiveWindow: false))
-        #expect(AetherEngine.audioDelayRecutIsPossible(state: .seeking, isLive: false, hasLiveWindow: false))
+        #expect(AetherEngine.audioDelayRecutIsPossible(state: .playing, isLive: false, liveWindow: nil))
+        #expect(AetherEngine.audioDelayRecutIsPossible(state: .paused, isLive: false, liveWindow: nil))
+        #expect(AetherEngine.audioDelayRecutIsPossible(state: .seeking, isLive: false, liveWindow: nil))
         // The states seek() itself refuses. Setting the value is still honoured; only the re-anchor
         // is skipped, and the next load reads it out of the options.
-        #expect(!AetherEngine.audioDelayRecutIsPossible(state: .idle, isLive: false, hasLiveWindow: false))
-        #expect(!AetherEngine.audioDelayRecutIsPossible(state: .loading, isLive: false, hasLiveWindow: false))
-        #expect(!AetherEngine.audioDelayRecutIsPossible(state: .ended, isLive: false, hasLiveWindow: false))
+        #expect(!AetherEngine.audioDelayRecutIsPossible(state: .idle, isLive: false, liveWindow: nil))
+        #expect(!AetherEngine.audioDelayRecutIsPossible(state: .loading, isLive: false, liveWindow: nil))
+        #expect(!AetherEngine.audioDelayRecutIsPossible(state: .ended, isLive: false, liveWindow: nil))
     }
 
     @Test("live without a DVR window has no position to come back to")
     func liveWithoutDVR() {
-        #expect(!AetherEngine.audioDelayRecutIsPossible(state: .playing, isLive: true, hasLiveWindow: false))
-        #expect(AetherEngine.audioDelayRecutIsPossible(state: .playing, isLive: true, hasLiveWindow: true))
+        // Round 2: these are the windows `load` actually builds, not a Bool a call site derives. The
+        // gate used to be handed `liveWindow != nil`, which is true for BOTH of these, so the whole
+        // live-only branch was unreachable and a live session took the re-anchor either way.
+        #expect(!AetherEngine.audioDelayRecutIsPossible(
+            state: .playing, isLive: true, liveWindow: LiveWindow(windowSeconds: nil)))
+        #expect(AetherEngine.audioDelayRecutIsPossible(
+            state: .playing, isLive: true, liveWindow: LiveWindow(windowSeconds: 1800)))
+        // The remote-HLS live shape: `load` gives it an unbounded window, and it does rewind.
+        #expect(AetherEngine.audioDelayRecutIsPossible(
+            state: .playing, isLive: true, liveWindow: LiveWindow(windowSeconds: .greatestFiniteMagnitude)))
+    }
+
+    @Test("the gate agrees with the one the seek path uses, which is where the sessions actually meet")
+    func agreesWithTheSeekRefusal() {
+        // A live `.software` re-anchor is a `seek(origin: .host)`, so a gate that lets one through
+        // that `seek` then refuses as `liveWithoutDVR` costs a teardown to change nothing. The two
+        // rules have to read the same field, and this is what pins that they do.
+        for window in [Double?.none, 1800, .greatestFiniteMagnitude] {
+            let seekRefuses = AetherEngine.liveSeekRefusedWithoutDVR(origin: .host, windowSeconds: window)
+            let gateAllows = AetherEngine.audioDelayRecutIsPossible(
+                state: .playing, isLive: true, liveWindow: LiveWindow(windowSeconds: window))
+            #expect(gateAllows == !seekRefuses)
+        }
     }
 }
 

--- a/Tests/AetherEngineTests/Issue464ReloadPreservesSessionTests.swift
+++ b/Tests/AetherEngineTests/Issue464ReloadPreservesSessionTests.swift
@@ -1,0 +1,77 @@
+import Foundation
+import Testing
+@testable import AetherEngine
+
+/// AE#464 round 2 (cmcpherson274, measured on tvOS 26.6): what a session-preserving reload has to
+/// preserve. Both of these were reachable from every rebuild the engine makes on its own, not just
+/// from an audio-delay nudge, and neither failed visibly: one settled the rebuilt host paused with
+/// no error, the other rebuilt the session at its head.
+@Suite("AE#464 round 2: a session-preserving rebuild preserves the transport")
+struct Issue464RebuildTransportTests {
+
+    @Test("a host that owns transport gets its session back playing, not frozen on the mount flag")
+    func nativeIntentWins() {
+        // The reported shape: LoadOptions.autoplay = false because the app drives transport itself.
+        // Replaying that flag left the rebuilt host at timeControlStatus=paused for 40 s while the
+        // producer parked on a consumer that would never ask for a segment, and the host reported
+        // progress the whole time. What the rebuild has to come back in is the session's own intent.
+        #expect(AetherEngine.rebuildResumesPlaying(state: .playing, nativeTransportIntent: true))
+        #expect(!AetherEngine.rebuildResumesPlaying(state: .playing, nativeTransportIntent: false))
+    }
+
+    @Test("the durable intent outranks the momentary state, so a rebuild mid-seek is not a pause")
+    func intentSurvivesAScrub() {
+        // #122: `transportIntentIsPlaying` is the last engine-routed transport command and survives a
+        // seek; `state` is `.seeking` for the whole landing. Reading the state there would turn every
+        // correction raised during a scrub into a stop.
+        #expect(AetherEngine.rebuildResumesPlaying(state: .seeking, nativeTransportIntent: true))
+        // And the reverse: a paused scrub stays paused, which is the same thing #123's finalize wants.
+        #expect(!AetherEngine.rebuildResumesPlaying(state: .seeking, nativeTransportIntent: false))
+    }
+
+    @Test("routes with no competing transport owner answer from state, as togglePlayPause does")
+    func softwareAndAudioFallBackToState() {
+        #expect(AetherEngine.rebuildResumesPlaying(state: .playing, nativeTransportIntent: nil))
+        #expect(AetherEngine.rebuildResumesPlaying(state: .seeking, nativeTransportIntent: nil))
+        #expect(!AetherEngine.rebuildResumesPlaying(state: .paused, nativeTransportIntent: nil))
+    }
+
+    @Test("a session that was not running does not come back running")
+    func terminalStatesDoNotResume() {
+        #expect(!AetherEngine.rebuildResumesPlaying(state: .idle, nativeTransportIntent: nil))
+        #expect(!AetherEngine.rebuildResumesPlaying(state: .loading, nativeTransportIntent: nil))
+        #expect(!AetherEngine.rebuildResumesPlaying(state: .ended, nativeTransportIntent: nil))
+        #expect(!AetherEngine.rebuildResumesPlaying(state: .error("x"), nativeTransportIntent: nil))
+    }
+}
+
+@Suite("AE#464 round 2: a rebuild stacked behind another one keeps the playhead")
+struct Issue464RebuildPositionTests {
+
+    @Test("with no load in flight the clock is the playhead, exactly as before")
+    func steadyStateReadsTheClock() {
+        #expect(AetherEngine.rebuildPosition(state: .playing, clock: 15.3, underReconstruction: nil) == 15.3)
+        #expect(AetherEngine.rebuildPosition(state: .playing, clock: 15.3, underReconstruction: 0) == 15.3)
+        #expect(AetherEngine.rebuildPosition(state: .paused, clock: 15.3, underReconstruction: 0) == 15.3)
+    }
+
+    @Test("a load in flight has zeroed the clock, so the parked position is the honest one")
+    func stackedReloadKeepsThePosition() {
+        // The measured leg: three stepper presses inside one runloop turn (10:32:42.804-.807) started
+        // three reloads. Generations 2 and 3 were superseded, and the survivor snapshotted a clock
+        // that generation 2's load had already reset, so it cut seg0+ on a title 15 s in.
+        #expect(AetherEngine.rebuildPosition(state: .loading, clock: 0, underReconstruction: 15.3) == 15.3)
+    }
+
+    @Test("nothing parked means nothing invented; the clock still answers")
+    func nothingParkedFallsThrough() {
+        #expect(AetherEngine.rebuildPosition(state: .loading, clock: 0, underReconstruction: nil) == 0)
+    }
+
+    @Test("a cold load parks its own head, so a reload during startup does not resurrect a stale position")
+    func coldLoadParksZero() {
+        // `load` parks `startPosition ?? 0`. A fresh load at the head therefore parks 0, which is
+        // what a reload stacked onto it must read: the previous session's playhead is gone.
+        #expect(AetherEngine.rebuildPosition(state: .loading, clock: 0, underReconstruction: 0) == 0)
+    }
+}

--- a/docs/api.md
+++ b/docs/api.md
@@ -127,6 +127,10 @@ explicit subtitle authority (subtitles explicitly OFF included) and the live rej
 re-derives them by auto-selection. This reload keeps all of it, at the same teardown cost the plain
 `reloadAtCurrentPosition()` already pays.
 
+`autoplay` is the one listed field this cannot change. The rebuild comes back in the transport state
+the session is actually in (AE#464 round 2), so a correction that sets it is overwritten rather than
+refused; use `play()` / `pause()` around the correction if the rebuild should change the transport.
+
 Two refusals, both raised BEFORE any teardown, so a refused correction leaves the session playing:
 
 | Thrown | When |
@@ -363,7 +367,7 @@ try await player.reloadAtCurrentPosition()
 | --- | --- |
 | `load(url:startPosition:options:audioSourceStreamIndex:discTitleID:)` | `async throws -> SourceProbe?`. Discardable. Tears down any running session first. |
 | `load(source:startPosition:options:audioSourceStreamIndex:discTitleID:)` | Same, for `MediaSource.url` or `.custom(IOReader, formatHint:)`. A custom source whose initial probe fails throws, since it cannot be reopened by URL. |
-| `reloadAtCurrentPosition()` | `async throws`. Background reopen at the current position, preserving options. Session-preserving: it finishes an installed audio tap and keeps the native host where it can. |
+| `reloadAtCurrentPosition()` | `async throws`. Background reopen at the current position, preserving options. Session-preserving: it finishes an installed audio tap and keeps the native host where it can. It also preserves the session's TRANSPORT rather than replaying `autoplay`, so a session that was playing comes back playing and one that was paused comes back paused, whatever the mount was given (AE#464 round 2). The one exception is the resume after a background teardown, which has no transport left to read and is the host's call, so there the mount flag still decides. |
 | `stop(resetDisplayCriteria:finalTeardown:)` | Ends the session, `state` becomes `.idle`, `startupProgress` becomes nil. `resetDisplayCriteria: false` keeps the panel in its current mode across an item handoff. |
 | `AetherEngine.probe(url:options:)` / `probe(source:options:)` | `nonisolated static throws -> SourceProbe`. Demux-only metadata read, no decoders, no session. `options` is read for `httpHeaders` only. For a custom reader the caller keeps ownership, `close()` is not called, and the cursor is left unspecified. |
 | `AetherEngine.probeDetectingAtmos(url:options:atmosDetection:)` | `probe` plus a bounded decode pass that authoritatively resolves E-AC-3 JOC for an Atmos badge. Strictly more expensive; never on the playback-start path. Decode-side failures degrade to "not confirmed" rather than throwing. |
@@ -666,7 +670,7 @@ All flags default to safe values; the table is the full set. Depth for the media
 | `sequentialOrigin` | false | Declare an origin that fabricates range answers: one long-lived unranged GET, no ranged probes, non-seekable pb. **Seeking is unavailable**; re-request the archive at a shifted start instead. |
 | `declaredDurationSeconds` | nil | Trusted duration, overriding the container's. Required alongside `sequentialOrigin` on VOD, where the tail read is gone. |
 | `maxConcurrentSourceRequests` | nil | Most requests the reader may have open against this origin at once, across every path it fetches on (pump ranges, detour blocks, size probes, tail prefetch, subtitle side reader). nil counts without capping and lowers the ceiling on its own after a 429/503/509. Set it when the provider states a limit; `1` also switches off the speculative parallel paths, which exist only to overlap with the pump. Counts **requests**, not TCP connections, because over HTTP/2 a session multiplexes every request onto one connection while the origin still counts each one (AE#377). It is also the only ceiling: several engines playing from one origin are bounded by this value and by what the origin refuses, not by a transport pool underneath it (AE#450). |
-| `autoplay` | true | False mounts paused: the load skips the terminal `play()` and settles at `.paused` for a host that resumes later. |
+| `autoplay` | true | False mounts paused: the load skips the terminal `play()` and settles at `.paused` for a host that resumes later. It describes THIS MOUNT and nothing after it: the rebuilds a session makes on its own (`reloadAtCurrentPosition`, an option correction, the AirPlay LAN swap, an audio-delay nudge) come back in the transport state the session is in, not in this one. Correcting it through `reloadAtCurrentPosition(applying:)` therefore does nothing; call `play()` or `pause()` instead. |
 
 ## Value types
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -134,6 +134,23 @@ numbers.
 
 `--audio-delay <ms>` sets `LoadOptions.audioDelaySeconds` for the load, and `--switch-audio-delay <ms>[@ms]` calls `setAudioDelay(_:)` on a session that is already playing (default +20 s, same reason as the teletext switch). The runtime half is the interesting one: at load the offset is just a number handed to a muxer or a renderer, while mid-session it has to reach media the session has already committed to the previous value, and the two routes pay differently for that (a seek on `.software`, the session-preserving reload on `.loopback`). The engine states the delivered offset rather than the requested one: `[AudioOutput] AE#464 audio delay in effect: +200 ms (sample at 3.994s delivered at 4.194s)` on the software path, `[MP4SegmentMuxer] AE#464 cutting seg1+ with audio delay -150 ms` on the loopback one (AE#464).
 
+`--switch-audio-delay` is repeatable and `--paused` mounts with `autoplay = false`, which is what makes
+the round-2 pair of AE#464 reproducible without hardware. `--paused --host-calls play` is a host that
+owns transport (mount paused, play next to its own load), and the rebuild the engine raises for a nudge
+has no such caller: before the fix item #2 settled `timeControlStatus=paused reason=- t+0.00s`, never
+reached `playing`, and the producer parked on `#65 backpressure PARK (advance) ... (consumer paused)`
+while the run still ended `VERDICT: OK`. After it, `#2 timeControlStatus=playing t+0.06s`. Three presses
+inside one runloop turn (`--switch-audio-delay 50@15000 --switch-audio-delay 100@15003
+--switch-audio-delay 150@15006`) stack three reloads, two superseded by generation, and before the fix
+the survivor loaded `startPos=nil` and cut `seg0+` on a session 14.90 s in; after it,
+`startPos=14.90s`, `initial producer anchored at idx=3` and `seg3+`.
+
+`play --live` without `--dvr-window` is the live-only shape, and it is the one that shows the re-anchor
+gate: `AE#464: audio delay = +150 ms stands, but this session cannot re-anchor at the playhead
+(state=playing, live=true); it arrives at the next seam`. With `--dvr-window 1800` the same run takes the
+re-anchor and re-cuts. Before round 2 the gate read `liveWindow != nil`, which is true for both, so the
+live-only session took a rebuild that rejoins at the edge.
+
 `--reload-applying <key>=<value>` (repeatable, with one shared `--reload-applying-at <ms>`, default +20 s) corrects a `LoadOption` on the playing session through `reloadAtCurrentPosition(applying:)` (#460). Keys: `header.<Name>`, `audio-bridge`, `preferred-audio`, `decode-path`, and `is-live`, which is there to drive the refusal, since a field that names the session has to be observably refused rather than observably ignored. Both outcomes print, which is the pair a host's recovery ladder has to tell apart. Pair it with a header-logging origin to read the correction from the other end: with `--header "X-Auth: stale"` at load and `--reload-applying header.X-Auth=fresh`, the origin log shows three requests carrying the stale value, then three carrying the fresh one, and the transport telemetry carries straight through the rebuild (`resumed at 10.90s from 9.90s`).
 
 `play --sw` sets `LoadOptions.preferredDecodePath = .software` (#461), the shipping per-session lever, rather than the process-global `setForceSoftwarePathForTesting` it drove before; that hook is still what `live --sw` and `dvr` use, since those harnesses run several sessions and want every one of them on the software host. `--reload-applying decode-path=software` is the same lever applied to a session that is already playing: on the 300 s H.264 fixture the run dispatches `codec=27 → native`, takes the correction at t=9.90 s and comes back `codec=27 → software` at 10.81 s, playing. On a live load the override reaches the same routing decision, which is the case with no alternative, since the #2 capability gate is VOD-only and a live session is never classified at all.


### PR DESCRIPTION
Round 2 of AE#464, reported and measured on tvOS 26.6 by @cmcpherson274. Four findings, two of which turned out not to be about the audio delay at all.

## A session-preserving reload preserves the transport

`reloadAtCurrentPosition` replayed `LoadOptions.autoplay`, and that flag describes the FIRST mount rather than the session. A host that owns transport and mounts with `autoplay = false` therefore got a frozen picture and no error out of every rebuild the engine raises on its own: the AirPlay LAN swap (which fires from a route-change notification, so there is no host call anywhere near it to pair a `play()` with), a #460 correction, an audio-delay nudge. The rebuilt host settled `paused`, the producer parked on a consumer that would never ask for a segment, and the host went on reporting progress.

The rebuild comes back in the state the session is in now, read from the native host's durable #122 transport intent where there is one, so a rebuild raised mid-scrub does not come back paused. A resume after a background teardown has no transport left to read and stays the host's call, so that path replays the mount flag exactly as before.

Consequence: `autoplay` is not correctable through `reloadAtCurrentPosition(applying:)` any more, since the rebuild takes the session's transport state over it.

## A reload stacked behind another one keeps the playhead

The reload's position snapshot read `currentTime`, which `load` zeroes at its start before the session it is building has anything to put there, so a reload raised while another was still in flight rebuilt the session at its head. Both branches had it (`reloadAtCurrentPosition`, and `reloadWithAudioOverride`'s `resumeAt`). The position each load was handed is parked across that window and read back while a load is in flight.

## The re-anchor gate reads the field that carries the distinction

The gate asked `liveWindow != nil`, which is true for every live session (`load` builds one for each), so its own documented branch, that a live source without a DVR window keeps the value for the next seam rather than paying a rebuild, was unreachable. `windowSeconds` carries it, exactly as `liveSeekRefusedWithoutDVR` reads it, and the gate takes the window itself now so there is no derivation left at a call site to get wrong.

The rule was already tested, including a case named for this exact situation. A pure gate exercised only through its own parameters is proof of the RULE and says nothing about the ARGUMENT, which is where it died. One of the new cases asserts the gate and the seek refusal agree across all three window shapes.

## The loopback re-anchor states what it did

It ran under `try?` beneath a line that had already announced the re-cut. It asks `sessionReloadRefusal` before the teardown, where a refusal still costs nothing (#460 rule 2), and names the outcome after it.

## Measured

aetherctl, 300 s H.264 + AAC fixture, before and after arms on the same build of the harness:

| arm | before | after |
| --- | --- | --- |
| paused mount, nudge at t=14.80s | `#2 timeControlStatus=paused t+0.00s`, never leaves it, `#65 backpressure PARK (consumer paused)`, run ends `VERDICT: OK` | `#2 timeControlStatus=playing t+0.06s` |
| three presses in one runloop turn | `startPos=nil`, `cutting seg0+` on a session 14.90 s in | `startPos=14.90s`, `anchored at idx=3`, `cutting seg3+` |
| `play --live`, no DVR window | `cutting seg0+`, the full rebuild, 69 s in | the value stands for the next seam |
| `play --live --dvr-window 1800` | re-anchors | re-anchors |

Harness additions that made those runs possible: `play --paused` mounts with `autoplay = false`, and `--switch-audio-delay` is repeatable so presses can stack inside one runloop turn.

Full suite green on both runners: 606 XCTest (1 skipped), 2608 swift-testing in 357 suites.

Part of #464. The reporter's trial is what settles it.
