### PR TITLE
fix(io): a held connection ends on a pause, not on a parked producer (#377)

### DIFF
--- a/Sources/AetherEngine/Demuxer/AVIOReader.swift
+++ b/Sources/AetherEngine/Demuxer/AVIOReader.swift
@@ -566,6 +566,10 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
     /// the first as the second re-requests every few seconds, which is what this flag exists to
     /// stop. A pause is the unbounded case #310's worst episode came from (11 minutes), so it is
     /// bounded here and nowhere else.
+    /// How often a held connection on a full window re-reads the play intent. A pause is not
+    /// broadcast on `winCond` -- nothing reads during one -- so this is what lets the paused
+    /// budget below start at all.
+    private static let heldPlayIntentPollSeconds: TimeInterval = 1
     static let heldPausedBudgetDefault: TimeInterval = 300
 
     /// Overridable so a test can express a pause without sleeping through the real budget.
@@ -2870,7 +2874,14 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
         }
         let gap = Double(DispatchTime.now().uptimeNanoseconds - lastDeliveryAt.uptimeNanoseconds)
             / 1_000_000_000
-        if gap < connStallTimeout {
+        // A held connection sitting on a full window has no read outstanding: the pump asked for a
+        // budget, was told there was no room, and is waiting. Nothing is late, so there is no gap to
+        // judge. The pushed path cannot reach this state -- it ends at the high water instead -- which
+        // is why the verdict was safe to take on a full window before. Re-arm rather than end, and the
+        // watchdog still owns the case this path can have: bytes asked for and none arriving.
+        let heldAndFull = heldConnectionEnabled
+            && (winHighWater - (window.count - max(0, Int(position - winStart)))) < Self.heldPullSlack
+        if heldAndFull || gap < connStallTimeout {
             winCond.unlock()
             // Data landed since this closure was scheduled; wait out what is left of the window.
             armDeliveryGapWatchdog(generation: generation, after: max(0.02, connStallTimeout - gap))
@@ -3949,8 +3960,14 @@ extension AVIOReader: HeldSourceConnectionDelegate {
                 // A full window under a playing consumer is the producer parked with a full
                 // segment cache, not a stopped one. Issue no read and wait: no byte is on the
                 // wire, the socket fills, and the sender stops itself.
+                //
+                // The wait carries a poll rather than blocking outright, because the thing it is
+                // waiting to hear about does not broadcast: nobody reads during a pause, so a
+                // consumer that pauses AFTER the window filled would never wake this loop and the
+                // paused budget below would never start. Measured: a 420 s pause held the
+                // connection to the end of the drill with no bound spent.
                 pauseDeadline = nil
-                winCond.wait()
+                _ = winCond.wait(until: Date().addingTimeInterval(Self.heldPlayIntentPollSeconds))
                 continue
             }
             let deadline = pauseDeadline ?? Date().addingTimeInterval(heldPausedBudgetSeconds)

--- a/Sources/AetherEngine/Demuxer/AVIOReader.swift
+++ b/Sources/AetherEngine/Demuxer/AVIOReader.swift
@@ -566,7 +566,10 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
     /// the first as the second re-requests every few seconds, which is what this flag exists to
     /// stop. A pause is the unbounded case #310's worst episode came from (11 minutes), so it is
     /// bounded here and nowhere else.
-    private static let heldPausedBudgetSeconds: TimeInterval = 300
+    static let heldPausedBudgetDefault: TimeInterval = 300
+
+    /// Overridable so a test can express a pause without sleeping through the real budget.
+    nonisolated(unsafe) var heldPausedBudgetSeconds: TimeInterval = AVIOReader.heldPausedBudgetDefault
     /// Ceiling on a single pull. The window's remaining room is normally the smaller number; this
     /// only keeps one read from asking the transport for an unbounded amount while the window is
     /// empty (an open, a seek).
@@ -3950,7 +3953,7 @@ extension AVIOReader: HeldSourceConnectionDelegate {
                 winCond.wait()
                 continue
             }
-            let deadline = pauseDeadline ?? Date().addingTimeInterval(Self.heldPausedBudgetSeconds)
+            let deadline = pauseDeadline ?? Date().addingTimeInterval(heldPausedBudgetSeconds)
             pauseDeadline = deadline
             if Date() >= deadline {
                 connEndedByBackpressure = true
@@ -3966,7 +3969,7 @@ extension AVIOReader: HeldSourceConnectionDelegate {
         if let pausedEndAhead {
             EngineLog.emit(
                 "[AVIOReader] \(label) held connection paused for "
-                + "\(Int(Self.heldPausedBudgetSeconds))s with \(pausedEndAhead / 1024 / 1024)MB "
+                + "\(Int(heldPausedBudgetSeconds))s with \(pausedEndAhead / 1024 / 1024)MB "
                 + "ahead; ending it, will re-request at the frontier when playback resumes",
                 category: .demux)
         }

--- a/Sources/AetherEngine/Demuxer/AVIOReader.swift
+++ b/Sources/AetherEngine/Demuxer/AVIOReader.swift
@@ -164,6 +164,12 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
         }
     }
 
+    /// Whether the consumer intends to play, mirrored from the same source the segment producer
+    /// reads (`HLSVideoEngine.playIntentProvider`). Nil means playing, so a reader nobody wired
+    /// keeps today's behaviour. Read on the held connection's pump thread; a plain stored property
+    /// is enough because it is written once during open and the closure itself is `@Sendable`.
+    nonisolated(unsafe) var playIntentProvider: (@Sendable () -> Bool)?
+
     /// Leaf lock over the sink and its gate: takes no other lock, and no other lock is held across it.
     private let networkPhaseLock = NSLock()
     private var _onNetworkPhaseChanged: (@Sendable (ReaderNetworkPhase) -> Void)?
@@ -555,17 +561,37 @@ final class AVIOReader: AVIOProvider, @unchecked Sendable {
     /// at that same 1.2 Mbps and 7 ms at 70 Mbps, so the steady state sits in the regime that
     /// never fired rather than relying on a measurement nobody can take on demand.
     private static let heldPullSlack = 64 * 1024
+    /// How long a held connection may stay open while the consumer is PAUSED before it is ended.
+    /// Playback never spends this: a parked producer is not a stopped one, and a reader that reads
+    /// the first as the second re-requests every few seconds, which is what this flag exists to
+    /// stop. A pause is the unbounded case #310's worst episode came from (11 minutes), so it is
+    /// bounded here and nowhere else.
+    private static let heldPausedBudgetSeconds: TimeInterval = 300
     /// Ceiling on a single pull. The window's remaining room is normally the smaller number; this
     /// only keeps one read from asking the transport for an unbounded amount while the window is
     /// empty (an open, a seek).
     private static let heldMaxPullBytes = 1 * 1024 * 1024
-    /// How long a held connection may sit on a full window before it is ended. This bounds the one
-    /// dormant stretch the slack cannot: a consumer that has STOPPED. A paused viewer would
-    /// otherwise hold a dormant flow for the length of the pause, which is exactly where #310's
-    /// worst single episode (11 minutes) came from, so a pause ends the connection here and the
-    /// read loop re-requests at the frontier when playback resumes. The reader's own delivery-gap
-    /// watchdog sits at 20 s, well above this, so the deliberate end always gets there first.
-    private static let heldIdleBudgetSeconds: TimeInterval = 5
+    /// A held connection issues no read while the window is full and is not ended for it.
+    ///
+    /// The 16 MB window is a ceiling on a transport that could not be stopped: #174 crashed at
+    /// 3.4 GB with the muxer correctly backpressured and the network thread still delivering, and
+    /// #220 measured 911 MB arriving after a suspend. A pull transport has no such problem, so on
+    /// this path the window is not a thing to be held under, it is a thing that fills when the
+    /// consumer stops drawing and drains when it resumes. Waiting on it costs nothing on the wire:
+    /// no read is issued, the socket buffer fills, and the sender stops itself.
+    ///
+    /// Ending it instead is what a pushed range does, and doing that here spends the flag's whole
+    /// purpose. A field hour on a refusing origin ended 213 held connections this way, none of them
+    /// at a pause: the segment producer races ahead, parks with a full cache while the muxer works,
+    /// and a reader that reads a parked consumer as a stopped one re-requests every 17 seconds. That
+    /// is 218 requests where the design describes one, and against an origin that refuses requests
+    /// it is 218 chances to be refused.
+    ///
+    /// The dormancy that leaves is the one every immune player already has. ffmpeg's HTTP reader
+    /// sits exactly like this whenever its demuxer stops reading, and Infuse, VLC and mpv are built
+    /// on it. On the device, arm B of the transport probe held a stream task on a closed window for
+    /// 60 s while 1 Hz canaries against the origin and a neutral host stayed 206 throughout, and
+    /// arm C could not reproduce #220's mechanism there at all.
     // #377: how long a pump range waits for an origin slot before going on the link anyway. The
     // pump is the main line and everything that can be holding a slot ahead of it is short (a 4 MB
     // detour block, a size probe), so this is "wait for the short thing", not "give up". Generous
@@ -3902,9 +3928,10 @@ extension AVIOReader: HeldSourceConnectionDelegate {
     /// generation that is abandoned (a seek, a close, a reconnect) wakes this immediately and
     /// answers 0 rather than waiting out its budget.
     func heldConnectionPullBudget(_ connection: HeldSourceConnection) -> Int {
-        let deadline = Date().addingTimeInterval(Self.heldIdleBudgetSeconds)
         var budget = 0
-        var idleEndAhead: Int? = nil
+        var pausedEndAhead: Int? = nil
+        // Only a paused consumer carries a deadline, and only from the moment it paused.
+        var pauseDeadline: Date? = nil
         winCond.lock()
         while true {
             guard connection.generation == connGeneration, !connEnded, !isClosed else { break }
@@ -3914,22 +3941,33 @@ extension AVIOReader: HeldSourceConnectionDelegate {
                 budget = min(room, Self.heldMaxPullBytes)
                 break
             }
+            let playing = playIntentProvider?() ?? true
+            if playing {
+                // A full window under a playing consumer is the producer parked with a full
+                // segment cache, not a stopped one. Issue no read and wait: no byte is on the
+                // wire, the socket fills, and the sender stops itself.
+                pauseDeadline = nil
+                winCond.wait()
+                continue
+            }
+            let deadline = pauseDeadline ?? Date().addingTimeInterval(Self.heldPausedBudgetSeconds)
+            pauseDeadline = deadline
             if Date() >= deadline {
                 connEndedByBackpressure = true
                 connEnded = true
                 activeTransfer = nil
-                idleEndAhead = ahead
+                pausedEndAhead = ahead
                 winCond.broadcast()
                 break
             }
             _ = winCond.wait(until: deadline)
         }
         winCond.unlock()
-        if let idleEndAhead {
+        if let pausedEndAhead {
             EngineLog.emit(
-                "[AVIOReader] \(label) held connection idle for \(Int(Self.heldIdleBudgetSeconds))s "
-                + "with \(idleEndAhead / 1024 / 1024)MB ahead; ending it, will re-request at the "
-                + "frontier once the consumer drains",
+                "[AVIOReader] \(label) held connection paused for "
+                + "\(Int(Self.heldPausedBudgetSeconds))s with \(pausedEndAhead / 1024 / 1024)MB "
+                + "ahead; ending it, will re-request at the frontier when playback resumes",
                 category: .demux)
         }
         return budget

--- a/Sources/AetherEngine/Demuxer/Demuxer.swift
+++ b/Sources/AetherEngine/Demuxer/Demuxer.swift
@@ -273,6 +273,13 @@ public final class Demuxer: @unchecked Sendable {
         didSet { (avioProvider as? AVIOReader)?.onNetworkPhaseChanged = onNetworkPhaseChanged }
     }
 
+    /// Passed to the source reader so a held connection can tell a parked producer from a paused
+    /// viewer. Same provider the segment producer reads. `didSet` re-forwards for the same reason
+    /// `onNetworkPhaseChanged` does: it may be set before or after `open()`.
+    var playIntentProvider: (@Sendable () -> Bool)? {
+        didSet { (avioProvider as? AVIOReader)?.playIntentProvider = playIntentProvider }
+    }
+
     /// #361: emitted as each stage of `open()` finishes, so the engine can publish startup progress
     /// through the one stretch of a load a host cannot otherwise see. Called on whatever thread the
     /// open runs on (the playback open is detached off the main actor), never after `open()` returns.
@@ -495,6 +502,7 @@ public final class Demuxer: @unchecked Sendable {
             heldConnection: openProfile.avioHeldConnection
         )
         reader.onNetworkPhaseChanged = onNetworkPhaseChanged
+        reader.playIntentProvider = playIntentProvider
         try openWithProvider(reader, isLive: isLive)
     }
 

--- a/Sources/AetherEngine/Video/HLSVideoEngine.swift
+++ b/Sources/AetherEngine/Video/HLSVideoEngine.swift
@@ -1037,6 +1037,7 @@ public final class HLSVideoEngine: @unchecked Sendable {
         }
         demuxer = dem
         dem.onNetworkPhaseChanged = onNetworkPhaseChanged   // surface source stall/reconnect to playbackPhase (#85)
+        dem.playIntentProvider = playIntentProvider   // a held connection ends on a pause, not on a parked producer
 
         let videoIndex = dem.videoStreamIndex
         guard videoIndex >= 0, let videoStream = dem.stream(at: videoIndex) else {

--- a/Tests/AetherEngineTests/Issue377HeldConnectionTests.swift
+++ b/Tests/AetherEngineTests/Issue377HeldConnectionTests.swift
@@ -392,12 +392,19 @@ struct Issue377HeldReaderTests {
         reader.heldPausedBudgetSeconds = 3
         try reader.open()
 
+        // Well past the budget a paused consumer would have spent.
         try await Task.sleep(for: .seconds(8))
-
-        #expect(reader.hasLiveConnectionForTesting,
-                "a parked producer is not a paused viewer; the connection must still be open")
         #expect(dataRanges(server, totalSize: totalSize).count == 1,
-                "the whole point is one request: \(dataRanges(server, totalSize: totalSize))")
+                "the wait itself must not have re-requested: \(dataRanges(server, totalSize: totalSize))")
+
+        // Draw again. A connection that survived the wait serves this from the same request; one
+        // that was ended would refill at the frontier and the origin would see a second ask. That
+        // is the contract, and unlike a liveness flag it does not depend on when the check lands.
+        let more = 8 * 1024 * 1024
+        #expect(drain(reader, bytes: more) >= more, "the reader did not deliver after the wait")
+        let asks = dataRanges(server, totalSize: totalSize)
+        #expect(asks.count == 1,
+                "a parked producer is not a paused viewer; drawing again must not cost a request: \(asks)")
     }
 
     @Test("consumption after an idle end refills at the frontier without going backwards")

--- a/Tests/AetherEngineTests/Issue377HeldConnectionTests.swift
+++ b/Tests/AetherEngineTests/Issue377HeldConnectionTests.swift
@@ -314,6 +314,15 @@ struct Issue377HeldReaderTests {
         return got
     }
 
+    /// Thread-safe because `playIntentProvider` is read on the held connection's pump thread.
+    private final class LockedFlag: @unchecked Sendable {
+        private let lock = NSLock()
+        private var value: Bool
+        init(_ value: Bool) { self.value = value }
+        func get() -> Bool { lock.lock(); defer { lock.unlock() }; return value }
+        func set(_ newValue: Bool) { lock.lock(); value = newValue; lock.unlock() }
+    }
+
     @Test("a held reader serves a long read on one request where the pushed reader needs several")
     func oneRequestForALongRead() async throws {
         let totalSize: Int64 = 256 * 1024 * 1024
@@ -345,26 +354,50 @@ struct Issue377HeldReaderTests {
                 "a held connection asked \(heldAsks.count) times for one continuous read: \(heldAsks)")
     }
 
-    @Test("a stalled consumer ends the held connection inside the idle budget and holds no flow")
-    func stalledConsumerEndsTheHeldConnection() async throws {
+    @Test("a PAUSED consumer ends the held connection inside its budget and holds no flow")
+    func pausedConsumerEndsTheHeldConnection() async throws {
         let totalSize: Int64 = 256 * 1024 * 1024
         let server = try #require(ThrottledOriginServer(totalSize: totalSize))
         defer { server.stop() }
         let reader = AVIOReader(url: URL(string: "http://127.0.0.1:\(server.port)/movie.bin")!,
                                 heldConnection: true)
         defer { reader.markClosed(); reader.close() }
+        reader.playIntentProvider = { false }
+        reader.heldPausedBudgetSeconds = 3
         try reader.open()
 
-        // Nobody consumes: the paused-viewer shape. #310's worst episode came out of exactly this
-        // state, so the connection has to be gone rather than merely quiet.
+        // Nobody consumes AND the consumer says it is paused. #310's worst episode came out of
+        // exactly this state, so the connection has to be gone rather than merely quiet.
         try await Task.sleep(for: .seconds(8))
 
         #expect(!reader.hasLiveConnectionForTesting,
                 "a paused consumer must hold no flow, which is the #310 invariant 6.11.0 shipped")
         let diag = reader.windowDiagnostics
-        #expect(diag.parked, "the idle end must be recorded as backpressure so the refill owns it")
+        #expect(diag.parked, "the end must be recorded as backpressure so the refill owns it")
         #expect(dataRanges(server, totalSize: totalSize).count == 1,
                 "nothing drained, so nothing may have been re-requested")
+    }
+
+    @Test("a PLAYING consumer that has stopped drawing keeps the held connection")
+    func playingStalledConsumerKeepsTheHeldConnection() async throws {
+        let totalSize: Int64 = 256 * 1024 * 1024
+        let server = try #require(ThrottledOriginServer(totalSize: totalSize))
+        defer { server.stop() }
+        let reader = AVIOReader(url: URL(string: "http://127.0.0.1:\(server.port)/movie.bin")!,
+                                heldConnection: true)
+        defer { reader.markClosed(); reader.close() }
+        // The segment producer's shape: it fills its cache, parks while the muxer works, and draws
+        // again. Reading that as a stopped consumer is what cost a field hour 213 re-requests.
+        reader.playIntentProvider = { true }
+        reader.heldPausedBudgetSeconds = 3
+        try reader.open()
+
+        try await Task.sleep(for: .seconds(8))
+
+        #expect(reader.hasLiveConnectionForTesting,
+                "a parked producer is not a paused viewer; the connection must still be open")
+        #expect(dataRanges(server, totalSize: totalSize).count == 1,
+                "the whole point is one request: \(dataRanges(server, totalSize: totalSize))")
     }
 
     @Test("consumption after an idle end refills at the frontier without going backwards")
