### PR TITLE
A seek landing reads what its run carries (#481)

### DIFF
--- a/Sources/AetherEngine/AetherEngine+Diagnostics.swift
+++ b/Sources/AetherEngine/AetherEngine+Diagnostics.swift
@@ -103,6 +103,33 @@ extension AetherEngine {
     static let placementVerificationIntervalMS = 250
     static let placementVerificationSlowIntervalMS = 1000
 
+    /// AE#481: how long after a seek the landing's run is read for. The reading needs a run that
+    /// HOLDS the target, so it has to outlast the landing itself; three seconds covers a landing that
+    /// buffers on a shaped link (measured: the run holding the landing was there within 1.5 s on every
+    /// arm at 600 kbps / 300 ms) without keeping a sampler alive into the next seek.
+    static let landingAxisWaitSeconds = 3.0
+
+    /// AE#481: read what the run holding a seek landing carries, and correct the axis when the timeline
+    /// disagrees with the composition it inherited. Silent in every session whose landing stays inside
+    /// the run it was already playing, which is what a fast link produces.
+    func verifyAxisAtSeekLanding(session: HLSVideoEngine, landingItemSeconds: Double) {
+        landingAxisTask?.cancel()
+        landingAxisTask = Task { @MainActor [weak self, weak session] in
+            var waited = 0.0
+            while waited < Self.landingAxisWaitSeconds {
+                try? await Task.sleep(for: .milliseconds(Self.placementVerificationIntervalMS))
+                waited += Double(Self.placementVerificationIntervalMS) / 1000
+                guard !Task.isCancelled, let self, let session else { return }
+                let ranges = await self.avPlayerLoadedRanges()
+                guard !Task.isCancelled else { return }
+                // A publication is the end of it: the axis it wrote is the one every later reading
+                // composes onto, and sampling on would re-read what this just published.
+                if session.applyLandingAxisReading(
+                    landingItemSeconds: landingItemSeconds, ranges: ranges) { return }
+            }
+        }
+    }
+
     func verifyPlacementAgainstLoadedRanges(session: HLSVideoEngine) {
         placementVerificationTask?.cancel()
         guard session.hasPlacementAwaitingMeasurement else { return }

--- a/Sources/AetherEngine/AetherEngine.swift
+++ b/Sources/AetherEngine/AetherEngine.swift
@@ -1445,6 +1445,9 @@ public final class AetherEngine: ObservableObject {
     /// AVPlayer says it holds the bytes that seam describes. One at a time, newest wins, cancelled in
     /// stopInternal: it exists only to check the axis just published, so an older check is stale.
     var placementVerificationTask: Task<Void, Never>?
+    /// AE#481: the sampler reading what the run holding a seek landing carries. One at a time, and the
+    /// newest seek owns it: an older landing describes a position the playhead has left.
+    var landingAxisTask: Task<Void, Never>?
 
     /// 1 Hz live-telemetry sampler. Lifecycle mirrors memoryProbeTask. Holds a weak engine reference
     /// so the retained task can't keep self alive past teardown.
@@ -4549,6 +4552,15 @@ public final class AetherEngine: ObservableObject {
         // still had when the seek was issued; from the landing forward the clock describes the axis
         // it will have instead.
         nativeVideoSession?.snapAxisAfterSeek(landingItemSeconds: clockTarget)
+        // AE#481: and what the landing's run carries is a READING, not the composition it inherits. A
+        // seek that opens a new run at a segment written on its planned position lands on a source-true
+        // stretch, which nothing else in the session ever looks at: measured on the #418 chain with the
+        // re-anchoring seek last, the clock stayed 9 s over the picture from the landing to the end of
+        // the session. Armed here rather than at the landing because the sampler waits for a run to
+        // hold the target anyway, and a superseded seek cancels it.
+        if let session = nativeVideoSession, nativeHost != nil {
+            verifyAxisAtSeekLanding(session: session, landingItemSeconds: clockTarget)
+        }
         // AE#412: inside a keyframe drought, audio opened plan boundaries the keyframe-gated cutter
         // folded, so the landing segment can carry no random-access point at all. AVPlayer reaches
         // back a fixed few seconds on a cold seek and does not look for one, so the picture would
@@ -5901,6 +5913,8 @@ public final class AetherEngine: ObservableObject {
         memoryProbeTask = nil
         placementVerificationTask?.cancel()
         placementVerificationTask = nil
+        landingAxisTask?.cancel()
+        landingAxisTask = nil
         // AE#446: the outage watcher belongs to the session whose window was closed with ENDLIST.
         liveOutageResumeWatcher?.cancel()
         liveOutageResumeWatcher = nil

--- a/Sources/AetherEngine/Video/HLSVideoEngine.swift
+++ b/Sources/AetherEngine/Video/HLSVideoEngine.swift
@@ -490,6 +490,11 @@ public final class HLSVideoEngine: @unchecked Sendable {
     /// AE#418 round 3: the placement this session last published an axis for, so the prediction can be
     /// checked against where AVPlayer actually put those bytes.
     private var lastPublishedPlacement: PublishedPlacement?
+    /// AE#481: the first segment the local server answered after the most recent seek, which is the one
+    /// whose content opens the run that landing sits in. Identifying it is what makes the landing
+    /// reading a question about ONE segment: asked of the whole plan, "does this run open on a playlist
+    /// position" is a coincidence 31 boundaries wide.
+    private var firstDeliveredIndexSinceSeek: Int?
     /// The last index a fetch declared. A cold fetch reaches the provider BEFORE the producer has
     /// opened its gate, so the placement can precede the offset it is worth; this is what lets the
     /// gate publish for a placement that already happened.
@@ -2749,6 +2754,11 @@ public final class HLSVideoEngine: @unchecked Sendable {
     /// leaves everything below the landing on the axis its bytes were placed with.
     func snapAxisAfterSeek(landingItemSeconds: Double) {
         guard !isLiveSession else { return }
+        // AE#481: the landing reading asks about the segment that opens the run it lands in, so the
+        // record starts empty at every seek. A stale one would describe the run before this seek.
+        anchorShiftLock.lock()
+        firstDeliveredIndexSinceSeek = nil
+        anchorShiftLock.unlock()
         let current = playlistShiftSeconds
         let snapped = Self.axisShiftAfterSeek(current)
         guard snapped != current else { return }
@@ -2765,6 +2775,102 @@ public final class HLSVideoEngine: @unchecked Sendable {
         lastPublishedPlacement = nil
         anchorShiftLock.unlock()
         publishPlaylistShift(snapped, seamItemSeconds: landingItemSeconds)
+    }
+
+    /// AE#481: what the run holding a seek landing carries, read off the playlist instead of inherited
+    /// from a composition measured somewhere else.
+    ///
+    /// The #418 axis is published once, at the advertised start of the segment whose gate re-aimed, and
+    /// it stands for everything after that seam. Measured with `play --picture-probe` on the #418 chain
+    /// with the re-anchoring seek LAST (`--seek-count 5 --seek-pattern 65,60,70,58,75`, `slowrange.py`
+    /// at 600 kbps / 300 ms), the picture says the axis is narrower than that:
+    ///
+    /// | item | 53.000 | 67.833 | 79.000 | 84.917 | ... | 119.958 |
+    /// | --- | --- | --- | --- | --- | --- | --- |
+    /// | `pic - picItem` | **-9.000** | 0.000 | 0.000 | 0.000 | | 0.000 |
+    ///
+    /// The offset belongs to the run `seg13` opened. A seek that opens a NEW run at a segment the
+    /// producer wrote at its planned position lands on a source-true stretch, and nothing tells this
+    /// side: `capErr` reads `+9.017` from the landing to the end of the session (2 of 2 runs at
+    /// 600 kbps / 300 ms, 1 of 1 at 1200 kbps / 200 ms, and not at 3200 kbps / 100 ms, where the
+    /// landing stays inside the run already playing). Ten rounds of #418 never saw it standing because
+    /// a seek burst heals it inside a second: the next seek composes a placement, and its reading comes
+    /// off the changed timeline.
+    ///
+    /// **The discriminator is where the run OPENS, asked of ONE segment.** A segment advertised at A
+    /// goes into a timeline carrying an axis at the seam that axis predicts, and into a timeline
+    /// carrying nothing at A itself, which is round 7's pair of admissible answers. The segment to ask
+    /// is the first one the local server answered after the seek, because that is the one whose content
+    /// opens the run the landing sits in. Asked of the PLAN instead ("does this run open on some
+    /// playlist position"), the same rule publishes on a coincidence: 31 boundaries over 120 s against a
+    /// half-second tolerance, and measured on the #418 chain it wrote a 0.000 axis into a timeline
+    /// carrying -27.875 s, taking `capErr` from +0.092 to -27.883 in one tick. A wrong candidate now
+    /// costs silence rather than an axis: neither answer matches and nothing is published.
+    static func landingAxisReading(
+        landingItemSeconds: Double,
+        ranges: [(Double, Double)],
+        openingSegmentStart: Double,
+        worth: Double,
+        assumedBase: Double,
+        standingAxis: Double
+    ) -> (axis: Double, runStart: Double)? {
+        guard let holding = ranges.first(where: {
+            $0.0.isFinite && $0.1.isFinite && $0.0 <= landingItemSeconds && landingItemSeconds <= $0.1
+        }) else { return nil }
+        let predicted = seamItemSeconds(advertisedStart: openingSegmentStart, currentShift: assumedBase)
+        // Round 7's two admissible answers, asked at a landing instead of at a placement: a run opens
+        // where the timeline this session knows would put this segment, or at the segment's own
+        // playlist position, which is what a timeline carrying nothing there does.
+        //
+        // Both halves are load-bearing. Asking only "does the run open on SOME playlist position"
+        // publishes on a coincidence: the plan has 31 boundaries over 120 s and the tolerance is half a
+        // second, and measured on the #418 chain that read a 0.000 axis into a timeline carrying
+        // -27.875 s (`capErr` +0.092 to -27.883 in one tick). One segment can be asked; the plan cannot.
+        guard abs(holding.0 - predicted) > placementSeamToleranceSeconds,
+              abs(holding.0 - openingSegmentStart) <= placementSeamToleranceSeconds else { return nil }
+        let base = measuredPlacementBase(
+            advertisedStart: openingSegmentStart, observedItemStart: holding.0)
+        let axis = base + worth
+        guard abs(axis - standingAxis) > axisRepublishEpsilonSeconds else { return nil }
+        return (axis, holding.0)
+    }
+
+    /// AE#481: read the axis where a seek landed and publish it when the timeline disagrees with the
+    /// composition it inherited. Returns whether anything was published.
+    func applyLandingAxisReading(landingItemSeconds: Double, ranges: [(Double, Double)]) -> Bool {
+        guard !isLiveSession else { return false }
+        anchorShiftLock.lock()
+        let pending = lastPublishedPlacement
+        let shifts = epochShiftByIndex
+        let displacement = lastPlacementDisplacement
+        let opening = firstDeliveredIndexSinceSeek
+        anchorShiftLock.unlock()
+        // A placement awaiting measurement has the more specific reading (round 7) and measures the
+        // same ranges; two writers on one axis would race, and the placement knows what it composed.
+        guard pending == nil, let opening else { return false }
+        restartLock.lock()
+        let advertisedStart = opening >= 0 && opening < segmentPlan.count
+            ? segmentPlan[opening].startSeconds : nil
+        restartLock.unlock()
+        guard let advertisedStart else { return false }
+        let standing = playlistShiftSeconds
+        guard let reading = Self.landingAxisReading(
+            landingItemSeconds: landingItemSeconds, ranges: ranges,
+            openingSegmentStart: advertisedStart, worth: shifts[opening] ?? 0,
+            assumedBase: Self.placementBase(axis: standing, displacement: displacement),
+            standingAxis: standing)
+        else { return false }
+        EngineLog.emit(
+            "[HLSVideoEngine] #481 the run holding the landing at item "
+            + "\(String(format: "%.3f", landingItemSeconds))s opens at "
+            + "\(String(format: "%.3f", reading.runStart))s, which is seg\(opening)'s own playlist "
+            + "position \(String(format: "%.3f", advertisedStart))s, so it carries "
+            + "\(String(format: "%.3f", reading.axis))s and not the "
+            + "\(String(format: "%.3f", standing))s this session was mapping with",
+            category: .session
+        )
+        publishPlaylistShift(reading.axis, seamItemSeconds: reading.runStart)
+        return true
     }
 
     /// AE#418 round 3: one placement, kept so the composition that was published for it can be checked
@@ -3083,6 +3189,7 @@ public final class HLSVideoEngine: @unchecked Sendable {
             segmentDeliveryByIndex = segmentDeliveryByIndex.filter { abs($0.key - index) <= 64 }
         }
         segmentDeliveryByIndex[index] = (segmentDeliverySerial, delivered)
+        if delivered, firstDeliveredIndexSinceSeek == nil { firstDeliveredIndexSinceSeek = index }
         anchorShiftLock.unlock()
     }
 

--- a/Tests/AetherEngineTests/Issue481LandingAxisTests.swift
+++ b/Tests/AetherEngineTests/Issue481LandingAxisTests.swift
@@ -1,0 +1,148 @@
+import Testing
+import Foundation
+@testable import AetherEngine
+
+/// AE#481: a standing axis outlives the stretch it was measured for.
+///
+/// The #418 axis is published once, at the advertised start of the segment whose gate re-aimed below
+/// its boundary, and it holds for everything after that seam. Measured with `play --picture-probe`
+/// over `Scripts/slowrange.py` at 600 kbps / 300 ms, the arm being the #418 chain with the re-anchoring
+/// seek LAST (`--seek-count 5 --seek-pattern 65,60,70,58,75`), the picture says it does not:
+///
+/// | item | 53.000 | 67.833 | 79.000 | 84.917 | ... | 119.958 |
+/// | --- | --- | --- | --- | --- | --- | --- |
+/// | `pic - picItem` | **-9.000** | 0.000 | 0.000 | 0.000 | | 0.000 |
+///
+/// The -9.000 belongs to the run `seg13` opened, not to the timeline from item 52.000 onward. When a
+/// seek opens a NEW run at a segment the producer wrote at its planned position, that run is
+/// source-true, and the session goes on mapping with the old axis: `capErr=+9.017` from the landing to
+/// the end of the session, 2 of 2 runs at 600 kbps / 300 ms and 1 of 1 at 1200 kbps / 200 ms (and not
+/// at 3200 kbps / 100 ms, where the landing stays inside the run it was already playing).
+///
+/// Ten rounds of #418 never saw it standing because a seek burst heals it: the next seek composes a
+/// placement whose reading comes off the changed timeline and corrects the axis within a second or
+/// two. Only a session whose last re-anchoring seek is also its last seek keeps the error.
+///
+/// **The discriminator is where the run OPENS, asked of ONE segment**: the first the local server
+/// answered after the seek, which is the one whose content opens the run the landing sits in. It goes
+/// into a timeline carrying an axis at the seam that axis predicts, and into a timeline carrying
+/// nothing at its own position, which is round 7's pair of admissible answers. Asked of the PLAN
+/// instead, the same rule publishes on a coincidence, and this suite pins the case that proved it: 31
+/// boundaries over 120 s against a half-second tolerance wrote a 0.000 axis into a timeline carrying
+/// -27.875 s, `capErr` +0.092 to -27.883 in one tick. A wrong candidate now costs silence.
+@Suite("AE#481: the axis belongs to the run, and a landing can read it")
+struct Issue481LandingAxisTests {
+
+    /// The measured arm. The session maps with -9.000, the run holding the landing opens at the
+    /// playlist position of the segment that opened it, so that run carries what the segment is worth,
+    /// which is nothing.
+    @Test("a run opened on its segment's own playlist position carries what the segment is worth")
+    func landingOnARebuiltRunReadsZero() {
+        let reading = HLSVideoEngine.landingAxisReading(
+            landingItemSeconds: 84.917,
+            ranges: [(52.0, 61.0), (75.125, 119.958)],
+            openingSegmentStart: 75.125,
+            worth: 0,
+            assumedBase: -9.0,
+            standingAxis: -9.0)
+        #expect(reading?.axis == 0.0)
+        #expect(reading?.runStart == 75.125)
+    }
+
+    /// Round 2's arm, which must not change: the landing stays inside the run that carries the axis, so
+    /// the run opens where the composition says it should and there is nothing to correct.
+    @Test("a run that opens where the composition predicts is the timeline this session knows")
+    func ownRunIsSilent() {
+        #expect(HLSVideoEngine.landingAxisReading(
+            landingItemSeconds: 80.0,
+            ranges: [(84.125, 119.0)],
+            openingSegmentStart: 75.125,
+            worth: 0,
+            assumedBase: -9.0,
+            standingAxis: -9.0) == nil)
+    }
+
+    /// The false positive this rule was rewritten to exclude, measured before it was: asking the whole
+    /// plan whether a run opens on "a" playlist position is a coincidence 31 boundaries wide, and on the
+    /// #418 chain it published a 0.000 axis into a timeline carrying -27.875 s (`capErr` +0.092 to
+    /// -27.883 in one tick). Asked of the segment that actually opened the run, the same numbers are
+    /// silent: the opening matches neither its predicted seam nor its own position.
+    @Test("a run opening near some other segment's boundary is not this segment's")
+    func aCoincidingBoundaryIsNotARebuild() {
+        #expect(HLSVideoEngine.landingAxisReading(
+            landingItemSeconds: 122.875,
+            ranges: [(115.875, 140.0)],
+            openingSegmentStart: 143.75,
+            worth: 0,
+            assumedBase: -27.875,
+            standingAxis: -27.875) == nil)
+    }
+
+    @Test("no run holds the landing, so there is nothing to read")
+    func noRunHoldsTheLanding() {
+        #expect(HLSVideoEngine.landingAxisReading(
+            landingItemSeconds: 200.0,
+            ranges: [(52.0, 96.0)],
+            openingSegmentStart: 52.0,
+            worth: -9.0,
+            assumedBase: 0,
+            standingAxis: -9.0) == nil)
+    }
+
+    /// A run opens where its segment's content begins, which is a frame or two off the boundary on
+    /// reordered material. The placement reading's tolerance covers it.
+    @Test("an opening a frame off its own position is still its own")
+    func frameScaleToleranceHolds() {
+        let reading = HLSVideoEngine.landingAxisReading(
+            landingItemSeconds: 78.0,
+            ranges: [(75.167, 119.958)],
+            openingSegmentStart: 75.125,
+            worth: 0,
+            assumedBase: -9.0,
+            standingAxis: -9.0)
+        // The run opens a frame ABOVE the position, so its content sits a frame below it, which is the
+        // same arithmetic a placement reading does with its residual.
+        #expect(abs((reading?.axis ?? .nan) + 0.042) < 0.0005)
+    }
+
+    /// What the opening segment is worth is part of the reading: a run opened by a re-aimed segment
+    /// carries that offset, not zero.
+    @Test("a run opened by a re-aimed segment carries its offset")
+    func runOpenedByAReaimedSegmentReadsItsWorth() {
+        let reading = HLSVideoEngine.landingAxisReading(
+            landingItemSeconds: 60.0,
+            ranges: [(52.0, 96.0)],
+            openingSegmentStart: 52.0,
+            worth: -9.0,
+            assumedBase: -14.0,
+            standingAxis: -14.0)
+        #expect(reading?.axis == -9.0)
+    }
+
+    /// With no standing axis the two admissible answers are the same position, so a landing has nothing
+    /// to tell apart and says nothing. A re-aim from zero always arrives with a placement, which is the
+    /// reading that owns that case.
+    @Test("without a standing axis the two answers coincide and the landing is silent")
+    func noStandingAxisMeansNoDiscriminator() {
+        #expect(HLSVideoEngine.landingAxisReading(
+            landingItemSeconds: 55.0,
+            ranges: [(52.0, 96.0)],
+            openingSegmentStart: 52.0,
+            worth: -9.0,
+            assumedBase: 0,
+            standingAxis: 0) == nil)
+    }
+
+    /// Reading back what is already standing is not a correction, and republishing it would re-arm the
+    /// verification for the rest of the session.
+    @Test("a reading that agrees with the standing axis publishes nothing")
+    func agreementIsSilent() {
+        #expect(HLSVideoEngine.landingAxisReading(
+            landingItemSeconds: 78.0,
+            ranges: [(75.125, 119.958)],
+            openingSegmentStart: 75.125,
+            worth: 0,
+            assumedBase: -9.0,
+            standingAxis: 0) == nil)
+    }
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -244,6 +244,23 @@ reading corrects the axis like any other, by 28.000 s on `tc-wide-cues-lie.mkv`,
 it the parameter on purpose, so its correction line was otherwise indistinguishable from one that had
 just taught a 28 s lesson.
 
