### PR TITLE
A frame that says nothing about colour inherits the container's declaration (#499)

### DIFF
--- a/Sources/AetherEngine/Decoder/ColorDescription.swift
+++ b/Sources/AetherEngine/Decoder/ColorDescription.swift
@@ -1,0 +1,81 @@
+import Foundation
+import AetherLibavutil
+import AetherLibavcodec
+
+/// A stream's colour description, held in one place because it arrives from two (AE#499).
+///
+/// A decoded `AVFrame` carries what the BITSTREAM declared: libavcodec writes the VUI, and a VUI that
+/// says nothing leaves the fields `unspecified` rather than falling back to anything. `AVCodecParameters`
+/// carries what the CONTAINER declared (Matroska's Colour element, MP4's `colr`), which for a remux is
+/// routinely the only place the description exists at all. Neither is authoritative alone, and reading
+/// one where the other was meant is what made an HDR still lose its tone map: the extractor gated on
+/// `codecpar` (PQ) and handed zscale the frame (unspecified), and zimg has no path to linear from
+/// nothing.
+///
+/// Same shape as `SoftwareVideoDecoder.declaredStreamSAR(bitstream:container:)`, and for the same
+/// reason: two declarations of one fact, resolved once so every consumer sees the same answer.
+struct ColorDescription: Equatable {
+    var primaries: AVColorPrimaries
+    var transfer: AVColorTransferCharacteristic
+    var matrix: AVColorSpace
+    var range: AVColorRange
+
+    static let unspecified = ColorDescription(
+        primaries: AVCOL_PRI_UNSPECIFIED,
+        transfer: AVCOL_TRC_UNSPECIFIED,
+        matrix: AVCOL_SPC_UNSPECIFIED,
+        range: AVCOL_RANGE_UNSPECIFIED)
+
+    init(primaries: AVColorPrimaries,
+         transfer: AVColorTransferCharacteristic,
+         matrix: AVColorSpace,
+         range: AVColorRange) {
+        self.primaries = primaries
+        self.transfer = transfer
+        self.matrix = matrix
+        self.range = range
+    }
+
+    init(frame: UnsafePointer<AVFrame>) {
+        self.init(primaries: frame.pointee.color_primaries,
+                  transfer: frame.pointee.color_trc,
+                  matrix: frame.pointee.colorspace,
+                  range: frame.pointee.color_range)
+    }
+
+    init(codecpar: UnsafePointer<AVCodecParameters>) {
+        self.init(primaries: codecpar.pointee.color_primaries,
+                  transfer: codecpar.pointee.color_trc,
+                  matrix: codecpar.pointee.color_space,
+                  range: codecpar.pointee.color_range)
+    }
+
+    /// The description to act on: the bitstream wherever it committed to a value, the container for the
+    /// fields it left open. Per field, because a partially filled VUI is the common case and the one
+    /// that fails silently (a matrix without a transfer reads HDR to a gate and reads nothing to zimg).
+    /// Two silences stay silent: an untagged stream is not improved by inventing BT.709 for it.
+    static func resolved(bitstream: ColorDescription, container: ColorDescription) -> ColorDescription {
+        ColorDescription(
+            primaries: bitstream.primaries == AVCOL_PRI_UNSPECIFIED ? container.primaries : bitstream.primaries,
+            transfer: bitstream.transfer == AVCOL_TRC_UNSPECIFIED ? container.transfer : bitstream.transfer,
+            matrix: bitstream.matrix == AVCOL_SPC_UNSPECIFIED ? container.matrix : bitstream.matrix,
+            range: bitstream.range == AVCOL_RANGE_UNSPECIFIED ? container.range : bitstream.range)
+    }
+
+    /// Write the resolved description back onto a freshly decoded frame, so every consumer downstream
+    /// (tone mapper, sws conversion, DV still converter, CoreVideo attachments) reads one answer instead
+    /// of each picking a source. Returns whether anything was filled in, which is also what makes it
+    /// safe to call per frame: the second pass over an already complete frame is a comparison and no
+    /// write.
+    @discardableResult
+    static func backfill(frame: UnsafeMutablePointer<AVFrame>, container: ColorDescription) -> Bool {
+        let current = ColorDescription(frame: frame)
+        let resolved = resolved(bitstream: current, container: container)
+        guard resolved != current else { return false }
+        frame.pointee.color_primaries = resolved.primaries
+        frame.pointee.color_trc = resolved.transfer
+        frame.pointee.colorspace = resolved.matrix
+        frame.pointee.color_range = resolved.range
+        return true
+    }
+}

