### PR TITLE
feat(network): a host decides which origins it trusts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,28 @@ the public-API contract.
 
 ## [Unreleased]
 
-_Nothing yet._
+### Added
+
+- **`EngineTLS.serverTrustEvaluator`: host opt-in to accept server
+  certificates that fail system trust evaluation.** Every engine fetch runs
+  over URLSession, which enforces system certificate trust that the
+  in-demuxer network stacks the engine replaces never did. A media server
+  fronted by a self-signed or private-CA certificate therefore keeps working
+  in a host whose own API layer bypasses trust, while the engine's open fails
+  its handshake before a byte is read. The evaluator is asked per challenge
+  about the origin it came from, so a host holding a LAN address behind a
+  private certificate and a WAN address with a real one answers for each, and
+  one that pins an SPKI hash decides for itself. nil by default; while nil,
+  and for every non-server-trust challenge, handling is unchanged. Covers
+  every session the engine owns: the AVIOReader probe, chunk, persistent and
+  streaming paths, the disc reader, both HLS ingest readers, the audio tap
+  fetcher, the carriage probe and the remote HLS subtitle proxy.
+
+### Changed
+
+- The live subtitle rendition fetch owns its session instead of borrowing
+  `URLSession.shared`, which cannot carry a delegate and was the one engine
+  fetch no host trust decision could reach.
 
 ## [6.70.0] - 2026-09-06
 

--- a/Sources/AetherEngine/AetherEngine+LiveSubtitleRenditions.swift
+++ b/Sources/AetherEngine/AetherEngine+LiveSubtitleRenditions.swift
@@ -180,10 +180,16 @@ extension AetherEngine {
         return cues.filter { $0.endTime >= horizon }
     }
 
+    /// `URLSession.shared` cannot carry a delegate, so this was the one engine fetch a host's trust
+    /// decision could never reach. Owned and process-wide for the same reason the carriage probe's
+    /// is: an uninvalidated session outlives its caller.
+    private static let renditionSession = URLSession(
+        configuration: .default, delegate: EngineTLS.sessionDelegate, delegateQueue: nil)
+
     private static func fetchText(_ url: URL, headers: [String: String]) async throws -> String {
         var request = URLRequest(url: url)
         for (key, value) in headers { request.setValue(value, forHTTPHeaderField: key) }
-        let (data, _) = try await URLSession.shared.data(for: request)
+        let (data, _) = try await renditionSession.data(for: request)
         guard let text = String(data: data, encoding: .utf8) else {
             throw HLSIngestError.playlistInvalid(reason: "rendition payload is not UTF-8")
         }

--- a/Sources/AetherEngine/Audio/Tap/AudioTapHLSFetcher.swift
+++ b/Sources/AetherEngine/Audio/Tap/AudioTapHLSFetcher.swift
@@ -33,7 +33,8 @@ final class AudioTapHLSFetcher: @unchecked Sendable {
             let cfg = URLSessionConfiguration.ephemeral
             cfg.timeoutIntervalForRequest = 10
             cfg.timeoutIntervalForResource = 30
-            self.session = URLSession(configuration: cfg)
+            self.session = URLSession(
+                configuration: cfg, delegate: EngineTLS.sessionDelegate, delegateQueue: nil)
         }
         self.httpHeaders = httpHeaders
     }

--- a/Sources/AetherEngine/Demuxer/AVIOReader.swift
+++ b/Sources/AetherEngine/Demuxer/AVIOReader.swift
@@ -3305,7 +3305,7 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
         let config = URLSessionConfiguration.default
         config.urlCache = nil
         config.timeoutIntervalForRequest = 20
-        return URLSession(configuration: config, delegate: nil, delegateQueue: nil)
+        return URLSession(configuration: config, delegate: EngineTLS.sessionDelegate, delegateQueue: nil)
     }()
 
     /// Total size from a data-connection response: `Content-Range` total on a 206, or
@@ -3574,7 +3574,7 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
     /// No invalidation overhead.
     private static let chunkSession: URLSession = {
         let config = makeSessionConfig()
-        return URLSession(configuration: config, delegate: nil, delegateQueue: nil)
+        return URLSession(configuration: config, delegate: EngineTLS.sessionDelegate, delegateQueue: nil)
     }()
 
     /// #220: long-lived session for the persistent streaming path, paired with a per-task
@@ -3590,7 +3590,7 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
     ///
     /// Never invalidated. Releasing a connection is `task.cancel()` now, not session teardown.
     private static let persistentSession: URLSession = {
-        URLSession(configuration: makeSessionConfig(longLived: true), delegate: nil, delegateQueue: nil)
+        URLSession(configuration: makeSessionConfig(longLived: true), delegate: EngineTLS.sessionDelegate, delegateQueue: nil)
     }()
 
     /// Outcome of an abortable semaphore wait (issue #27).