+AE#481 is the case those ten rounds could not see, because a seek burst heals it inside a second. The
+axis belongs to the RUN a re-aimed segment opened, not to the timeline from its advertised start on:
+run the same chain with the re-anchoring seek LAST (`--seek-count 5 --seek-pattern 65,60,70,58,75`,
+served through `Scripts/slowrange.py` at 600 kbps / 300 ms) and the picture reads `pic - picItem` of
+-9.000 at item 53.000 and 0.000 everywhere the landing goes, while the session keeps mapping with
+-9.000 and `capErr` sits at +9.017 to the end of the run. A seek landing now reads what its run
+carries, and says so: `#481 the run holding the landing at item Xs opens at Ys, which is segN's own
+playlist position, so it carries Zs and not the Ws this session was mapping with`. The discriminator
+is that opening, asked of ONE segment: the first the local server answered after the seek, which is the
+one whose content opens that run. It goes into a timeline carrying an axis at the seam that axis
+predicts and into a timeline carrying nothing at its own position, which is round 7's pair of
+admissible answers. Asked of the whole plan the same rule publishes on a coincidence (31 boundaries
+over 120 s against a half-second tolerance: measured, a 0.000 axis written into a timeline carrying
+-27.875 s). Measured on the arm above, `capErr` goes from +9.037 to +0.037, while the 24-seek arms it
+must not touch are unchanged (10 placements, axis -34.376, no reading fired in 2 of 2 runs) and the two
+slow ones improve (mean `|capErr|` 0.0230 and 0.0411 to 0.0162).
+
 `--start-position S` starts at a resume anchor, the same one `serve` takes. `--sw` forces the software path for a source that would route native, which is how a native-only fixture exercises the SW pipeline.
 
 `--malloc-census` turns on the large-allocation census (`AetherEngine.setLargeAllocationCensusEnabled`) for the run, for tracing a footprint that grows where the segment budget says it should not. Besides the 30 s sample it arms a jump trigger, which exists because the 30 s memprobe cannot catch a failure that completes inside one sample (every kill on #220 was that shape): a counter polled at `--census-hz N` runs the zone walk once it climbs `--census-threshold-mb N` above its running high-water. Both flags are inert without `--malloc-census`.


### PR DESCRIPTION
Fixes the defect measured in #481: a standing axis outlived the stretch it was measured for, so after a seek that opened a new run on a source-true segment the clock stayed off by the whole re-aim for the rest of the session (`capErr` +9.017 to the end, 3 of 3 runs on two link shapes).

A landing now takes round 7's reading, anchored on the segment the local server answered first after the seek, which is the one whose content opens the run the landing sits in. It goes into a timeline carrying an axis at the seam that axis predicts, and into a timeline carrying nothing at its own playlist position. A wrong candidate matches neither and publishes nothing.

The first version asked the whole PLAN whether a run opened on a playlist position, and the fixture refuted it: 31 boundaries over 120 s against a half-second tolerance wrote a 0.000 axis into a timeline carrying -27.875 s. That case is pinned in the suite.

Measured on one build, same arms, the link as the only variable:

| arm | before | after |
| --- | --- | --- |
| re-anchoring seek last, 600 kbps | `capErr` 9.037 to the end | 0.037, 2 of 2 |
| 24-seek chain, 3200 kbps (composed axis -34.376) | mean \|capErr\| 0.0162 | 0.0162, no reading fires, 2 of 2 |
| 24-seek chain, 600 kbps | 0.0230 | 0.0162 |
| 24-seek chain, 1200 kbps | 0.0411 | 0.0162 |

`swift test`: 2629 swift-testing in 360 suites and 606 XCTest, both green.