### PR TITLE
#407: extend the generated-PTS repair to AVI (measured XviD sample)

### DIFF
--- a/Sources/AetherEngine/Demuxer/Demuxer.swift
+++ b/Sources/AetherEngine/Demuxer/Demuxer.swift
@@ -717,7 +717,7 @@ public final class Demuxer: @unchecked Sendable {
         generatedPTSStreams.removeAll()
         guard let nameC = ctx.pointee.iformat?.pointee.name else { return }
         let formatName = String(cString: nameC)
-        guard VFWDecodeOrderPTSRepair.isMatroska(formatName) else { return }
+        guard VFWDecodeOrderPTSRepair.containerWithholdsPTS(formatName) else { return }
         for index in 0..<Int32(ctx.pointee.nb_streams) {
             guard let stream = ctx.pointee.streams[Int(index)],
                   let par = stream.pointee.codecpar,
@@ -731,7 +731,8 @@ public final class Demuxer: @unchecked Sendable {
             else { continue }
             generatedPTSStreams.insert(index)
             EngineLog.emit(
-                "[Demuxer] AE#407 stream=\(index) is VFW-carried (tag=\(fourCC(par.pointee.codec_tag)) "
+                "[Demuxer] AE#407 stream=\(index) in \(formatName) is FourCC-carried "
+                + "(tag=\(fourCC(par.pointee.codec_tag)) "
                 + "videoDelay=\(par.pointee.video_delay)); the container carries no PTS, so the "
                 + "+genpts axis is decode order. Clearing PTS, the decoder's reorder owns presentation.",
                 category: .demux

--- a/Sources/AetherEngine/Demuxer/VFWDecodeOrderPTSRepair.swift
+++ b/Sources/AetherEngine/Demuxer/VFWDecodeOrderPTSRepair.swift
@@ -37,11 +37,24 @@ import AetherLibavutil
 /// present on such a track was necessarily invented by `+genpts`. `video_delay > 0` narrows that to the
 /// streams where inventing it can transpose anything at all.
 ///
-/// Two deliberate exclusions:
+/// **AVI joins the gate (measured).** The exclusion above was for want of a sample; here is one.
+/// A 2000s XviD rip (`mpeg4`, Advanced Simple Profile, tag `XVID`, 720x304, `video_delay = 1`,
+/// packed B-frames) reaches `SoftwareVideoDecoder` with the same transposition, and `aetherctl
+/// swdecode` reports it in the same words:
 ///
-/// - **Matroska only.** AVI carries a FourCC on every track and is DTS-only as well, but the
-///   `ms_compat`/`codec_tag` equivalence is established in `matroskadec` and nowhere else, and a
-///   VC-1 AVI has not been measured. A gate that is exact on one container beats a guess on two.
+///     0.042  0.083  0.167  0.125  0.209  0.292  0.250  0.334  0.417  0.375
+///     Steps backwards: 12 of 37
+///
+/// AVI needs no `ms_compat` equivalence to establish the same fact, because `avidec` has no other
+/// mode: the container has no presentation timestamps at all, every track carries a FourCC, and the
+/// demuxer puts the frame index on `pkt->dts`. So on an AVI input any PTS present was necessarily
+/// invented by `+genpts`, which makes `codec_tag != 0` a tautology there rather than a signal, and
+/// `video_delay > 0` carries the whole gate. Progressive source, evenly spaced timestamps, no
+/// telecine: the packed bitstream is the only unusual property, and it is not the cause — the
+/// invented axis is.
+///
+/// One deliberate exclusion remains:
+///
 /// - **H.264 / HEVC / AV1 keep their PTS**, VFW-carried or not. Those are the codecs
 ///   `VideoRoutingPolicy` can route natively, which is the one path where packets reach the fMP4
 ///   muxer, and that muxer refuses a packet with no timestamp outright. A wrongly ordered picture is
@@ -69,9 +82,27 @@ enum VFWDecodeOrderPTSRepair {
 
     /// Whether `+genpts` is inventing a decode-order axis for this stream, so its PTS has to go.
     static func suppressesGeneratedPTS(formatName: String, shape: StreamShape) -> Bool {
-        guard isMatroska(formatName) else { return false }
-        guard shape.codecTag != 0, shape.videoDelay > 0 else { return false }
+        guard containerWithholdsPTS(formatName) else { return false }
+        // No reorder delay means decode order IS presentation order: the invented axis is the right
+        // one, and clearing it would only cost. True for both containers.
+        guard shape.videoDelay > 0 else { return false }
+        // Matroska carries a codec tag only on the VFW-carried tracks that withhold PTS; a natively
+        // mapped track gets real timestamps and must keep them. AVI has no such split — every track
+        // is FourCC-carried and none carries PTS — so there the tag says nothing.
+        if isMatroska(formatName), shape.codecTag == 0 { return false }
         return !nativelyRoutableCodecs.contains(shape.codecID)
+    }
+
+    /// Containers that supply no presentation timestamps, so anything on `pkt->pts` came from
+    /// `+genpts` and describes decode order.
+    static func containerWithholdsPTS(_ formatName: String) -> Bool {
+        isMatroska(formatName) || isAVI(formatName)
+    }
+
+    /// `avidec` registers under the bare name, but match it the same way as Matroska so a
+    /// comma-joined alias cannot slip past.
+    static func isAVI(_ formatName: String) -> Bool {
+        formatName.split(separator: ",").contains { $0 == "avi" }
     }
 
     /// libavformat registers both Matroska flavours under one comma-joined demuxer name

--- a/Tests/AetherEngineTests/VFWDecodeOrderPTSRepairTests.swift
+++ b/Tests/AetherEngineTests/VFWDecodeOrderPTSRepairTests.swift
@@ -42,16 +42,48 @@ struct VFWDecodeOrderPTSRepairTests {
             shape: shape(tag: 0x3143_5657, delay: 0)) == false)
     }
 
-    /// The equivalence behind the gate is established in `matroskadec` and nowhere else. AVI carries a
-    /// FourCC on every track and would otherwise match.
-    @Test("Same shape in a non-Matroska container is left alone")
-    func nonMatroskaContainer() {
-        for format in ["avi", "mov,mp4,m4a,3gp,3g2,mj2", "asf", "mpegts"] {
+    /// Containers that do supply presentation timestamps have nothing invented to drop, whatever
+    /// shape the stream has.
+    @Test("Same shape in a PTS-carrying container is left alone")
+    func ptsCarryingContainer() {
+        for format in ["mov,mp4,m4a,3gp,3g2,mj2", "asf", "mpegts"] {
             #expect(VFWDecodeOrderPTSRepair.suppressesGeneratedPTS(
                 formatName: format,
                 shape: shape(tag: 0x3143_5657, delay: 1)) == false,
                 "\(format) must not arm the repair")
         }
+    }
+
+    /// The measured AVI: a 2000s XviD rip, tag `XVID`, one picture of reorder delay. `avidec` has no
+    /// PTS to give, so the `+genpts` axis is decode order exactly as in the Matroska case.
+    @Test("XviD AVI loses its generated PTS")
+    func xvidAVI() {
+        #expect(VFWDecodeOrderPTSRepair.suppressesGeneratedPTS(
+            formatName: "avi",
+            shape: shape(tag: 0x4449_5658, delay: 1, codec: AV_CODEC_ID_MPEG4)) == true)
+    }
+
+    /// AVI has no natively mapped flavour to distinguish, so the codec tag carries no signal there and
+    /// its absence must not veto the repair the way it does on Matroska.
+    @Test("AVI does not gate on the codec tag")
+    func aviIgnoresCodecTag() {
+        #expect(VFWDecodeOrderPTSRepair.suppressesGeneratedPTS(
+            formatName: "avi",
+            shape: shape(tag: 0, delay: 1, codec: AV_CODEC_ID_MPEG4)) == true)
+    }
+
+    /// The two exclusions hold in AVI as well: nothing to transpose, and the natively routable codecs
+    /// whose packets can reach the fMP4 muxer.
+    @Test("AVI keeps the shared exclusions")
+    func aviExclusions() {
+        #expect(VFWDecodeOrderPTSRepair.suppressesGeneratedPTS(
+            formatName: "avi",
+            shape: shape(tag: 0x4449_5658, delay: 0, codec: AV_CODEC_ID_MPEG4)) == false,
+            "no reorder delay means decode order is presentation order")
+        #expect(VFWDecodeOrderPTSRepair.suppressesGeneratedPTS(
+            formatName: "avi",
+            shape: shape(tag: 0x3436_3268, delay: 1, codec: AV_CODEC_ID_H264)) == false,
+            "H.264 can route natively and must keep its PTS")
     }
 
     /// H.264 / HEVC / AV1 can stay on the native path, where packets reach the fMP4 muxer and a
@@ -85,5 +117,14 @@ struct VFWDecodeOrderPTSRepairTests {
         #expect(VFWDecodeOrderPTSRepair.isMatroska("webm") == true)
         #expect(VFWDecodeOrderPTSRepair.isMatroska("avi") == false)
         #expect(VFWDecodeOrderPTSRepair.isMatroska("") == false)
+    }
+
+    /// Same per-element match for AVI, so a comma-joined alias cannot slip past either.
+    @Test("AVI name matching is per element, not substring")
+    func aviNameMatching() {
+        #expect(VFWDecodeOrderPTSRepair.isAVI("avi") == true)
+        #expect(VFWDecodeOrderPTSRepair.isAVI("matroska,webm") == false)
+        #expect(VFWDecodeOrderPTSRepair.isAVI("avisynth") == false)
+        #expect(VFWDecodeOrderPTSRepair.isAVI("") == false)
     }
 }


### PR DESCRIPTION
Fixes #516.

`VFWDecodeOrderPTSRepair` already describes this failure exactly; its gate was Matroska-only because no AVI had been measured:

> **Matroska only.** AVI carries a FourCC on every track and is DTS-only as well, but the `ms_compat`/`codec_tag` equivalence is established in `matroskadec` and nowhere else, and a VC-1 AVI has not been measured. A gate that is exact on one container beats a guess on two.