@@ -3864,6 +3864,15 @@ private final class PersistentReadDelegate: NSObject, URLSessionDataDelegate, @u
     func urlSession(
         _ session: URLSession,
         task: URLSessionTask,
+        didReceive challenge: URLAuthenticationChallenge,
+        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+    ) {
+        EngineTLS.resolve(challenge, completionHandler: completionHandler)
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
         willPerformHTTPRedirection response: HTTPURLResponse,
         newRequest request: URLRequest,
         completionHandler: @escaping (URLRequest?) -> Void
@@ -3951,6 +3960,15 @@ private final class ChunkFetchDelegate: NSObject, URLSessionDataDelegate, @unche
     init(extraHeaders: [String: String], bodyLimit: Int?) {
         self.extraHeaders = extraHeaders
         self.bodyLimit = bodyLimit
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        didReceive challenge: URLAuthenticationChallenge,
+        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+    ) {
+        EngineTLS.resolve(challenge, completionHandler: completionHandler)
     }
 
     func urlSession(
@@ -4076,6 +4094,15 @@ private final class StreamingDelegate: NSObject, URLSessionDataDelegate {
 
     func urlSession(
         _ session: URLSession,
+        task: URLSessionTask,
+        didReceive challenge: URLAuthenticationChallenge,
+        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+    ) {
+        EngineTLS.resolve(challenge, completionHandler: completionHandler)
+    }
+
+    func urlSession(
+        _ session: URLSession,
         dataTask: URLSessionDataTask,
         didReceive response: URLResponse,
         completionHandler: @escaping (URLSession.ResponseDisposition) -> Void
@@ -4121,6 +4148,15 @@ private final class ProbeDelegate: NSObject, URLSessionDataDelegate, @unchecked 
 
     init(extraHeaders: [String: String]) {
         self.extraHeaders = extraHeaders
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        didReceive challenge: URLAuthenticationChallenge,
+        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+    ) {
+        EngineTLS.resolve(challenge, completionHandler: completionHandler)
     }
 
     func urlSession(

--- a/Sources/AetherEngine/IO/HLSIngest/HLSCarriageProbe.swift
+++ b/Sources/AetherEngine/IO/HLSIngest/HLSCarriageProbe.swift
@@ -26,7 +26,8 @@ enum HLSCarriageProbe {
     private static let sharedSession: URLSession = {
         let configuration = URLSessionConfiguration.ephemeral
         configuration.timeoutIntervalForRequest = 10
-        return URLSession(configuration: configuration)
+        return URLSession(
+            configuration: configuration, delegate: EngineTLS.sessionDelegate, delegateQueue: nil)
     }()
 
     /// AE#296: what the playlist chain established, and whether a media byte is still needed to settle it.

--- a/Sources/AetherEngine/IO/HLSIngest/HLSLiveIngestReader.swift
+++ b/Sources/AetherEngine/IO/HLSIngest/HLSLiveIngestReader.swift
@@ -156,7 +156,8 @@ public final class HLSLiveIngestReader: IOReader, LiveIngestSourceInfo, @uncheck
         config.timeoutIntervalForRequest = 10
         config.timeoutIntervalForResource = 30
         // 30s resource ceiling: one-shot fetches must fail fast so the host can fall back. The c7592ed no-ceiling lesson applies to long-lived stream connections, not bounded one-shot fetches.
-        self.session = URLSession(configuration: config)
+        self.session = URLSession(
+            configuration: config, delegate: EngineTLS.sessionDelegate, delegateQueue: nil)
     }
 
     // MARK: - IOReader

--- a/Sources/AetherEngine/IO/HLSIngest/HLSVODIngestReader.swift
+++ b/Sources/AetherEngine/IO/HLSIngest/HLSVODIngestReader.swift
@@ -64,7 +64,9 @@ final class HLSVODIngestReader: TimeSeekableIOReader, @unchecked Sendable {
             configuration.timeoutIntervalForResource = 45
             configuration.requestCachePolicy = .reloadIgnoringLocalAndRemoteCacheData
             configuration.urlCache = nil
-            self.session = URLSession(configuration: configuration)
+            self.session = URLSession(
+                configuration: configuration, delegate: EngineTLS.sessionDelegate,
+                delegateQueue: nil)
             ownsSession = true
         }
     }

--- a/Sources/AetherEngine/IO/HTTPDiscIOReader.swift
+++ b/Sources/AetherEngine/IO/HTTPDiscIOReader.swift
@@ -60,7 +60,8 @@ final class HTTPDiscIOReader: IOReader, @unchecked Sendable {
             c.requestCachePolicy = .reloadIgnoringLocalCacheData
             return c
         }()
-        self.session = URLSession(configuration: config)
+        self.session = URLSession(
+            configuration: config, delegate: EngineTLS.sessionDelegate, delegateQueue: nil)
 
         guard let size = Self.probeSize(
             url: url, extraHeaders: extraHeaders, session: session,

--- a/Sources/AetherEngine/Native/RemoteHLSSubtitleProxy.swift
+++ b/Sources/AetherEngine/Native/RemoteHLSSubtitleProxy.swift
@@ -109,7 +109,8 @@ enum RemoteHLSSubtitleProxy {
         config.timeoutIntervalForRequest = budgetSeconds / 2
         config.timeoutIntervalForResource = budgetSeconds
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
-        return URLSession(configuration: config)
+        return URLSession(
+            configuration: config, delegate: EngineTLS.sessionDelegate, delegateQueue: nil)
     }
 
     /// Returns the body and the URL it finally came from; every relative URI in the playlist resolves

--- a/Sources/AetherEngine/Network/EngineTLS.swift
+++ b/Sources/AetherEngine/Network/EngineTLS.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+/// Host-app TLS trust policy for the engine's outbound HTTP connections.
+///
+/// URLSession enforces system certificate trust, which the in-demuxer network
+/// stacks this engine replaces never did. A media server fronted by a
+/// self-signed or private-CA certificate therefore keeps working in a host
+/// whose own API layer bypasses trust, while every engine fetch fails its
+/// handshake before a byte is read and the open surfaces as bare invalid
+/// data. The host answers per origin, and while no evaluator is set every
+/// challenge keeps the system's default handling.
+public enum EngineTLS {
+
+    /// Decides whether to accept a server certificate that failed system
+    /// trust evaluation, for the origin the challenge came from.
+    ///
+    /// nil, the default, keeps the system's default handling everywhere. The
+    /// blunt answer is one line (`{ _ in true }`), and a host holding a LAN
+    /// address behind a private certificate alongside a WAN address with a
+    /// real one can answer for each rather than relaxing both. A host that
+    /// wants to pin an SPKI hash reads the protection space and decides.
+    ///
+    /// Read per challenge, so replacing it applies from the next connection
+    /// without rebuilding sessions. Called off the main actor, from whichever
+    /// queue the session raised the challenge on, so it has to be
+    /// thread-safe. Lock-guarded like `EngineLog.handler`.
+    public static var serverTrustEvaluator: (@Sendable (URLProtectionSpace) -> Bool)? {
+        get { lock.lock(); defer { lock.unlock() }; return _evaluator }
+        set { lock.lock(); _evaluator = newValue; lock.unlock() }
+    }
+    private static let lock = NSLock()
+    nonisolated(unsafe) private static var _evaluator: (@Sendable (URLProtectionSpace) -> Bool)?
+
+    /// Session-level delegate for the owned sessions that otherwise run
+    /// without one (disc reader, HLS ingest readers, audio tap fetcher,
+    /// carriage probe, subtitle proxy, live rendition fetch) and the fallback
+    /// for tasks that missed a per-task delegate.
+    static let sessionDelegate = SessionTrustDelegate()
+
+    /// Single disposition shared by the session-level delegate and the
+    /// per-task delegates in AVIOReader. Anything other than a server-trust
+    /// challenge the host accepted is left to default handling, so client
+    /// certificates and HTTP auth behave exactly as before.
+    static func resolve(
+        _ challenge: URLAuthenticationChallenge,
+        completionHandler: (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+    ) {
+        guard
+            challenge.protectionSpace.authenticationMethod
+                == NSURLAuthenticationMethodServerTrust,
+            let evaluator = serverTrustEvaluator,
+            evaluator(challenge.protectionSpace),
+            let trust = challenge.protectionSpace.serverTrust
+        else {
+            completionHandler(.performDefaultHandling, nil)
+            return
+        }
+        completionHandler(.useCredential, URLCredential(trust: trust))
+    }
+
+    final class SessionTrustDelegate: NSObject, URLSessionDelegate, @unchecked Sendable {
+        func urlSession(
+            _ session: URLSession,
+            didReceive challenge: URLAuthenticationChallenge,
+            completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?)
+                -> Void
+        ) {
+            EngineTLS.resolve(challenge, completionHandler: completionHandler)
+        }
+    }
+}

--- a/Tests/AetherEngineTests/EngineTLSHandshakeTests.swift
+++ b/Tests/AetherEngineTests/EngineTLSHandshakeTests.swift
@@ -1,0 +1,293 @@
+// Live-handshake proof for `EngineTLS.serverTrustEvaluator`. The resolver
+// unit tests cannot show the load-bearing part: that URLSession actually
+// delivers the server-trust challenge to the reader's per-task delegates.
+// NWListener rejects an imported in-memory identity with EINVAL, so the
+// self-signed origin runs as a Python subprocess, which limits this suite to
+// macOS, the platform `swift test` runs on anyway.
+#if os(macOS)
+
+    import Foundation
+    import Testing
+
+    @testable import AetherEngine
+
+    /// Everything that sets `EngineTLS.serverTrustEvaluator` lives in this one
+    /// suite. The evaluator is process global and suites otherwise run in
+    /// parallel, so a second suite setting it would decide what this one is
+    /// testing.
+    @Suite("EngineTLS live handshake against a self-signed origin", .serialized)
+    struct EngineTLSHandshakeTests {
+
+        /// Lives here rather than beside the resolver tests because reading the
+        /// evaluator is as much a claim on the process global as writing it,
+        /// and a suite that only reads still races the ones that write.
+        @Test("No evaluator is set by default")
+        func defaultsToNoEvaluator() {
+            #expect(EngineTLS.serverTrustEvaluator == nil)
+        }
+
+        @Test("No evaluator: the handshake is refused and no request reaches the origin")
+        func refusedByDefault() async throws {
+            let server = try #require(SelfSignedTLSOrigin())
+            defer { server.stop() }
+
+            let previous = EngineTLS.serverTrustEvaluator
+            defer { EngineTLS.serverTrustEvaluator = previous }
+            EngineTLS.serverTrustEvaluator = nil
+
+            let reader = AVIOReader(
+                url: URL(string: "https://127.0.0.1:\(server.port)/movie.bin")!,
+                chunkRequestTimeout: 5, chunkMaxRetries: 1)
+            defer { reader.markClosed(); reader.close() }
+            let refusal = Self.openFailure(of: reader)
+
+            try await Task.sleep(for: .seconds(1))
+            #expect(server.requestsServed == 0,
+                    "a request crossed a handshake that system trust should have refused")
+            #expect(Self.isTrustRefusal(refusal),
+                    "open failed as \(String(describing: refusal)), not a trust refusal")
+        }
+
+        @Test("Accepted for this origin: the same server serves the reader")
+        func acceptedWhenOptedIn() async throws {
+            let server = try #require(SelfSignedTLSOrigin())
+            defer { server.stop() }
+
+            let previous = EngineTLS.serverTrustEvaluator
+            defer { EngineTLS.serverTrustEvaluator = previous }
+            EngineTLS.serverTrustEvaluator = { _ in true }
+
+            let reader = AVIOReader(
+                url: URL(string: "https://127.0.0.1:\(server.port)/movie.bin")!,
+                chunkRequestTimeout: 10, chunkMaxRetries: 2)
+            defer { reader.markClosed(); reader.close() }
+            try reader.open()
+
+            let sliceCap = 64 * 1024
+            let buf = UnsafeMutablePointer<UInt8>.allocate(capacity: sliceCap)
+            defer { buf.deallocate() }
+            var got = 0
+            let deadline = Date().addingTimeInterval(20)
+            while got < sliceCap && Date() < deadline {
+                let n = reader.read(into: buf, size: Int32(sliceCap - got))
+                if n <= 0 { break }
+                got += Int(n)
+            }
+            #expect(got == sliceCap, "delivered \(got) of \(sliceCap) bytes")
+            #expect(buf[0] == 0xA7)
+            #expect(server.requestsServed > 0)
+        }
+
+
+        @Test("An evaluator that answers for another host leaves this one refused")
+        func refusedForAnOriginTheHostDidNotAccept() async throws {
+            let server = try #require(SelfSignedTLSOrigin())
+            defer { server.stop() }
+
+            // The case a process-wide flag cannot express: a host holding a LAN
+            // address behind a private certificate and a WAN address with a real
+            // one, accepting the first without quietly relaxing the second.
+            let previous = EngineTLS.serverTrustEvaluator
+            defer { EngineTLS.serverTrustEvaluator = previous }
+            EngineTLS.serverTrustEvaluator = { $0.host == "media.example" }
+
+            let reader = AVIOReader(
+                url: URL(string: "https://127.0.0.1:\(server.port)/movie.bin")!,
+                chunkRequestTimeout: 5, chunkMaxRetries: 1)
+            defer { reader.markClosed(); reader.close() }
+            let refusal = Self.openFailure(of: reader)
+
+            try await Task.sleep(for: .seconds(1))
+            #expect(server.requestsServed == 0,
+                    "a request crossed a handshake the evaluator did not accept")
+            #expect(Self.isTrustRefusal(refusal),
+                    "open failed as \(String(describing: refusal)), not a trust refusal")
+        }
+
+        /// A refused handshake reaches the host as a typed failure rather than as unreadable media,
+        /// so the refusal arms assert the classification and not only that no byte was served.
+        private static func openFailure(of reader: AVIOReader) -> Error? {
+            do {
+                try reader.open()
+                return nil
+            } catch {
+                return error
+            }
+        }
+
+        private static func isTrustRefusal(_ error: Error?) -> Bool {
+            guard case .transportSecurityFailed = error as? AVIOReaderError else { return false }
+            return true
+        }
+    }
+
+    /// Loopback HTTPS origin with a self-signed certificate for 127.0.0.1,
+    /// serving Range requests from a constant 0xA7 body. Every request that
+    /// makes it past the TLS handshake is appended to a log file, which is
+    /// the refusal observable: a client that distrusts the certificate never
+    /// gets a request line onto the wire.
+    final class SelfSignedTLSOrigin {
+        let port: UInt16
+        private let process: Process
+        private let workDir: URL
+
+        var requestsServed: Int {
+            let log = workDir.appendingPathComponent("requests.log")
+            guard let text = try? String(contentsOf: log, encoding: .utf8) else { return 0 }
+            return text.split(separator: "\n").count
+        }
+
+        init?() {
+            let dir = FileManager.default.temporaryDirectory
+                .appendingPathComponent("aether-tls-origin-\(UUID().uuidString)")
+            guard (try? FileManager.default.createDirectory(
+                at: dir, withIntermediateDirectories: true)) != nil else { return nil }
+            workDir = dir
+            do {
+                try Self.certPEM.write(
+                    to: dir.appendingPathComponent("cert.pem"), atomically: true, encoding: .utf8)
+                try Self.keyPEM.write(
+                    to: dir.appendingPathComponent("key.pem"), atomically: true, encoding: .utf8)
+                try Self.serverPy.write(
+                    to: dir.appendingPathComponent("origin.py"), atomically: true, encoding: .utf8)
+            } catch { return nil }
+
+            let proc = Process()
+            proc.executableURL = URL(fileURLWithPath: "/usr/bin/python3")
+            proc.arguments = [dir.appendingPathComponent("origin.py").path]
+            proc.currentDirectoryURL = dir
+            let stdout = Pipe()
+            proc.standardOutput = stdout
+            proc.standardError = FileHandle.nullDevice
+            do { try proc.run() } catch { return nil }
+            process = proc
+
+            // The server prints "READY <port>" once it is listening.
+            var readyLine = ""
+            var pending = Data()
+            let deadline = Date().addingTimeInterval(10)
+            while Date() < deadline, !readyLine.contains("READY") {
+                let chunk = stdout.fileHandleForReading.availableData
+                if chunk.isEmpty {
+                    Thread.sleep(forTimeInterval: 0.05)
+                    continue
+                }
+                pending.append(chunk)
+                readyLine = String(decoding: pending, as: UTF8.self)
+            }
+            guard let match = readyLine.split(separator: " ").last,
+                let bound = UInt16(match.trimmingCharacters(in: .whitespacesAndNewlines))
+            else {
+                proc.terminate()
+                return nil
+            }
+            port = bound
+        }
+
+        func stop() {
+            process.terminate()
+            try? FileManager.default.removeItem(at: workDir)
+        }
+
+        private static let serverPy = """
+            import http.server, os, re, ssl, sys
+
+            TOTAL = 4 * 1024 * 1024
+            BODY_BYTE = b"\\xa7"
+
+            class Handler(http.server.BaseHTTPRequestHandler):
+                protocol_version = "HTTP/1.1"
+
+                def log_message(self, *args):
+                    pass
+
+                def do_GET(self):
+                    with open("requests.log", "a") as f:
+                        f.write(self.path + "\\n")
+                    start, end = 0, TOTAL - 1
+                    m = re.match(r"bytes=(\\d*)-(\\d*)", self.headers.get("Range", ""))
+                    ranged = bool(m)
+                    if m:
+                        if m.group(1):
+                            start = min(int(m.group(1)), TOTAL - 1)
+                        if m.group(2):
+                            end = min(int(m.group(2)), TOTAL - 1)
+                    length = max(0, end - start + 1)
+                    self.send_response(206 if ranged else 200)
+                    if ranged:
+                        self.send_header("Content-Range", f"bytes {start}-{end}/{TOTAL}")
+                    self.send_header("Content-Length", str(length))
+                    self.send_header("Accept-Ranges", "bytes")
+                    self.end_headers()
+                    remaining = length
+                    while remaining > 0:
+                        chunk = min(remaining, 65536)
+                        try:
+                            self.wfile.write(BODY_BYTE * chunk)
+                        except OSError:
+                            return
+                        remaining -= chunk
+
+            server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+            ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+            ctx.load_cert_chain("cert.pem", "key.pem")
+            server.socket = ctx.wrap_socket(server.socket, server_side=True)
+            print("READY", server.server_address[1], flush=True)
+            server.serve_forever()
+            """
+
+        static let certPEM = """
+            -----BEGIN CERTIFICATE-----
+            MIIDGjCCAgKgAwIBAgIUPCvl3+omqHtbGt28tTO8nBwZNtwwDQYJKoZIhvcNAQEL
+            BQAwFDESMBAGA1UEAwwJMTI3LjAuMC4xMB4XDTI2MDgwMjA1MjIyOFoXDTM2MDcz
+            MDA1MjIyOFowFDESMBAGA1UEAwwJMTI3LjAuMC4xMIIBIjANBgkqhkiG9w0BAQEF
+            AAOCAQ8AMIIBCgKCAQEA1dnlqErHwZiOfKnONSyxp+WGfORM8RzCp5dFgm8xJpGi
+            R6I/Ly2Tezt2scNP9lBq8AEETtocm9dYObrSp6zHfZi4dUb6ixRc5DkYE8k37WEi
+            1/AVAQI7VPpasuuUOrmfeMd3dZOozu+6JprgpJyPzdGuw84dSREsbb1gGaOU/wWt
+            R4X0U2IHttV0uVLoj7MzZt1PsMqsimOuuau46TtH/9nwd7NjHykW0+dj8uJKe5Pw
+            y20WhT2jf0Ls3leE2fuJfGb1gKaJYY/7vT46F7iJMq7VlstNeKK40OU5MtKKBRbZ
+            96A1AZRXwHwhSysJeAo8UZW61wN20MWhrupEx0eAqwIDAQABo2QwYjAdBgNVHQ4E
+            FgQUhzShz4pSJL1oBklsC6pzezgk4HUwHwYDVR0jBBgwFoAUhzShz4pSJL1oBkls
+            C6pzezgk4HUwDwYDVR0TAQH/BAUwAwEB/zAPBgNVHREECDAGhwR/AAABMA0GCSqG
+            SIb3DQEBCwUAA4IBAQCzSx/tNHjYcwWlK0LMBFSVvn6ss3as8rX1U/CUve/AdDCG
+            vhC+uew++YqDX2zeibDqN17kqtyY35lvIsWeNMw8QnF+QBofWWLd6YxyE+hnEti5
+            Rx3cVpUnJ0MKSprRLRpzSYnSOo6Q42AMl4/ki1VDddIxQixAQzzcHQLZimJsw/kZ
+            Efhd1lTbD+ZghMuXpq+JLiylEd3LSW5UvTox1FOe03AVEQAMeWPcZwoEBtm3Qsbn
+            ahzZULJX/KFQHDfLD337xzfgNYR2w77rx6yaCUzrHZXha8qpevV3tMc1s/pi2KJ5
+            wAWlaPiab3bnQj5zmw4VdYBFptCfRRcLTZuCKTwu
+            -----END CERTIFICATE-----
+            """
+
+        static let keyPEM = """
+            -----BEGIN PRIVATE KEY-----
+            MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDV2eWoSsfBmI58
+            qc41LLGn5YZ85EzxHMKnl0WCbzEmkaJHoj8vLZN7O3axw0/2UGrwAQRO2hyb11g5
+            utKnrMd9mLh1RvqLFFzkORgTyTftYSLX8BUBAjtU+lqy65Q6uZ94x3d1k6jO77om
+            muCknI/N0a7Dzh1JESxtvWAZo5T/Ba1HhfRTYge21XS5UuiPszNm3U+wyqyKY665
+            q7jpO0f/2fB3s2MfKRbT52Py4kp7k/DLbRaFPaN/QuzeV4TZ+4l8ZvWApolhj/u9
+            PjoXuIkyrtWWy014orjQ5Tky0ooFFtn3oDUBlFfAfCFLKwl4CjxRlbrXA3bQxaGu
+            6kTHR4CrAgMBAAECggEAFrD6R3M34vj3FY9HDClj6HbYYGQxLdxpYzMP8xktU/Rc
+            DdHPdogVgBv9KjuZPn+l+TWCaYOHSZn+CJIkTBpvSIpt+DPB3gQZHzZXsbHGN2/5
+            LISTFfpQpWGzQgzxO5H6s+wmZtl2Lg8N547Di3P5ZlN7gddbECe8WSChE9dhtfWI
+            kjf+zh4dlTeU8RB+NT9puqASWuvePx+D2N1ySUFM+eVKV4T4M2UtYBG/fT33cbaP
+            qY6J2kGnQvETzqMHfE+9vb0jWJpVs+Zkii4p0OB3iS66ZDPdbW+pdVmWHVvvq+IH
+            ZQL2yWBvE7y9m5qRuC8kX8tabcbPjEi8NEVC6xuhgQKBgQDxCOilXiPRtl7S4+d8
+            iYwLVyctr/2sVtTXLvTwXJj3Xr2dUJWggrhxBqI2PvAFHhWAnils3xuAf0+Orly1
+            oGfr35fQb3IH6FKnSj/uoYiXMsjsDgOypNmg5KyWM4kqDW27HJq/PioC6MJzAeO/
+            WjOE0cWVjKW1qyIkgz+T6jsBiwKBgQDjIOwNIa38vqwBc3F8c8wLWHZDLBXGS1kh
+            5AyW+QcZ9EyKozPbxyqZrmEZa0v/IxuUniBq0O27dXJF09eJrAVd8dDMW0kJTmKk
+            ddbB44MzsADgE2jJiEcu22VZCoy0kjbODHw6L9KR8k+utx97fgl/p+BC/nwv6jYi
+            pXcI6EshYQKBgAeM9OTBRzP5l4zZsNW45VcxmruWqMauTaqUAP5KmEwffqcf8CAA
+            GFEKGSjD3fb7E0ddLQUJFC55Tn+0vJi/9qFv9qyD4TmYMIanD8uk6cd6wsqKQdll
+            yp98ql9mK+TSWN6krcBR7TT8H6NEquLCq5x8icj+h+5h9wbXybUTgFezAoGBAOKQ
+            TqdytzntgWsZG1WHtTyEC8RJz5a0Rr812xEmbF0Jguiwj+RmMiqG9jkC/RYOkU6Y
+            xcGHk/1w1IKvJMwiGmBx/VQ8owhzdpaTLZzPNGt04Aqlkdum40rsc5Z0nZLqX1z+
+            u1TXq3cGfVHNPcxUF2mNrnllnb+2JDY/VBRAk+FBAoGAI+Nb/JgYjihUqiqKcK0t
+            76scm4eNsR6wl1WWsZUMZlVVfQr8BqjIxz5yB8qTqdEMgMe0M/RdDgsqm8UIc9q6
+            GCRPZZR6CB0MobtvS9eczqo4Ov6pEnIk2I6T2oNuXbqscNJgWSHFGoK3Bl1aPJsa
+            TqL2wDYvLDkN1MEol+GDgSM=
+            -----END PRIVATE KEY-----
+            """
+    }
+
+#endif

--- a/Tests/AetherEngineTests/EngineTLSTests.swift
+++ b/Tests/AetherEngineTests/EngineTLSTests.swift
@@ -1,0 +1,101 @@
+import Foundation
+import Testing
+
+@testable import AetherEngine
+
+// Self-signed and private-CA media servers fail URLSession's system trust,
+// which the FFmpeg stack never enforced, so hosts need an explicit opt-in.
+// The resolver must stay on default handling for everything except a
+// server-trust challenge the host answered for.
+@Suite("EngineTLS trust resolution", .serialized)
+struct EngineTLSTests {
+
+    private final class RecordingSender: NSObject, URLAuthenticationChallengeSender {
+        func use(_ credential: URLCredential, for challenge: URLAuthenticationChallenge) {}
+        func continueWithoutCredential(for challenge: URLAuthenticationChallenge) {}
+        func cancel(_ challenge: URLAuthenticationChallenge) {}
+    }
+
+    private func challenge(
+        method: String, host: String = "server.example"
+    ) -> URLAuthenticationChallenge {
+        let space = URLProtectionSpace(
+            host: host, port: 443, protocol: "https",
+            realm: nil, authenticationMethod: method)
+        return URLAuthenticationChallenge(
+            protectionSpace: space, proposedCredential: nil, previousFailureCount: 0,
+            failureResponse: nil, error: nil, sender: RecordingSender())
+    }
+
+    private func disposition(
+        evaluator: (@Sendable (URLProtectionSpace) -> Bool)?,
+        method: String,
+        host: String = "server.example"
+    ) -> URLSession.AuthChallengeDisposition {
+        let previous = EngineTLS.serverTrustEvaluator
+        defer { EngineTLS.serverTrustEvaluator = previous }
+        EngineTLS.serverTrustEvaluator = evaluator
+
+        var got: URLSession.AuthChallengeDisposition?
+        EngineTLS.resolve(challenge(method: method, host: host)) { disposition, _ in
+            got = disposition
+        }
+        return got ?? .performDefaultHandling
+    }
+
+    @Test("No evaluator keeps default handling for server trust")
+    func noEvaluatorServerTrust() {
+        #expect(
+            disposition(evaluator: nil, method: NSURLAuthenticationMethodServerTrust)
+                == .performDefaultHandling)
+    }
+
+    @Test("Non-trust challenges never reach the evaluator")
+    func httpAuthUntouched() {
+        let asked = Mutex(false)
+        let got = disposition(
+            evaluator: { _ in asked.set(true); return true },
+            method: NSURLAuthenticationMethodHTTPBasic)
+
+        #expect(got == .performDefaultHandling)
+        #expect(asked.get() == false, "HTTP auth is not a trust decision the host was asked for")
+    }
+
+    @Test("The evaluator is asked about the origin the challenge came from")
+    func evaluatorSeesTheOrigin() {
+        let seen = Mutex<String?>(nil)
+        _ = disposition(
+            evaluator: { space in seen.set(space.host); return false },
+            method: NSURLAuthenticationMethodServerTrust,
+            host: "lan.media.example")
+
+        #expect(seen.get() == "lan.media.example")
+    }
+
+    @Test("An evaluator that declines keeps default handling")
+    func decliningEvaluator() {
+        #expect(
+            disposition(evaluator: { _ in false }, method: NSURLAuthenticationMethodServerTrust)
+                == .performDefaultHandling)
+    }
+
+    @Test("An accepted challenge with no evaluable trust object stays on default handling")
+    func acceptedWithoutTrustObject() {
+        // A challenge built outside a live handshake carries no SecTrust, so
+        // the resolver must fall through rather than send a nil credential.
+        #expect(
+            disposition(evaluator: { _ in true }, method: NSURLAuthenticationMethodServerTrust)
+                == .performDefaultHandling)
+    }
+
+    /// The evaluator is `@Sendable` and runs on whichever queue raised the
+    /// challenge, so a test recording what it saw cannot capture a plain var.
+    private final class Mutex<Value>: @unchecked Sendable {
+        private let lock = NSLock()
+        private var value: Value
+
+        init(_ value: Value) { self.value = value }
+        func get() -> Value { lock.lock(); defer { lock.unlock() }; return value }
+        func set(_ newValue: Value) { lock.lock(); value = newValue; lock.unlock() }
+    }
+}

--- a/Tests/AetherEngineTests/PublicAPIDocumentationTests.swift
+++ b/Tests/AetherEngineTests/PublicAPIDocumentationTests.swift
@@ -51,6 +51,7 @@ final class PublicAPIDocumentationTests: XCTestCase {
         "Diagnostics/EngineDiagnostics.swift",
         "Diagnostics/LiveTelemetry.swift",
         "Diagnostics/EngineLog.swift",
+        "Network/EngineTLS.swift",
         "FrameExtractor/FrameExtractor.swift",
     ]
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -620,6 +620,30 @@ reports an intention rather than an outcome.
 | `vodScrubThumbnail(atSeconds:maxWidth:)`, `liveScrubThumbnail(atSessionSeconds:maxWidth:)` | The two arms, for callers that know which axis they hold. |
 | `supportsCacheBackedStills` | True while a native session exists. Gate the scrub-preview affordance on it: it reports capability, not per-frame availability, so a transient nil from `scrubThumbnail` while a segment is still being produced is expected and means "time only, no image". |
 
+## Certificate trust
+
+A media server behind a self-signed or private-CA certificate is common in self-hosted setups, and
+URLSession refuses it where the in-demuxer network stacks the engine replaces never did. A host whose
+own API layer bypasses trust therefore lands in a split state: browsing works and every engine fetch
+fails its handshake before a byte is read.
+
+| Symbol | Notes |
+| --- | --- |
+| `EngineTLS` | Trust policy for the engine's outbound HTTP connections. Off by default, in the sense that no evaluator is set and every challenge keeps the system's default handling. |
+| `EngineTLS.serverTrustEvaluator` | `(@Sendable (URLProtectionSpace) -> Bool)?`, asked per challenge about the origin the challenge came from. nil, the default, keeps default handling everywhere. Read per challenge, so replacing it applies from the next connection without rebuilding sessions. Called off the main actor from whichever queue raised the challenge, so it has to be thread-safe. |
+
+```swift
+EngineTLS.serverTrustEvaluator = { $0.host == "media.lan" }
+```
+
+Answering per origin is the point of the closure rather than a flag: a host commonly holds a LAN
+address behind a private certificate and a WAN address with a real one, and accepting the first must
+not quietly relax the second. A host that pins an SPKI hash reads the protection space and decides.
+Returning true for everything is the blunt version and is one line.
+
+This governs the sessions the engine owns. A certificate the host does not accept still reaches the
+host as `PlaybackErrorKind.sourceCertificateRejected` rather than as unreadable media.
+
 ## Diagnostics
 
 | Symbol | Notes |


