### PR TITLE
AE#418 round 9: a placement reading says what it taught the standing distance

### DIFF
--- a/Scripts/timecode-fixture.sh
+++ b/Scripts/timecode-fixture.sh
@@ -96,6 +96,22 @@
 # measured one does not. Run the same line against `tc-bf1-cues-lie.mkv` for the other geometry: the
 # coefficient reads 0.00x and the chain must end on -23.000 / -27.000, with the picture agreeing.
 #
+# AE#418 round 9 needs a LONG chain, which is what the reporter's session had and the arms above do
+# not: three placements cannot separate a standing quantity from a one-off reading. Serve the fixture
+# over a throttled origin (Scripts/throttle-origin.py, or any range origin with a delay and a shared
+# rate) and drive twenty-four seeks through the drought:
+#
+#   aetherctl play --seconds 62 --start-position 53 --picture-probe --seek-every 2 --seek-count 24 \
+#     --seek-pattern 65,60,70,58,75,50,85,45,90,40,95,35,100,30,105,25,110,22,64,59,69,57,74,49 \
+#     http://127.0.0.1:8871/tc-cues-lie.mkv
+#
+# Ten placements, byte-identical across three runs: seg13, seg13, seg12, seg10, seg9, seg8, seg7,
+# seg5, seg4, seg3, composing to -34.334 with the picture agreeing. Nine of them read a distance of
+# 0.000 and `seg5` reads 0.042, so the composition after it is one frame out and the reading after
+# THAT puts it back. That is the reporter's arm 1 in miniature, and it is the arm to run before
+# proposing any smoothing rule for the standing distance: the fixture wants the deviation ignored and
+# his asset wants it followed, so a rule that is right on one is wrong on the other.
+#
 # For magnitudes this fixture cannot reach, engineer the droughts: a key 3 s below a boundary gives
 # -3, 5 s gives -5, and a key under a second below one gives an axis AVPlayer THROWS AWAY at the
 # next seek (measured: -0.500 and -0.875 snap to 0, -1.000 and above survive).

