### PR TITLE
A capped headroom is not a panel statement (#459)

### DIFF
--- a/Sources/AetherEngine/Display/DisplayCriteriaController.swift
+++ b/Sources/AetherEngine/Display/DisplayCriteriaController.swift
@@ -638,6 +638,15 @@ final class DisplayCriteriaController {
     /// Built pure because the values come from four different objects and the line is the instrument: a
     /// diagnostic whose format drifts cannot be compared against the one a reporter posted last month.
     ///
+    /// `headroomLimit` is `UITraitCollection.hdrHeadroomUsageLimit` (tvOS 26), which the header describes
+    /// as whether HDR headroom should be used for the current UI configuration, disabled for instance while
+    /// an app's windows are in the background. It is not a panel readout, and that is exactly why it belongs
+    /// next to one: a limit that is ACTIVE caps what the headroom properties are allowed to report, so a
+    /// 1.00 under it is a statement about this app's UI state and not about the display. Without it, that
+    /// case is indistinguishable from a panel that genuinely presents SDR. The reporter's own hypothesis for
+    /// the tvOS 27 silence is that the system UI is now mastered in HDR, which is precisely the kind of
+    /// change that would move when these limits apply.
+    ///
     /// `potentialEDR` is in here at DrHurt's suggestion and against my own measurement, which is the point.
     /// It read a flat 1.00 on an Apple TV 4K 3rd gen on tvOS 26.5 while `currentEDR` read 1.20 on the same
     /// `UIScreen` in the same moment, so it looked like a property tvOS does not maintain. That was one box
@@ -650,11 +659,13 @@ final class DisplayCriteriaController {
         switching: Bool,
         matching: Bool,
         hdrEligible: Bool,
-        proven: Bool
+        proven: Bool,
+        headroomLimit: String
     ) -> String {
         "[DisplayCriteria] panel readout \(phase): "
         + "currentEDR=\(String(format: "%.2f", currentEDR)) "
         + "potentialEDR=\(String(format: "%.2f", potentialEDR)) "
+        + "headroomLimit=\(headroomLimit) "
         + "switching=\(switching ? "yes" : "no") "
         + "matching=\(matching ? "on" : "off") "
         + "hdrEligible=\(hdrEligible ? "yes" : "no") "
@@ -1172,8 +1183,21 @@ final class DisplayCriteriaController {
                 switching: manager.isDisplayModeSwitchInProgress,
                 matching: manager.isDisplayCriteriaMatchingEnabled,
                 hdrEligible: AVPlayer.eligibleForHDRPlayback,
-                proven: panelProvenToEngageHDR),
+                proven: panelProvenToEngageHDR,
+                headroomLimit: Self.headroomLimitLabel(window.traitCollection)),
             category: .engine)
+    }
+
+    /// The trait's own three states, spelled out rather than mapped to a Bool: "unspecified" is a real
+    /// answer here and folding it into either of the others would invent a claim.
+    private static func headroomLimitLabel(_ traits: UITraitCollection) -> String {
+        guard #available(tvOS 26.0, *) else { return "n/a" }
+        switch traits.hdrHeadroomUsageLimit {
+        case .active: return "active"
+        case .inactive: return "inactive"
+        case .unspecified: return "unspecified"
+        @unknown default: return "unknown"
+        }
     }
 
     private func resolveWindow() -> UIWindow? {

--- a/Tests/AetherEngineTests/PanelReadoutLineTests.swift
+++ b/Tests/AetherEngineTests/PanelReadoutLineTests.swift
@@ -8,27 +8,33 @@ struct PanelReadoutLineTests {
     func printsBothHeadrooms() {
         let line = DisplayCriteriaController.panelReadoutLine(
             phase: "before apply", currentEDR: 1.2, potentialEDR: 1.0,
-            switching: false, matching: true, hdrEligible: true, proven: true)
+            switching: false, matching: true, hdrEligible: true, proven: true,
+            headroomLimit: "inactive")
         #expect(line == "[DisplayCriteria] panel readout before apply: currentEDR=1.20 "
-                + "potentialEDR=1.00 switching=no matching=on hdrEligible=yes provenHDR=yes")
+                + "potentialEDR=1.00 headroomLimit=inactive switching=no matching=on hdrEligible=yes "
+                + "provenHDR=yes")
     }
 
     @Test("AE#459: the silent panel's shape, which is what a reporter is asked to grep for")
     func silentPanelShape() {
         let line = DisplayCriteriaController.panelReadoutLine(
             phase: "before reset", currentEDR: 1.0, potentialEDR: 1.0,
-            switching: false, matching: false, hdrEligible: false, proven: false)
+            switching: false, matching: false, hdrEligible: false, proven: false,
+            headroomLimit: "active")
         #expect(line == "[DisplayCriteria] panel readout before reset: currentEDR=1.00 "
-                + "potentialEDR=1.00 switching=no matching=off hdrEligible=no provenHDR=no")
+                + "potentialEDR=1.00 headroomLimit=active switching=no matching=off hdrEligible=no "
+                + "provenHDR=no")
     }
 
     @Test("AE#459: two decimals, so a headroom that moves a little still shows it")
     func headroomKeepsTwoDecimals() {
         let line = DisplayCriteriaController.panelReadoutLine(
             phase: "before apply", currentEDR: 1.0499, potentialEDR: 16.0,
-            switching: true, matching: true, hdrEligible: true, proven: false)
+            switching: true, matching: true, hdrEligible: true, proven: false,
+            headroomLimit: "unspecified")
         #expect(line.contains("currentEDR=1.05"))
         #expect(line.contains("potentialEDR=16.00"))
         #expect(line.contains("switching=yes"))
+        #expect(line.contains("headroomLimit=unspecified"))
     }
 }


### PR DESCRIPTION
Follow-up to #502, same measurement, one more column.

`UITraitCollection.hdrHeadroomUsageLimit` (tvOS 26) is not a panel readout: the header describes it as
whether HDR headroom should be used for the current UI configuration, disabled for instance while an
app's windows are in the background. That is why it belongs in this line. While the limit is `active`
it caps what the headroom properties are allowed to report, so a `currentEDR=1.00` under it is a
statement about the app's UI state rather than about the display, and the reading we are asking a
reporter to take cannot tell those apart without the field.

The prompt for adding it is the reporter's own hypothesis for the tvOS 27 silence: that the system UI
is now mastered in HDR there, as it is on macOS 26. Whether or not that holds, it is the kind of change
that moves when headroom limits apply, and the column costs one trait read.

```
[DisplayCriteria] panel readout before apply: currentEDR=1.20 potentialEDR=1.00 headroomLimit=inactive switching=no matching=on hdrEligible=yes provenHDR=yes
```

Three states printed verbatim. `unspecified` is a real answer here and folding it into either of the
others would invent a claim.

Full suite green on both runners (XCTest 606, swift-testing 2674 in 368 suites, `REAL EXIT=0`) plus a
local tvOS Simulator build, which is the half `swift test` on macOS does not compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014tQ8MerNbZQdWBpDStitoD