### PR TITLE
feat(network): the trust decision reaches AVPlayer through the remote HLS stand-in (#495)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,28 @@ the public-API contract.
 
 ## [Unreleased]
 
-_Nothing yet._
+### Added
+
+- **`EngineTLS.serverTrustEvaluator`: host opt-in to accept server
+  certificates that fail system trust evaluation.** Every engine fetch runs
+  over URLSession, which enforces system certificate trust that the
+  in-demuxer network stacks the engine replaces never did. A media server
+  fronted by a self-signed or private-CA certificate therefore keeps working
+  in a host whose own API layer bypasses trust, while the engine's open fails
+  its handshake before a byte is read. The evaluator is asked per challenge
+  about the origin it came from, so a host holding a LAN address behind a
+  private certificate and a WAN address with a real one answers for each, and
+  one that pins an SPKI hash decides for itself. nil by default; while nil,
+  and for every non-server-trust challenge, handling is unchanged. Covers
+  every session the engine owns: the AVIOReader probe, chunk, persistent and
+  streaming paths, the disc reader, both HLS ingest readers, the audio tap
+  fetcher, the carriage probe and the remote HLS subtitle proxy.
+
+### Changed
+
+- The live subtitle rendition fetch owns its session instead of borrowing
+  `URLSession.shared`, which cannot carry a delegate and was the one engine
+  fetch no host trust decision could reach.
 
 ## [6.70.0] - 2026-09-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,28 @@ the public-API contract.
   streaming paths, the disc reader, both HLS ingest readers, the audio tap
   fetcher, the carriage probe and the remote HLS subtitle proxy.
 
+- **The remote HLS stand-in relays the origin so the trust evaluator reaches
+  AVPlayer.** `EngineTLS` only governs sessions the engine opens, and on that
+  route the origin URL goes to `AVURLAsset`, where AVPlayer resolves it through
+  its own networking and asks no delegate about the certificate. An origin
+  behind a self-signed certificate could direct play, since that reads through
+  AVIOReader, and then fail the moment it transcoded. Once a host has set an
+  evaluator, an `HLSOriginRelay` is mounted on the `HLSLocalServer` that #316
+  already stands in front of a remote master, so the https request is made by
+  the engine and the handshake happens where the evaluator is asked. Playlists
+  are rewritten so every variant, key, map and segment follows, and anything
+  else is relayed byte for byte with `Range` forwarded verbatim and
+  `Content-Range` mirrored. Relayed requests are charged to
+  `OriginRequestBudget` like every other fetch the engine makes, so a metered
+  origin arms the same pacer the reader and the subtitle prefetcher read.
+  Sessions with no evaluator set reach AVPlayer unchanged.
+
+- The trust opt-in and #316's subtitle renditions now **compose**. The
+  rewritten master carries the injected renditions and its variants come back
+  through the relay, so a self-signed origin with sidecars gets both. The
+  renditions the engine serves itself are named relatively and stay with the
+  server that owns them.
+
 ### Changed
 
 - The live subtitle rendition fetch owns its session instead of borrowing

--- a/Sources/AetherEngine/AetherEngine+LiveSubtitleRenditions.swift
+++ b/Sources/AetherEngine/AetherEngine+LiveSubtitleRenditions.swift
@@ -180,10 +180,16 @@ extension AetherEngine {
         return cues.filter { $0.endTime >= horizon }
     }
 
+    /// `URLSession.shared` cannot carry a delegate, so this was the one engine fetch a host's trust
+    /// decision could never reach. Owned and process-wide for the same reason the carriage probe's
+    /// is: an uninvalidated session outlives its caller.
+    private static let renditionSession = URLSession(
+        configuration: .default, delegate: EngineTLS.sessionDelegate, delegateQueue: nil)
+
     private static func fetchText(_ url: URL, headers: [String: String]) async throws -> String {
         var request = URLRequest(url: url)
         for (key, value) in headers { request.setValue(value, forHTTPHeaderField: key) }
-        let (data, _) = try await URLSession.shared.data(for: request)
+        let (data, _) = try await renditionSession.data(for: request)
         guard let text = String(data: data, encoding: .utf8) else {
             throw HLSIngestError.playlistInvalid(reason: "rendition payload is not UTF-8")
         }

--- a/Sources/AetherEngine/AetherEngine+Loading.swift
+++ b/Sources/AetherEngine/AetherEngine+Loading.swift
@@ -482,7 +482,11 @@ extension AetherEngine {
         // rewritten master's variants still point at the origin, so this changes nothing about where the
         // media comes from. Any refusal (live, a playlist that will not rewrite, a slow origin) returns
         // the origin URL and leaves the sidecars on the host overlay, which is the pre-#316 behaviour.
-        let playbackURL = await prepareRemoteHLSSubtitleProxy(
+        //
+        // AE#495: a host that answered the trust evaluator needs the media on a session the engine
+        // owns, and the same stand-in does that. With sidecars it mounts a relay behind the
+        // rewritten master, without them the relay stands alone.
+        let playbackURL = await prepareRemoteHLSStandIn(
             originURL: url, options: options, expectedGeneration: bypassGeneration) ?? url
 
         // Jellyfin HLS URLs carry auth (ApiKey / PlaySessionId / LiveStreamId) as query params, but
@@ -534,25 +538,35 @@ extension AetherEngine {
         // No startLiveTelemetrySampler: all sampler counters read the loopback pipeline (demuxer / producer / cache / server), none of which exists on this bypass.
     }
 
-    /// #316: stand a subtitle-injecting loopback origin in front of the remote master, and return the URL
-    /// AVPlayer should open. Nil means "play the origin directly", which is the answer for every live
-    /// source, every session without text sidecars, and every refusal inside the proxy.
+    /// Stand a loopback origin in front of the remote master and return the URL AVPlayer should open.
+    /// Nil means "play the origin directly", which is the answer for a live source, and for a session
+    /// with neither text sidecars to inject (#316) nor a trust evaluator to honor (AE#495).
     ///
     /// Bitmap sidecars (`.sup`) are excluded: WebVTT is a text rendition, and promising one for a PGS file
     /// would serve an empty `.vtt` that AVPlayer never re-fetches. Those keep the overlay (and Phase D OCR).
+    ///
+    /// The relay is asked for on any https origin once an evaluator exists, not only the ones it would
+    /// accept, because deciding here means asking about a protection space no handshake produced, with
+    /// no `serverTrust` for a host that reads one. The real question is put at the handshake the relay
+    /// makes, so an origin the evaluator declines fails there rather than being laundered.
     @MainActor
-    private func prepareRemoteHLSSubtitleProxy(originURL: URL,
-                                               options: LoadOptions,
-                                               expectedGeneration: UInt64) async -> URL? {
-        guard !options.isLive else { return nil }
-        let tracks = externalSubtitleRegistry
-            .filter { $0.value.isTextFormat }
-            .sorted { $0.key < $1.key }
-            .map { RemoteHLSSubtitleProvider.Track(externalID: $0.key, source: $0.value) }
-        guard !tracks.isEmpty else { return nil }
+    private func prepareRemoteHLSStandIn(originURL: URL,
+                                         options: LoadOptions,
+                                         expectedGeneration: UInt64) async -> URL? {
+        let needsRelay = EngineTLS.serverTrustEvaluator != nil
+            && originURL.scheme?.lowercased() == "https"
+        guard !options.isLive || needsRelay else { return nil }
+        let tracks = options.isLive
+            ? []
+            : externalSubtitleRegistry
+                .filter { $0.value.isTextFormat }
+                .sorted { $0.key < $1.key }
+                .map { RemoteHLSSubtitleProvider.Track(externalID: $0.key, source: $0.value) }
+        guard !tracks.isEmpty || needsRelay else { return nil }
 
         guard let prepared = await RemoteHLSSubtitleProxy.prepare(
-            originURL: originURL, tracks: tracks, httpHeaders: options.httpHeaders) else { return nil }
+            originURL: originURL, tracks: tracks, httpHeaders: options.httpHeaders,
+            needsRelay: needsRelay) else { return nil }
         // The playlist fetches suspend; a load()/stop() can have superseded this session meanwhile, and a
         // proxy nobody owns would keep its socket and decode task for the rest of the process.
         guard loadGeneration == expectedGeneration else {
@@ -560,9 +574,11 @@ extension AetherEngine {
             return nil
         }
         remoteHLSSubtitleProxy = prepared
-        injectedSubtitleRenditionNames = Dictionary(
-            uniqueKeysWithValues: zip(tracks.map(\.externalID),
-                                      RemoteHLSSubtitleProvider.renditions(for: tracks).map(\.name)))
+        injectedSubtitleRenditionNames = prepared.servesSubtitleRenditions
+            ? Dictionary(
+                uniqueKeysWithValues: zip(tracks.map(\.externalID),
+                                          RemoteHLSSubtitleProvider.renditions(for: tracks).map(\.name)))
+            : [:]
         #if os(iOS)
         // #86 / #227: a receiver cannot reach 127.0.0.1. Mounting while already AirPlaying has to hand out
         // the LAN address straight away; the route-change reload re-enters this path and re-resolves it.

--- a/Sources/AetherEngine/Audio/Tap/AudioTapHLSFetcher.swift
+++ b/Sources/AetherEngine/Audio/Tap/AudioTapHLSFetcher.swift
@@ -33,7 +33,8 @@ final class AudioTapHLSFetcher: @unchecked Sendable {
             let cfg = URLSessionConfiguration.ephemeral
             cfg.timeoutIntervalForRequest = 10
             cfg.timeoutIntervalForResource = 30
-            self.session = URLSession(configuration: cfg)
+            self.session = URLSession(
+                configuration: cfg, delegate: EngineTLS.sessionDelegate, delegateQueue: nil)
         }
         self.httpHeaders = httpHeaders
     }

--- a/Sources/AetherEngine/Demuxer/AVIOReader.swift
+++ b/Sources/AetherEngine/Demuxer/AVIOReader.swift
@@ -3305,7 +3305,7 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
         let config = URLSessionConfiguration.default
         config.urlCache = nil
         config.timeoutIntervalForRequest = 20
-        return URLSession(configuration: config, delegate: nil, delegateQueue: nil)
+        return URLSession(configuration: config, delegate: EngineTLS.sessionDelegate, delegateQueue: nil)
     }()
 
     /// Total size from a data-connection response: `Content-Range` total on a 206, or
@@ -3574,7 +3574,7 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
     /// No invalidation overhead.
     private static let chunkSession: URLSession = {
         let config = makeSessionConfig()
-        return URLSession(configuration: config, delegate: nil, delegateQueue: nil)
+        return URLSession(configuration: config, delegate: EngineTLS.sessionDelegate, delegateQueue: nil)
     }()
 
     /// #220: long-lived session for the persistent streaming path, paired with a per-task
@@ -3590,7 +3590,7 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
     ///
     /// Never invalidated. Releasing a connection is `task.cancel()` now, not session teardown.
     private static let persistentSession: URLSession = {
-        URLSession(configuration: makeSessionConfig(longLived: true), delegate: nil, delegateQueue: nil)
+        URLSession(configuration: makeSessionConfig(longLived: true), delegate: EngineTLS.sessionDelegate, delegateQueue: nil)
     }()
 
     /// Outcome of an abortable semaphore wait (issue #27).
@@ -3864,6 +3864,15 @@ private final class PersistentReadDelegate: NSObject, URLSessionDataDelegate, @u
     func urlSession(
         _ session: URLSession,
         task: URLSessionTask,
+        didReceive challenge: URLAuthenticationChallenge,
+        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+    ) {
+        EngineTLS.resolve(challenge, completionHandler: completionHandler)
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
         willPerformHTTPRedirection response: HTTPURLResponse,
         newRequest request: URLRequest,
         completionHandler: @escaping (URLRequest?) -> Void
@@ -3951,6 +3960,15 @@ private final class ChunkFetchDelegate: NSObject, URLSessionDataDelegate, @unche
     init(extraHeaders: [String: String], bodyLimit: Int?) {
         self.extraHeaders = extraHeaders
         self.bodyLimit = bodyLimit
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        didReceive challenge: URLAuthenticationChallenge,
+        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+    ) {
+        EngineTLS.resolve(challenge, completionHandler: completionHandler)
     }
 
     func urlSession(
@@ -4076,6 +4094,15 @@ private final class StreamingDelegate: NSObject, URLSessionDataDelegate {
 
     func urlSession(
         _ session: URLSession,
+        task: URLSessionTask,
+        didReceive challenge: URLAuthenticationChallenge,
+        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+    ) {
+        EngineTLS.resolve(challenge, completionHandler: completionHandler)
+    }
+
+    func urlSession(
+        _ session: URLSession,
         dataTask: URLSessionDataTask,
         didReceive response: URLResponse,
         completionHandler: @escaping (URLSession.ResponseDisposition) -> Void
@@ -4121,6 +4148,15 @@ private final class ProbeDelegate: NSObject, URLSessionDataDelegate, @unchecked 
 
     init(extraHeaders: [String: String]) {
         self.extraHeaders = extraHeaders
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        didReceive challenge: URLAuthenticationChallenge,
+        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+    ) {
+        EngineTLS.resolve(challenge, completionHandler: completionHandler)
     }
 
     func urlSession(

--- a/Sources/AetherEngine/IO/HLSIngest/HLSCarriageProbe.swift
+++ b/Sources/AetherEngine/IO/HLSIngest/HLSCarriageProbe.swift
@@ -26,7 +26,8 @@ enum HLSCarriageProbe {
     private static let sharedSession: URLSession = {
         let configuration = URLSessionConfiguration.ephemeral
         configuration.timeoutIntervalForRequest = 10
-        return URLSession(configuration: configuration)
+        return URLSession(
+            configuration: configuration, delegate: EngineTLS.sessionDelegate, delegateQueue: nil)
     }()
 
     /// AE#296: what the playlist chain established, and whether a media byte is still needed to settle it.

--- a/Sources/AetherEngine/IO/HLSIngest/HLSLiveIngestReader.swift
+++ b/Sources/AetherEngine/IO/HLSIngest/HLSLiveIngestReader.swift
@@ -156,7 +156,8 @@ public final class HLSLiveIngestReader: IOReader, LiveIngestSourceInfo, @uncheck
         config.timeoutIntervalForRequest = 10
         config.timeoutIntervalForResource = 30
         // 30s resource ceiling: one-shot fetches must fail fast so the host can fall back. The c7592ed no-ceiling lesson applies to long-lived stream connections, not bounded one-shot fetches.
-        self.session = URLSession(configuration: config)
+        self.session = URLSession(
+            configuration: config, delegate: EngineTLS.sessionDelegate, delegateQueue: nil)
     }
 
     // MARK: - IOReader

--- a/Sources/AetherEngine/IO/HLSIngest/HLSVODIngestReader.swift
+++ b/Sources/AetherEngine/IO/HLSIngest/HLSVODIngestReader.swift
@@ -64,7 +64,9 @@ final class HLSVODIngestReader: TimeSeekableIOReader, @unchecked Sendable {
             configuration.timeoutIntervalForResource = 45
             configuration.requestCachePolicy = .reloadIgnoringLocalAndRemoteCacheData
             configuration.urlCache = nil
-            self.session = URLSession(configuration: configuration)
+            self.session = URLSession(
+                configuration: configuration, delegate: EngineTLS.sessionDelegate,
+                delegateQueue: nil)
             ownsSession = true
         }
     }

--- a/Sources/AetherEngine/IO/HTTPDiscIOReader.swift
+++ b/Sources/AetherEngine/IO/HTTPDiscIOReader.swift
@@ -60,7 +60,8 @@ final class HTTPDiscIOReader: IOReader, @unchecked Sendable {
             c.requestCachePolicy = .reloadIgnoringLocalCacheData
             return c
         }()
-        self.session = URLSession(configuration: config)
+        self.session = URLSession(
+            configuration: config, delegate: EngineTLS.sessionDelegate, delegateQueue: nil)
 
         guard let size = Self.probeSize(
             url: url, extraHeaders: extraHeaders, session: session,

--- a/Sources/AetherEngine/Native/RemoteHLSSubtitleProvider.swift
+++ b/Sources/AetherEngine/Native/RemoteHLSSubtitleProvider.swift
@@ -16,7 +16,11 @@ final class RemoteHLSSubtitleProvider: HLSSegmentProvider, @unchecked Sendable {
     }
 
     let tracks: [Track]
-    let staticMasterPlaylistBody: String?
+
+    /// Settable because the relay can only rewrite this once the server it is mounted on has a
+    /// port and a token, which is after the provider exists. Written once during build, before
+    /// the server has answered anything.
+    private(set) var staticMasterPlaylistBody: String?
 
     /// Total program seconds, summed from the origin's own variant playlist. TARGETDURATION and the
     /// single EXTINF of every subtitle rendition are built from it.
@@ -44,6 +48,12 @@ final class RemoteHLSSubtitleProvider: HLSSegmentProvider, @unchecked Sendable {
         self.defaultHeaders = defaultHeaders
         self.vttFillWaitSeconds = vttFillWaitSeconds
         self.stores = tracks.map { _ in NativeSubtitleCueStore() }
+    }
+
+    /// Replaces the served master. Only the relay calls this, to send the origin's variants back
+    /// through the engine once the server's address is known.
+    func setMasterPlaylistBody(_ body: String) {
+        staticMasterPlaylistBody = body
     }
 
     /// The renditions as the rewriter needs to declare them, in `subs_{ordinal}` order.

--- a/Sources/AetherEngine/Native/RemoteHLSSubtitleProxy.swift
+++ b/Sources/AetherEngine/Native/RemoteHLSSubtitleProxy.swift
@@ -1,23 +1,38 @@
 import Foundation
 
-/// #316: stands a loopback origin in front of a remote HLS master so host-declared sidecars can be
-/// declared as legible renditions, without moving a single media byte off the origin.
+/// Stands a loopback origin in front of a remote HLS master, for either of two reasons.
 ///
-/// The sequence is deliberately cheap and entirely optional. Two playlist GETs (the master, then one
-/// variant for the program duration and the VOD verdict), a rewrite, a socket. Anything that does not
-/// line up, and the caller keeps the origin URL it already had: the sidecars stay overlay-only, exactly
-/// as before, and the load is never failed over a subtitle feature.
+/// #316: host-declared sidecars can only be declared as legible renditions through a playlist, so the
+/// engine writes a master of its own, without moving a single media byte off the origin.
+///
+/// AE#495: a host has answered `EngineTLS.serverTrustEvaluator`, and AVPlayer asks no delegate about a
+/// certificate inside its own networking, so the media has to move onto a session the engine owns. An
+/// `HLSOriginRelay` mounted on the same server does that.
+///
+/// They compose. With both, the master carries the injected renditions AND its variants come back
+/// through the relay, so a self-signed origin with sidecars gets both rather than choosing. With only
+/// the relay there are no tracks and no provider, and the player is pointed straight at the relay.
+///
+/// The #316 sequence is deliberately cheap and entirely optional. Two playlist GETs (the master, then
+/// one variant for the program duration and the VOD verdict), a rewrite, a socket. Anything that does
+/// not line up, and the sidecars stay overlay-only exactly as before. A load is never failed over a
+/// subtitle feature. A refusal with a relay wanted still stands the relay up on its own, because the
+/// media has nowhere else to go.
 enum RemoteHLSSubtitleProxy {
 
-    /// A standing proxy: the caller plays `masterURL` and owns the teardown.
+    /// A standing stand-in: the caller plays `masterURL` and owns the teardown.
     struct Prepared {
         let server: HLSLocalServer
-        let provider: RemoteHLSSubtitleProvider
+        let provider: RemoteHLSSubtitleProvider?
         let masterURL: URL
 
+        /// False when the relay stands alone and nothing was injected.
+        var servesSubtitleRenditions: Bool { provider != nil }
+
         func tearDown() {
-            provider.cancelFill()
+            provider?.cancelFill()
             server.stop()
+            server.relay?.stop()
         }
     }
 
@@ -36,22 +51,55 @@ enum RemoteHLSSubtitleProxy {
 
     static func prepare(originURL: URL,
                         tracks: [RemoteHLSSubtitleProvider.Track],
-                        httpHeaders: [String: String]) async -> Prepared? {
-        guard !tracks.isEmpty else { return nil }
+                        httpHeaders: [String: String],
+                        needsRelay: Bool) async -> Prepared? {
+        guard !tracks.isEmpty || needsRelay else { return nil }
+        if !tracks.isEmpty {
+            do {
+                let prepared = try await build(
+                    originURL: originURL, tracks: tracks, httpHeaders: httpHeaders,
+                    needsRelay: needsRelay)
+                EngineLog.emit(
+                    "[AetherEngine] #316: serving \(tracks.count) external subtitle rendition(s) over a "
+                    + "rewritten master at \(prepared.masterURL.absoluteString), media "
+                    + (needsRelay ? "comes back through the AE#495 relay" : "stays at the origin"),
+                    category: .engine)
+                return prepared
+            } catch {
+                EngineLog.emit(
+                    "[AetherEngine] #316: no subtitle renditions on this remote-HLS source (\(reason(error))), "
+                    + "the declared sidecars stay host-overlay only",
+                    category: .engine)
+            }
+        }
+        guard needsRelay else { return nil }
+        return relayOnly(originURL: originURL, httpHeaders: httpHeaders)
+    }
+
+    /// The AE#495 half with nothing to inject: no provider, no playlist reads, and the player is
+    /// pointed at the relay's own address for the origin.
+    private static func relayOnly(originURL: URL, httpHeaders: [String: String]) -> Prepared? {
+        let relay = HLSOriginRelay()
+        relay.admit(originURL, httpHeaders: httpHeaders)
+        let server = HLSLocalServer(relay: relay)
         do {
-            let prepared = try await build(originURL: originURL, tracks: tracks, httpHeaders: httpHeaders)
-            EngineLog.emit(
-                "[AetherEngine] #316: serving \(tracks.count) external subtitle rendition(s) over a "
-                + "rewritten master at \(prepared.masterURL.absoluteString); media stays at the origin",
-                category: .engine)
-            return prepared
+            try server.start()
         } catch {
             EngineLog.emit(
-                "[AetherEngine] #316: no subtitle renditions on this remote-HLS source (\(reason(error))); "
-                + "the declared sidecars stay host-overlay only",
-                category: .engine)
+                "[AetherEngine] AE#495: relay did not start (\(error)). AVPlayer goes to the origin, "
+                + "which needs a certificate the system trusts", category: .engine)
+            relay.stop()
             return nil
         }
+        guard let entry = server.relayURL(for: originURL) else {
+            server.stop()
+            relay.stop()
+            return nil
+        }
+        EngineLog.emit(
+            "[AetherEngine] AE#495: routing \(originURL.host ?? "the origin") through the relay so the "
+            + "handshake runs where the evaluator is asked", category: .engine)
+        return Prepared(server: server, provider: nil, masterURL: entry)
     }
 
     private static func reason(_ error: Error) -> String {
@@ -69,7 +117,8 @@ enum RemoteHLSSubtitleProxy {
 
     private static func build(originURL: URL,
                               tracks: [RemoteHLSSubtitleProvider.Track],
-                              httpHeaders: [String: String]) async throws -> Prepared {
+                              httpHeaders: [String: String],
+                              needsRelay: Bool) async throws -> Prepared {
         let session = makeSession()
         defer { session.finishTasksAndInvalidate() }
 
@@ -86,15 +135,28 @@ enum RemoteHLSSubtitleProxy {
         let provider = RemoteHLSSubtitleProvider(tracks: tracks, masterBody: master,
                                                  programDuration: duration,
                                                  defaultHeaders: httpHeaders)
-        let server = HLSLocalServer(provider: provider)
+        let relay: HLSOriginRelay? = needsRelay ? HLSOriginRelay() : nil
+        relay?.admit(finalURL, httpHeaders: httpHeaders)
+        let server = HLSLocalServer(provider: provider, relay: relay)
         do {
             try server.start()
         } catch {
+            relay?.stop()
             throw Refusal.serverUnavailable("\(error)")
         }
         guard let masterURL = server.playlistURL else {
             server.stop()
+            relay?.stop()
             throw Refusal.serverUnavailable("no playlist URL after start")
+        }
+        // The variants in that master are the origin's, and with a relay mounted they have to come
+        // back through it. Only now, because the address they point at is this server's own and does
+        // not exist until it is listening. The injected renditions are relative and stay untouched.
+        if let relay {
+            provider.setMasterPlaylistBody(
+                relay.rewritePlaylist(
+                    master, relativeTo: finalURL, port: server.port, token: server.pathToken,
+                    absoluteOnly: true))
         }
         // Decode up front: the rendition is fetched the moment the host selects it, and a whole-program
         // .vtt is fetched once and never again.

--- a/Sources/AetherEngine/Native/RemoteHLSSubtitleProxy.swift
+++ b/Sources/AetherEngine/Native/RemoteHLSSubtitleProxy.swift
@@ -109,7 +109,8 @@ enum RemoteHLSSubtitleProxy {
         config.timeoutIntervalForRequest = budgetSeconds / 2
         config.timeoutIntervalForResource = budgetSeconds
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
-        return URLSession(configuration: config)
+        return URLSession(
+            configuration: config, delegate: EngineTLS.sessionDelegate, delegateQueue: nil)
     }
 
     /// Returns the body and the URL it finally came from; every relative URI in the playlist resolves

--- a/Sources/AetherEngine/Network/EngineTLS.swift
+++ b/Sources/AetherEngine/Network/EngineTLS.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+/// Host-app TLS trust policy for the engine's outbound HTTP connections.
+///
+/// URLSession enforces system certificate trust, which the in-demuxer network
+/// stacks this engine replaces never did. A media server fronted by a
+/// self-signed or private-CA certificate therefore keeps working in a host
+/// whose own API layer bypasses trust, while every engine fetch fails its
+/// handshake before a byte is read and the open surfaces as bare invalid
+/// data. The host answers per origin, and while no evaluator is set every
+/// challenge keeps the system's default handling.
+public enum EngineTLS {
+
+    /// Decides whether to accept a server certificate that failed system
+    /// trust evaluation, for the origin the challenge came from.
+    ///
+    /// nil, the default, keeps the system's default handling everywhere. The
+    /// blunt answer is one line (`{ _ in true }`), and a host holding a LAN
+    /// address behind a private certificate alongside a WAN address with a
+    /// real one can answer for each rather than relaxing both. A host that
+    /// wants to pin an SPKI hash reads the protection space and decides.
+    ///
+    /// Read per challenge, so replacing it applies from the next connection
+    /// without rebuilding sessions. Called off the main actor, from whichever
+    /// queue the session raised the challenge on, so it has to be
+    /// thread-safe. Lock-guarded like `EngineLog.handler`.
+    public static var serverTrustEvaluator: (@Sendable (URLProtectionSpace) -> Bool)? {
+        get { lock.lock(); defer { lock.unlock() }; return _evaluator }
+        set { lock.lock(); _evaluator = newValue; lock.unlock() }
+    }
+    private static let lock = NSLock()
+    nonisolated(unsafe) private static var _evaluator: (@Sendable (URLProtectionSpace) -> Bool)?
+
+    /// Session-level delegate for the owned sessions that otherwise run
+    /// without one (disc reader, HLS ingest readers, audio tap fetcher,
+    /// carriage probe, subtitle proxy, live rendition fetch) and the fallback
+    /// for tasks that missed a per-task delegate.
+    static let sessionDelegate = SessionTrustDelegate()
+
+    /// Single disposition shared by the session-level delegate and the
+    /// per-task delegates in AVIOReader. Anything other than a server-trust
+    /// challenge the host accepted is left to default handling, so client
+    /// certificates and HTTP auth behave exactly as before.
+    static func resolve(
+        _ challenge: URLAuthenticationChallenge,
+        completionHandler: (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+    ) {
+        guard
+            challenge.protectionSpace.authenticationMethod
+                == NSURLAuthenticationMethodServerTrust,
+            let evaluator = serverTrustEvaluator,
+            evaluator(challenge.protectionSpace),
+            let trust = challenge.protectionSpace.serverTrust
+        else {
+            completionHandler(.performDefaultHandling, nil)
+            return
+        }
+        completionHandler(.useCredential, URLCredential(trust: trust))
+    }
+
+    final class SessionTrustDelegate: NSObject, URLSessionDelegate, @unchecked Sendable {
+        func urlSession(
+            _ session: URLSession,
+            didReceive challenge: URLAuthenticationChallenge,
+            completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?)
+                -> Void
+        ) {
+            EngineTLS.resolve(challenge, completionHandler: completionHandler)
+        }
+    }
+}

--- a/Sources/AetherEngine/Network/HLSLocalServer.swift
+++ b/Sources/AetherEngine/Network/HLSLocalServer.swift
@@ -411,9 +411,30 @@ final class HLSLocalServer: @unchecked Sendable {
     /// When set (e.g. `aether-engine://engine/`), segment URIs in the playlist are absolute custom-scheme URLs routed through AVAssetResourceLoader. Nil emits relative URIs for the aetherctl HTTP workflow.
     private let subResourceBaseURL: URL?
 
-    init(provider: HLSSegmentProvider, subResourceBaseURL: URL? = nil) {
+    /// AE#495: fetches a remote origin on this server's behalf. Mounted when a host has set
+    /// `EngineTLS.serverTrustEvaluator`, so the https handshake happens where that answer is
+    /// read instead of inside AVPlayer's own networking.
+    let relay: HLSOriginRelay?
+
+    /// A relay-only server has no provider: nothing here produces segments, every byte comes
+    /// from the origin, and the master is whatever the origin served.
+    init(provider: HLSSegmentProvider? = nil, subResourceBaseURL: URL? = nil,
+         relay: HLSOriginRelay? = nil) {
         self.provider = provider
         self.subResourceBaseURL = subResourceBaseURL
+        self.relay = relay
+    }
+
+    /// Admits `origin` to the relay and returns the address standing in for it, for a player
+    /// pointed at the relay rather than at a provider's playlists. Nil before `start()` or with
+    /// no relay mounted.
+    func relayURL(for origin: URL) -> URL? {
+        guard let relay, relay.admit(origin) != nil else { return nil }
+        stateLock.lock()
+        let listeningPort = port
+        stateLock.unlock()
+        guard listeningPort > 0 else { return nil }
+        return HLSOriginRelay.localURL(for: origin, port: listeningPort, token: pathToken)
     }
 
     // MARK: - Lifecycle
@@ -720,6 +741,25 @@ final class HLSLocalServer: @unchecked Sendable {
             // Range / capability header that explains the 404. Revert with the
             // arrival-line promotion above once #50 is root-caused.
             EngineLog.emit("[HLSLocalServer] first request headers fd=\(fd): \(headers)", category: .hlsServer)  // #50 diag: .info, revert post-root-cause
+        }
+
+        if normalizedPath == HLSOriginRelay.route {
+            guard let relay else {
+                return send404(fd: fd, path: normalizedPath, reason: "no relay mounted")
+            }
+            stateLock.lock()
+            let listeningPort = port
+            stateLock.unlock()
+            let headerLines = Array(text.components(separatedBy: "\r\n").dropFirst())
+            guard let answer = relay.respond(
+                query: query,
+                host: Self.requestHeader(named: "host", in: headerLines),
+                range: Self.requestHeader(named: "range", in: headerLines),
+                port: listeningPort, token: pathToken)
+            else {
+                return send404(fd: fd, path: normalizedPath, reason: "relay names no origin")
+            }
+            return sendRelay(fd: fd, path: normalizedPath, answer: answer)
         }
 
         switch normalizedPath {
@@ -1050,6 +1090,50 @@ final class HLSLocalServer: @unchecked Sendable {
         }
         return (.segment, streamFileToSocket(fileURL: fileURL, socketFd: fd, path: path,
                                              expectedLength: fileSize))
+    }
+
+    static func requestHeader(named name: String, in lines: [String]) -> String? {
+        let wanted = name.lowercased() + ":"
+        for line in lines where line.lowercased().hasPrefix(wanted) {
+            return line.dropFirst(wanted.count).trimmingCharacters(in: .whitespaces)
+        }
+        return nil
+    }
+
+    /// Writes a relayed answer. Separate from `send200` because this is the only path that
+    /// passes a status through from somewhere else and the only one that answers 206, which
+    /// a ranged segment fetch upstream comes back as.
+    private func sendRelay(fd: Int32, path: String, answer: HLSOriginRelay.Response) -> Bool {
+        var header = "HTTP/1.1 \(answer.status) \(Self.reasonPhrase(answer.status))\r\n"
+        header += "Content-Length: \(answer.body.count)\r\n"
+        header += "Content-Type: \(answer.contentType)\r\n"
+        if let contentRange = answer.contentRange {
+            header += "Content-Range: \(contentRange)\r\n"
+        }
+        header += "Accept-Ranges: bytes\r\n"
+        header += "Cache-Control: no-cache\r\n"
+        header += "Connection: keep-alive\r\n\r\n"
+
+        EngineLog.emit(
+            "[HLSLocalServer] -> \(answer.status) relay bytes=\(answer.body.count) "
+                + "type=\(answer.contentType)", category: .hlsServer, level: .verbose)
+        guard writeAll(fd: fd, data: Data(header.utf8), path: "\(path) [header]") else {
+            return false
+        }
+        return answer.body.isEmpty ? true : writeAll(fd: fd, data: answer.body, path: path)
+    }
+
+    static func reasonPhrase(_ status: Int) -> String {
+        switch status {
+        case 200: return "OK"
+        case 206: return "Partial Content"
+        case 400: return "Bad Request"
+        case 403: return "Forbidden"
+        case 404: return "Not Found"
+        case 416: return "Range Not Satisfiable"
+        case 502: return "Bad Gateway"
+        default: return "Status \(status)"
+        }
     }
 
     private func send404(fd: Int32, path: String, reason: String) -> Bool {

--- a/Sources/AetherEngine/Network/HLSOriginRelay.swift
+++ b/Sources/AetherEngine/Network/HLSOriginRelay.swift
@@ -1,0 +1,307 @@
+import Foundation
+
+/// AE#495: fetches a remote origin on the engine's behalf and sends every URI a playlist
+/// names back through the local server it is mounted on.
+///
+/// AVPlayer resolves a remote URL through its own networking. No delegate on the asset is
+/// ever asked about the certificate, and an ATS exception does not cover it, so an origin
+/// behind a self-signed or private CA certificate cannot play on the native remote HLS
+/// route however a host has answered `EngineTLS.serverTrustEvaluator`. Pointing the player
+/// at the local server instead moves the https request onto a URLSession the engine owns,
+/// which is where that answer is read.
+///
+/// This is the second reason `HLSLocalServer` stands in front of a remote master, after
+/// #316's subtitle renditions, and it composes with it: the rewritten master #316 builds
+/// goes through the same rewriter, so a session with sidecars against a self-signed origin
+/// gets both instead of choosing.
+final class HLSOriginRelay: @unchecked Sendable {
+
+    /// The single route the player is ever pointed at, under the server's session token.
+    /// The origin rides in the query, so one route covers playlists, keys and segments.
+    static let route = "/aether-origin-relay"
+    private static let originQueryKey = "origin"
+
+    /// What a relayed request produced, for the server to write.
+    struct Response {
+        let status: Int
+        let body: Data
+        let contentType: String
+        /// Mirrored from upstream so a ranged fetch stays a ranged answer.
+        let contentRange: String?
+    }
+
+    private let stateLock = NSLock()
+
+    /// Origins this relay will fetch, as scheme://host:port. Seeded by `admit(_:)` and grown
+    /// as playlists reveal where their own sub-resources live, so a stream split across hosts
+    /// keeps working while a request naming somewhere nobody advertised is still refused.
+    private var allowedOrigins = Set<String>()
+
+    /// Sent upstream on every fetch. Origins that gate on Referer, User-Agent or
+    /// Authorization need these, and they can no longer ride on the asset because the asset
+    /// now points at the local server.
+    private var upstreamHeaders: [String: String] = [:]
+
+    /// Built in init rather than on first use: the server handles connections concurrently,
+    /// and a lazy var raced by two of them can build two sessions where only one is ever
+    /// invalidated.
+    private let session: URLSession
+
+    init() {
+        let config = URLSessionConfiguration.ephemeral
+        config.requestCachePolicy = .reloadIgnoringLocalAndRemoteCacheData
+        config.urlCache = nil
+        config.timeoutIntervalForRequest = 30
+        config.timeoutIntervalForResource = 120
+        session = URLSession(
+            configuration: config, delegate: EngineTLS.sessionDelegate, delegateQueue: nil)
+    }
+
+    func stop() {
+        session.invalidateAndCancel()
+    }
+
+    // MARK: - Admission
+
+    /// Lets this relay fetch `origin`, and adopts the headers a load carries. Returns the
+    /// origin key, or nil for a URL with no host to fetch from.
+    @discardableResult
+    func admit(_ origin: URL, httpHeaders: [String: String] = [:]) -> String? {
+        guard let key = Self.originKey(for: origin) else { return nil }
+        stateLock.lock()
+        allowedOrigins.insert(key)
+        if !httpHeaders.isEmpty { upstreamHeaders = httpHeaders }
+        stateLock.unlock()
+        return key
+    }
+
+    /// scheme://host:port for `url`, which is the granularity the allow list works at.
+    static func originKey(for url: URL) -> String? {
+        guard let scheme = url.scheme?.lowercased(), let host = url.host?.lowercased() else {
+            return nil
+        }
+        if let port = url.port { return "\(scheme)://\(host):\(port)" }
+        return "\(scheme)://\(host)"
+    }
+
+    // MARK: - Addressing
+
+    /// The local address standing in for `origin`.
+    static func localURL(
+        for origin: URL, host: String = "127.0.0.1", port: UInt16, token: String
+    ) -> URL? {
+        // Encoding everything outside the alphanumerics keeps the origin's own query, which
+        // on a Jellyfin stream carries the api key and the play session, from being read as
+        // part of this URL's query.
+        guard
+            let encoded = origin.absoluteString.addingPercentEncoding(
+                withAllowedCharacters: .alphanumerics)
+        else { return nil }
+        return URL(string: "http://\(host):\(port)/\(token)\(route)?\(originQueryKey)=\(encoded)")
+    }
+
+    /// The origin a relay request names, or nil when the query does not carry one.
+    static func originURL(fromQuery query: String) -> URL? {
+        for field in query.split(separator: "&") {
+            let pair = field.split(separator: "=", maxSplits: 1)
+            guard pair.count == 2, pair[0] == originQueryKey else { continue }
+            guard let decoded = String(pair[1]).removingPercentEncoding, !decoded.isEmpty else {
+                return nil
+            }
+            return URL(string: decoded)
+        }
+        return nil
+    }
+
+    /// The authority a rewritten playlist should point its sub-resources at: whatever the
+    /// client used to reach the server, so a receiver that arrived on the LAN address keeps
+    /// fetching from it rather than being sent to a loopback it resolves to itself (#86).
+    /// Falls back to loopback when a request carries no usable Host.
+    static func rewriteAuthority(host header: String?) -> String {
+        guard let header, !header.isEmpty else { return "127.0.0.1" }
+        // Host is "address" or "address:port". An IPv6 literal keeps its brackets, and its
+        // colons are inside them.
+        if header.hasPrefix("[") {
+            guard let close = header.firstIndex(of: "]") else { return "127.0.0.1" }
+            return String(header[...close])
+        }
+        let address = header.split(separator: ":", maxSplits: 1).first.map(String.init) ?? header
+        return address.isEmpty ? "127.0.0.1" : address
+    }
+
+    // MARK: - Serving
+
+    /// Answers one relay request. Nil when the query names no origin the relay could fetch.
+    func respond(query: String, host: String?, range: String?, port: UInt16, token: String)
+        -> Response?
+    {
+        guard let origin = Self.originURL(fromQuery: query) else { return nil }
+        guard let key = Self.originKey(for: origin) else { return nil }
+
+        stateLock.lock()
+        let permitted = allowedOrigins.contains(key)
+        let headers = upstreamHeaders
+        stateLock.unlock()
+        guard permitted else {
+            EngineLog.emit(
+                "[HLSOriginRelay] -> 403 origin was never advertised: \(key)", category: .hlsServer)
+            return Response(status: 403, body: Data(), contentType: "text/plain", contentRange: nil)
+        }
+
+        guard let fetched = fetch(origin: origin, headers: headers, range: range) else {
+            return Response(status: 502, body: Data(), contentType: "text/plain", contentRange: nil)
+        }
+
+        guard Self.looksLikePlaylist(url: origin, contentType: fetched.contentType) else {
+            return Response(
+                status: fetched.status, body: fetched.body,
+                contentType: fetched.contentType ?? "application/octet-stream",
+                contentRange: fetched.contentRange)
+        }
+
+        let rewritten = rewritePlaylist(
+            String(decoding: fetched.body, as: UTF8.self), relativeTo: origin,
+            authority: Self.rewriteAuthority(host: host), port: port, token: token)
+        // A rewritten body has a different length than the range that produced it, so the
+        // partial framing cannot survive. Playlists are small and nothing ranges them.
+        return Response(
+            status: 200, body: Data(rewritten.utf8),
+            contentType: "application/vnd.apple.mpegurl", contentRange: nil)
+    }
+
+    private static func looksLikePlaylist(url: URL, contentType: String?) -> Bool {
+        if let type = contentType?.lowercased(), type.contains("mpegurl") || type.contains("m3u") {
+            return true
+        }
+        let path = url.path.lowercased()
+        return path.hasSuffix(".m3u8") || path.hasSuffix(".m3u")
+    }
+
+    // MARK: - Upstream
+
+    private struct Fetched {
+        let status: Int
+        let body: Data
+        let contentType: String?
+        let contentRange: String?
+    }
+
+    /// The answers that mean "you are asking too often", which arm the pacer for this origin.
+    private static let refusalStatuses: Set<Int> = [429, 503, 509]
+
+    /// How long a relayed request waits for a slot against a metered origin. Short on purpose:
+    /// `acquire` is fail-open and hands back an un-granted ticket rather than blocking forever,
+    /// and AVPlayer abandons a segment whose first byte has not arrived in about 3.5 seconds
+    /// (-12889), so waiting a pacer out past that trades a paced session for a failed one.
+    private static let slotWaitSeconds: TimeInterval = 2.5
+
+    /// Synchronous because the server answers a request on its own worker thread and the
+    /// response has to be written before it returns.
+    ///
+    /// The request is charged to `OriginRequestBudget` (#377, #465) like every other fetch the
+    /// engine makes. Without that, an origin metering the reader would be paced on one path and
+    /// asked freely on this one, and a 429 answered to the player would never arm the pacer that
+    /// the reader and the subtitle prefetcher already read.
+    private func fetch(origin: URL, headers: [String: String], range: String?) -> Fetched? {
+        var request = URLRequest(url: origin)
+        for (key, value) in headers { request.setValue(value, forHTTPHeaderField: key) }
+        // Forwarded verbatim rather than parsed and rebuilt: the remote HLS path leans on byte
+        // ranges, and normalising or coalescing one here would quietly undo the sizing the
+        // caller asked for. What comes back is relayed with the same framing.
+        if let range { request.setValue(range, forHTTPHeaderField: "Range") }
+
+        let ticket = OriginRequestBudget.shared.acquire(
+            for: origin, label: "relay", timeout: Self.slotWaitSeconds)
+        defer { OriginRequestBudget.shared.release(ticket) }
+
+        var out: Fetched?
+        let done = DispatchSemaphore(value: 0)
+        session.dataTask(with: request) { data, response, error in
+            defer { done.signal() }
+            if let error {
+                EngineLog.emit(
+                    "[HLSOriginRelay] upstream failed for \(origin.host ?? "origin"): "
+                        + "\(error.localizedDescription)", category: .hlsServer)
+                return
+            }
+            guard let http = response as? HTTPURLResponse else { return }
+            // #388: a portal that redirects to the host serving the bytes is one origin as far
+            // as requests are concerned, so the chain is folded rather than book-kept per hop.
+            if let finalURL = http.url, finalURL != origin {
+                OriginRequestBudget.shared.noteRedirect(from: origin, to: finalURL)
+            }
+            if Self.refusalStatuses.contains(http.statusCode) {
+                OriginRequestBudget.shared.noteRefusal(
+                    for: http.url ?? origin, status: http.statusCode,
+                    retryAfter: http.value(forHTTPHeaderField: "Retry-After").flatMap(TimeInterval.init))
+            }
+            out = Fetched(
+                status: http.statusCode, body: data ?? Data(),
+                contentType: http.value(forHTTPHeaderField: "Content-Type"),
+                contentRange: http.value(forHTTPHeaderField: "Content-Range"))
+        }.resume()
+        done.wait()
+        return out
+    }
+
+    // MARK: - Playlist rewriting
+
+    /// Sends every URI in the playlist back through the server. A relative URI is resolved
+    /// against the playlist it came from first, so what the player sees is always absolute
+    /// and always local.
+    /// - Parameter absoluteOnly: leaves a relative URI alone instead of resolving it against
+    ///   the origin. Set for the master #316 writes, whose injected subtitle renditions are the
+    ///   local server's own and are named relatively: resolving those would send the player back
+    ///   to the origin for a rendition only this engine has.
+    func rewritePlaylist(
+        _ playlist: String, relativeTo origin: URL, authority: String = "127.0.0.1",
+        port: UInt16, token: String, absoluteOnly: Bool = false
+    ) -> String {
+        var discovered = Set<String>()
+        let rewriteOne: (String) -> String = { raw in
+            if absoluteOnly, URL(string: raw)?.host == nil { return raw }
+            guard let resolved = URL(string: raw, relativeTo: origin)?.absoluteURL,
+                let local = Self.localURL(
+                    for: resolved, host: authority, port: port, token: token)
+            else { return raw }
+            if let key = Self.originKey(for: resolved) { discovered.insert(key) }
+            return local.absoluteString
+        }
+
+        var output: [String] = []
+        // Split on \n and drop a trailing \r rather than splitting on any newline, which
+        // would read a CRLF playlist as having a blank line between every real one. The
+        // output is \n throughout, which AVPlayer reads the same as what came in.
+        for rawLine in playlist.components(separatedBy: "\n") {
+            let line = rawLine.hasSuffix("\r") ? String(rawLine.dropLast()) : rawLine
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.isEmpty {
+                output.append(line)
+            } else if trimmed.hasPrefix("#") {
+                output.append(Self.rewriteURIAttribute(in: line, using: rewriteOne))
+            } else {
+                output.append(rewriteOne(trimmed))
+            }
+        }
+
+        if !discovered.isEmpty {
+            stateLock.lock()
+            allowedOrigins.formUnion(discovered)
+            stateLock.unlock()
+        }
+        return output.joined(separator: "\n")
+    }
+
+    /// Rewrites the `URI="..."` value a tag carries, which is how keys, maps, renditions and
+    /// i-frame variants name what they need. Tags without one come back untouched.
+    private static func rewriteURIAttribute(in line: String, using rewrite: (String) -> String)
+        -> String
+    {
+        guard let attr = line.range(of: "URI=\"") else { return line }
+        let afterQuote = attr.upperBound
+        guard let closing = line[afterQuote...].firstIndex(of: "\"") else { return line }
+        let value = String(line[afterQuote..<closing])
+        guard !value.isEmpty else { return line }
+        return line.replacingCharacters(in: afterQuote..<closing, with: rewrite(value))
+    }
+}

--- a/Tests/AetherEngineTests/EngineTLSHandshakeTests.swift
+++ b/Tests/AetherEngineTests/EngineTLSHandshakeTests.swift
@@ -1,0 +1,293 @@
+// Live-handshake proof for `EngineTLS.serverTrustEvaluator`. The resolver
+// unit tests cannot show the load-bearing part: that URLSession actually
+// delivers the server-trust challenge to the reader's per-task delegates.
+// NWListener rejects an imported in-memory identity with EINVAL, so the
+// self-signed origin runs as a Python subprocess, which limits this suite to
+// macOS, the platform `swift test` runs on anyway.
+#if os(macOS)
+
+    import Foundation
+    import Testing
+
+    @testable import AetherEngine
+
+    /// Everything that sets `EngineTLS.serverTrustEvaluator` lives in this one
+    /// suite. The evaluator is process global and suites otherwise run in
+    /// parallel, so a second suite setting it would decide what this one is
+    /// testing.
+    @Suite("EngineTLS live handshake against a self-signed origin", .serialized)
+    struct EngineTLSHandshakeTests {
+
+        /// Lives here rather than beside the resolver tests because reading the
+        /// evaluator is as much a claim on the process global as writing it,
+        /// and a suite that only reads still races the ones that write.
+        @Test("No evaluator is set by default")
+        func defaultsToNoEvaluator() {
+            #expect(EngineTLS.serverTrustEvaluator == nil)
+        }
+
+        @Test("No evaluator: the handshake is refused and no request reaches the origin")
+        func refusedByDefault() async throws {
+            let server = try #require(SelfSignedTLSOrigin())
+            defer { server.stop() }
+
+            let previous = EngineTLS.serverTrustEvaluator
+            defer { EngineTLS.serverTrustEvaluator = previous }
+            EngineTLS.serverTrustEvaluator = nil
+
+            let reader = AVIOReader(
+                url: URL(string: "https://127.0.0.1:\(server.port)/movie.bin")!,
+                chunkRequestTimeout: 5, chunkMaxRetries: 1)
+            defer { reader.markClosed(); reader.close() }
+            let refusal = Self.openFailure(of: reader)
+
+            try await Task.sleep(for: .seconds(1))
+            #expect(server.requestsServed == 0,
+                    "a request crossed a handshake that system trust should have refused")
+            #expect(Self.isTrustRefusal(refusal),
+                    "open failed as \(String(describing: refusal)), not a trust refusal")
+        }
+
+        @Test("Accepted for this origin: the same server serves the reader")
+        func acceptedWhenOptedIn() async throws {
+            let server = try #require(SelfSignedTLSOrigin())
+            defer { server.stop() }
+
+            let previous = EngineTLS.serverTrustEvaluator
+            defer { EngineTLS.serverTrustEvaluator = previous }
+            EngineTLS.serverTrustEvaluator = { _ in true }
+
+            let reader = AVIOReader(
+                url: URL(string: "https://127.0.0.1:\(server.port)/movie.bin")!,
+                chunkRequestTimeout: 10, chunkMaxRetries: 2)
+            defer { reader.markClosed(); reader.close() }
+            try reader.open()
+
+            let sliceCap = 64 * 1024
+            let buf = UnsafeMutablePointer<UInt8>.allocate(capacity: sliceCap)
+            defer { buf.deallocate() }
+            var got = 0
+            let deadline = Date().addingTimeInterval(20)
+            while got < sliceCap && Date() < deadline {
+                let n = reader.read(into: buf, size: Int32(sliceCap - got))
+                if n <= 0 { break }
+                got += Int(n)
+            }
+            #expect(got == sliceCap, "delivered \(got) of \(sliceCap) bytes")
+            #expect(buf[0] == 0xA7)
+            #expect(server.requestsServed > 0)
+        }
+
+
+        @Test("An evaluator that answers for another host leaves this one refused")
+        func refusedForAnOriginTheHostDidNotAccept() async throws {
+            let server = try #require(SelfSignedTLSOrigin())
+            defer { server.stop() }
+
+            // The case a process-wide flag cannot express: a host holding a LAN
+            // address behind a private certificate and a WAN address with a real
+            // one, accepting the first without quietly relaxing the second.
+            let previous = EngineTLS.serverTrustEvaluator
+            defer { EngineTLS.serverTrustEvaluator = previous }
+            EngineTLS.serverTrustEvaluator = { $0.host == "media.example" }
+
+            let reader = AVIOReader(
+                url: URL(string: "https://127.0.0.1:\(server.port)/movie.bin")!,
+                chunkRequestTimeout: 5, chunkMaxRetries: 1)
+            defer { reader.markClosed(); reader.close() }
+            let refusal = Self.openFailure(of: reader)
+
+            try await Task.sleep(for: .seconds(1))
+            #expect(server.requestsServed == 0,
+                    "a request crossed a handshake the evaluator did not accept")
+            #expect(Self.isTrustRefusal(refusal),
+                    "open failed as \(String(describing: refusal)), not a trust refusal")
+        }
+
+        /// A refused handshake reaches the host as a typed failure rather than as unreadable media,
+        /// so the refusal arms assert the classification and not only that no byte was served.
+        private static func openFailure(of reader: AVIOReader) -> Error? {
+            do {
+                try reader.open()
+                return nil
+            } catch {
+                return error
+            }
+        }
+
+        private static func isTrustRefusal(_ error: Error?) -> Bool {
+            guard case .transportSecurityFailed = error as? AVIOReaderError else { return false }
+            return true
+        }
+    }
+
+    /// Loopback HTTPS origin with a self-signed certificate for 127.0.0.1,
+    /// serving Range requests from a constant 0xA7 body. Every request that
+    /// makes it past the TLS handshake is appended to a log file, which is
+    /// the refusal observable: a client that distrusts the certificate never
+    /// gets a request line onto the wire.
+    final class SelfSignedTLSOrigin {
+        let port: UInt16
+        private let process: Process
+        private let workDir: URL
+
+        var requestsServed: Int {
+            let log = workDir.appendingPathComponent("requests.log")
+            guard let text = try? String(contentsOf: log, encoding: .utf8) else { return 0 }
+            return text.split(separator: "\n").count
+        }
+
+        init?() {
+            let dir = FileManager.default.temporaryDirectory
+                .appendingPathComponent("aether-tls-origin-\(UUID().uuidString)")
+            guard (try? FileManager.default.createDirectory(
+                at: dir, withIntermediateDirectories: true)) != nil else { return nil }
+            workDir = dir
+            do {
+                try Self.certPEM.write(
+                    to: dir.appendingPathComponent("cert.pem"), atomically: true, encoding: .utf8)
+                try Self.keyPEM.write(
+                    to: dir.appendingPathComponent("key.pem"), atomically: true, encoding: .utf8)
+                try Self.serverPy.write(
+                    to: dir.appendingPathComponent("origin.py"), atomically: true, encoding: .utf8)
+            } catch { return nil }
+
+            let proc = Process()
+            proc.executableURL = URL(fileURLWithPath: "/usr/bin/python3")
+            proc.arguments = [dir.appendingPathComponent("origin.py").path]
+            proc.currentDirectoryURL = dir
+            let stdout = Pipe()
+            proc.standardOutput = stdout
+            proc.standardError = FileHandle.nullDevice
+            do { try proc.run() } catch { return nil }
+            process = proc
+
+            // The server prints "READY <port>" once it is listening.
+            var readyLine = ""
+            var pending = Data()
+            let deadline = Date().addingTimeInterval(10)
+            while Date() < deadline, !readyLine.contains("READY") {
+                let chunk = stdout.fileHandleForReading.availableData
+                if chunk.isEmpty {
+                    Thread.sleep(forTimeInterval: 0.05)
+                    continue
+                }
+                pending.append(chunk)
+                readyLine = String(decoding: pending, as: UTF8.self)
+            }
+            guard let match = readyLine.split(separator: " ").last,
+                let bound = UInt16(match.trimmingCharacters(in: .whitespacesAndNewlines))
+            else {
+                proc.terminate()
+                return nil
+            }
+            port = bound
+        }
+
+        func stop() {
+            process.terminate()
+            try? FileManager.default.removeItem(at: workDir)
+        }
+
+        private static let serverPy = """
+            import http.server, os, re, ssl, sys
+
+            TOTAL = 4 * 1024 * 1024
+            BODY_BYTE = b"\\xa7"
+
+            class Handler(http.server.BaseHTTPRequestHandler):
+                protocol_version = "HTTP/1.1"
+
+                def log_message(self, *args):
+                    pass
+
+                def do_GET(self):
+                    with open("requests.log", "a") as f:
+                        f.write(self.path + "\\n")
+                    start, end = 0, TOTAL - 1
+                    m = re.match(r"bytes=(\\d*)-(\\d*)", self.headers.get("Range", ""))
+                    ranged = bool(m)
+                    if m:
+                        if m.group(1):
+                            start = min(int(m.group(1)), TOTAL - 1)
+                        if m.group(2):
+                            end = min(int(m.group(2)), TOTAL - 1)
+                    length = max(0, end - start + 1)
+                    self.send_response(206 if ranged else 200)
+                    if ranged:
+                        self.send_header("Content-Range", f"bytes {start}-{end}/{TOTAL}")
+                    self.send_header("Content-Length", str(length))
+                    self.send_header("Accept-Ranges", "bytes")
+                    self.end_headers()
+                    remaining = length
+                    while remaining > 0:
+                        chunk = min(remaining, 65536)
+                        try:
+                            self.wfile.write(BODY_BYTE * chunk)
+                        except OSError:
+                            return
+                        remaining -= chunk
+
+            server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+            ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+            ctx.load_cert_chain("cert.pem", "key.pem")
+            server.socket = ctx.wrap_socket(server.socket, server_side=True)
+            print("READY", server.server_address[1], flush=True)
+            server.serve_forever()
+            """
+
+        static let certPEM = """
+            -----BEGIN CERTIFICATE-----
+            MIIDGjCCAgKgAwIBAgIUPCvl3+omqHtbGt28tTO8nBwZNtwwDQYJKoZIhvcNAQEL
+            BQAwFDESMBAGA1UEAwwJMTI3LjAuMC4xMB4XDTI2MDgwMjA1MjIyOFoXDTM2MDcz
+            MDA1MjIyOFowFDESMBAGA1UEAwwJMTI3LjAuMC4xMIIBIjANBgkqhkiG9w0BAQEF
+            AAOCAQ8AMIIBCgKCAQEA1dnlqErHwZiOfKnONSyxp+WGfORM8RzCp5dFgm8xJpGi
+            R6I/Ly2Tezt2scNP9lBq8AEETtocm9dYObrSp6zHfZi4dUb6ixRc5DkYE8k37WEi
+            1/AVAQI7VPpasuuUOrmfeMd3dZOozu+6JprgpJyPzdGuw84dSREsbb1gGaOU/wWt
+            R4X0U2IHttV0uVLoj7MzZt1PsMqsimOuuau46TtH/9nwd7NjHykW0+dj8uJKe5Pw
+            y20WhT2jf0Ls3leE2fuJfGb1gKaJYY/7vT46F7iJMq7VlstNeKK40OU5MtKKBRbZ
+            96A1AZRXwHwhSysJeAo8UZW61wN20MWhrupEx0eAqwIDAQABo2QwYjAdBgNVHQ4E
+            FgQUhzShz4pSJL1oBklsC6pzezgk4HUwHwYDVR0jBBgwFoAUhzShz4pSJL1oBkls
+            C6pzezgk4HUwDwYDVR0TAQH/BAUwAwEB/zAPBgNVHREECDAGhwR/AAABMA0GCSqG
+            SIb3DQEBCwUAA4IBAQCzSx/tNHjYcwWlK0LMBFSVvn6ss3as8rX1U/CUve/AdDCG
+            vhC+uew++YqDX2zeibDqN17kqtyY35lvIsWeNMw8QnF+QBofWWLd6YxyE+hnEti5
+            Rx3cVpUnJ0MKSprRLRpzSYnSOo6Q42AMl4/ki1VDddIxQixAQzzcHQLZimJsw/kZ
+            Efhd1lTbD+ZghMuXpq+JLiylEd3LSW5UvTox1FOe03AVEQAMeWPcZwoEBtm3Qsbn
+            ahzZULJX/KFQHDfLD337xzfgNYR2w77rx6yaCUzrHZXha8qpevV3tMc1s/pi2KJ5
+            wAWlaPiab3bnQj5zmw4VdYBFptCfRRcLTZuCKTwu
+            -----END CERTIFICATE-----
+            """
+
+        static let keyPEM = """
+            -----BEGIN PRIVATE KEY-----
+            MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDV2eWoSsfBmI58
+            qc41LLGn5YZ85EzxHMKnl0WCbzEmkaJHoj8vLZN7O3axw0/2UGrwAQRO2hyb11g5
+            utKnrMd9mLh1RvqLFFzkORgTyTftYSLX8BUBAjtU+lqy65Q6uZ94x3d1k6jO77om
+            muCknI/N0a7Dzh1JESxtvWAZo5T/Ba1HhfRTYge21XS5UuiPszNm3U+wyqyKY665
+            q7jpO0f/2fB3s2MfKRbT52Py4kp7k/DLbRaFPaN/QuzeV4TZ+4l8ZvWApolhj/u9
+            PjoXuIkyrtWWy014orjQ5Tky0ooFFtn3oDUBlFfAfCFLKwl4CjxRlbrXA3bQxaGu
+            6kTHR4CrAgMBAAECggEAFrD6R3M34vj3FY9HDClj6HbYYGQxLdxpYzMP8xktU/Rc
+            DdHPdogVgBv9KjuZPn+l+TWCaYOHSZn+CJIkTBpvSIpt+DPB3gQZHzZXsbHGN2/5
+            LISTFfpQpWGzQgzxO5H6s+wmZtl2Lg8N547Di3P5ZlN7gddbECe8WSChE9dhtfWI
+            kjf+zh4dlTeU8RB+NT9puqASWuvePx+D2N1ySUFM+eVKV4T4M2UtYBG/fT33cbaP
+            qY6J2kGnQvETzqMHfE+9vb0jWJpVs+Zkii4p0OB3iS66ZDPdbW+pdVmWHVvvq+IH
+            ZQL2yWBvE7y9m5qRuC8kX8tabcbPjEi8NEVC6xuhgQKBgQDxCOilXiPRtl7S4+d8
+            iYwLVyctr/2sVtTXLvTwXJj3Xr2dUJWggrhxBqI2PvAFHhWAnils3xuAf0+Orly1
+            oGfr35fQb3IH6FKnSj/uoYiXMsjsDgOypNmg5KyWM4kqDW27HJq/PioC6MJzAeO/
+            WjOE0cWVjKW1qyIkgz+T6jsBiwKBgQDjIOwNIa38vqwBc3F8c8wLWHZDLBXGS1kh
+            5AyW+QcZ9EyKozPbxyqZrmEZa0v/IxuUniBq0O27dXJF09eJrAVd8dDMW0kJTmKk
+            ddbB44MzsADgE2jJiEcu22VZCoy0kjbODHw6L9KR8k+utx97fgl/p+BC/nwv6jYi
+            pXcI6EshYQKBgAeM9OTBRzP5l4zZsNW45VcxmruWqMauTaqUAP5KmEwffqcf8CAA
+            GFEKGSjD3fb7E0ddLQUJFC55Tn+0vJi/9qFv9qyD4TmYMIanD8uk6cd6wsqKQdll
+            yp98ql9mK+TSWN6krcBR7TT8H6NEquLCq5x8icj+h+5h9wbXybUTgFezAoGBAOKQ
+            TqdytzntgWsZG1WHtTyEC8RJz5a0Rr812xEmbF0Jguiwj+RmMiqG9jkC/RYOkU6Y
+            xcGHk/1w1IKvJMwiGmBx/VQ8owhzdpaTLZzPNGt04Aqlkdum40rsc5Z0nZLqX1z+
+            u1TXq3cGfVHNPcxUF2mNrnllnb+2JDY/VBRAk+FBAoGAI+Nb/JgYjihUqiqKcK0t
+            76scm4eNsR6wl1WWsZUMZlVVfQr8BqjIxz5yB8qTqdEMgMe0M/RdDgsqm8UIc9q6
+            GCRPZZR6CB0MobtvS9eczqo4Ov6pEnIk2I6T2oNuXbqscNJgWSHFGoK3Bl1aPJsa
+            TqL2wDYvLDkN1MEol+GDgSM=
+            -----END PRIVATE KEY-----
+            """
+    }
+
+#endif

--- a/Tests/AetherEngineTests/EngineTLSHandshakeTests.swift
+++ b/Tests/AetherEngineTests/EngineTLSHandshakeTests.swift
@@ -104,6 +104,101 @@
                     "open failed as \(String(describing: refusal)), not a trust refusal")
         }
 
+        @Test("Through the relay: a client that never sees the certificate gets the stream")
+        func relayServesThroughUntrustedOrigin() async throws {
+            let origin = try #require(SelfSignedHLSOrigin())
+            defer { origin.stop() }
+
+            let previous = EngineTLS.serverTrustEvaluator
+            defer { EngineTLS.serverTrustEvaluator = previous }
+            EngineTLS.serverTrustEvaluator = { _ in true }
+
+            let server = try Self.relayServer()
+            defer { server.stop(); server.relay?.stop() }
+
+            let master = URL(string: "https://127.0.0.1:\(origin.port)/master.m3u8")!
+            let entry = try #require(server.relayURL(for: master))
+
+            let playlist = try await Self.text(of: entry)
+            #expect(playlist.contains("#EXT-X-STREAM-INF"))
+            let variant = try #require(
+                playlist.components(separatedBy: "\n").first { $0.hasPrefix("http://127.0.0.1:") })
+
+            let media = try await Self.text(of: try #require(URL(string: variant)))
+            #expect(media.contains("#EXTINF"))
+            let segmentLine = try #require(
+                media.components(separatedBy: "\n").first {
+                    $0.hasPrefix("http://127.0.0.1:") && !$0.contains("m3u8")
+                })
+
+            let (bytes, response) = try await URLSession.shared.data(
+                from: try #require(URL(string: segmentLine)))
+            #expect((response as? HTTPURLResponse)?.statusCode == 200)
+            #expect(bytes.count == 4096, "served \(bytes.count) segment bytes")
+            #expect(bytes.first == 0x47, "not an MPEG-TS sync byte")
+        }
+
+        @Test("Through the relay: no evaluator refuses to launder an untrusted origin")
+        func relayRefusesWhenNotOptedIn() async throws {
+            let origin = try #require(SelfSignedHLSOrigin())
+            defer { origin.stop() }
+
+            let previous = EngineTLS.serverTrustEvaluator
+            defer { EngineTLS.serverTrustEvaluator = previous }
+            EngineTLS.serverTrustEvaluator = nil
+
+            let server = try Self.relayServer()
+            defer { server.stop(); server.relay?.stop() }
+
+            let master = URL(string: "https://127.0.0.1:\(origin.port)/master.m3u8")!
+            let entry = try #require(server.relayURL(for: master))
+
+            var request = URLRequest(url: entry)
+            request.timeoutInterval = 15
+            let (_, response) = try await URLSession.shared.data(for: request)
+            #expect((response as? HTTPURLResponse)?.statusCode == 502,
+                    "the upstream handshake should have failed system trust")
+        }
+
+        @Test("Through the relay: an origin the evaluator declines is not laundered either")
+        func relayRefusesAnOriginTheEvaluatorDeclines() async throws {
+            let origin = try #require(SelfSignedHLSOrigin())
+            defer { origin.stop() }
+
+            // The relay is mounted for every https origin once an evaluator
+            // exists, so the per-origin answer has to hold at the handshake it
+            // makes on the player's behalf.
+            let previous = EngineTLS.serverTrustEvaluator
+            defer { EngineTLS.serverTrustEvaluator = previous }
+            EngineTLS.serverTrustEvaluator = { $0.host == "media.example" }
+
+            let server = try Self.relayServer()
+            defer { server.stop(); server.relay?.stop() }
+
+            let master = URL(string: "https://127.0.0.1:\(origin.port)/master.m3u8")!
+            let entry = try #require(server.relayURL(for: master))
+
+            var request = URLRequest(url: entry)
+            request.timeoutInterval = 15
+            let (_, response) = try await URLSession.shared.data(for: request)
+            #expect((response as? HTTPURLResponse)?.statusCode == 502,
+                    "an origin the evaluator declined was served anyway")
+        }
+
+        private static func relayServer() throws -> HLSLocalServer {
+            let server = HLSLocalServer(relay: HLSOriginRelay())
+            try server.start()
+            return server
+        }
+
+        private static func text(of url: URL) async throws -> String {
+            var request = URLRequest(url: url)
+            request.timeoutInterval = 15
+            let (data, response) = try await URLSession.shared.data(for: request)
+            #expect((response as? HTTPURLResponse)?.statusCode == 200)
+            return String(decoding: data, as: UTF8.self)
+        }
+
         /// A refused handshake reaches the host as a typed failure rather than as unreadable media,
         /// so the refusal arms assert the classification and not only that no byte was served.
         private static func openFailure(of reader: AVIOReader) -> Error? {

--- a/Tests/AetherEngineTests/EngineTLSTests.swift
+++ b/Tests/AetherEngineTests/EngineTLSTests.swift
@@ -1,0 +1,101 @@
+import Foundation
+import Testing
+
+@testable import AetherEngine
+
+// Self-signed and private-CA media servers fail URLSession's system trust,
+// which the FFmpeg stack never enforced, so hosts need an explicit opt-in.
+// The resolver must stay on default handling for everything except a
+// server-trust challenge the host answered for.
+@Suite("EngineTLS trust resolution", .serialized)
+struct EngineTLSTests {
+
+    private final class RecordingSender: NSObject, URLAuthenticationChallengeSender {
+        func use(_ credential: URLCredential, for challenge: URLAuthenticationChallenge) {}
+        func continueWithoutCredential(for challenge: URLAuthenticationChallenge) {}
+        func cancel(_ challenge: URLAuthenticationChallenge) {}
+    }
+
+    private func challenge(
+        method: String, host: String = "server.example"
+    ) -> URLAuthenticationChallenge {
+        let space = URLProtectionSpace(
+            host: host, port: 443, protocol: "https",
+            realm: nil, authenticationMethod: method)
+        return URLAuthenticationChallenge(
+            protectionSpace: space, proposedCredential: nil, previousFailureCount: 0,
+            failureResponse: nil, error: nil, sender: RecordingSender())
+    }
+
+    private func disposition(
+        evaluator: (@Sendable (URLProtectionSpace) -> Bool)?,
+        method: String,
+        host: String = "server.example"
+    ) -> URLSession.AuthChallengeDisposition {
+        let previous = EngineTLS.serverTrustEvaluator
+        defer { EngineTLS.serverTrustEvaluator = previous }
+        EngineTLS.serverTrustEvaluator = evaluator
+
+        var got: URLSession.AuthChallengeDisposition?
+        EngineTLS.resolve(challenge(method: method, host: host)) { disposition, _ in
+            got = disposition
+        }
+        return got ?? .performDefaultHandling
+    }
+
+    @Test("No evaluator keeps default handling for server trust")
+    func noEvaluatorServerTrust() {
+        #expect(
+            disposition(evaluator: nil, method: NSURLAuthenticationMethodServerTrust)
+                == .performDefaultHandling)
+    }
+
+    @Test("Non-trust challenges never reach the evaluator")
+    func httpAuthUntouched() {
+        let asked = Mutex(false)
+        let got = disposition(
+            evaluator: { _ in asked.set(true); return true },
+            method: NSURLAuthenticationMethodHTTPBasic)
+
+        #expect(got == .performDefaultHandling)
+        #expect(asked.get() == false, "HTTP auth is not a trust decision the host was asked for")
+    }
+
+    @Test("The evaluator is asked about the origin the challenge came from")
+    func evaluatorSeesTheOrigin() {
+        let seen = Mutex<String?>(nil)
+        _ = disposition(
+            evaluator: { space in seen.set(space.host); return false },
+            method: NSURLAuthenticationMethodServerTrust,
+            host: "lan.media.example")
+
+        #expect(seen.get() == "lan.media.example")
+    }
+
+    @Test("An evaluator that declines keeps default handling")
+    func decliningEvaluator() {
+        #expect(
+            disposition(evaluator: { _ in false }, method: NSURLAuthenticationMethodServerTrust)
+                == .performDefaultHandling)
+    }
+
+    @Test("An accepted challenge with no evaluable trust object stays on default handling")
+    func acceptedWithoutTrustObject() {
+        // A challenge built outside a live handshake carries no SecTrust, so
+        // the resolver must fall through rather than send a nil credential.
+        #expect(
+            disposition(evaluator: { _ in true }, method: NSURLAuthenticationMethodServerTrust)
+                == .performDefaultHandling)
+    }
+
+    /// The evaluator is `@Sendable` and runs on whichever queue raised the
+    /// challenge, so a test recording what it saw cannot capture a plain var.
+    private final class Mutex<Value>: @unchecked Sendable {
+        private let lock = NSLock()
+        private var value: Value
+
+        init(_ value: Value) { self.value = value }
+        func get() -> Value { lock.lock(); defer { lock.unlock() }; return value }
+        func set(_ newValue: Value) { lock.lock(); value = newValue; lock.unlock() }
+    }
+}

--- a/Tests/AetherEngineTests/HLSOriginRelayTests.swift
+++ b/Tests/AetherEngineTests/HLSOriginRelayTests.swift
@@ -1,0 +1,410 @@
+// Addressing and rewriting, none of which asks the trust evaluator. The live
+// proof that a client which never sees the certificate still gets the stream
+// lives with the other tests that set an evaluator, in EngineTLSHandshakeTests.
+import Foundation
+import Testing
+
+@testable import AetherEngine
+
+@Suite("HLS origin relay addressing and rewriting")
+struct HLSOriginRelayAddressingTests {
+
+    private let token = String(repeating: "ab", count: 16)
+
+    @Test("An origin survives the round trip through a relay URL")
+    func roundTrip() throws {
+        let origin = URL(
+            string: "https://media.example.com:8920/videos/1/master.m3u8"
+                + "?ApiKey=abc123&PlaySessionId=x%20y&tag=a+b")!
+        let local = try #require(HLSOriginRelay.localURL(for: origin, port: 51234, token: token))
+
+        #expect(local.host == "127.0.0.1")
+        #expect(local.port == 51234)
+        #expect(local.path == "/\(token)\(HLSOriginRelay.route)")
+        let recovered = try #require(HLSOriginRelay.originURL(fromQuery: local.query ?? ""))
+        #expect(recovered == origin, "recovered \(recovered) from \(origin)")
+    }
+
+    @Test("A query that names no origin yields none")
+    func rejectsForeignQuery() {
+        #expect(HLSOriginRelay.originURL(fromQuery: "") == nil)
+        #expect(HLSOriginRelay.originURL(fromQuery: "other=https%3A%2F%2Fa.b") == nil)
+    }
+
+    @Test("The origin key keeps scheme, host and port apart")
+    func originKeys() {
+        #expect(HLSOriginRelay.originKey(for: URL(string: "https://A.example.com/x")!) == "https://a.example.com")
+        #expect(HLSOriginRelay.originKey(for: URL(string: "https://a.example.com:8920/x")!) == "https://a.example.com:8920")
+        #expect(HLSOriginRelay.originKey(for: URL(string: "http://a.example.com/x")!) == "http://a.example.com")
+        #expect(HLSOriginRelay.originKey(for: URL(string: "file:///tmp/x")!) == nil)
+    }
+
+    @Test("Sub-resources follow the address the request arrived on")
+    func rewriteFollowsTheRequestAuthority() {
+        // The AirPlay shape (#86): a receiver reaches the LAN address, and every
+        // URI it is handed next has to stay there rather than sending it to a
+        // loopback it resolves to itself.
+        #expect(HLSOriginRelay.rewriteAuthority(host: "192.168.1.40:51234") == "192.168.1.40")
+        #expect(HLSOriginRelay.rewriteAuthority(host: "127.0.0.1:51234") == "127.0.0.1")
+        #expect(HLSOriginRelay.rewriteAuthority(host: "[fe80::1]:51234") == "[fe80::1]")
+        #expect(HLSOriginRelay.rewriteAuthority(host: nil) == "127.0.0.1")
+        #expect(HLSOriginRelay.rewriteAuthority(host: "") == "127.0.0.1")
+    }
+
+    @Test("Every URI in a media playlist comes back pointing at the relay")
+    func rewritesMediaPlaylist() throws {
+        let relay = HLSOriginRelay()
+        let origin = URL(string: "https://media.example.com/hls/media.m3u8?ApiKey=k")!
+        relay.admit(origin)
+
+        let playlist = """
+            #EXTM3U
+            #EXT-X-TARGETDURATION:6
+            #EXT-X-MAP:URI="init.mp4"
+            #EXT-X-KEY:METHOD=AES-128,URI="https://keys.example.com/k1",IV=0x00
+            #EXTINF:6.0,
+            seg0.ts
+            #EXTINF:6.0,
+            https://cdn.example.com/seg1.ts
+            #EXT-X-ENDLIST
+            """
+
+        let rewritten = relay.rewritePlaylist(
+            playlist, relativeTo: origin, authority: "192.168.1.40", port: 51234, token: token)
+        let lines = rewritten.components(separatedBy: "\n")
+
+        #expect(lines.first == "#EXTM3U")
+        #expect(rewritten.contains("#EXT-X-TARGETDURATION:6"))
+        #expect(rewritten.contains("#EXT-X-ENDLIST"))
+        // Nothing that names a resource may still point outside.
+        #expect(!rewritten.contains("\"init.mp4\""))
+        #expect(!rewritten.contains("URI=\"https://keys.example.com/k1\""))
+        for line in lines where !line.hasPrefix("#") && !line.isEmpty {
+            #expect(line.hasPrefix("http://192.168.1.40:"), "segment line escaped the relay: \(line)")
+        }
+        for line in lines where line.contains("URI=\"") {
+            #expect(line.contains("URI=\"http://192.168.1.40:"), "tag escaped the relay: \(line)")
+        }
+
+        // A relative segment resolves against the playlist it came from.
+        let segLine = try #require(lines.first { !$0.hasPrefix("#") && !$0.isEmpty })
+        let query = try #require(URL(string: segLine)?.query)
+        let recovered = try #require(HLSOriginRelay.originURL(fromQuery: query))
+        #expect(recovered.absoluteString == "https://media.example.com/hls/seg0.ts")
+    }
+
+    @Test("An injected rendition stays with the server that owns it")
+    func absoluteOnlyLeavesTheServersOwnRenditions() {
+        // The #316 master carries the origin's variants as absolute URIs and the
+        // engine's own subtitle renditions as relative ones. Rewriting the second
+        // kind would send the player to the origin for a rendition only the
+        // engine has.
+        let relay = HLSOriginRelay()
+        let origin = URL(string: "https://media.example.com/hls/master.m3u8")!
+        relay.admit(origin)
+
+        let master = """
+            #EXTM3U
+            #EXT-X-MEDIA:TYPE=SUBTITLES,GROUP-ID="subs",NAME="English",URI="subs_0.m3u8"
+            #EXT-X-STREAM-INF:BANDWIDTH=5000000,SUBTITLES="subs"
+            https://media.example.com/hls/v0/index.m3u8
+            """
+
+        let rewritten = relay.rewritePlaylist(
+            master, relativeTo: origin, port: 51234, token: token, absoluteOnly: true)
+
+        #expect(rewritten.contains("URI=\"subs_0.m3u8\""), "the engine's own rendition moved")
+        #expect(!rewritten.contains("https://media.example.com/hls/v0/index.m3u8"),
+                "the origin's variant stayed at the origin")
+        #expect(rewritten.contains("http://127.0.0.1:51234/\(token)\(HLSOriginRelay.route)"))
+    }
+
+    @Test("A host discovered in a playlist becomes fetchable, one that was never named does not")
+    func allowListFollowsThePlaylist() async throws {
+        let relay = HLSOriginRelay()
+        let server = HLSLocalServer(relay: relay)
+        try server.start()
+        defer { server.stop(); relay.stop() }
+        // Closed ports on 127.0.0.1, which refuse at once rather than leaving the
+        // fetch to time out. Nothing here waits on a name resolving, and the three
+        // differ only by port, which the allow list treats as part of the origin.
+        let origin = URL(string: "https://127.0.0.1:9/hls/media.m3u8")!
+        relay.admit(origin)
+
+        _ = relay.rewritePlaylist(
+            "#EXTM3U\n#EXTINF:6.0,\nhttps://127.0.0.1:10/seg1.ts\n", relativeTo: origin,
+            port: server.port, token: server.pathToken)
+
+        let named = try #require(server.relayURL(for: URL(string: "https://127.0.0.1:10/seg1.ts")!))
+        let stranger = try #require(HLSOriginRelay.localURL(
+            for: URL(string: "https://127.0.0.1:11/x.ts")!, port: server.port,
+            token: server.pathToken))
+
+        #expect(try await status(of: named) == 502, "the playlist named this host")
+        #expect(try await status(of: stranger) == 403, "nothing ever named this host")
+    }
+
+    @Test("A request without this session's token never reaches the relay")
+    func rejectsForeignToken() async throws {
+        let relay = HLSOriginRelay()
+        let server = HLSLocalServer(relay: relay)
+        try server.start()
+        defer { server.stop(); relay.stop() }
+        let origin = URL(string: "https://127.0.0.1:9/hls/media.m3u8")!
+        relay.admit(origin)
+
+        let stranger = try #require(HLSOriginRelay.localURL(
+            for: origin, port: server.port, token: String(repeating: "cd", count: 16)))
+        #expect(try await status(of: stranger) == 404, "a stale or scanned token was answered")
+    }
+
+    @Test("A range is forwarded verbatim and its framing comes back")
+    func rangesPassThroughUntouched() async throws {
+        let upstream = try #require(RangeEchoOrigin())
+        defer { upstream.stop() }
+        let relay = HLSOriginRelay()
+        let server = HLSLocalServer(relay: relay)
+        try server.start()
+        defer { server.stop(); relay.stop() }
+
+        let origin = URL(string: "http://127.0.0.1:\(upstream.port)/movie.ts")!
+        let entry = try #require(server.relayURL(for: origin))
+
+        var request = URLRequest(url: entry)
+        request.timeoutInterval = 15
+        request.setValue("bytes=100-199", forHTTPHeaderField: "Range")
+        let (body, response) = try await URLSession.shared.data(for: request)
+        let http = try #require(response as? HTTPURLResponse)
+
+        #expect(http.statusCode == 206, "a partial answer was not relayed as one")
+        #expect(body.count == 100, "relayed \(body.count) bytes for a 100 byte range")
+        #expect(http.value(forHTTPHeaderField: "Content-Range") == "bytes 100-199/4096")
+        #expect(upstream.lastRange == "bytes=100-199", "the origin saw \(upstream.lastRange ?? "no range")")
+    }
+
+    @Test("A metered origin arms the pacer the reader already reads")
+    func refusalArmsTheSharedPacer() async throws {
+        OriginRequestBudget.shared.resetForTesting()
+        defer { OriginRequestBudget.shared.resetForTesting() }
+
+        let upstream = try #require(RangeEchoOrigin(status: 429))
+        defer { upstream.stop() }
+        let relay = HLSOriginRelay()
+        let server = HLSLocalServer(relay: relay)
+        try server.start()
+        defer { server.stop(); relay.stop() }
+
+        let origin = URL(string: "http://127.0.0.1:\(upstream.port)/movie.ts")!
+        let entry = try #require(server.relayURL(for: origin))
+        _ = try await URLSession.shared.data(for: URLRequest(url: entry))
+
+        // The budget is process-wide and per origin, so a refusal seen here has to be the same
+        // refusal the reader and the subtitle prefetcher would have been paced by.
+        #expect(OriginRequestBudget.shared.isPaced(origin),
+                "a 429 through the relay left the origin unpaced")
+    }
+
+    private func status(of url: URL) async throws -> Int {
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 15
+        let (_, response) = try await URLSession.shared.data(for: request)
+        return (response as? HTTPURLResponse)?.statusCode ?? 0
+    }
+}
+
+#if os(macOS)
+
+    /// Writes `files` and `script` into a scratch directory, runs the script with the system
+    /// Python, and waits for its "READY <port>" line. The two origins below differ only in what
+    /// they serve, so the launch is written once.
+    enum PythonOrigin {
+        static func launch(prefix: String, script: String, files: [String: String] = [:])
+            -> (process: Process, port: UInt16, workDir: URL)?
+        {
+            let dir = FileManager.default.temporaryDirectory
+                .appendingPathComponent("\(prefix)-\(UUID().uuidString)")
+            guard (try? FileManager.default.createDirectory(
+                at: dir, withIntermediateDirectories: true)) != nil else { return nil }
+            do {
+                for (name, body) in files {
+                    try body.write(to: dir.appendingPathComponent(name), atomically: true, encoding: .utf8)
+                }
+                try script.write(
+                    to: dir.appendingPathComponent("origin.py"), atomically: true, encoding: .utf8)
+            } catch { return nil }
+
+            let proc = Process()
+            proc.executableURL = URL(fileURLWithPath: "/usr/bin/python3")
+            proc.arguments = [dir.appendingPathComponent("origin.py").path]
+            proc.currentDirectoryURL = dir
+            let stdout = Pipe()
+            proc.standardOutput = stdout
+            proc.standardError = FileHandle.nullDevice
+            do { try proc.run() } catch { return nil }
+
+            var readyLine = ""
+            var pending = Data()
+            let deadline = Date().addingTimeInterval(10)
+            while Date() < deadline, !readyLine.contains("READY") {
+                let chunk = stdout.fileHandleForReading.availableData
+                if chunk.isEmpty {
+                    Thread.sleep(forTimeInterval: 0.05)
+                    continue
+                }
+                pending.append(chunk)
+                readyLine = String(decoding: pending, as: UTF8.self)
+            }
+            guard let match = readyLine.split(separator: " ").last,
+                let bound = UInt16(match.trimmingCharacters(in: .whitespacesAndNewlines))
+            else {
+                proc.terminate()
+                return nil
+            }
+            return (proc, bound, dir)
+        }
+    }
+
+    /// Loopback HTTP origin that answers Range requests exactly as asked and records the last
+    /// one it saw, which is what makes "forwarded verbatim" observable rather than asserted.
+    final class RangeEchoOrigin {
+        let port: UInt16
+        private let process: Process
+        private let workDir: URL
+
+        var lastRange: String? {
+            let log = workDir.appendingPathComponent("range.log")
+            guard let text = try? String(contentsOf: log, encoding: .utf8) else { return nil }
+            return text.split(separator: "\n").last.map(String.init)
+        }
+
+        init?(status: Int = 206) {
+            guard let launched = PythonOrigin.launch(
+                prefix: "aether-range-origin", script: Self.serverPy(status: status))
+            else { return nil }
+            process = launched.process
+            port = launched.port
+            workDir = launched.workDir
+        }
+
+        func stop() {
+            process.terminate()
+            try? FileManager.default.removeItem(at: workDir)
+        }
+
+        private static func serverPy(status: Int) -> String {
+            """
+            import http.server, re
+
+            TOTAL = 4096
+            REFUSE = \(status) if \(status) >= 400 else 0
+
+            class Handler(http.server.BaseHTTPRequestHandler):
+                protocol_version = "HTTP/1.1"
+
+                def log_message(self, *args):
+                    pass
+
+                def do_GET(self):
+                    raw = self.headers.get("Range", "")
+                    with open("range.log", "a") as f:
+                        f.write(raw + "\\n")
+                    if REFUSE:
+                        self.send_response(REFUSE)
+                        self.send_header("Content-Length", "0")
+                        self.end_headers()
+                        return
+                    m = re.match(r"bytes=(\\d+)-(\\d+)", raw)
+                    if m:
+                        start, end = int(m.group(1)), min(int(m.group(2)), TOTAL - 1)
+                        length = end - start + 1
+                        self.send_response(206)
+                        self.send_header("Content-Range", f"bytes {start}-{end}/{TOTAL}")
+                    else:
+                        start, length = 0, TOTAL
+                        self.send_response(200)
+                    self.send_header("Content-Length", str(length))
+                    self.send_header("Accept-Ranges", "bytes")
+                    self.end_headers()
+                    self.wfile.write(b"\\x47" * length)
+
+            server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+            print("READY", server.server_address[1], flush=True)
+            server.serve_forever()
+            """
+        }
+    }
+
+
+    final class SelfSignedHLSOrigin {
+        let port: UInt16
+        private let process: Process
+        private let workDir: URL
+
+        init?() {
+            guard let launched = PythonOrigin.launch(
+                prefix: "aether-hls-origin", script: Self.serverPy,
+                files: ["cert.pem": SelfSignedTLSOrigin.certPEM, "key.pem": SelfSignedTLSOrigin.keyPEM])
+            else { return nil }
+            process = launched.process
+            port = launched.port
+            workDir = launched.workDir
+        }
+
+        func stop() {
+            process.terminate()
+            try? FileManager.default.removeItem(at: workDir)
+        }
+
+        private static let serverPy = """
+            import http.server, ssl
+
+            MASTER = (
+                "#EXTM3U\\n"
+                "#EXT-X-STREAM-INF:BANDWIDTH=800000,CODECS=\\"avc1.640028,mp4a.40.2\\"\\n"
+                "media.m3u8?token=abc\\n"
+            )
+            MEDIA = (
+                "#EXTM3U\\n"
+                "#EXT-X-TARGETDURATION:6\\n"
+                "#EXT-X-VERSION:3\\n"
+                "#EXTINF:6.0,\\n"
+                "seg0.ts\\n"
+                "#EXT-X-ENDLIST\\n"
+            )
+            SEGMENT = b"\\x47" * 4096
+
+            class Handler(http.server.BaseHTTPRequestHandler):
+                protocol_version = "HTTP/1.1"
+
+                def log_message(self, *args):
+                    pass
+
+                def do_GET(self):
+                    path = self.path.split("?")[0]
+                    if path.endswith("master.m3u8"):
+                        body, ctype = MASTER.encode(), "application/vnd.apple.mpegurl"
+                    elif path.endswith("media.m3u8"):
+                        body, ctype = MEDIA.encode(), "application/vnd.apple.mpegurl"
+                    elif path.endswith("seg0.ts"):
+                        body, ctype = SEGMENT, "video/mp2t"
+                    else:
+                        self.send_response(404)
+                        self.send_header("Content-Length", "0")
+                        self.end_headers()
+                        return
+                    self.send_response(200)
+                    self.send_header("Content-Type", ctype)
+                    self.send_header("Content-Length", str(len(body)))
+                    self.end_headers()
+                    self.wfile.write(body)
+
+            server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+            ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+            ctx.load_cert_chain("cert.pem", "key.pem")
+            server.socket = ctx.wrap_socket(server.socket, server_side=True)
+            print("READY", server.server_address[1], flush=True)
+            server.serve_forever()
+            """
+    }
+
+#endif

--- a/Tests/AetherEngineTests/PublicAPIDocumentationTests.swift
+++ b/Tests/AetherEngineTests/PublicAPIDocumentationTests.swift
@@ -51,6 +51,7 @@ final class PublicAPIDocumentationTests: XCTestCase {
         "Diagnostics/EngineDiagnostics.swift",
         "Diagnostics/LiveTelemetry.swift",
         "Diagnostics/EngineLog.swift",
+        "Network/EngineTLS.swift",
         "FrameExtractor/FrameExtractor.swift",
     ]
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -620,6 +620,30 @@ reports an intention rather than an outcome.
 | `vodScrubThumbnail(atSeconds:maxWidth:)`, `liveScrubThumbnail(atSessionSeconds:maxWidth:)` | The two arms, for callers that know which axis they hold. |
 | `supportsCacheBackedStills` | True while a native session exists. Gate the scrub-preview affordance on it: it reports capability, not per-frame availability, so a transient nil from `scrubThumbnail` while a segment is still being produced is expected and means "time only, no image". |
 
+## Certificate trust
+
+A media server behind a self-signed or private-CA certificate is common in self-hosted setups, and
+URLSession refuses it where the in-demuxer network stacks the engine replaces never did. A host whose
+own API layer bypasses trust therefore lands in a split state: browsing works and every engine fetch
+fails its handshake before a byte is read.
+
+| Symbol | Notes |
+| --- | --- |
+| `EngineTLS` | Trust policy for the engine's outbound HTTP connections. Off by default, in the sense that no evaluator is set and every challenge keeps the system's default handling. |
+| `EngineTLS.serverTrustEvaluator` | `(@Sendable (URLProtectionSpace) -> Bool)?`, asked per challenge about the origin the challenge came from. nil, the default, keeps default handling everywhere. Read per challenge, so replacing it applies from the next connection without rebuilding sessions. Called off the main actor from whichever queue raised the challenge, so it has to be thread-safe. |
+
+```swift
+EngineTLS.serverTrustEvaluator = { $0.host == "media.lan" }
+```
+
+Answering per origin is the point of the closure rather than a flag: a host commonly holds a LAN
+address behind a private certificate and a WAN address with a real one, and accepting the first must
+not quietly relax the second. A host that pins an SPKI hash reads the protection space and decides.
+Returning true for everything is the blunt version and is one line.
+
+This governs the sessions the engine owns. A certificate the host does not accept still reaches the
+host as `PlaybackErrorKind.sourceCertificateRejected` rather than as unreadable media.
+
 ## Diagnostics
 
 | Symbol | Notes |


### PR DESCRIPTION
<!-- Thanks for contributing to AetherEngine. Keep this short; the test plan is the part that matters most. -->

## Summary

Second half of #495. The trust hook in #506 covers the sessions the engine opens, and AVPlayer's own networking is not one of them, so the native remote HLS route still could not play a self-signed origin. This mounts a relay on the stand-in #316 already puts in front of a remote master, so the engine makes the https request and the handshake happens where the evaluator is asked.

Stacked on #506. The first commit here is that PR; the second is this one.

Refs #495

## What changed

- **`HLSOriginRelay`**, mounted on `HLSLocalServer` rather than beside it. Allowlist seeded by the load and grown as playlists reveal where their sub-resources live, upstream fetch, playlist rewriting. No socket code of its own: the accept loop, session token, `0.0.0.0` bind and AirPlay LAN swap are the server's, so they come for free and are not reimplemented.
- **`HLSLocalServer`** takes an optional `relay`, its provider becomes optional so a relay-only session has none, and gains one route plus `sendRelay`, the only writer there that passes a status through from elsewhere and the only one that answers 206.
- **The two reasons compose.** `RemoteHLSSubtitleProxy.prepare(needsRelay:)` covers sidecars, relay, or both. With both, the #316 master carries the injected renditions and its origin variants come back through the relay. `rewritePlaylist(absoluteOnly:)` exists for exactly that: the injected renditions are named relatively and belong to the local server, so resolving them would send the player to the origin for a rendition only the engine has.
- **Relayed requests are charged to `OriginRequestBudget`.** Ticket around each fetch, `noteRedirect` when the final URL differs (#388), `noteRefusal` on 429/503/509 with `Retry-After`. Slot wait is 2.5 s, under AVPlayer's ~3.5 s first-byte window, and `acquire` is fail-open so a paced origin slows the session rather than failing it.
- **Ranges pass through untouched.** `Range` forwarded verbatim, never parsed or rebuilt, `Content-Range` and status mirrored. A rewritten playlist downgrades to 200 with no `Content-Range`, since its body no longer has the length the range described.
- The relay engages for any https origin once an evaluator exists, not only ones it would accept. Asking at load time means asking about a protection space no handshake produced, with no `serverTrust` for a host that reads one. The real question is put at the handshake the relay makes, so a declined origin fails there rather than being laundered. There's a test for that.

## On the four review questions

- **AirPlay.** Inherited from `HLSLocalServer`, which already binds every interface, carries the session token, and declares itself to `routeChangeNeedsReload`. Rewritten URIs follow the `Host` the request arrived on, so a receiver that reached the LAN address keeps fetching from it.
- **`RemoteHLSSubtitleProxy` overlap.** This is now one stand-in with two reasons to exist. The version I drafted before your review had a second socket server and silently dropped #316's renditions on a self-signed origin. Both are gone.
- **Rewrite ordering.** One rewriter, so there's no third order to compose. The #316 master is rewritten once, after `start()`, when the address exists.
- **Byte ranges.** Checked against the merged history rather than the issue titles. #468 is resident *segment index* runs for a scrub bar and shares no path with this. #465's range sizing was left on the contributor's branch per your merge note; what landed is the pacer, and the relay now participates in it. Before this fix a 429 seen through the relay never armed the pacer the reader and the subtitle prefetcher read.

## Test plan

- **Device / OS:** MacBook Pro (15,1, Intel i7-8850H), macOS 15.7.7, Swift 6.2.3
- **Source media (container / video codec + profile / audio / HDR-DV):** synthetic. Three loopback Python origins: a self-signed HLS origin serving a master, variant and 4 KB MPEG-TS segments; a self-signed ranged-body origin; and a plain-http origin that answers `Range` exactly as asked and logs what it saw. The last is what makes "forwarded verbatim" observable rather than asserted.
- **Result:** 22 tests across the three TLS and relay suites, plus 141 across the wider affected surface (`RemoteHLS*`, `HLSLocalServer*`, `AirPlay*`, `OriginRequestBudget`), all passing.
  - Through the relay: a client that never sees the certificate gets master, variant and a segment with the sync byte intact. No evaluator gets 502. An evaluator that answers for a different host also gets 502.
  - `bytes=100-199` reaches the origin as that exact string and comes back 206, 100 bytes, `Content-Range: bytes 100-199/4096`.
  - A 429 through the relay leaves `OriginRequestBudget.shared.isPaced(origin)` true.
  - An injected `subs_0.m3u8` survives `absoluteOnly` rewriting while the origin's variant is sent through the relay.
  - A request without this session's token is refused before it reaches the relay.
- `swift build --build-tests` clean. `PublicAPIDocumentationTests` green, both halves.

**Not tested:** AirPlay against a receiver. The iOS-only branch does not compile into the macOS test run, and I don't have a receiver here. The logic is the same as #316's, which is the strongest argument available, but it is inheritance, not a device.

## Checklist

- [x] `CHANGELOG.md` updated
- [x] Commit messages follow Conventional Commits (`feat(...)`, `fix(...)`, `chore(...)`)
- [x] The fix lives in the engine, not in a host-side workaround
- [x] Public API changes are intentional and documented (none new; `EngineTLS` is documented in #506)