--- a/Sources/AetherEngine/Video/HLSVideoEngine.swift
+++ b/Sources/AetherEngine/Video/HLSVideoEngine.swift
@@ -2682,6 +2682,19 @@ public final class HLSVideoEngine: @unchecked Sendable {
     /// session whose placements are AE#412 re-cuts (worth 0 and lead 0 by construction), there is
     /// never one. Measured on `tc-wide-cues-lie.mkv`, 13 of 13 placements across two runs carried
     /// `lead 0.000s`; the reporter's three arms produced a single sample between them.
+    ///
+    /// AE#418 round 9: the distance is a MEASUREMENT of a session, and a session's readings can
+    /// disagree by a frame. Reproduced on a ten-placement chain (`--seek-count 24` over a throttled
+    /// origin, 3 of 3 runs byte-identical): nine placements read 0.000 and `seg5` reads 0.042, so the
+    /// composition after it is one frame out and the reading after THAT puts it back. That is the
+    /// reporter's arm 1 exactly (`-0.036`, then `+0.004`, then a placement a frame out). What the two
+    /// disagree on is which reading is the outlier: on the fixture the standing value is 0.000 and one
+    /// reading deviates, on his 23.976 fps asset it is -0.041 and holds to 2 ms across two arms and
+    /// two placements. So neither a median (round 7's rule, which lags a genuine step by one reading
+    /// and would have cost him 0.041 s at `seg589`) nor a hold-until-confirmed rule is right on both,
+    /// and last-wins is kept: the deviation is one frame, it is undone by the next measurable
+    /// placement, and no instrument here resolves better than the frame it would be chasing. The
+    /// picture probe quantises at one frame too.
     static func placementDisplacement(axis: Double, measuredBase: Double) -> Double {
         let raw = axis - measuredBase
         guard raw.isFinite else { return 0 }
@@ -2913,8 +2926,14 @@ public final class HLSVideoEngine: @unchecked Sendable {
         // timeline AVPlayer rebuilt puts the segment on a base that is a statement about the rebuild,
         // and round 6 let exactly those readings set the parameter (the reporter's 2.00x, and a 21 s
         // residual on the fixture teaching the same value).
+        let teaching: DisplacementTeaching
         if source == .ownRun {
-            learnPlacementDisplacement(from: placement, measuredBase: reading.base)
+            teaching = learnPlacementDisplacement(from: placement, measuredBase: reading.base)
+        } else {
+            anchorShiftLock.lock()
+            let standing = lastPlacementDisplacement
+            anchorShiftLock.unlock()
+            teaching = .notTaught(standing: standing)
         }
         guard abs(reading.residual) > Self.axisRepublishEpsilonSeconds else {
             // Said out loud, because a check that only speaks when it disagrees cannot be told from one
@@ -2922,7 +2941,7 @@ public final class HLSVideoEngine: @unchecked Sendable {
             EngineLog.emit(
                 "[HLSVideoEngine] #418 seg\(placement.index) placement confirmed: AVPlayer holds it "
                 + "from item \(String(format: "%.3f", observedItemStart))s, base "
-                + "\(String(format: "%.3f", reading.base))s as published",
+                + "\(String(format: "%.3f", reading.base))s as published; \(teaching.clause)",
                 category: .session
             )
             return
@@ -2933,7 +2952,7 @@ public final class HLSVideoEngine: @unchecked Sendable {
             + "\(String(format: "%.3f", observedItemStart))s, clock \(String(format: "%.3f", itemClock))s, "
             + "residual \(String(format: "%+.3f", reading.residual))s): axis "
             + "\(String(format: "%.3f", placement.assumedBase + placement.worth))s -> "
-            + "\(String(format: "%.3f", reading.axis))s",
+            + "\(String(format: "%.3f", reading.axis))s; \(teaching.clause)",
             category: .session
         )
         publishPlaylistShift(reading.axis, seamItemSeconds: reading.seam)
@@ -2947,14 +2966,19 @@ public final class HLSVideoEngine: @unchecked Sendable {
     /// learned instead from the subset of placements carrying a presentation lead, which on a source
     /// without frame reordering, and on any session whose placements are AE#412 re-cuts, is none of
     /// them.
-    private func learnPlacementDisplacement(from placement: PublishedPlacement, measuredBase: Double) {
+    @discardableResult
+    private func learnPlacementDisplacement(
+        from placement: PublishedPlacement, measuredBase: Double
+    ) -> DisplacementTeaching {
         let sample = Self.placementDisplacement(
             axis: placement.axisInForce, measuredBase: measuredBase)
         anchorShiftLock.lock()
         let previous = lastPlacementDisplacement
         lastPlacementDisplacement = sample
         anchorShiftLock.unlock()
-        guard abs(sample - previous) > Self.axisRepublishEpsilonSeconds else { return }
+        guard abs(sample - previous) > Self.axisRepublishEpsilonSeconds else {
+            return .taught(sample: sample, moved: false)
+        }
         EngineLog.emit(
             "[HLSVideoEngine] #418 seg\(placement.index) sat "
             + "\(String(format: "%.3f", sample))s below the axis it composed on, not "
@@ -2963,6 +2987,37 @@ public final class HLSVideoEngine: @unchecked Sendable {
             + "\(String(format: "%.3f", measuredBase))s)",
             category: .session
         )
+        return .taught(sample: sample, moved: true)
+    }
+
+    /// AE#418 round 9: what a reading did to the standing distance, said on the reading's own line.
+    ///
+    /// Round 8 taught from every own-run reading and printed only the moves, so a reading that taught
+    /// the value it already had and a reading that was not allowed to teach at all printed the same
+    /// verdict. The reporter's round-8 retest ends on exactly that: three `placement confirmed` lines
+    /// with no `sat` line under them, and no way from the log to tell which of the two had happened.
+    /// A standing value that every later `placed` line quotes needs its provenance on the line that
+    /// sets it, not in the reader's head.
+    enum DisplacementTeaching: Equatable {
+        /// An own-run reading. `moved` is false when it taught the value already standing, which is a
+        /// confirmation of the distance rather than silence about it.
+        case taught(sample: Double, moved: Bool)
+        /// A reading off a timeline AVPlayer rebuilt, which is a statement about the rebuild and not
+        /// about where a placement sits below its axis (round 7). It corrects the axis and teaches
+        /// nothing.
+        case notTaught(standing: Double)
+
+        var clause: String {
+            switch self {
+            case .taught(let sample, let moved):
+                return moved
+                    ? "taught the distance \(String(format: "%.3f", sample))s"
+                    : "taught the standing distance \(String(format: "%.3f", sample))s again"
+            case .notTaught(let standing):
+                return "taught nothing, read off a rebuilt timeline; the distance stays "
+                    + "\(String(format: "%.3f", standing))s"
+            }
+        }
     }
 
     /// AE#418 round 7: the window closed with no run this placement could be read from, so the

--- a/Tests/AetherEngineTests/Issue418ReaimedGateAxisTests.swift
+++ b/Tests/AetherEngineTests/Issue418ReaimedGateAxisTests.swift
@@ -613,3 +613,48 @@ struct Issue418PlacementIdentityTests {
     }
 
 }
+
+@Suite("AE#418 round 9: a reading says what it taught")
+struct Issue418TeachingVisibilityTests {
+
+    @Test("a reading that moved the distance names the value it set")
+    func movedReadingNamesTheValue() {
+        let teaching = HLSVideoEngine.DisplacementTeaching.taught(sample: -0.041, moved: true)
+        #expect(teaching.clause.contains("taught the distance"))
+        #expect(teaching.clause.contains("-0.041"))
+    }
+
+    @Test("a reading that agreed with the standing distance still says it taught")
+    func unmovedReadingStillSaysItTaught() {
+        // The reporter's round-8 question: three `placement confirmed` lines with no `sat` line under
+        // them, and no way to tell a confirmation that taught 0.000 from one that was never allowed
+        // to teach. Round 8 printed only the moves, so silence covered both.
+        let teaching = HLSVideoEngine.DisplacementTeaching.taught(sample: 0, moved: false)
+        #expect(teaching.clause.contains("again"))
+        #expect(teaching.clause.contains("0.000"))
+        #expect(!teaching.clause.contains("nothing"))
+    }
+
+    @Test("a rebuilt timeline says it taught nothing, and what still stands")
+    func rebuiltTimelineTeachesNothing() {
+        // Round 7 refuses this reading the parameter on purpose: a timeline AVPlayer threw away puts
+        // the segment on its advertised start itself, which is a statement about the rebuild. The
+        // reading still corrects the axis, and on the wide fixture it corrects it by 28.000 s, so the
+        // line it prints is exactly the one a reader would otherwise credit with a 28 s lesson.
+        let teaching = HLSVideoEngine.DisplacementTeaching.notTaught(standing: 0.042)
+        #expect(teaching.clause.contains("taught nothing"))
+        #expect(teaching.clause.contains("rebuilt timeline"))
+        #expect(teaching.clause.contains("0.042"))
+    }
+
+    @Test("the three outcomes never read the same")
+    func theThreeOutcomesAreDistinct() {
+        let clauses = Set([
+            HLSVideoEngine.DisplacementTeaching.taught(sample: 0.042, moved: true).clause,
+            HLSVideoEngine.DisplacementTeaching.taught(sample: 0.042, moved: false).clause,
+            HLSVideoEngine.DisplacementTeaching.notTaught(standing: 0.042).clause,
+        ])
+        #expect(clauses.count == 3)
+    }
+
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -235,6 +235,15 @@ starts there`. An item's FIRST placement is no longer a case of its own: with no
 the distance is zero, which is what AVPlayer does there (measured base 0.000 on every arm of every
 fixture). The gate-open line still prints `lead=`, now purely as a source fact.
 
+Round 9 puts the lesson on the reading's own line, because round 8 printed only the MOVES and two
+different things were silent under that. Every verdict line now ends in one of three clauses: `taught
+the distance Xs` (an own-run reading that moved it, with the `sat` line under it), `taught the
+standing distance Xs again` (an own-run reading that agreed with it), or `taught nothing, read off a
+rebuilt timeline; the distance stays Xs`. The third is the one worth having: a rebuilt-timeline
+reading corrects the axis like any other, by 28.000 s on `tc-wide-cues-lie.mkv`, and round 7 refuses
+it the parameter on purpose, so its correction line was otherwise indistinguishable from one that had
+just taught a 28 s lesson.
+
 `--start-position S` starts at a resume anchor, the same one `serve` takes. `--sw` forces the software path for a source that would route native, which is how a native-only fixture exercises the SW pipeline.
 
 `--malloc-census` turns on the large-allocation census (`AetherEngine.setLargeAllocationCensusEnabled`) for the run, for tracing a footprint that grows where the segment budget says it should not. Besides the 30 s sample it arms a jump trigger, which exists because the 30 s memprobe cannot catch a failure that completes inside one sample (every kill on #220 was that shape): a counter polled at `--census-hz N` runs the zone walk once it climbs `--census-threshold-mb N` above its running high-water. Both flags are inert without `--malloc-census`.


### PR DESCRIPTION
Round 8 learns the distance a placement sits below its axis from every own-run reading, confirmations included, and prints only the readings that MOVE it. Two different things are silent under that rule:

- a reading that taught the value already standing, and
- a reading off a timeline AVPlayer rebuilt, which round 7 refuses the parameter on purpose.

The reporter's round-8 retest ends on exactly that ambiguity: three `placement confirmed` lines with no `sat` line under them, and no way from the log to tell which had happened. The second case is the one worth naming, because a rebuilt-timeline reading corrects the axis like any other (by 28.000 s on `tc-wide-cues-lie.mkv`), so its correction line read identically to one that had just taught a 28 s lesson.

Every verdict line now ends in one of three clauses:

- `taught the distance Xs` (own run, the value moved, with the `sat` line under it)
- `taught the standing distance Xs again` (own run, it agreed)
- `taught nothing, read off a rebuilt timeline; the distance stays Xs`

## Measured alongside, and recorded rather than acted on

A ten-placement chain on `tc-cues-lie.mkv` over a throttled origin (24 seeks, 3 of 3 runs byte-identical) reproduces the reporter's arm 1 in miniature. Nine placements read a distance of 0.000, `seg5` reads 0.042, the composition after it is one frame out, and the reading after that puts it back.

The fixture wants that deviation ignored; his 23.976 fps asset wants its `-0.041` followed to 2 ms across two arms. So a median (round 7's rule) lags a genuine step by one reading and would have cost him 0.041 s at `seg589`, and a hold-until-confirmed rule holds the wrong value on his arm 1. Last-wins stays: the deviation is one frame, the next measurable placement undoes it, and the picture probe quantises at one frame too. The arm is written into `Scripts/timecode-fixture.sh` so the next rule proposal has to run it.

Re #418. The reporter's retest is what settles this one.

Tests: 2621 swift-testing in 359 suites, 606 XCTest, both green.