@@ -375,15 +408,20 @@ struct Issue377HeldReaderTests {
         let reader = AVIOReader(url: URL(string: "http://127.0.0.1:\(server.port)/movie.bin")!,
                                 heldConnection: true)
         defer { reader.markClosed(); reader.close() }
+        // A pause is what ends a held connection, so that is what this drives before resuming.
+        let playing = LockedFlag(false)
+        reader.playIntentProvider = { playing.get() }
+        reader.heldPausedBudgetSeconds = 3
         try reader.open()
 
-        try await Task.sleep(for: .seconds(8))   // past the idle budget
+        try await Task.sleep(for: .seconds(8))   // past the paused budget
         let afterIdle = dataRanges(server, totalSize: totalSize)
         #expect(afterIdle.count == 1)
 
+        playing.set(true)
         let target = 48 * 1024 * 1024
         #expect(drain(reader, bytes: target) >= target,
-                "the reader did not resume after the idle end")
+                "the reader did not resume after the pause ended")
 
         let asks = dataRanges(server, totalSize: totalSize)
         #expect(asks.count == 2,


### PR DESCRIPTION
The 5 s full-window end fires during playback rather than at a pause, which spends most of what `heldSourceConnection` is for. Measured on the origin from #377 rather than reasoned about.

## What the field run showed