--- a/Sources/AetherEngine/Decoder/SoftwareVideoDecoder.swift
+++ b/Sources/AetherEngine/Decoder/SoftwareVideoDecoder.swift
@@ -78,6 +78,13 @@ final class SoftwareVideoDecoder: VideoDecodingPipeline, @unchecked Sendable {
     /// applied to the filter there (mutating it mid-stream would need a graph rebuild).
     var deinterlaceConfig = DeinterlaceConfig()
 
+    /// AE#499: what the container declared about colour, captured at `open` before a single frame
+    /// exists. A decoded frame carries the VUI alone, and a remux whose VUI is empty would otherwise
+    /// reach `attachColorSpace` as an untagged picture, so an HDR10 file decoded in software lost its
+    /// PQ / BT.2020 attachments while the same file through the hardware decoder (which reads
+    /// `codecpar`) kept them. Written once under `lock` in `open`, read on the decode thread.
+    private var containerColor = ColorDescription.unspecified
+
     /// Deinterlaced frames dropped for carrying no PTS (see the drop site in decode()). Guarded by `lock`.
     private var droppedUntimestampedFields = 0
 
@@ -158,6 +165,7 @@ final class SoftwareVideoDecoder: VideoDecodingPipeline, @unchecked Sendable {
         }
         av_dict_free(&opts)
 
+        containerColor = ColorDescription(codecpar: codecpar)
         let bitsPerSample = codecpar.pointee.bits_per_raw_sample
         let isHDRTransfer = ColorAttachments.isHDRTransfer(codecpar.pointee.color_trc)
         use10Bit = bitsPerSample > 8 || isHDRTransfer
@@ -245,6 +253,10 @@ final class SoftwareVideoDecoder: VideoDecodingPipeline, @unchecked Sendable {
             guard codecContext != nil else { lock.unlock(); break }
             let ret = avcodec_receive_frame(ctx, f)
             guard ret >= 0 else { lock.unlock(); break }
+
+            // AE#499: fill the fields the VUI left open from the container's declaration BEFORE any
+            // consumer reads the frame, for the same reason the timestamp repair below runs here.
+            ColorDescription.backfill(frame: f, container: containerColor)
 
             // #407: repair the frame's own timestamp BEFORE anything reads it. A frame that reaches
             // the renderer with no PTS is unschedulable and gets dropped there, so every consumer

--- a/Sources/AetherEngine/Decoder/SoftwareVideoDecoder.swift
+++ b/Sources/AetherEngine/Decoder/SoftwareVideoDecoder.swift
@@ -82,7 +82,8 @@ final class SoftwareVideoDecoder: VideoDecodingPipeline, @unchecked Sendable {
     /// exists. A decoded frame carries the VUI alone, and a remux whose VUI is empty would otherwise
     /// reach `attachColorSpace` as an untagged picture, so an HDR10 file decoded in software lost its
     /// PQ / BT.2020 attachments while the same file through the hardware decoder (which reads
-    /// `codecpar`) kept them. Written once under `lock` in `open`, read on the decode thread.
+    /// `codecpar`) kept them. Written once in `open`, before the host can feed a packet, and read on
+    /// the decode thread afterwards, the same discipline `use10Bit` and the other open-time fields keep.
     private var containerColor = ColorDescription.unspecified
 
     /// Deinterlaced frames dropped for carrying no PTS (see the drop site in decode()). Guarded by `lock`.

--- a/Sources/AetherEngine/FrameExtractor/FrameDecodeContext.swift
+++ b/Sources/AetherEngine/FrameExtractor/FrameDecodeContext.swift
@@ -39,6 +39,12 @@ final class FrameDecodeContext: @unchecked Sendable {
     /// this the thumbnail draws square-pixel and looks stretched. Defaults 1:1.
     private var streamSAR = AVRational(num: 1, den: 1)
     private(set) var isOpen = false
+    /// AE#499: the container's colour declaration, captured at open. `isHDR` below is read off
+    /// exactly this, so a frame whose VUI says nothing has to inherit it or the two disagree: the gate
+    /// switches tone mapping on from the container while zscale reads the frame and finds no path to
+    /// linear (`code 3074`), and the still falls back to an untone-mapped conversion.
+    private var containerColor = ColorDescription.unspecified
+
     private(set) var isHDR = false
     /// True for Dolby Vision Profile 5 / Profile 10.0 (no base layer): the decoded planes are
     /// IPT-PQ-C2, not standard YCbCr, so they route through DolbyVisionStillConverter (#103).
@@ -201,6 +207,7 @@ final class FrameDecodeContext: @unchecked Sendable {
         if declared.num > 0, declared.den > 0 {
             streamSAR = declared
         }
+        containerColor = ColorDescription(codecpar: codecpar)
         isHDR = Self.isHDRTransfer(codecpar.pointee.color_trc)
         isDolbyVisionNoBaseLayer = Self.isDVNoBaseLayer(codecpar: codecpar)
         guard let codec = avcodec_find_decoder(codecpar.pointee.codec_id) else {
@@ -508,6 +515,10 @@ final class FrameDecodeContext: @unchecked Sendable {
                     if draining { return nil }      // avoid re-flushing the same error forever
                     break                           // real error: try next packet
                 }
+
+                // AE#499: before the DV, tone-map and sws branches below read it, and before the
+                // hardware transfer copies its props onto the software frame.
+                ColorDescription.backfill(frame: f, container: containerColor)
 
                 // Skip frames before targetPTS for frame-accuracy. No-PTS frames
                 // (AV_NOPTS_VALUE == Int64.min) are accepted, so PTS-less streams

--- a/Sources/AetherEngine/FrameExtractor/HDRToneMapper.swift
+++ b/Sources/AetherEngine/FrameExtractor/HDRToneMapper.swift
@@ -21,10 +21,17 @@ struct HDRToneMapper {
         let sar = frame.pointee.sample_aspect_ratio
         let sarNum = sar.num > 0 ? sar.num : 1
         let sarDen = sar.den > 0 ? sar.den : 1
+        // AE#499: colorspace and range belong in the args. Without them the link is configured as
+        // unspecified, the first frame arrives as BT.2020 and buffersrc warns that changing frame
+        // properties on the fly is not supported by all filters. zscale reads the frame rather than the
+        // link, so this was never the cause of a failure, but a graph that describes its own input
+        // wrongly is a bad place to debug the next one from.
         let args = "video_size=\(frame.pointee.width)x\(frame.pointee.height)" +
                    ":pix_fmt=\(frame.pointee.format)" +
                    ":time_base=\(timeBase.num)/\(timeBase.den)" +
-                   ":pixel_aspect=\(sarNum)/\(sarDen)"
+                   ":pixel_aspect=\(sarNum)/\(sarDen)" +
+                   ":colorspace=\(frame.pointee.colorspace.rawValue)" +
+                   ":range=\(frame.pointee.color_range.rawValue)"
 
         var srcCtx: UnsafeMutablePointer<AVFilterContext>?
         var sinkCtx: UnsafeMutablePointer<AVFilterContext>?

--- a/Tests/AetherEngineTests/ColorDescriptionTests.swift
+++ b/Tests/AetherEngineTests/ColorDescriptionTests.swift
@@ -1,0 +1,81 @@
+import Foundation
+import Testing
+import AetherLibavutil
+@testable import AetherEngine
+
+struct ColorDescriptionTests {
+
+    private let pq = ColorDescription(
+        primaries: AVCOL_PRI_BT2020, transfer: AVCOL_TRC_SMPTE2084,
+        matrix: AVCOL_SPC_BT2020_NCL, range: AVCOL_RANGE_MPEG)
+
+    @Test("AE#499: a bitstream that describes itself is never overruled by the container")
+    func bitstreamWins() {
+        let container = ColorDescription(
+            primaries: AVCOL_PRI_BT709, transfer: AVCOL_TRC_BT709,
+            matrix: AVCOL_SPC_BT709, range: AVCOL_RANGE_JPEG)
+        #expect(ColorDescription.resolved(bitstream: pq, container: container) == pq)
+    }
+
+    @Test("AE#499: an empty VUI takes the container's description rather than staying unspecified")
+    func containerFillsAnEmptyVUI() {
+        #expect(ColorDescription.resolved(bitstream: .unspecified, container: pq) == pq)
+    }
+
+    @Test("AE#499: the fields resolve one by one, which is the case that reached the tone mapper")
+    func fieldsResolveIndependently() {
+        // The reported frame carried a matrix and a range and no transfer: enough for the extractor's
+        // HDR gate to read PQ off the stream, not enough for zscale to find a path to linear.
+        let partial = ColorDescription(
+            primaries: AVCOL_PRI_UNSPECIFIED, transfer: AVCOL_TRC_UNSPECIFIED,
+            matrix: AVCOL_SPC_BT2020_NCL, range: AVCOL_RANGE_MPEG)
+        #expect(ColorDescription.resolved(bitstream: partial, container: pq) == pq)
+
+        let containerSaysHLG = ColorDescription(
+            primaries: AVCOL_PRI_BT2020, transfer: AVCOL_TRC_ARIB_STD_B67,
+            matrix: AVCOL_SPC_BT2020_NCL, range: AVCOL_RANGE_MPEG)
+        let bitstreamSaysPQ = ColorDescription(
+            primaries: AVCOL_PRI_UNSPECIFIED, transfer: AVCOL_TRC_SMPTE2084,
+            matrix: AVCOL_SPC_UNSPECIFIED, range: AVCOL_RANGE_UNSPECIFIED)
+        let mixed = ColorDescription.resolved(bitstream: bitstreamSaysPQ, container: containerSaysHLG)
+        #expect(mixed.transfer == AVCOL_TRC_SMPTE2084)
+        #expect(mixed.primaries == AVCOL_PRI_BT2020)
+        #expect(mixed.matrix == AVCOL_SPC_BT2020_NCL)
+        #expect(mixed.range == AVCOL_RANGE_MPEG)
+    }
+
+    @Test("AE#499: two silences stay silent, so nothing is invented for an untagged stream")
+    func nothingIsInvented() {
+        #expect(ColorDescription.resolved(bitstream: .unspecified, container: .unspecified) == .unspecified)
+    }
+
+    @Test("AE#499: backfilling writes the resolved description onto the frame, once")
+    func backfillWritesTheFrame() throws {
+        var frame: UnsafeMutablePointer<AVFrame>? = av_frame_alloc()
+        let f = try #require(frame)
+        defer { av_frame_free(&frame) }
+        f.pointee.color_primaries = AVCOL_PRI_UNSPECIFIED
+        f.pointee.color_trc = AVCOL_TRC_UNSPECIFIED
+        f.pointee.colorspace = AVCOL_SPC_BT2020_NCL
+        f.pointee.color_range = AVCOL_RANGE_MPEG
+
+        #expect(ColorDescription.backfill(frame: f, container: pq) == true)
+        #expect(ColorDescription(frame: f) == pq)
+        // Idempotent: the second pass has nothing left to fill and says so.
+        #expect(ColorDescription.backfill(frame: f, container: pq) == false)
+    }
+
+    @Test("AE#499: a container with nothing to say leaves the frame alone")
+    func silentContainerChangesNothing() throws {
+        var frame: UnsafeMutablePointer<AVFrame>? = av_frame_alloc()
+        let f = try #require(frame)
+        defer { av_frame_free(&frame) }
+        f.pointee.color_primaries = AVCOL_PRI_UNSPECIFIED
+        f.pointee.color_trc = AVCOL_TRC_UNSPECIFIED
+        f.pointee.colorspace = AVCOL_SPC_UNSPECIFIED
+        f.pointee.color_range = AVCOL_RANGE_UNSPECIFIED
+
+        #expect(ColorDescription.backfill(frame: f, container: .unspecified) == false)
+        #expect(ColorDescription(frame: f) == .unspecified)
+    }
+}


### PR DESCRIPTION
Closes #499.

## What was wrong

The extractor gates tone mapping on the **stream** (`isHDR = isHDRTransfer(codecpar.color_trc)`) and
hands zscale the **frame**. libavcodec writes the VUI onto a frame and never falls back to `codecpar`,
so a source whose colour description lives only in the container (a remux with an empty VUI) arrives at
zimg as unspecified, there is no path to linear, and the graph fails with `code 3074`. The still falls
through to the plain sws conversion, which is an untone-mapped PQ picture.

The software decoder is the same defect one layer down and was not in the report: `attachColorSpace`
read the frame while `HardwareVideoDecoder` reads `codecpar`, so the same file kept its PQ / BT.2020
attachments through one decoder and lost them through the other.

## What changed

`ColorDescription` holds the fact once and resolves the two declarations per field: the bitstream wins
wherever it committed to a value, the container fills what it left open, and two silences stay silent
so nothing is invented for an untagged stream. Same shape as `declaredStreamSAR(bitstream:container:)`,
which resolves the other two-source fact in this codebase.

Freshly decoded frames are backfilled from it before any consumer reads them, in both decode loops.
The tone-map buffer source also declares colorspace and range now; zscale reads the frame rather than
the link so this never caused a failure, but the graph no longer describes its own input wrongly.

## Measured

`aetherctl extract` on a two-second HEVC 10-bit clip muxed twice, once with the description in the VUI
and once with it only in the container:

| binary | container-only file | VUI file |
|---|---|---|
| before | `a05002e4…` | `7273d188…` |
| after | `7273d188…` | `7273d188…` |

The container-only file now produces the byte-identical image the VUI file always produced, and the VUI
file's own output did not move, so the path that already worked is untouched.

6 new tests. Full suite green on both runners: XCTest 606 (1 skipped, 0 failures), swift-testing
2668 in 366 suites, `REAL EXIT=0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014tQ8MerNbZQdWBpDStitoD