### PR TITLE
fix(ci): a used-by submission reaches its pull request regardless of how it was filed

### DIFF
--- a/.github/workflows/used-by-add.yml
+++ b/.github/workflows/used-by-add.yml
@@ -1,8 +1,8 @@
 name: Add to Used by
 
-# When a maintainer adds the "approved" label to a "used-by-submission" issue,
-# parse the issue form, insert the entry into the README's Used by list (between
-# the <!-- used-by:start --> / <!-- used-by:end --> markers), and open a PR.
+# When a "used-by-submission" issue carries the "approved" label, parse the issue
+# form, insert the entry into the README's Used by list (between the
+# <!-- used-by:start --> / <!-- used-by:end --> markers), and open a PR.
 # Merging the PR is the final approval gate; this workflow never pushes to main.
 
 on:
@@ -15,19 +15,57 @@ permissions:
 
 jobs:
   add-entry:
+    # Either label can arrive last. Submissions that reach the tracker outside the
+    # issue form (mobile clients, the API) carry no template label, so the
+    # maintainer adds it after "approved" is already on; keying the run on
+    # "approved" alone lost those runs with no way to retry but to re-apply the label.
     if: >
-      github.event.label.name == 'approved' &&
+      (github.event.label.name == 'approved' || github.event.label.name == 'used-by-submission') &&
+      contains(github.event.issue.labels.*.name, 'approved') &&
       contains(github.event.issue.labels.*.name, 'used-by-submission')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Normalise the issue body
+        id: normalise
+        env:
+          # Body content stays in env, it is never interpolated into the script.
+          ISSUE_BODY: ${{ github.event.issue.body }}
+        run: |
+          set -euo pipefail
+
+          # The parser splits a section into key and value on the blank line that
+          # the web form writes after each "### " heading. A body that arrives
+          # without it (mobile clients, hand-written, copied between issues)
+          # collapses the whole section into the key, leaves the value undefined,
+          # and JSON.stringify drops undefined, so the parser returns {} and every
+          # field reads as missing. Re-inserting the blank line makes both shapes
+          # parse; a doubled blank line is harmless, the parser filters empties.
+          # Written outside the checkout so it cannot end up in the commit.
+          printf '%s\n' "$ISSUE_BODY" | awk '
+            BEGIN { fence = 0 }
+            /^```/ { fence = !fence; print; next }
+            !fence && /^### / { print; print ""; next }
+            { print }
+          ' > "$RUNNER_TEMP/body.md"
+
+          # Random delimiter: the body is untrusted and must not be able to close
+          # its own heredoc and write further outputs.
+          delim="BODY_EOF_$(openssl rand -hex 16)"
+          {
+            echo "body<<$delim"
+            cat "$RUNNER_TEMP/body.md"
+            echo "$delim"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Parse issue form
         id: parse
         uses: stefanbuck/github-issue-parser@v3
         with:
           template-path: .github/ISSUE_TEMPLATE/used-by-submission.yml
+          issue-body: ${{ steps.normalise.outputs.body }}
 
       - name: Build entry and insert into README
         id: build
@@ -41,10 +79,26 @@ jobs:
           url=$(printf '%s' "$ISSUE_JSON" | jq -r '.url // empty' | head -n1)
           desc=$(printf '%s' "$ISSUE_JSON" | jq -r '.description // empty' | head -n1)
 
+          # A submission that cannot be read is a failure, not a no-op. It used to
+          # exit 0, which left a green run, no PR and no hint that anything broke.
           if [ -z "$name" ] || [ -z "$url" ] || [ -z "$desc" ]; then
-            echo "Missing a required field (name/url/description). Skipping."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
+            {
+              echo "### Could not read the submission"
+              echo
+              echo "Missing:"
+              if [ -z "$name" ]; then echo "- app name"; fi
+              if [ -z "$url" ];  then echo "- url"; fi
+              if [ -z "$desc" ]; then echo "- description"; fi
+              echo
+              echo "Parsed form:"
+              echo '```json'
+              printf '%s\n' "$ISSUE_JSON"
+              echo '```'
+              echo
+              echo "Fix the issue body to match the form, then re-apply the \`approved\` label."
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "::error::Could not read name/url/description from the submission."
+            exit 1
           fi
 
           # Normalise: trim whitespace, collapse to one trailing period.