### PR DESCRIPTION
<!-- Thanks for contributing to AetherEngine. Keep this short; the test plan is the part that matters most. -->

## Summary

Gives a host a way to accept a server certificate the system will not vouch for, so a media server behind a self-signed or private CA certificate can play. Answers per origin rather than per process, as discussed in the issue.

Refs #495 (the loopback stand-in follows in a second PR, so this doesnt close it)

## What changed

- **`EngineTLS.serverTrustEvaluator`**, `(@Sendable (URLProtectionSpace) -> Bool)?`, asked per challenge about the origin the challenge came from. nil, the default, keeps the system's default handling everywhere. Read per challenge rather than at session construction, so replacing it applies from the next connection without rebuilding sessions, and lock-guarded like `EngineLog.handler`.
- **A session-level delegate** for the owned sessions that ran without one, and a fallback for tasks that missed a per-task delegate. AVIOReader's four paths (probe, chunk, persistent, streaming) resolve through the same disposition.
- **Session coverage re-counted on current main**, not on the fork's base. Added `HLSCarriageProbe` and `RemoteHLSSubtitleProxy` to the six from the issue.
- **The live subtitle rendition fetch owns its session** instead of borrowing `URLSession.shared`, which cannot carry a delegate and was the one engine fetch no host decision could reach.
- **Docs**: a `Certificate trust` section in `docs/api.md`, and `Network/EngineTLS.swift` added to `PublicAPIDocumentationTests.hostFacingTypeFiles` so the naming rule covers this surface from here on.