Here is the measurement. A 2000s XviD rip — `mpeg4` Advanced Simple Profile, tag `XVID`, 720x304, `video_delay = 1`, packed B-frames — takes the same transposition, and `aetherctl swdecode` reports it in the same words the Matroska case did:

```
before   0.042  0.083  0.167  0.125  0.209  0.292  0.250  0.334  0.417  0.375
         Steps backwards: 12 of 37
         VERDICT: the pictures are paired with the wrong timestamps. The container
                  withheld its PTS and something invented one from decode order (#407).

after    0.042  0.083  0.125  0.167  0.209  0.250  0.292  0.334  0.375  0.417
         Steps backwards: 0 of 37
```

## Why AVI needs no equivalence of its own

`avidec` has no second mode. The container carries no presentation timestamps at all, every track carries a FourCC, and the demuxer puts the frame index on `pkt->dts`. So on an AVI input any PTS present was necessarily invented by `+genpts` — which makes `codec_tag != 0` a tautology there rather than a signal, and leaves `video_delay > 0` carrying the whole gate.

The Matroska branch keeps its tag condition untouched: there the tag is what separates the VFW-carried tracks that withhold PTS from the natively mapped ones that must keep theirs.

Both existing exclusions hold unchanged in AVI, and are pinned by tests:

- zero reorder delay — decode order *is* presentation order, so the invented axis is the right one;
- H.264 / HEVC / AV1 — they can stay on the native path, where the fMP4 muxer refuses a timestamp-less packet outright.

## Ruling out the alternatives on this sample

So the diagnosis does not rest on the verdict alone:

- **Not interlacing.** `field_order=unknown`, and `interlaced_frame=0` / `repeat_pict=0` on every frame of a mid-file 25-frame window. Toggling `deinterlaceMode` and `deinterlaceFieldRate` on device changed nothing, consistent with the deinterlacer correctly never engaging.
- **Not cadence or a damaged rate.** `best_effort_timestamp_time` advances evenly at 0.0417 s with no gaps and no duplicates.
- **Not the decode path.** Forcing `preferredDecodePath = .software` changed nothing.
- **Not the packed bitstream itself.** It is the only unusual property of the file, but the pictures decode fine; libavcodec's `mpeg4_unpack_bframes` suggestion is left alone deliberately — a separate, independent improvement, out of scope for a gate change.

## Tests

`nonMatroskaContainer` pinned the old decision that `"avi"` must not arm the repair. It becomes `ptsCarryingContainer` over the containers that genuinely supply timestamps (`mov,mp4,…`, `asf`, `mpegts`), and four AVI cases join the suite: the measured XviD shape, tag-independence, the two shared exclusions, and per-element name matching for `isAVI`.

Full suite on this branch: **2743 tests in 373 suites, all passing.**

## Scope

The gate can now arm only on AVI, and only where `video_delay > 0` — files that today play with their pictures in the wrong order. Nothing that plays correctly changes behaviour.

Happy to adjust naming or split the test changes if you would rather keep `VFW` in the type name now that it covers a second carriage.
