### PR TITLE
Print what the display says before writing to it (#459)

### DIFF
--- a/Sources/AetherEngine/Display/DisplayCriteriaController.swift
+++ b/Sources/AetherEngine/Display/DisplayCriteriaController.swift
@@ -632,6 +632,35 @@ final class DisplayCriteriaController {
         elapsedMs(fromNanos: start.uptimeNanoseconds, toNanos: DispatchTime.now().uptimeNanoseconds)
     }
 
+    /// AE#459: one line carrying everything the system will say about the display, in a fixed shape so a
+    /// reporter can be asked to grep for it.
+    ///
+    /// Built pure because the values come from four different objects and the line is the instrument: a
+    /// diagnostic whose format drifts cannot be compared against the one a reporter posted last month.
+    ///
+    /// `potentialEDR` is in here at DrHurt's suggestion and against my own measurement, which is the point.
+    /// It read a flat 1.00 on an Apple TV 4K 3rd gen on tvOS 26.5 while `currentEDR` read 1.20 on the same
+    /// `UIScreen` in the same moment, so it looked like a property tvOS does not maintain. That was one box
+    /// on one OS, and the box this issue is about answers differently on the other property, so the honest
+    /// move is to print both and let a second panel decide rather than to carry my own result as a rule.
+    nonisolated static func panelReadoutLine(
+        phase: String,
+        currentEDR: CGFloat,
+        potentialEDR: CGFloat,
+        switching: Bool,
+        matching: Bool,
+        hdrEligible: Bool,
+        proven: Bool
+    ) -> String {
+        "[DisplayCriteria] panel readout \(phase): "
+        + "currentEDR=\(String(format: "%.2f", currentEDR)) "
+        + "potentialEDR=\(String(format: "%.2f", potentialEDR)) "
+        + "switching=\(switching ? "yes" : "no") "
+        + "matching=\(matching ? "on" : "off") "
+        + "hdrEligible=\(hdrEligible ? "yes" : "no") "
+        + "provenHDR=\(proven ? "yes" : "no")"
+    }
+
     init() {}
 
     /// Program AVDisplayCriteria before the session starts. `.sdr` programs a rate-only criteria so Match Frame Rate still engages. `codecTag` nil derives from format (`'dvh1'` for DV, `'hvc1'` otherwise). `omitColorExtensions` skips BT.2020 extensions for diagnostic builds. Returns `.willSwitch` when a dynamic-range switch is expected (caller should call waitForSwitch), `.applied` for an SDR rate-only write, or `.unchanged` when the criteria are already active and nothing was written (#133).
@@ -652,6 +681,9 @@ final class DisplayCriteriaController {
         }
 
         let displayManager = window.avDisplayManager
+        // AE#459: before the guard below, not after. A box with Match Content off is exactly the
+        // configuration whose panel state nothing else in this log describes.
+        logPanelReadout("before apply", window: window)
 
         // isDisplayCriteriaMatchingEnabled covers both Match Dynamic Range and Match Frame Rate; tvOS picks the applicable dimension internally.
         guard displayManager.isDisplayCriteriaMatchingEnabled else {
@@ -1115,6 +1147,7 @@ final class DisplayCriteriaController {
             lastApplied = nil
             return
         }
+        logPanelReadout("before reset", window: window)
         window.avDisplayManager.preferredDisplayCriteria = nil
         didApply = false
         lastApplied = nil   // #133: a RESET returns the panel to default; the next apply must re-establish it.
@@ -1125,6 +1158,24 @@ final class DisplayCriteriaController {
     // MARK: - Window resolution
 
     #if os(tvOS)
+    /// Emit the readout for one phase. Called before the engine writes or clears criteria, because a write
+    /// is what makes a later reading unattributable: the whole of #459 is a value read at the one moment it
+    /// has nothing to say. Deliberately NOT routed through `observeHeadroom`: a diagnostic that also latches
+    /// the HDR proof would change routing, and this round is meant to measure, not to decide.
+    private func logPanelReadout(_ phase: String, window: UIWindow) {
+        let manager = window.avDisplayManager
+        EngineLog.emit(
+            Self.panelReadoutLine(
+                phase: phase,
+                currentEDR: window.screen.currentEDRHeadroom,
+                potentialEDR: window.screen.potentialEDRHeadroom,
+                switching: manager.isDisplayModeSwitchInProgress,
+                matching: manager.isDisplayCriteriaMatchingEnabled,
+                hdrEligible: AVPlayer.eligibleForHDRPlayback,
+                proven: panelProvenToEngageHDR),
+            category: .engine)
+    }
+
     private func resolveWindow() -> UIWindow? {
         if let provider = Self.windowProvider, let win = provider() as? UIWindow {
             return win

--- a/Tests/AetherEngineTests/PanelReadoutLineTests.swift
+++ b/Tests/AetherEngineTests/PanelReadoutLineTests.swift
@@ -1,0 +1,34 @@
+import Foundation
+import Testing
+@testable import AetherEngine
+
+struct PanelReadoutLineTests {
+
+    @Test("AE#459: the readout prints both headrooms, because the two panels in this thread disagree")
+    func printsBothHeadrooms() {
+        let line = DisplayCriteriaController.panelReadoutLine(
+            phase: "before apply", currentEDR: 1.2, potentialEDR: 1.0,
+            switching: false, matching: true, hdrEligible: true, proven: true)
+        #expect(line == "[DisplayCriteria] panel readout before apply: currentEDR=1.20 "
+                + "potentialEDR=1.00 switching=no matching=on hdrEligible=yes provenHDR=yes")
+    }
+
+    @Test("AE#459: the silent panel's shape, which is what a reporter is asked to grep for")
+    func silentPanelShape() {
+        let line = DisplayCriteriaController.panelReadoutLine(
+            phase: "before reset", currentEDR: 1.0, potentialEDR: 1.0,
+            switching: false, matching: false, hdrEligible: false, proven: false)
+        #expect(line == "[DisplayCriteria] panel readout before reset: currentEDR=1.00 "
+                + "potentialEDR=1.00 switching=no matching=off hdrEligible=no provenHDR=no")
+    }
+
+    @Test("AE#459: two decimals, so a headroom that moves a little still shows it")
+    func headroomKeepsTwoDecimals() {
+        let line = DisplayCriteriaController.panelReadoutLine(
+            phase: "before apply", currentEDR: 1.0499, potentialEDR: 16.0,
+            switching: true, matching: true, hdrEligible: true, proven: false)
+        #expect(line.contains("currentEDR=1.05"))
+        #expect(line.contains("potentialEDR=16.00"))
+        #expect(line.contains("switching=yes"))
+    }
+}


### PR DESCRIPTION
Does not close #459. This round is an instrument, not a fix.

The reporter's box answers `no HDR reading in 12116ms (max headroom 1.00, 47 samples)` and stays at
1.00 across a genuine SDR to HDR mode switch, so the readout the routing gate depends on is silent
there. He cannot downgrade to 26.x to date that against tvOS 27 beta, so the next measurement has to
come off the same hardware.

One line per criteria event, before the engine writes or clears anything:

```
[DisplayCriteria] panel readout before apply: currentEDR=1.20 potentialEDR=1.00 switching=no matching=on hdrEligible=yes provenHDR=yes
```

`potentialEDRHeadroom` is in there at his suggestion and against my own measurement. It read a flat
1.00 on an Apple TV 4K 3rd gen on tvOS 26.5 while `currentEDRHeadroom` read 1.20 on the same
`UIScreen` in the same moment, which is why it was written off. One box, one OS, and the box in
question already disagrees on the other property, so both get printed and a second panel decides.

Placement matters twice. At apply it goes before the Match Content guard, because a box with matching
off is exactly the configuration nothing else in the log describes. And it is not routed through
`observeHeadroom`: latching the HDR proof from a diagnostic would change routing, and this round is
meant to measure.

3 tests pin the line shape, so the grep a reporter is handed stays valid across releases. Full suite
green on both runners (XCTest 606, swift-testing 2674 in 368 suites, `REAL EXIT=0`) plus a local tvOS
Simulator build, which is the half `swift test` on macOS never compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014tQ8MerNbZQdWBpDStitoD