Anything other than a server-trust challenge the evaluator accepted is left to default handling, so client certificates and HTTP auth are untouched.

## Test plan

- **Device / OS:** MacBook Pro (15,1, Intel i7-8850H), macOS 15.7.7, Swift 6.2.3
- **Source media (container / video codec + profile / audio / HDR-DV):** synthetic. A loopback HTTPS origin with a self-signed certificate for 127.0.0.1, run as a Python subprocess because NWListener rejects an imported in-memory identity with EINVAL. It serves Range requests from a constant 4 MB body and logs every request that crosses the handshake, which is what makes a refusal observable rather than inferred.
- **Result:** `swift test --filter EngineTLS`, 9 tests in 2 suites, all passing.
  - Resolver: no evaluator keeps default handling; a non-trust challenge never reaches the evaluator at all; the evaluator is asked about the origin the challenge came from; a declining evaluator keeps default handling; an accepted challenge with no evaluable `SecTrust` falls through rather than sending a nil credential.
  - Live handshake: no evaluator refuses and no request reaches the origin; an evaluator accepting this origin serves the reader 64 KB with the expected body byte; an evaluator that answers only for another host leaves this one refused.
  - The two refusal arms assert `AVIOReaderError.transportSecurityFailed` and not only that no byte crossed, so they are proof of the 6.69.0 classification as well.
- `swift build` clean, `swift test --filter PublicAPIDocumentationTests` green including the XCTest half.

## Checklist

- [x] `CHANGELOG.md` updated
- [x] Commit messages follow Conventional Commits (`feat(...)`, `fix(...)`, `chore(...)`)
- [x] The fix lives in the engine, not in a host-side workaround
- [x] Public API changes are intentional and documented