Apple TV 4K 3rd gen, tvOS 26.6, 6.75.0, one hour with the flag on and one hour without, same title, same evening, same edge, back to back:

```
                       held    pushed
connections             218      1055
429s                      0       157
```

The flag works. But 218 is not the one connection the design describes, and the reason is in the log:

```
[AVIOReader] pump held connection idle for 5s with 15MB ahead; ending it, will re-request at the frontier once the consumer drains
```

213 of those in the hour, and the viewer never paused once.

## Why it fires

The constant's own comment names the case it is for:

> This bounds the one dormant stretch the slack cannot: a consumer that has STOPPED. A paused viewer would otherwise hold a dormant flow for the length of the pause

But it infers "stopped" from a full window, and `HLSSegmentProducer` races ahead, fills the window, and parks with a full segment cache while the muxer works (`parked=10s` in the same capture). From the reader those are the same thing, so the pause fallback fires roughly every 17 seconds during ordinary playback.

That matters more here than the request count suggests. 218 connections against an origin that refuses requests are 218 chances to be refused, and 3.6 per minute is about 435 over a two hour film.

## The change

The wait carries a deadline only while the consumer is actually paused. The signal is `playIntentProvider`, which `HLSVideoEngine` already owns and already hands to the producer; this plumbs the same closure to the reader alongside `onNetworkPhaseChanged`, engine → demuxer → reader. Nil means playing, so a reader nobody wires keeps today's behaviour.

A playing consumer with a full window issues no read and waits. No byte is on the wire, the socket buffer fills, and the sender stops itself, which is what an ffmpeg-based player does whenever its demuxer stops reading.

A paused one keeps a bound, at 300 s rather than 5. That is the unbounded stretch #310's worst episode came from, and it is the only one left once a parked producer is no longer read as a stopped one.

## After

Same device, same source, ten minutes:

```
connections   6   (all in the open phase: header, index, tail)
pause ends    0
429s          0
```

The count stops growing once the file is open, which is the shape ffmpeg has against this same URL (three requests, one connection).

## What is not measured

A multi-minute pause with the connection held. The 300 s bound is reasoned from #310's dose rather than measured, and if you would rather it were smaller, or driven by something other than wall clock, that is a number I have no evidence for. Arm B of the transport probe held a stream task on a closed window for 60 s on this device with 1 Hz canaries clean against both the origin and a neutral host, and arm C could not reproduce #220's mechanism there at all, but neither of those reaches a ten minute pause.

Happy to run whatever else against this origin.