@@ -52,10 +106,18 @@ jobs:
           url=$(printf '%s'  "$url"  | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
           desc=$(printf '%s' "$desc" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' -e 's/\.*$//')
 
+          # The markers are what the insert aims at. Without them awk would print
+          # the file back unchanged and the PR step would find nothing to commit.
+          if ! grep -q '<!-- used-by:start -->' README.md || ! grep -q '<!-- used-by:end -->' README.md; then
+            echo "::error::The used-by markers are missing from README.md."
+            exit 1
+          fi
+
           # Dedupe: bail out if the URL is already listed between the markers.
           block=$(sed -n '/<!-- used-by:start -->/,/<!-- used-by:end -->/p' README.md)
           if printf '%s' "$block" | grep -qF "$url"; then
             echo "$url is already in the Used by list. Skipping."
+            echo "Skipped: [$name]($url) is already in the Used by list." >> "$GITHUB_STEP_SUMMARY"
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -70,6 +132,12 @@ jobs:
           ' README.md > "$tmp"
           mv "$tmp" README.md
 
+          # Prove the insert landed, so an empty PR can never be the outcome.
+          if git diff --quiet -- README.md; then
+            echo "::error::README.md is unchanged after the insert."
+            exit 1
+          fi
+
           echo "skip=false" >> "$GITHUB_OUTPUT"
           echo "name=$name" >> "$GITHUB_OUTPUT"
           {
@@ -82,8 +150,11 @@ jobs:
 
       - name: Open pull request
         if: steps.build.outputs.skip == 'false'
+        id: pr
         uses: peter-evans/create-pull-request@v6
         with:
+          # Only the README, so no stray runner file can ride along.
+          add-paths: README.md
           branch: used-by/issue-${{ github.event.issue.number }}
           commit-message: "docs(used-by): add ${{ steps.build.outputs.name }}"
           title: "docs(used-by): add ${{ steps.build.outputs.name }}"
@@ -95,3 +166,16 @@ jobs:
             Closes #${{ github.event.issue.number }}
           labels: used-by-submission
           delete-branch: true
+
+      - name: Confirm the pull request exists
+        if: steps.build.outputs.skip == 'false'
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.pull-request-number }}
+          PR_URL: ${{ steps.pr.outputs.pull-request-url }}
+        run: |
+          set -euo pipefail
+          if [ -z "$PR_NUMBER" ]; then
+            echo "::error::The README changed but no pull request was created."
+            exit 1
+          fi
+          echo "Pull request: $PR_URL" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/used-by-label.yml
+++ b/.github/workflows/used-by-label.yml
@@ -1,0 +1,43 @@
+name: Label used-by submissions
+
+# The "used-by-submission" label from the issue form only ever lands when the
+# issue is actually filed through the web form. Most submissions do not arrive
+# that way (the API, gh, mobile clients, a body pasted from elsewhere), and then
+# the label is simply absent and "Add to Used by" has nothing to key on. Recognise
+# a submission by its shape instead and label it here.
+#
+# This only ever adds "used-by-submission". "approved" stays a maintainer action,
+# and it is what actually opens a pull request.
+#
+# Note: a label added with GITHUB_TOKEN does not start another workflow run, so
+# this never triggers "Add to Used by" on its own. That is the intended order:
+# the label lands at submission time, the maintainer's later "approved" is the
+# human event that starts the run.
+
+on:
+  issues:
+    types: [opened, edited]
+
+permissions:
+  issues: write
+
+jobs:
+  label:
+    if: >
+      !contains(github.event.issue.labels.*.name, 'used-by-submission') &&
+      (
+        startsWith(github.event.issue.title, '[Used by]') ||
+        (contains(github.event.issue.body, '### App name') &&
+         contains(github.event.issue.body, '### Repository or website URL'))
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add the label
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          ISSUE: ${{ github.event.issue.number }}
+        run: |
+          set -euo pipefail
+          gh issue edit "$ISSUE" --repo "$REPO" --add-label used-by-submission
+          echo "Labelled #$ISSUE as a used-by submission." >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Approved submissions were ending without a pull request, and no run ever went red.

## Why the label was missing

The `used-by-submission` label from the issue form only lands when the issue is really filed **through the web form**. Measured across the 256 issues opened by other people in this tracker:

- **114 carry a template label at all (45%).** The other 55% reach the tracker past the templates, through the API, `gh`, a mobile client, or a body pasted from somewhere else. `blank_issues_enabled: false` does not stop any of those.
- The correlation is clean: issues **with** a template label have the form's `### ` headings, issues **without** one mostly have no headings at all.

Two of the nine used-by submissions (#484, #525) arrived that way and had to be labelled by hand.

## What was wrong

**1. The label order decided whether anything ran.** The job required `approved` to be the label that arrived. When the maintainer adds the missing `used-by-submission` afterwards, that event does not match, so nothing runs. The only escape was removing and re-applying `approved` by hand.

Timeline of #525, the whole trap in three events:

| time | event | run |
|---|---|---|
| 13:13:44 | `approved` added (issue had no `used-by-submission`) | skipped |
| 13:14:15 | `used-by-submission` added | no run, wrong label name |
| 13:14:31 | `approved` removed and re-applied by hand | ran |

**2. The parser returns `{}` when the body has no blank line after a heading.** `github-issue-parser` splits a section into key and value on `/\r?\n\r?\n/`. Without the blank line the whole section becomes the key, the value is `undefined`, and `JSON.stringify` drops undefined keys. #525 arrived in exactly that shape; its log shows `ISSUE_JSON: {}` then "Missing a required field".

**3. A failed parse was indistinguishable from a success.** It exited 0, so the run went green with no PR and no notification. #525 has two green runs and no PR.

## What changed

**`used-by-add.yml`**
- The condition accepts either label as the one arriving last, so adding the missing label after `approved` starts the run.
- The body is normalised (a blank line re-inserted after each `### ` heading, code fences respected) before it reaches the parser. Fixes the broken shape, leaves the web-form shape untouched.
- An unreadable submission now fails with exit 1 and names the missing fields in the step summary.
- Three further silent no-ops closed: missing README markers, an insert that changed nothing, and a PR step that produced no PR.
- `add-paths: README.md` so no runner file can ride along in the commit.

**`used-by-label.yml`** (new)
- Recognises a submission by its shape (a `[Used by]` title, or the form's headings in the body) and applies `used-by-submission` itself, so the label no longer depends on how the issue was filed.
- Only ever adds that one label. `approved` stays a maintainer action and remains the thing that opens a pull request.

## Verification

The workflow's own `run:` steps replayed against the real issue bodies:

| case | before | after |
|---|---|---|
| #525 Vivid (no blank lines) | `{}`, green, no PR | parses, inserts `- [Vivid](https://github.com/blurbery/vivid): open-source media app for iPhone, iPad and Apple TV.` |
| #497 Moonfin (web form) | parses | parses, unchanged |
| free text, no form | green, no PR | exit 1, missing fields named |
| duplicate URL | skip, exit 0 | skip, exit 0, now in the summary |

The labelling condition evaluated against every issue in the tracker: **9 of 9** used-by submissions matched, **0** false positives across 256 issues, 0 missed.

Workflow events run from the default branch, so this only takes effect once merged. After merging, re-applying either label on #525 opens the Vivid PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDKAJrLjLXVsCvJVNdJEPw